### PR TITLE
docs(ops): add domain-based ops catalog

### DIFF
--- a/docs/ops-catalog.md
+++ b/docs/ops-catalog.md
@@ -1,0 +1,71 @@
+# Ops Catalog
+
+## asset
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.asset.create` | mutation | advanced | mvp-core | ScriptableObjectなどのAssetを新規作成する。 | 予定 |
+| `ucli.asset.schema` | query | safe | mvp-support | Asset型または対象Assetの設定可能項目を取得する。 | 予定 |
+| `ucli.asset.set` | mutation | advanced | mvp-core | Assetのシリアライズ値を更新する。 | 予定 |
+
+## assets
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.assets.find` | query | safe | mvp-support | 条件に一致するAssetを検索する。 | 予定 |
+
+## comp
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.comp.ensure` | mutation | advanced | mvp-core | 対象に指定コンポーネントが存在する状態を保証する。 | 予定 |
+| `ucli.comp.schema` | query | safe | mvp-support | コンポーネント型の設定可能項目を取得する。 | 予定 |
+| `ucli.comp.set` | mutation | advanced | mvp-core | 対象コンポーネントのシリアライズ値を更新する。 | 予定 |
+
+## cs
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.cs.invoke` | mutation | dangerous | experimental | 指定エントリポイントの任意コードを呼び出す。 | 予定 |
+
+## go
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.go.create` | mutation | advanced | mvp-core | 指定親配下にGameObjectを作成する。 | 予定 |
+| `ucli.go.describe` | query | safe | mvp-support | GameObjectの構造とコンポーネント情報を取得する。 | 予定 |
+
+## prefab
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.prefab.create` | mutation | advanced | mvp-core | GameObjectからPrefabを新規作成する。 | 予定 |
+| `ucli.prefab.open` | query | safe | mvp-core | 指定Prefabを編集コンテキストとして開く。 | 予定 |
+| `ucli.prefab.save` | mutation | advanced | mvp-core | 編集中のPrefabを保存する。 | 予定 |
+
+## project
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.project.refresh` | mutation | advanced | mvp-support | AssetDatabase更新やインポートを実行する。 | 予定 |
+| `ucli.project.save` | mutation | advanced | mvp-support | プロジェクト内の未保存変更を保存する。 | 予定 |
+
+## resolve
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.resolve` | query | safe | mvp-core | セレクタを対象オブジェクト参照へ解決する。 | 予定 |
+
+## scene
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.scene.open` | query | safe | mvp-core | 指定Sceneを開いて編集対象にする。 | 予定 |
+| `ucli.scene.save` | mutation | advanced | mvp-core | 指定Sceneの変更を保存する。 | 予定 |
+| `ucli.scene.tree` | query | safe | mvp-support | Sceneの階層構造を取得する。 | 予定 |
+
+## scenes
+
+| op | kind | policy | status | 概要 | argsSchema |
+| --- | --- | --- | --- | --- | --- |
+| `ucli.scenes.findComponents` | query | safe | mvp-support | 複数Sceneを横断して対象コンポーネントを検索する。 | 予定 |

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -206,6 +206,7 @@
 ## オペレーション
 オペレーションは、JSONの `ops[]` に並ぶ **最小ステップ** の処理単位。  
 `plan` と `call` は同じ `ops[]` を、実行フェーズ（plan/call）だけ変えて回す。
+一覧は [`ops-catalog.md`](./ops-catalog.md) を参照。
 
 ### 命名規約
 - コア：`ucli.<domain>.<verb>`（例：`ucli.scene.open`, `ucli.comp.set`）


### PR DESCRIPTION
## Summary
- `docs/ops-catalog.md` を新規作成し、opをドメイン単位ヘッダーで整理しました。
- `docs/uCLI.md` のオペレーション節からカタログへの参照リンクを追加しました。
- 指摘に合わせて不要行を削除し、`ucli.project.save` の行を追加しました。

## Scope
- docs/ops-catalog.md
- docs/uCLI.md

## Verification
- Gate level: Skipped（ユーザー指示により検証ゲートは省略）
- Diff budget: PASS（2 files changed, 72 insertions）
- Spec drift: Skipped（Issueなし）
- Format: PASS（`dotnet format Ucli.slnx --no-restore` / `--verify-no-changes` 実行済み）
- Tests: Skipped（ユーザー指示）
- Coverage: N/A

## Risks / Rollback
- リスク: ドキュメント変更のみのため実行時挙動への影響はありません。
- ロールバック: PRのコミット `3fd0a59` をrevertすれば元に戻せます。

## Checklist
- [x] ドメイン単位ヘッダーでopテーブルを整理
- [x] 必須8件を含むop行を記載
- [x] `uCLI.md` からカタログへ導線を追加

Issue: none (ad-hoc task)
