### PR TITLE
docs: add ucli test integration spec and archive uni-test-hub readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,55 @@
 # uCLI - CLI workflow for Unity
 
+uCLI は Unity プロジェクトを安全に自動化するための CLI です。  
+Unity Editor API を経由した編集操作を中心に、Unity Test Framework 実行の統合も進めています。
+
+## 主な機能
+- JSON リクエストによる Unity 編集オペレーション（`validate` / `plan` / `call`）
+- デーモン実行と oneshot 実行の切り替え
+- Unity テスト実行と結果の正規化（`ucli test`、統合予定）
+
 ## Get Started
 
+### 1. プロジェクト設定を初期化する
+```bash
+ucli init
+```
+
+### 2. 変更前に計画を確認する
+```bash
+ucli plan < request.json
+```
+
+### 3. 変更を適用する
+```bash
+ucli call --planToken "<PLAN_TOKEN>" < request.json
+```
+
+### 4. Unity テストを実行する（統合後の予定）
+※ `ucli test` は現時点では未実装です。次は統合仕様の利用例です。
+
+```bash
+ucli test run \
+  --projectPath ./UnityProject \
+  --testPlatform editmode \
+  --assemblyName MyGame.Tests.EditMode
+```
+
+テスト成果物は既定で `./.ucli/local/artifacts/` 配下に出力されます。
+
 ## Commands
+- `ucli init`
+- `ucli validate`
+- `ucli plan`
+- `ucli call`
+- `ucli resolve`
+- `ucli query`
+- `ucli refresh`
+- `ucli ops`
+- `ucli status`
+- `ucli daemon`
+- `ucli test run`（予定）
+- `ucli test profile init`（予定）
+
+詳細仕様は `docs/uCLI.md` を参照してください。  
+`uni-test-hub` 旧READMEは `docs/uni-test-hub.md` にアーカイブしています。

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -13,6 +13,7 @@
 - CLI起動、ユーザー起動のGUIインスタンス、両方でデーモンは起動する
 - 変更は Unity Editor API（AssetDatabase / Scene / Prefab / SerializedObject 等）に限定する。YAML直編集を前提にしない
 - すべての入出力はJSONを基本にする
+- Unity Test Framework の実行と結果正規化を、`ucli test` として統合提供する予定である
 
 ## アーキテクチャ
 - コア：.NET製 CLI（`ucli`）
@@ -43,22 +44,51 @@
 
 ## 入出力のJSON契約
 - すべてのコマンドの成功・失敗レスポンスはJSONで返す
-- `protocolVersion` はリクエスト・レスポンス双方で必須
+- 進行ログと診断ログは `stderr` に出力する
+- `stdout` は常にJSONレスポンス1件のみを出力する
+- `protocolVersion` はすべてのレスポンスで必須
+- JSONリクエストを受け取るコマンド（`validate` / `plan` / `call` / `resolve` / `query` / `refresh`）では、リクエストにも `protocolVersion` を必須とする
 - 互換性判定は `protocolVersion` で行う
 
 ### CLI出力契約
-- `stdout` は常にJSONレスポンス1件のみを出力する
-- 進行ログと診断ログは `stderr` に出力する
-- 終了コードは `status` と連動する
-  - `status=ok` のとき `exit code = 0`
-  - `status=error` のとき `exit code != 0`
+- `status` は `ok | error` を使用する
+  - `ok`：コマンドが契約どおり完了した
+  - `error`：入力不正、インフラ障害、外部ツール障害などで完了できなかった
+- 終了コードはコマンド別契約に従う
+  - JSONリクエスト系コマンドは `status=ok` のとき `exit code = 0`、`status=error` のとき `exit code != 0`
+  - `ucli test run` は `status=ok` かつ `payload.result=fail` の場合に `exit code = 1` を返す
+
+### コマンドレスポンス共通エンベロープ
+`init` / `ops` / `status` / `daemon` / `test` は、次の共通エンベロープでレスポンスを返す。
+
+- `protocolVersion`：プロトコルメジャーバージョン整数（必須）
+- `command`：コマンド識別子（必須、例：`test.run`）
+- `status`：`ok | error`（必須）
+- `exitCode`：プロセス終了コード（必須）
+- `message`：説明（必須）
+- `payload`：コマンド固有結果（必須）
+- `errors`：エラー配列（必須、正常時は空配列）
+
+```json
+{
+  "protocolVersion": 1,
+  "command": "test.run",
+  "status": "ok",
+  "exitCode": 1,
+  "message": "Unity test execution completed with failed tests.",
+  "payload": {
+    "result": "fail"
+  },
+  "errors": []
+}
+```
 
 ### `protocolVersion` 規則
 - 初版はメジャーバージョン整数のみを使用する（例：`1`）
 - 受信したメジャーバージョンがサーバー対応値と一致しない場合は、処理を実行せずJSONエラーを返す
 - 推奨エラーコード：`PROTOCOL_VERSION_MISMATCH`
 
-### リクエスト最小構造
+### JSONリクエスト系コマンドのリクエスト最小構造
 - `protocolVersion`：プロトコルメジャーバージョン整数（必須）
 - `requestId`：追跡用UUID（必須）
 - `ops`：実行するオペレーション配列（必須、順次実行）
@@ -71,7 +101,7 @@
 }
 ```
 
-### レスポンス最小構造
+### JSONリクエスト系コマンドのレスポンス最小構造
 - `protocolVersion`：リクエストと同じ値（必須）
 - `requestId`：リクエストと同じ値（必須）
 - `status`：`ok | error`（必須）
@@ -474,12 +504,122 @@ CWDがUnityプロジェクトと判定可能な場合はそれを使う。そう
 - `ucli status`：
   - CWDか `--projectPath` でプロジェクト指定
   - `--mode` の実行可能性を判定してJSONで返す（`mode`, `unityVersion`, `ucliUnityVersion`, `compileState` 等）
+- `ucli test`：Unity Test Framework 実行と結果正規化
+  - `run`：Unityテストを実行し、正規化結果をJSONで返す
+  - `profile init`：`test` 実行用のプロファイルJSON雛形を生成する
 - `ucli daemon`：常駐サーバ管理
   - `start`：対象 `projectFingerprint` のデーモンを起動
   - `stop`：デーモンを停止
   - `status`：デーモン状態を取得
   - `logs`：デーモンログを取得
   - `--projectPath <path>`：対象Unityプロジェクト指定
+
+## test コマンド（統合仕様）
+本節は、旧 `uni-test-hub` の機能を uCLI へ統合するための仕様を示す（現時点では未実装）。
+旧仕様と背景情報は `docs/uni-test-hub.md` にアーカイブしている。
+
+### `ucli test run`
+Unity を `-batchmode -nographics -runTests` で起動し、実行結果を正規化して返す。
+
+#### `run` options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--projectPath <string?>` | `-p` | Unity project root path |
+| `--profilePath <string?>` | `-c` | Profile configuration path |
+| `--mode <string?>` | - | `auto` (default), `daemon`, or `oneshot` |
+| `--unityVersion <string?>` | `-u` | Unity editor version |
+| `--unityEditorPath <string?>` | - | Unity editor executable path or editor directory path |
+| `--testPlatform <string?>` | - | `editmode` or `playmode` |
+| `--buildTarget <string?>` | `-t` | Build target used when `testPlatform=playmode` |
+| `--testFilter <string?>` | `-f` | Test name filter pattern |
+| `--testCategory <string[]?>` | - | Test categories (repeat or comma-separated) |
+| `--assemblyName <string[]?>` | `-a` | Assembly names (repeat or comma-separated) |
+| `--testSettingsPath <string?>` | `-s` | Path to `TestSettings.json` |
+| `--outputDir <string?>` | `-o` | Artifact output root directory (default: `<projectRoot>/.ucli/local/artifacts`) |
+| `--timeoutSeconds <int?>` | - | Timeout in seconds (`1..86400`) |
+
+#### `run` の `payload` 契約
+- `result`：`pass | fail`（`status=error` の場合は `null`）
+- `errorKind`：`invalidInput | infraError | toolError | null`
+- `runId`：実行ID
+- `artifactsDir`：成果物ディレクトリ
+- `summaryJsonPath`：サマリーJSONのパス
+
+#### `run` の終了コード
+| Code | Meaning |
+| --- | --- |
+| `0` | pass |
+| `1` | fail |
+| `2` | infraError |
+| `3` | invalidInput |
+| `4` | toolError |
+
+#### `run` 実行例
+```bash
+ucli test run \
+  --projectPath ./UnityProject \
+  --testPlatform editmode \
+  --assemblyName MyGame.Tests.EditMode
+```
+
+### `ucli test profile init`
+`test` 実行用のプロファイルJSON雛形を作成する。
+
+#### `profile init` options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--outputPath <string?>` | `-o` | Output path for profile JSON (default: `.ucli/test.profile.json`) |
+| `--force` | `-f` | Overwrite existing file |
+
+#### 生成テンプレート
+```json
+{
+  "schemaVersion": 1,
+  "projectPath": ".",
+  "unityVersion": null,
+  "unityEditorPath": null,
+  "testPlatform": "editmode",
+  "buildTarget": null,
+  "testFilter": null,
+  "testCategories": [],
+  "assemblyNames": [],
+  "testSettingsPath": null,
+  "outputDir": ".ucli/local/artifacts",
+  "timeoutSeconds": 1800
+}
+```
+
+### `test` 設定解決順序
+- `CLI options > profile.json > defaults`
+
+### UnityバージョンとEditor解決順序
+`unityVersion` は次の順で解決する。
+
+1. `--unityVersion`
+2. `profile.json` `unityVersion`
+3. `ProjectSettings/ProjectVersion.txt` (`m_EditorVersion`)
+
+`unityEditorPath` は次の順で解決する。
+
+1. `--unityEditorPath`
+2. `profile.json` `unityEditorPath`
+3. 既定の検索ルートで、解決済み `unityVersion` に一致するEditorを探索
+
+### Artifacts layout
+各実行の成果物は次の構造で保存する。
+
+`<outputDir>/test/<runId>/`
+
+```text
+<outputDir>/test/<runId>/
+  meta.json
+  results.xml
+  editor.log
+  results.json
+  summary.json
+```
 
 ## サーバー
 別ディレクトリのworktreeは別fingerprintの別デーモンでなければならない。  
@@ -488,6 +628,7 @@ CWDがUnityプロジェクトと判定可能な場合はそれを使う。そう
 
 ### local保存
 - `.ucli/local/` はGit管理対象外とする（`.ucli/.gitignore` で除外）
+- テスト成果物の既定出力先は `<projectRoot>/.ucli/local/artifacts/` とする
 - `planToken` 本体は通常非永続化（呼び出し側のメモリ受け渡し）
 - 永続化するのは署名鍵のみ
   - パス：`<projectRoot>/.ucli/local/<projectFingerprint>/plan-token.key`

--- a/docs/uni-test-hub.md
+++ b/docs/uni-test-hub.md
@@ -1,0 +1,213 @@
+> [!NOTE]
+> この文書は、`uni-test-hub` の元READMEを移設したアーカイブです。  
+> `uni-test-hub` の機能は、`ucli test` として uCLI へ統合予定です（現時点では未実装）。  
+> 統合仕様案は `docs/uCLI.md` の「test コマンド（統合仕様）」を参照してください。
+
+# UniTestHub - Integrated Unity Test Runner CLI
+
+`uni-test-hub` is a CLI tool that unifies execution of the Unity Test Framework and collects and normalizes test results. It standardizes the verification process and quality gates.
+
+- 複数のUnityバージョンのテストを統一されたCLIで実行
+- Unity Editorとバージョンの自動検出
+- テストプロファイルJSONでテスト構成を定義
+
+## Installation
+
+Install as a global .NET tool (requires .NET 8.0 or later):
+
+```bash
+dotnet tool install --global MackySoft.UniTestHub
+uni-test-hub --version
+```
+
+Update:
+
+```bash
+dotnet tool update --global MackySoft.UniTestHub
+```
+
+## Get Started
+
+最初に、Unityのテストを実行する
+
+```bash
+uni-test-hub run \
+  --projectPath ./UnityProject \
+  --mode editmode \
+  --assemblyName MyGame.Tests.EditMode \
+  --outputDir ./artifacts/test-results
+```
+
+Run PlayMode tests with build target:
+
+```bash
+uni-test-hub run \
+  --projectPath ./UnityProject \
+  --mode playmode \
+  --buildTarget StandaloneWindows64 \
+  --assemblyName MyGame.Tests.PlayMode
+```
+
+## Profile JSON
+
+プロファイルJSONファイルは、テスト実行の構成を定義できます。基本的にはCLIオプションと同じフィールドを持ち、CLIオプションを指定する代わりにJSONとしてプリセットを保持することが出来ます。
+
+プロファイルJSONのテンプレートは、次のコマンドで生成できます。
+
+```bash
+uni-test-hub profile init
+```
+
+Generated:
+
+```json
+{
+  "schemaVersion": 1,
+  "projectPath": ".",
+  "unityVersion": null,
+  "unityEditorPath": null,
+  "mode": "editmode",
+  "buildTarget": null,
+  "testFilter": null,
+  "testCategories": [],
+  "assemblyNames": [],
+  "testSettingsPath": null,
+  "outputDir": "./artifacts/uni-test-hub",
+  "timeoutSeconds": 1800
+}
+```
+
+プロファイルの設定がCLIオプションと競合する場合は、CLIオプションが優先されます。
+`CLI options > profile.json > defaults`
+
+```bash
+uni-test-hub profile init --outputPath ./profile.json
+uni-test-hub run --projectPath ./UnityProject --profilePath ./profile.json
+```
+
+## Commands
+
+- `uni-test-hub run`: Executes Unity tests and emits a JSON result to stdout.
+- `uni-test-hub profile init`: Generates a `profile.json` template.
+
+### `run` options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--projectPath <string?>` | `-p` | Unity project root path |
+| `--profilePath <string?>` | `-c` | Profile configuration path |
+| `--unityVersion <string?>` | `-u` | Unity editor version |
+| `--unityEditorPath <string?>` | - | Unity editor executable path or editor directory path |
+| `--mode <string?>` | `-m` | `editmode` or `playmode` |
+| `--buildTarget <string?>` | `-t` | Build target used when `mode=playmode` |
+| `--testFilter <string?>` | `-f` | Test name filter pattern |
+| `--testCategory <string[]?>` | - | Test categories (repeat or comma-separated) |
+| `--assemblyName <string[]?>` | `-a` | Assembly names (repeat or comma-separated) |
+| `--testSettingsPath <string?>` | `-s` | Path to `TestSettings.json` |
+| `--outputDir <string?>` | `-o` | Artifact output root directory |
+| `--timeoutSeconds <int?>` | - | Timeout in seconds (`1..86400`) |
+
+### `profile init` options
+
+| Option | Short | Description |
+| --- | --- | --- |
+| `--outputPath <string?>` | `-o` | Output path for profile JSON (default: `profile.json`) |
+| `--force` | `-f` | Overwrite existing file |
+
+
+## Unity version and editor resolution
+
+Unityバージョンは基本的に、Unityプロジェクトの `ProjectSettings/ProjectVersion.txt` に記載されたバージョンから自動的に解決されます。
+
+`unityVersion` is resolved in this order:
+
+1. `--unityVersion`
+2. `profile.json` `unityVersion`
+3. `ProjectSettings/ProjectVersion.txt` (`m_EditorVersion`)
+
+`unityEditorPath` is resolved in this order:
+
+1. `--unityEditorPath`
+2. `profile.json` `unityEditorPath`
+3. Search default installation roots for the resolved `unityVersion`
+
+Default search roots include:
+
+- Windows: `%ProgramFiles%/Unity/Hub/Editor`, `%ProgramFiles%/Unity/Editor`, `%ProgramFiles(x86)%/Unity/Hub/Editor`, `%ProgramFiles(x86)%/Unity/Editor`
+- macOS: `/Applications/Unity/Hub/Editor`, `/Applications/Unity/Editor`
+- Linux: `/opt/Unity/Hub/Editor`, `/opt/unity/hub/editor`, `$HOME/Unity/Hub/Editor`
+
+## Artifacts layout
+
+For each run, artifacts are written to:
+
+`<outputDir>/<runId>/`
+
+```text
+<outputDir>/<runId>/
+  meta.json
+  results.xml
+  editor.log
+  results.json
+  summary.json
+```
+
+File purpose:
+
+- `meta.json`: resolved configuration snapshot and run metadata
+- `results.xml`: raw Unity Test Framework output
+- `editor.log`: Unity editor log for the run
+- `results.json`: normalized per-test result
+- `summary.json`: compact status, counts, and top failures
+
+## JSON output contracts
+
+### `run` stdout JSON
+
+`run` always emits a single JSON object to stdout:
+
+```json
+{
+  "status": "pass|fail|error",
+  "errorKind": "invalidInput|infraError|toolError|null",
+  "exitCode": 0,
+  "message": "...",
+  "runId": "...",
+  "artifactsDir": "...",
+  "summaryJsonPath": "..."
+}
+```
+
+### `profile init` stdout JSON
+
+`profile init` always emits a single JSON object to stdout:
+
+```json
+{
+  "status": "success|error",
+  "errorKind": "invalidInput|infraError|null",
+  "exitCode": 0,
+  "message": "...",
+  "profilePath": "..."
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | pass |
+| `1` | fail |
+| `2` | infraError |
+| `3` | invalidInput |
+| `4` | toolError |
+
+## Common failure cases and fixes
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `InvalidInput: projectPath does not exist` | `--projectPath` is wrong | Pass a valid Unity project root |
+| `InvalidInput: mode must be editmode or playmode` | Unsupported mode string | Use `editmode` or `playmode` |
+| `InvalidInput: buildTarget is not allowed when mode=editmode` | `buildTarget` used in EditMode | Remove `--buildTarget` or switch to `playmode` |
+| `EditorNotInstalled: Unity Editor is not installed for unityVersion ...` | Matching Unity version was not found in search roots | Install that editor version or specify `--unityEditorPath` |
+| `InvalidInput: timeoutSeconds must be in range 1..86400` | Timeout out of allowed range | Use a value between `1` and `86400` |


### PR DESCRIPTION
## Summary
- uCLIドキュメントに、uni-test-hub機能を`ucli test`へ統合するための仕様案（未実装）を追加しました。
- テスト成果物の既定出力先を`<projectRoot>/.ucli/local/artifacts`に統一して明記しました。
- 旧`uni-test-hub` READMEを`docs/uni-test-hub.md`へ移設し、統合予定である旨を注記しました。

## Scope
- `README.md`: `ucli test`の位置づけを統合予定として整理、参照導線を追加。
- `docs/uCLI.md`: JSON出力契約の追記、`test`統合仕様セクションの追加、`local`配下の成果物ポリシー追記。
- `docs/uni-test-hub.md`: 旧READMEのアーカイブと移行注記の追加。

## Verification
- Gate level: Skipped (user requested no verification)
- Diff budget: Skipped
- Spec drift: Skipped (Issueなし)
- Format: Skipped (user requested no verification)
- Tests: Skipped (user requested no verification)
- Coverage: N/A

## Risks / Rollback
- Risk: 仕様先行のため、実装時にドキュメントとの差分が発生する可能性があります。
- Rollback: このPRのコミットをrevertすればドキュメント変更を取り消せます。

## Checklist
- [ ] `ucli test`実装時に本仕様との差分レビューを実施する
- [ ] 実装PRでformat/testsを含む検証を実施する

Issue: none (ad-hoc task)
