### PR TITLE
fix(unity): enforce GitHub Packages-only contracts restore

### DIFF
--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -7,33 +7,38 @@
 
 ## Unity Dependency Restore
 - `src/Ucli.Unity/Assets/NuGet.config` で以下のソースを利用する。
-  - `https://nuget.pkg.github.com/mackysoft/index.json`
-  - `../Packages/nuget-local-source`
-  - `https://api.nuget.org/v3/index.json`
+  - `PrivateNuGet`: `https://nuget.pkg.github.com/mackysoft/index.json`
+  - `nuget.org`: `https://api.nuget.org/v3/index.json`
 - NuGetForUnity の復元成果物は生成物として扱う。
   - `src/Ucli.Unity/Assets/Packages/`
   - `src/Ucli.Unity/.nuget-cache/`
   - `src/Ucli.Unity/.nuget-packages/`
-  - `src/Ucli.Unity/Packages/nuget-local-source/`
 
 ## GitHub Packages Authentication
 - 認証情報はリポジトリに含めない。
-- 各開発環境の `~/.nuget/NuGet/NuGet.Config` に credentials を設定する。
-
-## Local Pre-Release Validation
-公開前バージョンを Unity で検証する場合は、ローカルフィードへ pack する。
+- NuGetForUnity は `ApplicationData/NuGet/NuGet.Config` を参照する。
+  - macOS/Linux: `~/.config/NuGet/NuGet.Config`
+  - Windows: `%AppData%\NuGet\NuGet.Config`
+- `dotnet` CLI は通常 `~/.nuget/NuGet/NuGet.Config` を参照する。
+- Unity と CLI の設定を揃えるため、`~/.config/NuGet/NuGet.Config` と `~/.nuget/NuGet/NuGet.Config` は同一内容に維持する。
+- `packageSourceCredentials` のキー名は、`NuGet.config` の source key と一致させる（`PrivateNuGet`）。
+- GitHub Packages 読み取りには `read:packages` 権限が必要。private repository 配下のパッケージは `repo` も必要。
 
 ```bash
-dotnet pack src/Ucli.Contracts/Ucli.Contracts.csproj \
-  --configuration Release \
-  -p:PackageVersion=0.1.0 \
-  --output src/Ucli.Unity/Packages/nuget-local-source
+dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
+  --name "PrivateNuGet" \
+  --username "<github-user>" \
+  --password "<github-pat>" \
+  --store-password-in-clear-text \
+  --configfile "$HOME/.config/NuGet/NuGet.Config"
 ```
 
-その後、Unity を batchmode で開くと NuGetForUnity が `packages.config` の依存を復元する。
+上記設定後に Unity を batchmode で開くと、NuGetForUnity が `packages.config` の依存を GitHub Packages から復元する。
 
 ## Release Workflow
-`contracts/<major>.<minor>.<patch>` タグを push すると、`contracts-publish` workflow が GitHub Packages へ公開する。
+- `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
+- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
+- タグは `v` プレフィックスを付けない（例: `contracts/0.1.0`）。
 
 ```bash
 git tag contracts/0.1.0

--- a/src/Ucli.Unity/Assets/NuGet.config
+++ b/src/Ucli.Unity/Assets/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="PrivateNuGet" value="https://nuget.pkg.github.com/mackysoft/index.json" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
-    <add key="LocalContracts" value="../Packages/nuget-local-source" enableCredentialProvider="false" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" enableCredentialProvider="false" />
   </packageSources>
 


### PR DESCRIPTION
## Summary
- Unity の Contracts 復元経路を GitHub Packages に固定し、ローカルフィードへのフォールバックを禁止しました。
- `NuGet.config` から `LocalContracts` ソースを削除し、`PrivateNuGet` と `nuget.org` のみを残しました。
- パッケージ運用ドキュメントを現行実装に合わせ、NuGetForUnity の認証参照先と workflow 意図を明確化しました。

## Scope
- `src/Ucli.Unity/Assets/NuGet.config`
  - `LocalContracts` パッケージソースを削除
- `docs/package-operations.md`
  - GitHub Packages 認証手順を更新
  - NuGetForUnity の参照パス（ApplicationData）と `dotnet` CLI の参照パス差分を追記
  - `contracts-package-verify` / `contracts-package-publish` の役割・トリガーを明記

## Verification
- Gate level: Standard
- Diff budget: PASS (`2 files changed, 19 insertions(+), 15 deletions(-)`)
- Spec drift: Skipped (`docs/agents/feature_issue-12-unity-ipc-foundation/spec.md` が存在しないため)
- Format: Skipped（ドキュメント/XML設定のみの差分で、受け入れ判定に formatter 実行が不要）
- Tests: Skipped（実行コード・テスト対象ロジックへの変更なし）
- Coverage: N/A

## Risks / Rollback
- リスク: GitHub Packages 認証（PAT scope 不足・期限切れ）がある環境では復元が即時失敗する。
- ロールバック: `66c2ce4` と `edce441` を revert すれば、変更前の復元設定とドキュメントへ戻せる。

## Checklist
- [x] Unity 側 NuGet source が GitHub Packages 前提に固定されている
- [x] パッケージ運用ドキュメントが現在の CI/workflow と整合している
- [ ] レビュアー確認（ローカルフィード経路が不要であること）

Closes #12
