### PR TITLE
[v1.0][F2] project解決とconfig/init/status基盤を実装する

### DIFF
--- a/src/Ucli/Cli/CommandResult.cs
+++ b/src/Ucli/Cli/CommandResult.cs
@@ -22,8 +22,8 @@ namespace MackySoft.Ucli.Cli
         private static readonly IReadOnlyList<CommandError> EmptyErrors = Array.Empty<CommandError>();
 
         /// <summary> Creates a successful command result. </summary>
-        /// <param name="command"> The command name written to the result. Whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The success message written to the result. Whitespace values are replaced by a fallback message. </param>
+        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+        /// <param name="message"> The success message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
         /// <param name="payload"> The command payload. When <see langword="null" />, an empty payload object is used. </param>
         /// <returns> A command result with <c>ok</c> status and the success exit code. </returns>
         public static CommandResult Success (string command, string message, object? payload = null)
@@ -41,7 +41,7 @@ namespace MackySoft.Ucli.Cli
         }
 
         /// <summary> Creates a placeholder error result for a command that is not implemented yet. </summary>
-        /// <param name="command"> The command name written to the result. Whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
         /// <param name="message"> The optional custom message. When <see langword="null" />, a default not-implemented message is generated. </param>
         /// <returns> A command result with <c>error</c> status and the <c>COMMAND_NOT_IMPLEMENTED</c> error code. </returns>
         public static CommandResult NotImplemented (string command, string? message = null)
@@ -56,8 +56,8 @@ namespace MackySoft.Ucli.Cli
         }
 
         /// <summary> Creates an error result for invalid command arguments. </summary>
-        /// <param name="command"> The command name written to the result. Whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The argument validation message written to the result. Whitespace values are replaced by a fallback message. </param>
+        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+        /// <param name="message"> The argument validation message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
         /// <returns> A command result with <c>error</c> status and the invalid-argument exit code. </returns>
         public static CommandResult InvalidArgument (string command, string message)
         {
@@ -69,8 +69,8 @@ namespace MackySoft.Ucli.Cli
         }
 
         /// <summary> Creates an error result for unexpected runtime failures. </summary>
-        /// <param name="command"> The command name written to the result. Whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The failure message written to the result. Whitespace values are replaced by a fallback message. </param>
+        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+        /// <param name="message"> The failure message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
         /// <returns> A command result with <c>error</c> status and the tool-error exit code. </returns>
         public static CommandResult InternalError (string command, string message)
         {
@@ -111,7 +111,7 @@ namespace MackySoft.Ucli.Cli
 
         /// <summary> Normalizes the command name used in command results. </summary>
         /// <param name="command"> The command name to normalize. </param>
-        /// <returns> The input command name, or <see cref="CliProtocol.RootCommand" /> when the input is empty or whitespace. </returns>
+        /// <returns> The input command name, or <see cref="CliProtocol.RootCommand" /> when the input is <see langword="null" />, empty, or whitespace. </returns>
         private static string NormalizeCommand (string command)
         {
             return string.IsNullOrWhiteSpace(command) ? CliProtocol.RootCommand : command;
@@ -119,7 +119,7 @@ namespace MackySoft.Ucli.Cli
 
         /// <summary> Normalizes the message value used in command results. </summary>
         /// <param name="message"> The message to normalize. </param>
-        /// <returns> The input message, or a fallback error message when the input is empty or whitespace. </returns>
+        /// <returns> The input message, or a fallback error message when the input is <see langword="null" />, empty, or whitespace. </returns>
         private static string NormalizeMessage (string message)
         {
             return string.IsNullOrWhiteSpace(message) ? "An unknown error occurred." : message;

--- a/src/Ucli/Cli/CommandResultWriter.cs
+++ b/src/Ucli/Cli/CommandResultWriter.cs
@@ -13,8 +13,11 @@ namespace MackySoft.Ucli.Cli
 
         /// <summary> Writes the specified command result to standard output in JSON format. </summary>
         /// <param name="result"> The command result to serialize. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="result" /> is <see langword="null" />. </exception>
         public static void WriteToStandardOutput (CommandResult result)
         {
+            ArgumentNullException.ThrowIfNull(result);
+
             Console.Out.WriteLine(JsonSerializer.Serialize(result, SerializerOptions));
         }
     }

--- a/src/Ucli/Cli/InitCommand.cs
+++ b/src/Ucli/Cli/InitCommand.cs
@@ -1,4 +1,6 @@
 using ConsoleAppFramework;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Init;
 
 namespace MackySoft.Ucli.Cli
 {
@@ -8,24 +10,64 @@ namespace MackySoft.Ucli.Cli
         /// <summary> Gets the command name used by this command handler. </summary>
         internal const string CommandName = "init";
 
-        /// <summary> Writes the placeholder result for the <c>init</c> command. </summary>
-        /// <param name="force"> Reserved option for future overwrite behavior. The current implementation ignores this value. </param>
+        private readonly IInitService initService;
+
+        /// <summary> Initializes a new instance of the <see cref="InitCommand" /> class. </summary>
+        /// <param name="initService"> The init service dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="initService" /> is <see langword="null" />. </exception>
+        public InitCommand (IInitService initService)
+        {
+            this.initService = initService ?? throw new ArgumentNullException(nameof(initService));
+        }
+
+        /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
+        /// <param name="force"> Whether existing template files can be overwritten. </param>
+        /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
         /// <returns> The exit code contained in the emitted command result. </returns>
         [Command(CommandName)]
         public int Init (
             bool force = false,
+            string? projectPath = null,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             CommandExecutionState.MarkStarted();
 
-            _ = force;
-
-            var result = CommandResult.NotImplemented(CommandName);
+            var executionResult = initService.Execute(force, projectPath, cancellationToken);
+            var result = CreateCommandResult(executionResult);
             CommandResultWriter.WriteToStandardOutput(result);
             return result.ExitCode;
+        }
+
+        /// <summary> Creates the command-level JSON result from an init service execution result. </summary>
+        /// <param name="executionResult"> The init service execution result. </param>
+        /// <returns> The command result serialized to stdout. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="executionResult" /> is <see langword="null" />. </exception>
+        private static CommandResult CreateCommandResult (InitExecutionResult executionResult)
+        {
+            ArgumentNullException.ThrowIfNull(executionResult);
+
+            if (executionResult.IsSuccess)
+            {
+                var output = executionResult.Output!;
+                return CommandResult.Success(
+                    command: CommandName,
+                    message: "uCLI initialization completed.",
+                    payload: new
+                    {
+                        projectPath = output.ProjectPath,
+                        projectFingerprint = output.ProjectFingerprint,
+                        configPath = output.ConfigPath,
+                        gitignorePath = output.GitIgnorePath,
+                    });
+            }
+
+            var error = executionResult.Error!;
+            return error.Kind == ExecutionErrorKind.InvalidArgument
+                ? CommandResult.InvalidArgument(CommandName, error.Message)
+                : CommandResult.InternalError(CommandName, error.Message);
         }
     }
 }

--- a/src/Ucli/Cli/ParseErrorBuffer.cs
+++ b/src/Ucli/Cli/ParseErrorBuffer.cs
@@ -15,9 +15,12 @@ namespace MackySoft.Ucli.Cli
         public static bool HasAny => !MessagesCore.IsEmpty;
 
         /// <summary> Adds a parse error message to the buffer. </summary>
-        /// <param name="message"> The parse error message to store. </param>
+        /// <param name="message"> The parse error message to store. Must not be <see langword="null" />. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message" /> is <see langword="null" />. </exception>
         public static void Add (string message)
         {
+            ArgumentNullException.ThrowIfNull(message);
+
             MessagesCore.Enqueue(message);
         }
 

--- a/src/Ucli/Cli/StatusCommand.cs
+++ b/src/Ucli/Cli/StatusCommand.cs
@@ -9,7 +9,7 @@ namespace MackySoft.Ucli.Cli
         internal const string CommandName = "status";
 
         /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
-        /// <param name="projectPath"> Reserved option for target project path selection. The current implementation ignores this value. </param>
+        /// <param name="projectPath">--projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
         /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
         /// <returns> The exit code contained in the emitted command result. </returns>
@@ -22,9 +22,6 @@ namespace MackySoft.Ucli.Cli
             cancellationToken.ThrowIfCancellationRequested();
 
             CommandExecutionState.MarkStarted();
-
-            _ = projectPath;
-            _ = mode;
 
             var result = CommandResult.NotImplemented(CommandName);
             CommandResultWriter.WriteToStandardOutput(result);

--- a/src/Ucli/Configuration/ConfigSource.cs
+++ b/src/Ucli/Configuration/ConfigSource.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Identifies where <see cref="UcliConfig" /> values were loaded from. </summary>
+    internal enum ConfigSource
+    {
+        /// <summary> The configuration file was not found and default values were applied. </summary>
+        Default = 0,
+
+        /// <summary> The configuration file was loaded from disk. </summary>
+        File = 1,
+    }
+}

--- a/src/Ucli/Configuration/IUcliConfigStore.cs
+++ b/src/Ucli/Configuration/IUcliConfigStore.cs
@@ -1,0 +1,34 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Provides read/write access to <c>.ucli/config.json</c>. </summary>
+    internal interface IUcliConfigStore
+    {
+        /// <summary> Resolves the absolute path to the config file under a UnityProject root. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
+        /// <returns> The absolute config path. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
+        /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
+        /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
+        string GetConfigPath (string unityProjectRoot);
+
+        /// <summary> Loads config values for a UnityProject. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+        UcliConfigLoadResult Load (
+            string unityProjectRoot,
+            CancellationToken cancellationToken = default);
+
+        /// <summary> Saves config values for a UnityProject. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+        /// <param name="config"> The config values to persist. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The config-save result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+        UcliConfigSaveResult Save (
+            string unityProjectRoot,
+            UcliConfig config,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli/Configuration/OperationPolicy.cs
+++ b/src/Ucli/Configuration/OperationPolicy.cs
@@ -1,0 +1,15 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Defines allowed operation safety levels configured in <c>.ucli/config.json</c>. </summary>
+    internal enum OperationPolicy
+    {
+        /// <summary> Allows only safe operations. </summary>
+        Safe = 0,
+
+        /// <summary> Allows safe and advanced operations. </summary>
+        Advanced = 1,
+
+        /// <summary> Allows safe, advanced, and dangerous operations. </summary>
+        Dangerous = 2,
+    }
+}

--- a/src/Ucli/Configuration/PlanTokenMode.cs
+++ b/src/Ucli/Configuration/PlanTokenMode.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Defines plan-token requirements configured in <c>.ucli/config.json</c>. </summary>
+    internal enum PlanTokenMode
+    {
+        /// <summary> Allows command execution with or without a plan token. </summary>
+        Optional = 0,
+
+        /// <summary> Requires command execution to include a plan token. </summary>
+        Required = 1,
+    }
+}

--- a/src/Ucli/Configuration/UcliConfig.cs
+++ b/src/Ucli/Configuration/UcliConfig.cs
@@ -1,0 +1,31 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Represents parsed values from <c>.ucli/config.json</c>. </summary>
+    /// <param name="SchemaVersion"> The config schema version. </param>
+    /// <param name="OperationPolicy"> The allowed operation safety level. </param>
+    /// <param name="PlanTokenMode"> The plan token requirement level. </param>
+    /// <param name="OperationAllowlist"> The operation-name allowlist patterns. </param>
+    internal sealed record UcliConfig (
+        int SchemaVersion,
+        OperationPolicy OperationPolicy,
+        PlanTokenMode PlanTokenMode,
+        IReadOnlyList<string> OperationAllowlist)
+    {
+        private const int CurrentSchemaVersion = 1;
+        private const string DefaultAllowlistPattern = "^ucli\\.";
+
+        /// <summary> Creates default configuration values for missing config files. </summary>
+        /// <returns> The default config instance. </returns>
+        public static UcliConfig CreateDefault ()
+        {
+            return new UcliConfig(
+                SchemaVersion: CurrentSchemaVersion,
+                OperationPolicy: OperationPolicy.Safe,
+                PlanTokenMode: PlanTokenMode.Optional,
+                OperationAllowlist:
+                [
+                    DefaultAllowlistPattern,
+                ]);
+        }
+    }
+}

--- a/src/Ucli/Configuration/UcliConfigLoadResult.cs
+++ b/src/Ucli/Configuration/UcliConfigLoadResult.cs
@@ -1,0 +1,38 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Represents the result of loading <see cref="UcliConfig" /> values. </summary>
+    /// <param name="Config"> The loaded config, or <see langword="null" /> on failure. </param>
+    /// <param name="Source"> The source used for config values. </param>
+    /// <param name="Error"> The structured load error, or <see langword="null" /> on success. </param>
+    internal sealed record UcliConfigLoadResult (
+        UcliConfig? Config,
+        ConfigSource Source,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether config load succeeded. </summary>
+        public bool IsSuccess => Config is not null && Error is null;
+
+        /// <summary> Creates a successful config-load result. </summary>
+        /// <param name="config"> The loaded config values. </param>
+        /// <param name="source"> The source used for the loaded values. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+        public static UcliConfigLoadResult Success (UcliConfig config, ConfigSource source)
+        {
+            ArgumentNullException.ThrowIfNull(config);
+            return new UcliConfigLoadResult(config, source, null);
+        }
+
+        /// <summary> Creates a failed config-load result. </summary>
+        /// <param name="error"> The structured load error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static UcliConfigLoadResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new UcliConfigLoadResult(null, ConfigSource.Default, error);
+        }
+    }
+}

--- a/src/Ucli/Configuration/UcliConfigSaveResult.cs
+++ b/src/Ucli/Configuration/UcliConfigSaveResult.cs
@@ -1,0 +1,30 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Represents the result of persisting <see cref="UcliConfig" /> values. </summary>
+    /// <param name="Error"> The structured save error, or <see langword="null" /> on success. </param>
+    internal sealed record UcliConfigSaveResult (
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether config save succeeded. </summary>
+        public bool IsSuccess => Error is null;
+
+        /// <summary> Creates a successful config-save result. </summary>
+        /// <returns> The successful result. </returns>
+        public static UcliConfigSaveResult Success ()
+        {
+            return new UcliConfigSaveResult(Error: null);
+        }
+
+        /// <summary> Creates a failed config-save result. </summary>
+        /// <param name="error"> The structured save error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static UcliConfigSaveResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new UcliConfigSaveResult(Error: error);
+        }
+    }
+}

--- a/src/Ucli/Configuration/UcliConfigStore.cs
+++ b/src/Ucli/Configuration/UcliConfigStore.cs
@@ -1,0 +1,460 @@
+using System.Text.Json;
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Provides filesystem-backed access to <c>.ucli/config.json</c>. </summary>
+    internal sealed class UcliConfigStore : IUcliConfigStore
+    {
+        private const string UcliDirectoryName = ".ucli";
+        private const string ConfigFileName = "config.json";
+        private const int SupportedSchemaVersion = 1;
+
+        private static readonly JsonSerializerOptions SerializerOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+        };
+
+        /// <summary> Resolves the absolute path to <c>.ucli/config.json</c> for a UnityProject root. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
+        /// <returns> The absolute config path. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
+        /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
+        /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
+        public string GetConfigPath (string unityProjectRoot)
+        {
+            var fullPath = Path.GetFullPath(unityProjectRoot);
+            return Path.Combine(fullPath, UcliDirectoryName, ConfigFileName);
+        }
+
+        /// <summary> Loads configuration values for a UnityProject root. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+        public UcliConfigLoadResult Load (
+            string unityProjectRoot,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(unityProjectRoot))
+            {
+                return UcliConfigLoadResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
+            }
+
+            string configPath;
+            try
+            {
+                configPath = GetConfigPath(unityProjectRoot);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                    $"UnityProject root path is invalid: {unityProjectRoot}"));
+            }
+
+            if (!File.Exists(configPath))
+            {
+                return UcliConfigLoadResult.Success(UcliConfig.CreateDefault(), ConfigSource.Default);
+            }
+
+            string json;
+            try
+            {
+                json = File.ReadAllText(configPath);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                    $"Config path is invalid: {configPath}"));
+            }
+            catch (Exception ex) when (IsIoFailure(ex))
+            {
+                return UcliConfigLoadResult.Failure(CreateInternalError(
+                    $"Failed to read config file: {configPath}. {ex.Message}"));
+            }
+
+            UcliConfigDocument? document;
+            try
+            {
+                document = JsonSerializer.Deserialize<UcliConfigDocument>(json, SerializerOptions);
+            }
+            catch (JsonException ex)
+            {
+                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                    $"Config JSON is invalid: {configPath}. {ex.Message}"));
+            }
+
+            if (document is null)
+            {
+                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                    $"Config JSON is invalid: {configPath}."));
+            }
+
+            var parseResult = TryConvertToConfig(document, configPath);
+            if (!parseResult.IsSuccess)
+            {
+                return UcliConfigLoadResult.Failure(parseResult.Error!);
+            }
+
+            return UcliConfigLoadResult.Success(parseResult.Config!, ConfigSource.File);
+        }
+
+        /// <summary> Saves configuration values to <c>.ucli/config.json</c>. </summary>
+        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+        /// <param name="config"> The config values to persist. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The config-save result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+        public UcliConfigSaveResult Save (
+            string unityProjectRoot,
+            UcliConfig config,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(unityProjectRoot))
+            {
+                return UcliConfigSaveResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
+            }
+
+            ArgumentNullException.ThrowIfNull(config);
+
+            string configPath;
+            try
+            {
+                configPath = GetConfigPath(unityProjectRoot);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                    $"UnityProject root path is invalid: {unityProjectRoot}"));
+            }
+
+            var configValidationResult = ValidateConfig(config, configPath);
+            if (!configValidationResult.IsSuccess)
+            {
+                return UcliConfigSaveResult.Failure(configValidationResult.Error!);
+            }
+
+            var json = JsonSerializer.Serialize(ToDocument(config), SerializerOptions);
+            string? configDirectoryPath = null;
+            try
+            {
+                configDirectoryPath = Path.GetDirectoryName(configPath);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                    $"Config path is invalid: {configPath}. {ex.Message}"));
+            }
+
+            if (string.IsNullOrWhiteSpace(configDirectoryPath))
+            {
+                return UcliConfigSaveResult.Failure(CreateInternalError(
+                    $"Config directory path could not be determined: {configPath}"));
+            }
+
+            try
+            {
+                Directory.CreateDirectory(configDirectoryPath);
+                File.WriteAllText(configPath, json + Environment.NewLine);
+                return UcliConfigSaveResult.Success();
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                    $"Config path is invalid: {configPath}. {ex.Message}"));
+            }
+            catch (Exception ex) when (IsIoFailure(ex))
+            {
+                return UcliConfigSaveResult.Failure(CreateInternalError(
+                    $"Failed to write config file: {configPath}. {ex.Message}"));
+            }
+        }
+
+        /// <summary> Converts deserialized config JSON into a validated <see cref="UcliConfig" /> instance. </summary>
+        /// <param name="document"> The deserialized config document. </param>
+        /// <param name="configPath"> The source config path. </param>
+        /// <returns> The conversion result. </returns>
+        private static ConfigParseResult TryConvertToConfig (
+            UcliConfigDocument document,
+            string configPath)
+        {
+            if (document.SchemaVersion != SupportedSchemaVersion)
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {document.SchemaVersion}."));
+            }
+
+            if (!TryParseOperationPolicy(document.OperationPolicy, out var operationPolicy))
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config operationPolicy is invalid: {document.OperationPolicy}."));
+            }
+
+            if (!TryParsePlanTokenMode(document.PlanTokenMode, out var planTokenMode))
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config planTokenMode is invalid: {document.PlanTokenMode}."));
+            }
+
+            if (document.OperationAllowlist is null)
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist must be an array: {configPath}."));
+            }
+
+            var normalizedAllowlist = new List<string>(document.OperationAllowlist.Length);
+            foreach (var pattern in document.OperationAllowlist)
+            {
+                if (string.IsNullOrWhiteSpace(pattern))
+                {
+                    return ConfigParseResult.Failure(CreateInvalidArgument(
+                        $"Config operationAllowlist contains an empty pattern: {configPath}."));
+                }
+
+                normalizedAllowlist.Add(pattern.Trim());
+            }
+
+            var config = new UcliConfig(
+                SchemaVersion: document.SchemaVersion,
+                OperationPolicy: operationPolicy,
+                PlanTokenMode: planTokenMode,
+                OperationAllowlist: normalizedAllowlist);
+            return ConfigParseResult.Success(config);
+        }
+
+        /// <summary> Validates configuration values before writing them to disk. </summary>
+        /// <param name="config"> The config values to validate. </param>
+        /// <param name="configPath"> The destination config path. </param>
+        /// <returns> The validation result. </returns>
+        private static ConfigValidationResult ValidateConfig (
+            UcliConfig config,
+            string configPath)
+        {
+            if (config.SchemaVersion != SupportedSchemaVersion)
+            {
+                return ConfigValidationResult.Failure(CreateInvalidArgument(
+                    $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {config.SchemaVersion}."));
+            }
+
+            if (config.OperationAllowlist is null)
+            {
+                return ConfigValidationResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist must not be null: {configPath}."));
+            }
+
+            foreach (var pattern in config.OperationAllowlist)
+            {
+                if (string.IsNullOrWhiteSpace(pattern))
+                {
+                    return ConfigValidationResult.Failure(CreateInvalidArgument(
+                        $"Config operationAllowlist contains an empty pattern: {configPath}."));
+                }
+            }
+
+            return ConfigValidationResult.Success();
+        }
+
+        /// <summary> Converts typed config values into serializable JSON DTO values. </summary>
+        /// <param name="config"> The typed config values. </param>
+        /// <returns> The serializable DTO. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+        private static UcliConfigDocument ToDocument (UcliConfig config)
+        {
+            ArgumentNullException.ThrowIfNull(config);
+
+            return new UcliConfigDocument(
+                SchemaVersion: config.SchemaVersion,
+                OperationPolicy: ToStringValue(config.OperationPolicy),
+                PlanTokenMode: ToStringValue(config.PlanTokenMode),
+                OperationAllowlist: config.OperationAllowlist.ToArray());
+        }
+
+        /// <summary> Converts <see cref="OperationPolicy" /> to the config string value. </summary>
+        /// <param name="operationPolicy"> The operation policy value. </param>
+        /// <returns> The config string representation. </returns>
+        /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="operationPolicy" /> is outside supported values. </exception>
+        private static string ToStringValue (OperationPolicy operationPolicy)
+        {
+            return operationPolicy switch
+            {
+                OperationPolicy.Safe => UcliConfigValueConstants.OperationPolicySafe,
+                OperationPolicy.Advanced => UcliConfigValueConstants.OperationPolicyAdvanced,
+                OperationPolicy.Dangerous => UcliConfigValueConstants.OperationPolicyDangerous,
+                _ => throw new ArgumentOutOfRangeException(nameof(operationPolicy), operationPolicy, "Unsupported operationPolicy."),
+            };
+        }
+
+        /// <summary> Converts <see cref="PlanTokenMode" /> to the config string value. </summary>
+        /// <param name="planTokenMode"> The plan token mode value. </param>
+        /// <returns> The config string representation. </returns>
+        /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="planTokenMode" /> is outside supported values. </exception>
+        private static string ToStringValue (PlanTokenMode planTokenMode)
+        {
+            return planTokenMode switch
+            {
+                PlanTokenMode.Optional => UcliConfigValueConstants.PlanTokenModeOptional,
+                PlanTokenMode.Required => UcliConfigValueConstants.PlanTokenModeRequired,
+                _ => throw new ArgumentOutOfRangeException(nameof(planTokenMode), planTokenMode, "Unsupported planTokenMode."),
+            };
+        }
+
+        /// <summary> Parses operation-policy config values. </summary>
+        /// <param name="value"> The config string value. </param>
+        /// <param name="operationPolicy"> The parsed enum value. </param>
+        /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryParseOperationPolicy (string? value, out OperationPolicy operationPolicy)
+        {
+            if (string.Equals(value, UcliConfigValueConstants.OperationPolicySafe, StringComparison.OrdinalIgnoreCase))
+            {
+                operationPolicy = OperationPolicy.Safe;
+                return true;
+            }
+
+            if (string.Equals(value, UcliConfigValueConstants.OperationPolicyAdvanced, StringComparison.OrdinalIgnoreCase))
+            {
+                operationPolicy = OperationPolicy.Advanced;
+                return true;
+            }
+
+            if (string.Equals(value, UcliConfigValueConstants.OperationPolicyDangerous, StringComparison.OrdinalIgnoreCase))
+            {
+                operationPolicy = OperationPolicy.Dangerous;
+                return true;
+            }
+
+            operationPolicy = default;
+            return false;
+        }
+
+        /// <summary> Parses plan-token-mode config values. </summary>
+        /// <param name="value"> The config string value. </param>
+        /// <param name="planTokenMode"> The parsed enum value. </param>
+        /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryParsePlanTokenMode (string? value, out PlanTokenMode planTokenMode)
+        {
+            if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeOptional, StringComparison.OrdinalIgnoreCase))
+            {
+                planTokenMode = PlanTokenMode.Optional;
+                return true;
+            }
+
+            if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeRequired, StringComparison.OrdinalIgnoreCase))
+            {
+                planTokenMode = PlanTokenMode.Required;
+                return true;
+            }
+
+            planTokenMode = default;
+            return false;
+        }
+
+        /// <summary> Creates an invalid-argument error. </summary>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The structured invalid-argument error. </returns>
+        private static ExecutionError CreateInvalidArgument (string message)
+        {
+            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+        }
+
+        /// <summary> Creates an internal-error value. </summary>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The structured internal-error value. </returns>
+        private static ExecutionError CreateInternalError (string message)
+        {
+            return new ExecutionError(ExecutionErrorKind.InternalError, message);
+        }
+
+        /// <summary> Determines whether an exception should be treated as invalid path formatting. </summary>
+        /// <param name="exception"> The exception to classify. </param>
+        /// <returns> <see langword="true" /> when invalid path formatting is detected; otherwise <see langword="false" />. </returns>
+        private static bool IsPathFormatException (Exception exception)
+        {
+            return exception is ArgumentException
+                or NotSupportedException
+                or PathTooLongException;
+        }
+
+        /// <summary> Determines whether an exception should be treated as an internal I/O failure. </summary>
+        /// <param name="exception"> The exception to classify. </param>
+        /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
+        private static bool IsIoFailure (Exception exception)
+        {
+            return exception is IOException
+                or UnauthorizedAccessException;
+        }
+
+        /// <summary> Serializable JSON DTO for config values. </summary>
+        /// <param name="SchemaVersion"> The config schema version. </param>
+        /// <param name="OperationPolicy"> The operation-policy value. </param>
+        /// <param name="PlanTokenMode"> The plan-token-mode value. </param>
+        /// <param name="OperationAllowlist"> The operation-name allowlist. </param>
+        private sealed record UcliConfigDocument (
+            int SchemaVersion,
+            string OperationPolicy,
+            string PlanTokenMode,
+            string[] OperationAllowlist);
+
+        /// <summary> Represents result values from config parse operations. </summary>
+        /// <param name="Config"> The parsed config instance. </param>
+        /// <param name="Error"> The parse error, when parse fails. </param>
+        private readonly record struct ConfigParseResult (
+            UcliConfig? Config,
+            ExecutionError? Error)
+        {
+            /// <summary> Gets a value indicating whether parse succeeded. </summary>
+            public bool IsSuccess => Config is not null && Error is null;
+
+            /// <summary> Creates a successful parse result. </summary>
+            /// <param name="config"> The parsed config instance. </param>
+            /// <returns> The successful parse result. </returns>
+            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+            public static ConfigParseResult Success (UcliConfig config)
+            {
+                ArgumentNullException.ThrowIfNull(config);
+                return new ConfigParseResult(config, null);
+            }
+
+            /// <summary> Creates a failed parse result. </summary>
+            /// <param name="error"> The parse error. </param>
+            /// <returns> The failed parse result. </returns>
+            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+            public static ConfigParseResult Failure (ExecutionError error)
+            {
+                ArgumentNullException.ThrowIfNull(error);
+                return new ConfigParseResult(null, error);
+            }
+        }
+
+        /// <summary> Represents result values from config validation before save. </summary>
+        /// <param name="Error"> The validation error, when validation fails. </param>
+        private readonly record struct ConfigValidationResult (
+            ExecutionError? Error)
+        {
+            /// <summary> Gets a value indicating whether validation succeeded. </summary>
+            public bool IsSuccess => Error is null;
+
+            /// <summary> Creates a successful validation result. </summary>
+            /// <returns> The successful validation result. </returns>
+            public static ConfigValidationResult Success ()
+            {
+                return new ConfigValidationResult(Error: null);
+            }
+
+            /// <summary> Creates a failed validation result. </summary>
+            /// <param name="error"> The validation error. </param>
+            /// <returns> The failed validation result. </returns>
+            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+            public static ConfigValidationResult Failure (ExecutionError error)
+            {
+                ArgumentNullException.ThrowIfNull(error);
+                return new ConfigValidationResult(Error: error);
+            }
+        }
+    }
+}

--- a/src/Ucli/Configuration/UcliConfigValueConstants.cs
+++ b/src/Ucli/Configuration/UcliConfigValueConstants.cs
@@ -1,0 +1,21 @@
+namespace MackySoft.Ucli.Configuration
+{
+    /// <summary> Defines string literals used in <c>.ucli/config.json</c> enum-like fields. </summary>
+    internal static class UcliConfigValueConstants
+    {
+        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Safe" />. </summary>
+        public const string OperationPolicySafe = "safe";
+
+        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Advanced" />. </summary>
+        public const string OperationPolicyAdvanced = "advanced";
+
+        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Dangerous" />. </summary>
+        public const string OperationPolicyDangerous = "dangerous";
+
+        /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Optional" />. </summary>
+        public const string PlanTokenModeOptional = "optional";
+
+        /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Required" />. </summary>
+        public const string PlanTokenModeRequired = "required";
+    }
+}

--- a/src/Ucli/Context/IInitStatusContextResolver.cs
+++ b/src/Ucli/Context/IInitStatusContextResolver.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.Context
+{
+    /// <summary> Resolves foundation context shared by <c>init</c> and future <c>status</c> implementations. </summary>
+    internal interface IInitStatusContextResolver
+    {
+        /// <summary> Resolves UnityProject and config values into an execution context. </summary>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The context-resolution result that contains either a fully resolved context or a structured error. </returns>
+        InitStatusContextResolutionResult Resolve (
+            string? projectPath,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli/Context/InitStatusContext.cs
+++ b/src/Ucli/Context/InitStatusContext.cs
@@ -1,0 +1,14 @@
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Context
+{
+    /// <summary> Represents shared foundation values for init/status command execution. </summary>
+    /// <param name="UnityProject"> The resolved UnityProject context. </param>
+    /// <param name="Config"> The loaded config values. </param>
+    /// <param name="ConfigSource"> The source where config values were loaded from. </param>
+    internal sealed record InitStatusContext (
+        ResolvedUnityProjectContext UnityProject,
+        UcliConfig Config,
+        ConfigSource ConfigSource);
+}

--- a/src/Ucli/Context/InitStatusContextResolutionResult.cs
+++ b/src/Ucli/Context/InitStatusContextResolutionResult.cs
@@ -1,0 +1,35 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Context
+{
+    /// <summary> Represents the result of resolving <see cref="InitStatusContext" /> values. </summary>
+    /// <param name="Context"> The resolved context, or <see langword="null" /> on failure. </param>
+    /// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
+    internal sealed record InitStatusContextResolutionResult (
+        InitStatusContext? Context,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether context resolution succeeded. </summary>
+        public bool IsSuccess => Context is not null && Error is null;
+
+        /// <summary> Creates a successful context-resolution result. </summary>
+        /// <param name="context"> The resolved context value. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
+        public static InitStatusContextResolutionResult Success (InitStatusContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return new InitStatusContextResolutionResult(context, null);
+        }
+
+        /// <summary> Creates a failed context-resolution result. </summary>
+        /// <param name="error"> The structured resolution error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static InitStatusContextResolutionResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new InitStatusContextResolutionResult(null, error);
+        }
+    }
+}

--- a/src/Ucli/Context/InitStatusContextResolver.cs
+++ b/src/Ucli/Context/InitStatusContextResolver.cs
@@ -1,0 +1,54 @@
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Context
+{
+    /// <summary> Resolves shared foundation context for init/status command pipelines. </summary>
+    internal sealed class InitStatusContextResolver : IInitStatusContextResolver
+    {
+        private readonly IUnityProjectResolver unityProjectResolver;
+        private readonly IUcliConfigStore configStore;
+
+        /// <summary> Initializes a new instance of the <see cref="InitStatusContextResolver" /> class. </summary>
+        /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
+        /// <param name="configStore"> The config-store dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" /> or <paramref name="configStore" /> is <see langword="null" />. </exception>
+        public InitStatusContextResolver (
+            IUnityProjectResolver unityProjectResolver,
+            IUcliConfigStore configStore)
+        {
+            this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
+            this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+        }
+
+        /// <summary> Resolves UnityProject and config values into a shared init/status context. </summary>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The context-resolution result that contains either a fully resolved context or a structured error. </returns>
+        public InitStatusContextResolutionResult Resolve (
+            string? projectPath,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var unityProjectResult = unityProjectResolver.Resolve(projectPath, cancellationToken);
+            if (!unityProjectResult.IsSuccess)
+            {
+                return InitStatusContextResolutionResult.Failure(unityProjectResult.Error!);
+            }
+
+            var unityProjectContext = unityProjectResult.Context!;
+            var configLoadResult = configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken);
+            if (!configLoadResult.IsSuccess)
+            {
+                return InitStatusContextResolutionResult.Failure(configLoadResult.Error!);
+            }
+
+            var context = new InitStatusContext(
+                UnityProject: unityProjectContext,
+                Config: configLoadResult.Config!,
+                ConfigSource: configLoadResult.Source);
+            return InitStatusContextResolutionResult.Success(context);
+        }
+    }
+}

--- a/src/Ucli/Foundation/ExecutionError.cs
+++ b/src/Ucli/Foundation/ExecutionError.cs
@@ -1,0 +1,9 @@
+namespace MackySoft.Ucli.Foundation
+{
+    /// <summary> Represents a structured error returned from foundation services. </summary>
+    /// <param name="Kind"> The classification used to map the error to the CLI contract. </param>
+    /// <param name="Message"> The user-facing error message. </param>
+    internal sealed record ExecutionError (
+        ExecutionErrorKind Kind,
+        string Message);
+}

--- a/src/Ucli/Foundation/ExecutionErrorKind.cs
+++ b/src/Ucli/Foundation/ExecutionErrorKind.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Foundation
+{
+    /// <summary> Defines high-level error categories used by foundation services. </summary>
+    internal enum ExecutionErrorKind
+    {
+        /// <summary> Indicates an invalid argument or invalid contract input. </summary>
+        InvalidArgument = 0,
+
+        /// <summary> Indicates an unexpected infrastructure or runtime failure. </summary>
+        InternalError = 1,
+    }
+}

--- a/src/Ucli/Init/IInitService.cs
+++ b/src/Ucli/Init/IInitService.cs
@@ -1,0 +1,16 @@
+namespace MackySoft.Ucli.Init
+{
+    /// <summary> Executes initialization flow for generating the <c>.ucli</c> template files. </summary>
+    internal interface IInitService
+    {
+        /// <summary> Executes initialization for a target UnityProject. </summary>
+        /// <param name="force"> Whether existing files can be overwritten. </param>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The initialization execution result that contains either generated file paths or a structured error. </returns>
+        InitExecutionResult Execute (
+            bool force,
+            string? projectPath,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli/Init/InitExecutionOutput.cs
+++ b/src/Ucli/Init/InitExecutionOutput.cs
@@ -1,0 +1,13 @@
+namespace MackySoft.Ucli.Init
+{
+    /// <summary> Represents output values produced by a successful init execution. </summary>
+    /// <param name="ProjectPath"> The resolved UnityProject root path. </param>
+    /// <param name="ProjectFingerprint"> The resolved UnityProject fingerprint. </param>
+    /// <param name="ConfigPath"> The path of the generated config file. </param>
+    /// <param name="GitIgnorePath"> The path of the generated <c>.ucli/.gitignore</c> file. </param>
+    internal sealed record InitExecutionOutput (
+        string ProjectPath,
+        string ProjectFingerprint,
+        string ConfigPath,
+        string GitIgnorePath);
+}

--- a/src/Ucli/Init/InitExecutionResult.cs
+++ b/src/Ucli/Init/InitExecutionResult.cs
@@ -1,0 +1,35 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Init
+{
+    /// <summary> Represents the result of init execution. </summary>
+    /// <param name="Output"> The init output values on success. </param>
+    /// <param name="Error"> The structured init error on failure. </param>
+    internal sealed record InitExecutionResult (
+        InitExecutionOutput? Output,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether init execution succeeded. </summary>
+        public bool IsSuccess => Output is not null && Error is null;
+
+        /// <summary> Creates a successful init-execution result. </summary>
+        /// <param name="output"> The init output values. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="output" /> is <see langword="null" />. </exception>
+        public static InitExecutionResult Success (InitExecutionOutput output)
+        {
+            ArgumentNullException.ThrowIfNull(output);
+            return new InitExecutionResult(output, null);
+        }
+
+        /// <summary> Creates a failed init-execution result. </summary>
+        /// <param name="error"> The structured init error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static InitExecutionResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new InitExecutionResult(null, error);
+        }
+    }
+}

--- a/src/Ucli/Init/InitService.cs
+++ b/src/Ucli/Init/InitService.cs
@@ -1,0 +1,182 @@
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Context;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Init
+{
+    /// <summary> Implements init flow that generates the <c>.ucli</c> template files. </summary>
+    internal sealed class InitService : IInitService
+    {
+        private const string UcliDirectoryName = ".ucli";
+        private const string GitIgnoreFileName = ".gitignore";
+        private const string GitIgnoreContents = "local/";
+
+        private readonly IUnityProjectResolver unityProjectResolver;
+        private readonly IInitStatusContextResolver contextResolver;
+        private readonly IUcliConfigStore configStore;
+
+        /// <summary> Initializes a new instance of the <see cref="InitService" /> class. </summary>
+        /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
+        /// <param name="contextResolver"> The init/status context resolver dependency. </param>
+        /// <param name="configStore"> The config store dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" />, <paramref name="contextResolver" />, or <paramref name="configStore" /> is <see langword="null" />. </exception>
+        public InitService (
+            IUnityProjectResolver unityProjectResolver,
+            IInitStatusContextResolver contextResolver,
+            IUcliConfigStore configStore)
+        {
+            this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
+            this.contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
+            this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+        }
+
+        /// <summary> Executes initialization to create or overwrite <c>.ucli/config.json</c> and <c>.ucli/.gitignore</c>. </summary>
+        /// <param name="force"> Whether existing files can be overwritten. </param>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The init execution result that contains generated file paths on success or a structured error on failure. </returns>
+        public InitExecutionResult Execute (
+            bool force,
+            string? projectPath,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var unityProjectResult = unityProjectResolver.Resolve(projectPath, cancellationToken);
+            if (!unityProjectResult.IsSuccess)
+            {
+                return InitExecutionResult.Failure(unityProjectResult.Error!);
+            }
+
+            var unityProjectContext = unityProjectResult.Context!;
+            var unityProjectRoot = unityProjectContext.UnityProjectRoot;
+            var ucliDirectoryPath = Path.Combine(unityProjectRoot, UcliDirectoryName);
+            var configPath = unityProjectContext.ConfigPath;
+            var gitIgnorePath = Path.Combine(ucliDirectoryPath, GitIgnoreFileName);
+            var existingPaths = CollectExistingTemplatePaths(configPath, gitIgnorePath);
+
+            if (!force && existingPaths.Count > 0)
+            {
+                var joinedPaths = string.Join(", ", existingPaths);
+                return InitExecutionResult.Failure(CreateInvalidArgument(
+                    $"Initialization failed because template files already exist. Use --force to overwrite: {joinedPaths}"));
+            }
+
+            if (!force)
+            {
+                // NOTE:
+                // Keep init and status using the same context pipeline.
+                // This ensures config parse/validation behavior stays consistent across command foundations.
+                var contextResult = contextResolver.Resolve(projectPath, cancellationToken);
+                if (!contextResult.IsSuccess)
+                {
+                    return InitExecutionResult.Failure(contextResult.Error!);
+                }
+            }
+
+            try
+            {
+                Directory.CreateDirectory(ucliDirectoryPath);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return InitExecutionResult.Failure(CreateInvalidArgument(
+                    $"UnityProject path is invalid: {unityProjectRoot}. {ex.Message}"));
+            }
+            catch (Exception ex) when (IsIoFailure(ex))
+            {
+                return InitExecutionResult.Failure(CreateInternalError(
+                    $"Failed to create .ucli directory: {ucliDirectoryPath}. {ex.Message}"));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var defaultConfig = UcliConfig.CreateDefault();
+            var configSaveResult = configStore.Save(unityProjectRoot, defaultConfig, cancellationToken);
+            if (!configSaveResult.IsSuccess)
+            {
+                return InitExecutionResult.Failure(configSaveResult.Error!);
+            }
+
+            try
+            {
+                File.WriteAllText(gitIgnorePath, GitIgnoreContents + Environment.NewLine);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return InitExecutionResult.Failure(CreateInvalidArgument(
+                    $"Git ignore path is invalid: {gitIgnorePath}. {ex.Message}"));
+            }
+            catch (Exception ex) when (IsIoFailure(ex))
+            {
+                return InitExecutionResult.Failure(CreateInternalError(
+                    $"Failed to write git ignore file: {gitIgnorePath}. {ex.Message}"));
+            }
+
+            var output = new InitExecutionOutput(
+                ProjectPath: unityProjectRoot,
+                ProjectFingerprint: unityProjectContext.ProjectFingerprint,
+                ConfigPath: configPath,
+                GitIgnorePath: gitIgnorePath);
+            return InitExecutionResult.Success(output);
+        }
+
+        /// <summary> Collects existing init-template files for precondition checks. </summary>
+        /// <param name="configPath"> The config file path. </param>
+        /// <param name="gitIgnorePath"> The git-ignore file path. </param>
+        /// <returns> Existing file paths that would be overwritten. </returns>
+        private static List<string> CollectExistingTemplatePaths (
+            string configPath,
+            string gitIgnorePath)
+        {
+            var existingPaths = new List<string>(2);
+            if (File.Exists(configPath))
+            {
+                existingPaths.Add(configPath);
+            }
+
+            if (File.Exists(gitIgnorePath))
+            {
+                existingPaths.Add(gitIgnorePath);
+            }
+
+            return existingPaths;
+        }
+
+        /// <summary> Creates an invalid-argument error value. </summary>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The structured invalid-argument error. </returns>
+        private static ExecutionError CreateInvalidArgument (string message)
+        {
+            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+        }
+
+        /// <summary> Creates an internal-error value. </summary>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The structured internal-error value. </returns>
+        private static ExecutionError CreateInternalError (string message)
+        {
+            return new ExecutionError(ExecutionErrorKind.InternalError, message);
+        }
+
+        /// <summary> Determines whether an exception indicates invalid path formatting. </summary>
+        /// <param name="exception"> The exception to classify. </param>
+        /// <returns> <see langword="true" /> when it is a path-format exception; otherwise <see langword="false" />. </returns>
+        private static bool IsPathFormatException (Exception exception)
+        {
+            return exception is ArgumentException
+                or NotSupportedException
+                or PathTooLongException;
+        }
+
+        /// <summary> Determines whether an exception indicates a filesystem I/O failure. </summary>
+        /// <param name="exception"> The exception to classify. </param>
+        /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
+        private static bool IsIoFailure (Exception exception)
+        {
+            return exception is IOException
+                or UnauthorizedAccessException;
+        }
+    }
+}

--- a/src/Ucli/Program.cs
+++ b/src/Ucli/Program.cs
@@ -1,5 +1,10 @@
 using ConsoleAppFramework;
 using MackySoft.Ucli.Cli;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Context;
+using MackySoft.Ucli.Init;
+using MackySoft.Ucli.UnityProject;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MackySoft.Ucli
 {
@@ -10,8 +15,11 @@ namespace MackySoft.Ucli
         /// <summary> Executes the CLI command pipeline and emits JSON command results. </summary>
         /// <param name="args"> The command-line arguments passed to the process. </param>
         /// <returns> The process exit code determined by command execution. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
         private static async Task<int> Main (string[] args)
         {
+            ArgumentNullException.ThrowIfNull(args);
+
             ParseErrorBuffer.Clear();
             CommandExecutionState.Reset();
 
@@ -26,7 +34,14 @@ namespace MackySoft.Ucli
                 return Environment.ExitCode;
             }
 
-            var app = ConsoleApp.Create();
+            var app = ConsoleApp.Create()
+                .ConfigureServices(services =>
+                {
+                    services.AddSingleton<IUnityProjectResolver, UnityProjectResolver>();
+                    services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
+                    services.AddSingleton<IInitStatusContextResolver, InitStatusContextResolver>();
+                    services.AddSingleton<IInitService, InitService>();
+                });
             app.Add<InitCommand>();
             app.Add<StatusCommand>();
 
@@ -63,8 +78,11 @@ namespace MackySoft.Ucli
         /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
         /// <para> Otherwise, <see langword="false" />. </para>
         /// </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
         private static bool TryHandleUnknownCommand (string[] args)
         {
+            ArgumentNullException.ThrowIfNull(args);
+
             if (args.Length == 0)
             {
                 return false;
@@ -96,8 +114,11 @@ namespace MackySoft.Ucli
         /// <para> The normalized command name for parse errors. </para>
         /// <para> Returns <see cref="CliProtocol.RootCommand" /> when no known command can be identified. </para>
         /// </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
         private static string ResolveCommandName (string[] args)
         {
+            ArgumentNullException.ThrowIfNull(args);
+
             if (args.Length == 0)
             {
                 return CliProtocol.RootCommand;

--- a/src/Ucli/UnityProject/IUnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/IUnityProjectResolver.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.UnityProject
+{
+    /// <summary> Resolves and validates a UnityProject path for CLI command execution. </summary>
+    internal interface IUnityProjectResolver
+    {
+        /// <summary> Resolves the UnityProject context from an optional <c>--projectPath</c> argument. </summary>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
+        UnityProjectResolutionResult Resolve (
+            string? projectPath,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli/UnityProject/ResolvedUnityProjectContext.cs
+++ b/src/Ucli/UnityProject/ResolvedUnityProjectContext.cs
@@ -1,0 +1,13 @@
+namespace MackySoft.Ucli.UnityProject
+{
+    /// <summary> Represents a resolved UnityProject context shared by command foundation services. </summary>
+    /// <param name="UnityProjectRoot"> The normalized absolute UnityProject root path. </param>
+    /// <param name="ProjectFingerprint"> The deterministic fingerprint for project identity checks. </param>
+    /// <param name="PathSource"> The path source used during resolution. </param>
+    /// <param name="ConfigPath"> The absolute path to <c>.ucli/config.json</c>. </param>
+    internal sealed record ResolvedUnityProjectContext (
+        string UnityProjectRoot,
+        string ProjectFingerprint,
+        UnityProjectPathSource PathSource,
+        string ConfigPath);
+}

--- a/src/Ucli/UnityProject/UnityProjectPathSource.cs
+++ b/src/Ucli/UnityProject/UnityProjectPathSource.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.UnityProject
+{
+    /// <summary> Identifies where the UnityProject path was obtained during resolution. </summary>
+    internal enum UnityProjectPathSource
+    {
+        /// <summary> The resolver used the current working directory. </summary>
+        CurrentDirectory = 0,
+
+        /// <summary> The resolver used the explicit <c>--projectPath</c> option value. </summary>
+        CommandOption = 1,
+    }
+}

--- a/src/Ucli/UnityProject/UnityProjectResolutionResult.cs
+++ b/src/Ucli/UnityProject/UnityProjectResolutionResult.cs
@@ -1,0 +1,35 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.UnityProject
+{
+    /// <summary> Represents the result of UnityProject path resolution. </summary>
+    /// <param name="Context"> The resolved UnityProject context, or <see langword="null" /> on failure. </param>
+    /// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
+    internal sealed record UnityProjectResolutionResult (
+        ResolvedUnityProjectContext? Context,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether the resolution succeeded. </summary>
+        public bool IsSuccess => Context is not null && Error is null;
+
+        /// <summary> Creates a successful UnityProject resolution result. </summary>
+        /// <param name="context"> The resolved UnityProject context. </param>
+        /// <returns> The successful resolution result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
+        public static UnityProjectResolutionResult Success (ResolvedUnityProjectContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return new UnityProjectResolutionResult(context, null);
+        }
+
+        /// <summary> Creates a failed UnityProject resolution result. </summary>
+        /// <param name="error"> The structured resolution error. </param>
+        /// <returns> The failed resolution result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static UnityProjectResolutionResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new UnityProjectResolutionResult(null, error);
+        }
+    }
+}

--- a/src/Ucli/UnityProject/UnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/UnityProjectResolver.cs
@@ -1,0 +1,175 @@
+using System.Security.Cryptography;
+using System.Text;
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.UnityProject
+{
+    /// <summary> Resolves UnityProject identity information from command inputs. </summary>
+    internal sealed class UnityProjectResolver : IUnityProjectResolver
+    {
+        private const string ProjectSettingsDirectoryName = "ProjectSettings";
+        private const string ProjectVersionFileName = "ProjectVersion.txt";
+
+        private const string UcliDirectoryName = ".ucli";
+        private const string ConfigFileName = "config.json";
+
+        /// <summary> Resolves UnityProject context from command options and validates required project markers. </summary>
+        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+        /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
+        public UnityProjectResolutionResult Resolve (
+            string? projectPath,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var pathSource = string.IsNullOrWhiteSpace(projectPath)
+                ? UnityProjectPathSource.CurrentDirectory
+                : UnityProjectPathSource.CommandOption;
+            var pathCandidate = pathSource == UnityProjectPathSource.CurrentDirectory
+                ? Environment.CurrentDirectory
+                : projectPath!;
+            var fullPathResult = TryNormalizePath(pathCandidate);
+            if (!fullPathResult.IsSuccess)
+            {
+                return UnityProjectResolutionResult.Failure(fullPathResult.Error!);
+            }
+
+            var unityProjectRoot = fullPathResult.Path!;
+            if (!Directory.Exists(unityProjectRoot))
+            {
+                return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
+                    $"UnityProject path does not exist: {unityProjectRoot}"));
+            }
+
+            var projectVersionPath = Path.Combine(
+                unityProjectRoot,
+                ProjectSettingsDirectoryName,
+                ProjectVersionFileName);
+            if (!File.Exists(projectVersionPath))
+            {
+                return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
+                    $"UnityProject is invalid. Missing file: {projectVersionPath}"));
+            }
+
+            var projectFingerprint = CreateProjectFingerprint(unityProjectRoot);
+            var configPath = Path.Combine(unityProjectRoot, UcliDirectoryName, ConfigFileName);
+            return UnityProjectResolutionResult.Success(new ResolvedUnityProjectContext(
+                UnityProjectRoot: unityProjectRoot,
+                ProjectFingerprint: projectFingerprint,
+                PathSource: pathSource,
+                ConfigPath: configPath));
+        }
+
+        /// <summary> Creates a deterministic SHA-256 fingerprint for the normalized UnityProject root path. </summary>
+        /// <param name="unityProjectRoot"> The normalized absolute UnityProject root path. </param>
+        /// <returns> The lowercase hexadecimal SHA-256 string. </returns>
+        private static string CreateProjectFingerprint (string unityProjectRoot)
+        {
+            var normalizedPath = NormalizeForFingerprint(unityProjectRoot);
+            var normalizedBytes = Encoding.UTF8.GetBytes(normalizedPath);
+            var hashBytes = SHA256.HashData(normalizedBytes);
+            return Convert.ToHexString(hashBytes).ToLowerInvariant();
+        }
+
+        /// <summary> Normalizes a UnityProject path value to improve fingerprint stability. </summary>
+        /// <param name="unityProjectRoot"> The input UnityProject root path. </param>
+        /// <returns> The normalized path value used as fingerprint input. </returns>
+        private static string NormalizeForFingerprint (string unityProjectRoot)
+        {
+            var fullPath = Path.GetFullPath(unityProjectRoot);
+            fullPath = fullPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            var pathRoot = Path.GetPathRoot(fullPath);
+            if (!string.IsNullOrEmpty(pathRoot) && string.Equals(fullPath, pathRoot, PathComparison))
+            {
+                return NormalizeCase(fullPath);
+            }
+
+            var trimmedPath = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return NormalizeCase(trimmedPath);
+        }
+
+        /// <summary> Normalizes path casing for platforms with case-insensitive paths. </summary>
+        /// <param name="path"> The path value to normalize. </param>
+        /// <returns> The normalized path string. </returns>
+        private static string NormalizeCase (string path)
+        {
+            return OperatingSystem.IsWindows()
+                ? path.ToUpperInvariant()
+                : path;
+        }
+
+        /// <summary> Attempts to normalize a path into an absolute path while converting path format errors to structured output. </summary>
+        /// <param name="pathValue"> The input path value. </param>
+        /// <returns> The normalization result. </returns>
+        private static PathNormalizationResult TryNormalizePath (string pathValue)
+        {
+            try
+            {
+                var fullPath = Path.GetFullPath(pathValue);
+                return PathNormalizationResult.Success(fullPath);
+            }
+            catch (Exception ex) when (IsPathFormatException(ex))
+            {
+                return PathNormalizationResult.Failure(CreateInvalidArgument(
+                    $"UnityProject path is invalid: {pathValue}"));
+            }
+        }
+
+        /// <summary> Determines whether an exception represents invalid input path formatting. </summary>
+        /// <param name="exception"> The exception to inspect. </param>
+        /// <returns>
+        /// <para> <see langword="true" /> when the exception should be mapped to <c>INVALID_ARGUMENT</c>. </para>
+        /// <para> Otherwise, <see langword="false" />. </para>
+        /// </returns>
+        private static bool IsPathFormatException (Exception exception)
+        {
+            return exception is ArgumentException
+                or NotSupportedException
+                or PathTooLongException;
+        }
+
+        /// <summary> Creates an invalid-argument foundation error. </summary>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The structured invalid-argument error. </returns>
+        private static ExecutionError CreateInvalidArgument (string message)
+        {
+            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+        }
+
+        /// <summary> Gets the path comparison mode for the current operating system. </summary>
+        private static StringComparison PathComparison =>
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        /// <summary> Represents the result of path normalization. </summary>
+        /// <param name="Path"> The normalized absolute path. </param>
+        /// <param name="Error"> The structured error when normalization fails. </param>
+        private readonly record struct PathNormalizationResult (
+            string? Path,
+            ExecutionError? Error)
+        {
+            /// <summary> Gets a value indicating whether path normalization succeeded. </summary>
+            public bool IsSuccess => !string.IsNullOrWhiteSpace(Path) && Error is null;
+
+        /// <summary> Creates a successful path normalization result. </summary>
+        /// <param name="path"> The normalized absolute path. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="path" /> is <see langword="null" />. </exception>
+        public static PathNormalizationResult Success (string path)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            return new PathNormalizationResult(path, null);
+        }
+
+        /// <summary> Creates a failed path normalization result. </summary>
+        /// <param name="error"> The structured error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static PathNormalizationResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new PathNormalizationResult(null, error);
+        }
+        }
+    }
+}

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -7,21 +7,47 @@ namespace MackySoft.Ucli.Tests
 {
     public sealed class CliOutputContractTests
     {
+        private const string ConfigFileName = "config.json";
+
+        private const string DefaultOperationAllowlistPattern = "^ucli\\.";
+
+        private const string DefaultOperationPolicy = "safe";
+
+        private const string DefaultPlanTokenMode = "optional";
+
+        private const string ForceOption = "--force";
+
+        private const string GitIgnoreFileName = ".gitignore";
+
+        private const string LegacyConfigJson = """{"schemaVersion":999}""";
+
+        private const string LegacyGitIgnoreContent = "legacy/";
+
+        private const string LocalDirectoryIgnoreEntry = "local/";
+
+        private const string ProjectPathOption = "--projectPath";
+
+        private const string UcliDirectoryName = ".ucli";
+
+        private const string UnityProjectDirectoryName = "UnityProject";
+
+        private const string UnknownOption = "--unknown";
+
+        private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+
         private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(15);
 
-        [Theory]
+        [Fact]
         [Trait("Size", "Medium")]
-        [InlineData(InitCommand.CommandName)]
-        [InlineData(StatusCommand.CommandName)]
-        public async Task PlaceholderCommand_ReturnsNotImplementedErrorAsSingleJson (string command)
+        public async Task Status_ReturnsNotImplementedErrorAsSingleJson ()
         {
-            var result = await RunToolAsync(command);
+            var result = await RunToolAsync(StatusCommand.CommandName);
 
             using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
             Assert.Equal((int)CliExitCode.ToolError, result.ExitCode);
             AssertCommandResultCommon(
                 outputJson.RootElement,
-                command: command,
+                command: StatusCommand.CommandName,
                 status: CliProtocol.StatusError,
                 exitCode: (int)CliExitCode.ToolError);
             AssertSingleError(
@@ -29,11 +55,125 @@ namespace MackySoft.Ucli.Tests
                 expectedCode: ErrorCodes.CommandNotImplemented);
         }
 
+        [Theory]
+        [Trait("Size", "Medium")]
+        [InlineData(false, "init-success")]
+        [InlineData(true, "init-force-success")]
+        public async Task Init_ReturnsSuccessJsonContractAsSingleJson (bool force, string scopeName)
+        {
+            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+            var (unityProjectPath, configPath, gitIgnorePath) = CreateUnityProjectPaths(scope);
+            if (force)
+            {
+                PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
+            }
+
+            var result = await RunInitAsync(unityProjectPath, force);
+
+            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+            Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+            AssertCommandResultCommon(
+                outputJson.RootElement,
+                command: InitCommand.CommandName,
+                status: CliProtocol.StatusOk,
+                exitCode: (int)CliExitCode.Success);
+            AssertNoErrors(outputJson.RootElement);
+            JsonAssert.For(outputJson.RootElement)
+                .HasProperty("payload", payload => payload
+                    .HasString("projectPath", unityProjectPath)
+                    .HasValueKind("projectFingerprint", JsonValueKind.String)
+                    .HasString("configPath", configPath)
+                    .HasString("gitignorePath", gitIgnorePath));
+        }
+
+        [Theory]
+        [Trait("Size", "Medium")]
+        [InlineData(true, "init-config-file")]
+        [InlineData(false, "init-gitignore-file")]
+        public async Task Init_WithProjectPath_CreatesTemplateFiles (bool isConfigFile, string scopeName)
+        {
+            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+            var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
+            var templateFilePath = isConfigFile
+                ? GetConfigPath(unityProjectPath)
+                : GetGitIgnorePath(unityProjectPath);
+
+            await RunInitAsync(unityProjectPath);
+
+            FileSystemAssert.ForFile(templateFilePath).Exists();
+        }
+
+        [Theory]
+        [Trait("Size", "Medium")]
+        [InlineData(false, "init-default-config-values")]
+        [InlineData(true, "init-force-config-overwrite")]
+        public async Task Init_WritesDefaultConfigValues (bool force, string scopeName)
+        {
+            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+            var (unityProjectPath, configPath, _) = CreateUnityProjectPaths(scope);
+            if (force)
+            {
+                PrepareLegacyTemplateFiles(scope, configPath, GetGitIgnorePath(unityProjectPath));
+            }
+
+            await RunInitAsync(unityProjectPath, force);
+
+            AssertDefaultConfigValues(configPath);
+        }
+
+        [Theory]
+        [Trait("Size", "Medium")]
+        [InlineData(false, "init-gitignore-contents")]
+        [InlineData(true, "init-force-gitignore-overwrite")]
+        public async Task Init_WritesLocalOnlyGitIgnoreContents (bool force, string scopeName)
+        {
+            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+            var (unityProjectPath, _, gitIgnorePath) = CreateUnityProjectPaths(scope);
+            if (force)
+            {
+                PrepareLegacyTemplateFiles(scope, GetConfigPath(unityProjectPath), gitIgnorePath);
+            }
+
+            await RunInitAsync(unityProjectPath, force);
+
+            Assert.Equal(LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
+        }
+
+        [Theory]
+        [Trait("Size", "Medium")]
+        [InlineData(true, LegacyConfigJson, "init-existing-config")]
+        [InlineData(false, LegacyGitIgnoreContent, "init-existing-gitignore")]
+        public async Task Init_WithoutForce_WhenTemplateFileExists_ReturnsInvalidArgumentErrorAsSingleJson (
+            bool isConfigFile,
+            string existingContent,
+            string scopeName)
+        {
+            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+            var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
+            var existingTemplateFilePath = isConfigFile
+                ? GetConfigPath(unityProjectPath)
+                : GetGitIgnorePath(unityProjectPath);
+            WriteFileUnderScope(scope, existingTemplateFilePath, existingContent);
+
+            var result = await RunInitAsync(unityProjectPath);
+
+            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+            Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+            AssertCommandResultCommon(
+                outputJson.RootElement,
+                command: InitCommand.CommandName,
+                status: CliProtocol.StatusError,
+                exitCode: (int)CliExitCode.InvalidArgument);
+            AssertSingleError(
+                outputJson.RootElement,
+                expectedCode: ErrorCodes.InvalidArgument);
+        }
+
         [Fact]
         [Trait("Size", "Medium")]
         public async Task Status_WithUnknownOption_ReturnsInvalidArgumentErrorAsSingleJson ()
         {
-            var result = await RunToolAsync(StatusCommand.CommandName, "--unknown");
+            var result = await RunToolAsync(StatusCommand.CommandName, UnknownOption);
 
             using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
             Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
@@ -45,7 +185,7 @@ namespace MackySoft.Ucli.Tests
             AssertSingleError(
                 outputJson.RootElement,
                 expectedCode: ErrorCodes.InvalidArgument);
-            Assert.Contains("Argument '--unknown' is not recognized.", result.StdErr, StringComparison.Ordinal);
+            Assert.Contains(UnknownOptionMessage, result.StdErr, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -80,6 +220,12 @@ namespace MackySoft.Ucli.Tests
                 .HasValueKind("message", JsonValueKind.String)
                 .HasValueKind("payload", JsonValueKind.Object)
                 .HasValueKind("errors", JsonValueKind.Array);
+        }
+
+        private static void AssertNoErrors (JsonElement root)
+        {
+            JsonAssert.For(root)
+                .HasArrayLength("errors", 0);
         }
 
         private static void AssertSingleError (JsonElement root, string expectedCode)
@@ -138,6 +284,64 @@ namespace MackySoft.Ucli.Tests
                 ExitCode: process.ExitCode,
                 StdOut: await stdOutTask,
                 StdErr: await stdErrTask);
+        }
+
+        private static async Task<CommandExecutionResult> RunInitAsync (string unityProjectPath, bool force = false)
+        {
+            if (force)
+            {
+                return await RunToolAsync(InitCommand.CommandName, ProjectPathOption, unityProjectPath, ForceOption);
+            }
+
+            return await RunToolAsync(InitCommand.CommandName, ProjectPathOption, unityProjectPath);
+        }
+
+        private static (string UnityProjectPath, string ConfigPath, string GitIgnorePath) CreateUnityProjectPaths (TestDirectoryScope scope)
+        {
+            var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, UnityProjectDirectoryName);
+            var configPath = GetConfigPath(unityProjectPath);
+            var gitIgnorePath = GetGitIgnorePath(unityProjectPath);
+            return (unityProjectPath, configPath, gitIgnorePath);
+        }
+
+        private static string GetConfigPath (string unityProjectPath)
+        {
+            return Path.Combine(unityProjectPath, UcliDirectoryName, ConfigFileName);
+        }
+
+        private static string GetGitIgnorePath (string unityProjectPath)
+        {
+            return Path.Combine(unityProjectPath, UcliDirectoryName, GitIgnoreFileName);
+        }
+
+        private static void AssertDefaultConfigValues (string configPath)
+        {
+            using var configJson = JsonDocument.Parse(File.ReadAllText(configPath));
+            JsonAssert.For(configJson.RootElement)
+                .HasInt32("schemaVersion", 1)
+                .HasString("operationPolicy", DefaultOperationPolicy)
+                .HasString("planTokenMode", DefaultPlanTokenMode)
+                .HasArrayLength("operationAllowlist", 1)
+                .HasProperty("operationAllowlist", 0, static allowlistValue => allowlistValue
+                    .HasString(DefaultOperationAllowlistPattern));
+        }
+
+        private static void PrepareLegacyTemplateFiles (
+            TestDirectoryScope scope,
+            string configPath,
+            string gitIgnorePath)
+        {
+            WriteFileUnderScope(scope, configPath, LegacyConfigJson);
+            WriteFileUnderScope(scope, gitIgnorePath, LegacyGitIgnoreContent);
+        }
+
+        private static void WriteFileUnderScope (
+            TestDirectoryScope scope,
+            string absolutePath,
+            string contents)
+        {
+            var relativePath = Path.GetRelativePath(scope.FullPath, absolutePath);
+            scope.WriteFile(relativePath, contents);
         }
 
         private readonly record struct CommandExecutionResult (

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -9,29 +9,15 @@ namespace MackySoft.Ucli.Tests
     {
         private const string ConfigFileName = "config.json";
 
-        private const string DefaultOperationAllowlistPattern = "^ucli\\.";
-
-        private const string DefaultOperationPolicy = "safe";
-
-        private const string DefaultPlanTokenMode = "optional";
-
-        private const string ForceOption = "--force";
-
         private const string GitIgnoreFileName = ".gitignore";
 
         private const string LegacyConfigJson = """{"schemaVersion":999}""";
 
         private const string LegacyGitIgnoreContent = "legacy/";
 
-        private const string LocalDirectoryIgnoreEntry = "local/";
-
-        private const string ProjectPathOption = "--projectPath";
-
         private const string UcliDirectoryName = ".ucli";
 
         private const string UnityProjectDirectoryName = "UnityProject";
-
-        private const string UnknownOption = "--unknown";
 
         private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
 
@@ -136,7 +122,7 @@ namespace MackySoft.Ucli.Tests
 
             await RunInitAsync(unityProjectPath, force);
 
-            Assert.Equal(LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
+            Assert.Equal(UcliContractConstants.LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
         }
 
         [Theory]
@@ -173,7 +159,7 @@ namespace MackySoft.Ucli.Tests
         [Trait("Size", "Medium")]
         public async Task Status_WithUnknownOption_ReturnsInvalidArgumentErrorAsSingleJson ()
         {
-            var result = await RunToolAsync(StatusCommand.CommandName, UnknownOption);
+            var result = await RunToolAsync(StatusCommand.CommandName, UcliContractConstants.CliOption.Unknown);
 
             using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
             Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
@@ -290,10 +276,14 @@ namespace MackySoft.Ucli.Tests
         {
             if (force)
             {
-                return await RunToolAsync(InitCommand.CommandName, ProjectPathOption, unityProjectPath, ForceOption);
+                return await RunToolAsync(
+                    InitCommand.CommandName,
+                    UcliContractConstants.CliOption.ProjectPath,
+                    unityProjectPath,
+                    UcliContractConstants.CliOption.Force);
             }
 
-            return await RunToolAsync(InitCommand.CommandName, ProjectPathOption, unityProjectPath);
+            return await RunToolAsync(InitCommand.CommandName, UcliContractConstants.CliOption.ProjectPath, unityProjectPath);
         }
 
         private static (string UnityProjectPath, string ConfigPath, string GitIgnorePath) CreateUnityProjectPaths (TestDirectoryScope scope)
@@ -318,12 +308,12 @@ namespace MackySoft.Ucli.Tests
         {
             using var configJson = JsonDocument.Parse(File.ReadAllText(configPath));
             JsonAssert.For(configJson.RootElement)
-                .HasInt32("schemaVersion", 1)
-                .HasString("operationPolicy", DefaultOperationPolicy)
-                .HasString("planTokenMode", DefaultPlanTokenMode)
+                .HasInt32("schemaVersion", UcliContractConstants.Config.SchemaVersion)
+                .HasString("operationPolicy", UcliContractConstants.Config.OperationPolicySafe)
+                .HasString("planTokenMode", UcliContractConstants.Config.PlanTokenModeOptional)
                 .HasArrayLength("operationAllowlist", 1)
                 .HasProperty("operationAllowlist", 0, static allowlistValue => allowlistValue
-                    .HasString(DefaultOperationAllowlistPattern));
+                    .HasString(UcliContractConstants.Config.DefaultOperationAllowlistPattern));
         }
 
         private static void PrepareLegacyTemplateFiles (

--- a/tests/Ucli.Tests/CommandResultTests.cs
+++ b/tests/Ucli.Tests/CommandResultTests.cs
@@ -12,11 +12,11 @@ namespace MackySoft.Ucli.Tests
         public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
         {
             {
-                CommandResult.NotImplemented(InitCommand.CommandName),
-                InitCommand.CommandName,
+                CommandResult.NotImplemented(StatusCommand.CommandName),
+                StatusCommand.CommandName,
                 (int)CliExitCode.ToolError,
                 ErrorCodes.CommandNotImplemented,
-                $"Command '{InitCommand.CommandName}' is not implemented yet."
+                $"Command '{StatusCommand.CommandName}' is not implemented yet."
             },
             {
                 CommandResult.InvalidArgument(StatusCommand.CommandName, UnknownOptionMessage),

--- a/tests/Ucli.Tests/Helpers/Contracts/UcliContractConstants.cs
+++ b/tests/Ucli.Tests/Helpers/Contracts/UcliContractConstants.cs
@@ -1,0 +1,30 @@
+namespace MackySoft.Ucli.Tests;
+
+internal static class UcliContractConstants
+{
+    internal static class CliOption
+    {
+        public const string Force = "--force";
+
+        public const string ProjectPath = "--projectPath";
+
+        public const string Unknown = "--unknown";
+    }
+
+    internal static class Config
+    {
+        public const int SchemaVersion = 1;
+
+        public const string DefaultOperationAllowlistPattern = "^ucli\\.";
+
+        public const string OperationPolicyDangerous = "dangerous";
+
+        public const string OperationPolicySafe = "safe";
+
+        public const string PlanTokenModeOptional = "optional";
+
+        public const string PlanTokenModeRequired = "required";
+    }
+
+    public const string LocalDirectoryIgnoreEntry = "local/";
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssert.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssert.cs
@@ -30,7 +30,7 @@ internal sealed class JsonAssertion
 
     public JsonAssertion HasProperty (string propertyName)
     {
-        _ = ResolveOrThrow(propertyName);
+        ResolveOrThrow(propertyName);
         return this;
     }
 
@@ -50,7 +50,7 @@ internal sealed class JsonAssertion
 
     public JsonAssertion HasIndex (int index)
     {
-        _ = ResolveIndexOrThrow(index);
+        ResolveIndexOrThrow(index);
         return this;
     }
 
@@ -70,7 +70,7 @@ internal sealed class JsonAssertion
 
         foreach (var propertyName in propertyNames)
         {
-            _ = ResolveOrThrow(propertyName);
+            ResolveOrThrow(propertyName);
         }
 
         return this;

--- a/tests/Ucli.Tests/Helpers/PathAssertions/FileSystemAssert.cs
+++ b/tests/Ucli.Tests/Helpers/PathAssertions/FileSystemAssert.cs
@@ -56,7 +56,7 @@ internal sealed class DirectoryAssertion : PathAssertionBase<DirectoryAssertion>
     {
         ArgumentNullException.ThrowIfNull(assertion);
 
-        _ = HasDirectory(childName);
+        HasDirectory(childName);
         var childPath = ResolveChildPath(childName);
         assertion(new DirectoryAssertion(childPath));
         return this;
@@ -80,7 +80,7 @@ internal sealed class DirectoryAssertion : PathAssertionBase<DirectoryAssertion>
     {
         ArgumentNullException.ThrowIfNull(assertion);
 
-        _ = HasFile(childName);
+        HasFile(childName);
         var childPath = ResolveChildPath(childName);
         assertion(new FileAssertion(childPath));
         return this;

--- a/tests/Ucli.Tests/Helpers/UnityProjects/UnityProjectTestFactory.cs
+++ b/tests/Ucli.Tests/Helpers/UnityProjects/UnityProjectTestFactory.cs
@@ -1,0 +1,29 @@
+namespace MackySoft.Tests;
+
+/// <summary> Provides helper methods for creating minimal UnityProject directory structures in tests. </summary>
+internal static class UnityProjectTestFactory
+{
+    private const string DefaultProjectVersionContent = "m_EditorVersion: 6000.1.4f1";
+
+    /// <summary> Creates a minimal valid UnityProject structure with <c>ProjectVersion.txt</c>. </summary>
+    /// <param name="scope"> The root test-directory scope. </param>
+    /// <param name="projectRelativePath"> The relative project path under the scope root. </param>
+    /// <param name="projectVersionContent"> Optional <c>ProjectVersion.txt</c> contents. </param>
+    /// <returns> The absolute UnityProject root path. </returns>
+    internal static string CreateMinimalUnityProject (
+        TestDirectoryScope scope,
+        string projectRelativePath,
+        string projectVersionContent = DefaultProjectVersionContent)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectRelativePath);
+
+        scope.CreateDirectory(projectRelativePath);
+        scope.CreateDirectory(Path.Combine(projectRelativePath, "ProjectSettings"));
+        scope.WriteFile(
+            Path.Combine(projectRelativePath, "ProjectSettings", "ProjectVersion.txt"),
+            projectVersionContent);
+
+        return scope.GetPath(projectRelativePath);
+    }
+}

--- a/tests/Ucli.Tests/InitStatusContextResolverTests.cs
+++ b/tests/Ucli.Tests/InitStatusContextResolverTests.cs
@@ -1,0 +1,104 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Tests;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Context;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.UnityProject;
+
+public sealed class InitStatusContextResolverTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsContextWithDefaultConfig_WhenConfigFileDoesNotExist ()
+    {
+        using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "default-config");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var resolver = CreateResolver();
+
+        var result = resolver.Resolve(unityProjectPath);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Error);
+        var context = Assert.IsType<InitStatusContext>(result.Context);
+        Assert.Equal(unityProjectPath, context.UnityProject.UnityProjectRoot);
+        Assert.Equal(ConfigSource.Default, context.ConfigSource);
+        Assert.Equal(OperationPolicy.Safe, context.Config.OperationPolicy);
+        Assert.Equal(PlanTokenMode.Optional, context.Config.PlanTokenMode);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsContextWithFileConfig_WhenConfigFileExists ()
+    {
+        using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "file-config");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var saveResult = configStore.Save(
+            unityProjectPath,
+            new UcliConfig(
+                SchemaVersion: 1,
+                OperationPolicy: OperationPolicy.Advanced,
+                PlanTokenMode: PlanTokenMode.Required,
+                OperationAllowlist:
+                [
+                    "^ucli\\.",
+                    "^extension\\.",
+                ]));
+        Assert.True(saveResult.IsSuccess);
+
+        var resolver = new InitStatusContextResolver(new UnityProjectResolver(), configStore);
+
+        var result = resolver.Resolve(unityProjectPath);
+
+        Assert.True(result.IsSuccess);
+        var context = Assert.IsType<InitStatusContext>(result.Context);
+        Assert.Equal(ConfigSource.File, context.ConfigSource);
+        Assert.Equal(OperationPolicy.Advanced, context.Config.OperationPolicy);
+        Assert.Equal(PlanTokenMode.Required, context.Config.PlanTokenMode);
+        Assert.Equal(new[] { "^ucli\\.", "^extension\\." }, context.Config.OperationAllowlist);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsInvalidArgument_WhenUnityProjectIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "invalid-unity-project");
+        var invalidPath = scope.GetPath("MissingUnityProject");
+        var resolver = CreateResolver();
+
+        var result = resolver.Resolve(invalidPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Context);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsInvalidArgument_WhenConfigFileIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "invalid-config");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var configPath = configStore.GetConfigPath(unityProjectPath);
+        var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
+        scope.WriteFile(relativeConfigPath, "{");
+        var resolver = new InitStatusContextResolver(new UnityProjectResolver(), configStore);
+
+        var result = resolver.Resolve(unityProjectPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Context);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    private static InitStatusContextResolver CreateResolver ()
+    {
+        return new InitStatusContextResolver(
+            new UnityProjectResolver(),
+            new UcliConfigStore());
+    }
+}

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -1,0 +1,118 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Foundation;
+
+public sealed class UcliConfigStoreTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Load_ReturnsDefaultConfig_WhenConfigFileDoesNotExist ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "load-default");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+
+        var result = configStore.Load(unityProjectPath);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Error);
+        Assert.Equal(ConfigSource.Default, result.Source);
+        var config = Assert.IsType<UcliConfig>(result.Config);
+        Assert.Equal(1, config.SchemaVersion);
+        Assert.Equal(OperationPolicy.Safe, config.OperationPolicy);
+        Assert.Equal(PlanTokenMode.Optional, config.PlanTokenMode);
+        Assert.Equal(new[] { "^ucli\\." }, config.OperationAllowlist);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Save_ThenLoad_RoundTripsConfigValues ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "save-round-trip");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var config = new UcliConfig(
+            SchemaVersion: 1,
+            OperationPolicy: OperationPolicy.Dangerous,
+            PlanTokenMode: PlanTokenMode.Required,
+            OperationAllowlist:
+            [
+                "^ucli\\.",
+                "^mylab\\.",
+            ]);
+
+        var saveResult = configStore.Save(unityProjectPath, config);
+
+        Assert.True(saveResult.IsSuccess);
+        Assert.Null(saveResult.Error);
+
+        var loadResult = configStore.Load(unityProjectPath);
+        Assert.True(loadResult.IsSuccess);
+        Assert.Equal(ConfigSource.File, loadResult.Source);
+        var loadedConfig = Assert.IsType<UcliConfig>(loadResult.Config);
+        Assert.Equal(config.SchemaVersion, loadedConfig.SchemaVersion);
+        Assert.Equal(config.OperationPolicy, loadedConfig.OperationPolicy);
+        Assert.Equal(config.PlanTokenMode, loadedConfig.PlanTokenMode);
+        Assert.Equal(config.OperationAllowlist, loadedConfig.OperationAllowlist);
+
+        var configPath = configStore.GetConfigPath(unityProjectPath);
+        using var jsonDocument = JsonDocument.Parse(File.ReadAllText(configPath));
+        JsonAssert.For(jsonDocument.RootElement)
+            .HasInt32("schemaVersion", 1)
+            .HasString("operationPolicy", "dangerous")
+            .HasString("planTokenMode", "required")
+            .HasArrayLength("operationAllowlist", 2);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Load_ReturnsInvalidArgument_WhenConfigJsonIsMalformed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "malformed-json");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var configPath = configStore.GetConfigPath(unityProjectPath);
+        var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
+        scope.WriteFile(relativeConfigPath, "{");
+
+        var result = configStore.Load(unityProjectPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Config);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("invalid", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Load_ReturnsInvalidArgument_WhenSchemaVersionDoesNotMatch ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "schema-version-mismatch");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var configPath = configStore.GetConfigPath(unityProjectPath);
+        var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
+        scope.WriteFile(
+            relativeConfigPath,
+            """
+            {
+              "schemaVersion": 2,
+              "operationPolicy": "safe",
+              "planTokenMode": "optional",
+              "operationAllowlist": ["^ucli\\."]
+            }
+            """);
+
+        var result = configStore.Load(unityProjectPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Config);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("schemaVersion", error.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -21,10 +21,10 @@ public sealed class UcliConfigStoreTests
         Assert.Null(result.Error);
         Assert.Equal(ConfigSource.Default, result.Source);
         var config = Assert.IsType<UcliConfig>(result.Config);
-        Assert.Equal(1, config.SchemaVersion);
+        Assert.Equal(UcliContractConstants.Config.SchemaVersion, config.SchemaVersion);
         Assert.Equal(OperationPolicy.Safe, config.OperationPolicy);
         Assert.Equal(PlanTokenMode.Optional, config.PlanTokenMode);
-        Assert.Equal(new[] { "^ucli\\." }, config.OperationAllowlist);
+        Assert.Equal(new[] { UcliContractConstants.Config.DefaultOperationAllowlistPattern }, config.OperationAllowlist);
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public sealed class UcliConfigStoreTests
             PlanTokenMode: PlanTokenMode.Required,
             OperationAllowlist:
             [
-                "^ucli\\.",
+                UcliContractConstants.Config.DefaultOperationAllowlistPattern,
                 "^mylab\\.",
             ]);
 
@@ -61,9 +61,9 @@ public sealed class UcliConfigStoreTests
         var configPath = configStore.GetConfigPath(unityProjectPath);
         using var jsonDocument = JsonDocument.Parse(File.ReadAllText(configPath));
         JsonAssert.For(jsonDocument.RootElement)
-            .HasInt32("schemaVersion", 1)
-            .HasString("operationPolicy", "dangerous")
-            .HasString("planTokenMode", "required")
+            .HasInt32("schemaVersion", UcliContractConstants.Config.SchemaVersion)
+            .HasString("operationPolicy", UcliContractConstants.Config.OperationPolicyDangerous)
+            .HasString("planTokenMode", UcliContractConstants.Config.PlanTokenModeRequired)
             .HasArrayLength("operationAllowlist", 2);
     }
 
@@ -96,16 +96,17 @@ public sealed class UcliConfigStoreTests
         var configStore = new UcliConfigStore();
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
+        var invalidSchemaConfigJson = JsonSerializer.Serialize(
+            new
+            {
+                schemaVersion = 2,
+                operationPolicy = UcliContractConstants.Config.OperationPolicySafe,
+                planTokenMode = UcliContractConstants.Config.PlanTokenModeOptional,
+                operationAllowlist = new[] { UcliContractConstants.Config.DefaultOperationAllowlistPattern },
+            });
         scope.WriteFile(
             relativeConfigPath,
-            """
-            {
-              "schemaVersion": 2,
-              "operationPolicy": "safe",
-              "planTokenMode": "optional",
-              "operationAllowlist": ["^ucli\\."]
-            }
-            """);
+            invalidSchemaConfigJson);
 
         var result = configStore.Load(unityProjectPath);
 

--- a/tests/Ucli.Tests/UnityProjectResolverTests.cs
+++ b/tests/Ucli.Tests/UnityProjectResolverTests.cs
@@ -1,0 +1,97 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Tests;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.UnityProject;
+
+public sealed class UnityProjectResolverTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_WithValidUnityProjectPath_ReturnsResolvedContext ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-project-resolver", "valid-path");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var resolver = new UnityProjectResolver();
+
+        var result = resolver.Resolve(unityProjectPath);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Error);
+        var context = Assert.IsType<ResolvedUnityProjectContext>(result.Context);
+        Assert.Equal(unityProjectPath, context.UnityProjectRoot);
+        Assert.Equal(UnityProjectPathSource.CommandOption, context.PathSource);
+        Assert.Equal(Path.Combine(unityProjectPath, ".ucli", "config.json"), context.ConfigPath);
+        Assert.Matches("^[0-9a-f]{64}$", context.ProjectFingerprint);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_WithRelativePath_NormalizesToAbsolutePath ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-project-resolver", "relative-path");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var relativePath = Path.GetRelativePath(Environment.CurrentDirectory, unityProjectPath);
+        var resolver = new UnityProjectResolver();
+
+        var result = resolver.Resolve(relativePath);
+
+        Assert.True(result.IsSuccess);
+        var context = Assert.IsType<ResolvedUnityProjectContext>(result.Context);
+        FileSystemAssert.ForPath(context.UnityProjectRoot)
+            .IsRooted()
+            .EqualsNormalized(unityProjectPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsInvalidArgument_WhenProjectDirectoryDoesNotExist ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-project-resolver", "missing-directory");
+        var missingPath = scope.GetPath("MissingUnityProject");
+        var resolver = new UnityProjectResolver();
+
+        var result = resolver.Resolve(missingPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Context);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("does not exist", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsInvalidArgument_WhenProjectVersionFileIsMissing ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-project-resolver", "missing-project-version");
+        scope.CreateDirectory(Path.Combine("UnityProject", "ProjectSettings"));
+        var unityProjectPath = scope.GetPath("UnityProject");
+        var resolver = new UnityProjectResolver();
+
+        var result = resolver.Resolve(unityProjectPath);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Context);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("Missing file", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_ReturnsStableFingerprint_ForEquivalentPathRepresentations ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-project-resolver", "fingerprint-stability");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var pathWithTrailingSeparator = unityProjectPath + Path.DirectorySeparatorChar;
+        var resolver = new UnityProjectResolver();
+
+        var primary = resolver.Resolve(unityProjectPath);
+        var secondary = resolver.Resolve(pathWithTrailingSeparator);
+
+        Assert.True(primary.IsSuccess);
+        Assert.True(secondary.IsSuccess);
+        Assert.Equal(primary.Context!.ProjectFingerprint, secondary.Context!.ProjectFingerprint);
+    }
+}


### PR DESCRIPTION
## Summary
- #11 の Foundation として、UnityProject 解決・`.ucli/config.json` 読込/保存・`init` 実装・`status` 共通基盤を追加しました。
- 外部契約は `projectPath` 名を維持しつつ、内部は UnityProject 用語に統一しています。
- `init --projectPath/--force` の JSON 契約とエラー契約を実装し、`status` は NotImplemented 契約を維持しました。
- XMLドキュメントを規約準拠へ全体修正し、テスト構造とテストヘルパー利用規約を反映しました。

## Scope
- CLI/Foundation 実装:
  - `src/Ucli/UnityProject/*` に UnityProjectResolver と fingerprint/context/result を追加
  - `src/Ucli/Configuration/*` に config model/store/load-save result/enum constants を追加
  - `src/Ucli/Context/*` に init/status 共通コンテキスト解決を追加
  - `src/Ucli/Init/*` に InitService と実行結果型を追加
  - `src/Ucli/Cli/InitCommand.cs`, `src/Ucli/Program.cs` で実行配線と `--projectPath` を反映
- テスト:
  - `tests/Ucli.Tests/UnityProjectResolverTests.cs`
  - `tests/Ucli.Tests/UcliConfigStoreTests.cs`
  - `tests/Ucli.Tests/InitStatusContextResolverTests.cs`
  - `tests/Ucli.Tests/CliOutputContractTests.cs` を構造規約に沿って再編
  - `tests/Ucli.Tests/Helpers/UnityProjects/UnityProjectTestFactory.cs` を追加
  - `tests/Ucli.Tests/Helpers/Contracts/UcliContractConstants.cs` でテスト契約定数を集約

## Verification
- Gate level: Standard
- Diff budget: PASS (Split waived in #11)
- Spec drift: Skipped (`docs/agents/feature_issue-11-project-config-init-status/spec.md` が存在しないため)
- Format: Skipped (今回の受け入れ判定に必須ではないため Auto 判定で未実行)
- Tests: PASS (`dotnet test Ucli.slnx --nologo`)
- Coverage: N/A

## Risks / Rollback
- Risk: `init` のオプション契約や config バリデーションの変更により、CLI 呼び出し側との契約差分があるとエラーコード 3/4 の観測が増える可能性があります。
- Rollback: この PR の3コミット (`feat(core)` / `test(core)` / `test(core)`) を revert することで、#11 の追加基盤を一括で元に戻せます。

## Checklist
- [x] Issue #11 の Acceptance Criteria チェック状態を実装結果に合わせて更新する
- [x] Diff budget 超過の扱い（Split waived）を Issue 側に反映する

Closes #11
