### PR TITLE
[v1.0][F4] Implement op registry/validate/ops foundation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# C# sources are formatted with CRLF based on .editorconfig.
+*.cs text eol=crlf

--- a/src/Ucli/Cli/CommandResult.cs
+++ b/src/Ucli/Cli/CommandResult.cs
@@ -1,128 +1,140 @@
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Represents the JSON contract payload emitted by every CLI command execution. </summary>
+/// <param name="ProtocolVersion"> The protocol version of the emitted JSON payload. </param>
+/// <param name="Command"> The normalized command name associated with this result. </param>
+/// <param name="Status"> The execution status string defined by <see cref="CliProtocol" />. </param>
+/// <param name="ExitCode"> The process exit code associated with this result. </param>
+/// <param name="Message"> The user-facing message that explains the execution outcome. </param>
+/// <param name="Payload"> The JSON-serializable payload object for additional command output. </param>
+/// <param name="Errors"> The machine-readable error list. Empty when <paramref name="Status" /> is <c>ok</c>. </param>
+internal sealed record CommandResult (
+    int ProtocolVersion,
+    string Command,
+    string Status,
+    int ExitCode,
+    string Message,
+    object Payload,
+    IReadOnlyList<CommandError> Errors)
 {
-    /// <summary> Represents the JSON contract payload emitted by every CLI command execution. </summary>
-    /// <param name="ProtocolVersion"> The protocol version of the emitted JSON payload. </param>
-    /// <param name="Command"> The normalized command name associated with this result. </param>
-    /// <param name="Status"> The execution status string defined by <see cref="CliProtocol" />. </param>
-    /// <param name="ExitCode"> The process exit code associated with this result. </param>
-    /// <param name="Message"> The user-facing message that explains the execution outcome. </param>
-    /// <param name="Payload"> The JSON-serializable payload object for additional command output. </param>
-    /// <param name="Errors"> The machine-readable error list. Empty when <paramref name="Status" /> is <c>ok</c>. </param>
-    internal sealed record CommandResult (
-        int ProtocolVersion,
-        string Command,
-        string Status,
-        int ExitCode,
-        string Message,
-        object Payload,
-        IReadOnlyList<CommandError> Errors)
+    private static readonly object EmptyPayload = new();
+
+    private static readonly IReadOnlyList<CommandError> EmptyErrors = Array.Empty<CommandError>();
+
+    /// <summary> Creates a successful command result. </summary>
+    /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+    /// <param name="message"> The success message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
+    /// <param name="payload"> The command payload. When <see langword="null" />, an empty payload object is used. </param>
+    /// <returns> A command result with <c>ok</c> status and the success exit code. </returns>
+    public static CommandResult Success (string command, string message, object? payload = null)
     {
-        private static readonly object EmptyPayload = new();
+        var normalizedCommand = NormalizeCommand(command);
+        var normalizedMessage = NormalizeMessage(message);
+        return new CommandResult(
+            ProtocolVersion: CliProtocol.CurrentVersion,
+            Command: normalizedCommand,
+            Status: CliProtocol.StatusOk,
+            ExitCode: (int)CliExitCode.Success,
+            Message: normalizedMessage,
+            Payload: payload ?? EmptyPayload,
+            Errors: EmptyErrors);
+    }
 
-        private static readonly IReadOnlyList<CommandError> EmptyErrors = Array.Empty<CommandError>();
+    /// <summary> Creates a placeholder error result for a command that is not implemented yet. </summary>
+    /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+    /// <param name="message"> The optional custom message. When <see langword="null" />, a default not-implemented message is generated. </param>
+    /// <returns> A command result with <c>error</c> status and the <c>COMMAND_NOT_IMPLEMENTED</c> error code. </returns>
+    public static CommandResult NotImplemented (string command, string? message = null)
+    {
+        var normalizedCommand = NormalizeCommand(command);
+        var normalizedMessage = message ?? $"Command '{normalizedCommand}' is not implemented yet.";
+        return CreateError(
+            command: normalizedCommand,
+            message: normalizedMessage,
+            exitCode: CliExitCode.ToolError,
+            errorCode: ErrorCodes.CommandNotImplemented);
+    }
 
-        /// <summary> Creates a successful command result. </summary>
-        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The success message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
-        /// <param name="payload"> The command payload. When <see langword="null" />, an empty payload object is used. </param>
-        /// <returns> A command result with <c>ok</c> status and the success exit code. </returns>
-        public static CommandResult Success (string command, string message, object? payload = null)
-        {
-            var normalizedCommand = NormalizeCommand(command);
-            var normalizedMessage = NormalizeMessage(message);
-            return new CommandResult(
-                ProtocolVersion: CliProtocol.CurrentVersion,
-                Command: normalizedCommand,
-                Status: CliProtocol.StatusOk,
-                ExitCode: (int)CliExitCode.Success,
-                Message: normalizedMessage,
-                Payload: payload ?? EmptyPayload,
-                Errors: EmptyErrors);
-        }
+    /// <summary> Creates an error result for invalid command arguments. </summary>
+    /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+    /// <param name="message"> The argument validation message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
+    /// <returns> A command result with <c>error</c> status and the invalid-argument exit code. </returns>
+    public static CommandResult InvalidArgument (string command, string message)
+    {
+        return CreateError(
+            command: command,
+            message: message,
+            exitCode: CliExitCode.InvalidArgument,
+            errorCode: ErrorCodes.InvalidArgument);
+    }
 
-        /// <summary> Creates a placeholder error result for a command that is not implemented yet. </summary>
-        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The optional custom message. When <see langword="null" />, a default not-implemented message is generated. </param>
-        /// <returns> A command result with <c>error</c> status and the <c>COMMAND_NOT_IMPLEMENTED</c> error code. </returns>
-        public static CommandResult NotImplemented (string command, string? message = null)
-        {
-            var normalizedCommand = NormalizeCommand(command);
-            var normalizedMessage = message ?? $"Command '{normalizedCommand}' is not implemented yet.";
-            return CreateError(
-                command: normalizedCommand,
-                message: normalizedMessage,
-                exitCode: CliExitCode.ToolError,
-                errorCode: ErrorCodes.CommandNotImplemented);
-        }
+    /// <summary> Creates an error result for command cancellation. </summary>
+    /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+    /// <param name="message"> The cancellation message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
+    /// <returns> A command result with <c>error</c> status and the tool-error exit code. </returns>
+    public static CommandResult Canceled (string command, string message)
+    {
+        return CreateError(
+            command: command,
+            message: message,
+            exitCode: CliExitCode.ToolError,
+            errorCode: ErrorCodes.Canceled);
+    }
 
-        /// <summary> Creates an error result for invalid command arguments. </summary>
-        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The argument validation message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
-        /// <returns> A command result with <c>error</c> status and the invalid-argument exit code. </returns>
-        public static CommandResult InvalidArgument (string command, string message)
-        {
-            return CreateError(
-                command: command,
-                message: message,
-                exitCode: CliExitCode.InvalidArgument,
-                errorCode: ErrorCodes.InvalidArgument);
-        }
+    /// <summary> Creates an error result for unexpected runtime failures. </summary>
+    /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
+    /// <param name="message"> The failure message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
+    /// <returns> A command result with <c>error</c> status and the tool-error exit code. </returns>
+    public static CommandResult InternalError (string command, string message)
+    {
+        return CreateError(
+            command: command,
+            message: message,
+            exitCode: CliExitCode.ToolError,
+            errorCode: ErrorCodes.InternalError);
+    }
 
-        /// <summary> Creates an error result for unexpected runtime failures. </summary>
-        /// <param name="command"> The command name written to the result. <see langword="null" />, empty, and whitespace values are normalized to <see cref="CliProtocol.RootCommand" />. </param>
-        /// <param name="message"> The failure message written to the result. <see langword="null" />, empty, and whitespace values are replaced by a fallback message. </param>
-        /// <returns> A command result with <c>error</c> status and the tool-error exit code. </returns>
-        public static CommandResult InternalError (string command, string message)
-        {
-            return CreateError(
-                command: command,
-                message: message,
-                exitCode: CliExitCode.ToolError,
-                errorCode: ErrorCodes.InternalError);
-        }
+    /// <summary> Creates a normalized error result with a single error entry. </summary>
+    /// <param name="command"> The command name written to the result. </param>
+    /// <param name="message"> The error message written to the result. </param>
+    /// <param name="exitCode"> The exit code associated with the error result. </param>
+    /// <param name="errorCode"> The machine-readable error code added to the error list. </param>
+    /// <returns> A normalized command result with <c>error</c> status. </returns>
+    private static CommandResult CreateError (
+        string command,
+        string message,
+        CliExitCode exitCode,
+        string errorCode)
+    {
+        var normalizedCommand = NormalizeCommand(command);
+        var normalizedMessage = NormalizeMessage(message);
 
-        /// <summary> Creates a normalized error result with a single error entry. </summary>
-        /// <param name="command"> The command name written to the result. </param>
-        /// <param name="message"> The error message written to the result. </param>
-        /// <param name="exitCode"> The exit code associated with the error result. </param>
-        /// <param name="errorCode"> The machine-readable error code added to the error list. </param>
-        /// <returns> A normalized command result with <c>error</c> status. </returns>
-        private static CommandResult CreateError (
-            string command,
-            string message,
-            CliExitCode exitCode,
-            string errorCode)
-        {
-            var normalizedCommand = NormalizeCommand(command);
-            var normalizedMessage = NormalizeMessage(message);
+        return new CommandResult(
+            ProtocolVersion: CliProtocol.CurrentVersion,
+            Command: normalizedCommand,
+            Status: CliProtocol.StatusError,
+            ExitCode: (int)exitCode,
+            Message: normalizedMessage,
+            Payload: EmptyPayload,
+            Errors:
+            [
+                new CommandError(errorCode, normalizedMessage, null),
+            ]);
+    }
 
-            return new CommandResult(
-                ProtocolVersion: CliProtocol.CurrentVersion,
-                Command: normalizedCommand,
-                Status: CliProtocol.StatusError,
-                ExitCode: (int)exitCode,
-                Message: normalizedMessage,
-                Payload: EmptyPayload,
-                Errors:
-                [
-                    new CommandError(errorCode, normalizedMessage, null),
-                ]);
-        }
+    /// <summary> Normalizes the command name used in command results. </summary>
+    /// <param name="command"> The command name to normalize. </param>
+    /// <returns> The input command name, or <see cref="CliProtocol.RootCommand" /> when the input is <see langword="null" />, empty, or whitespace. </returns>
+    private static string NormalizeCommand (string command)
+    {
+        return string.IsNullOrWhiteSpace(command) ? CliProtocol.RootCommand : command;
+    }
 
-        /// <summary> Normalizes the command name used in command results. </summary>
-        /// <param name="command"> The command name to normalize. </param>
-        /// <returns> The input command name, or <see cref="CliProtocol.RootCommand" /> when the input is <see langword="null" />, empty, or whitespace. </returns>
-        private static string NormalizeCommand (string command)
-        {
-            return string.IsNullOrWhiteSpace(command) ? CliProtocol.RootCommand : command;
-        }
-
-        /// <summary> Normalizes the message value used in command results. </summary>
-        /// <param name="message"> The message to normalize. </param>
-        /// <returns> The input message, or a fallback error message when the input is <see langword="null" />, empty, or whitespace. </returns>
-        private static string NormalizeMessage (string message)
-        {
-            return string.IsNullOrWhiteSpace(message) ? "An unknown error occurred." : message;
-        }
+    /// <summary> Normalizes the message value used in command results. </summary>
+    /// <param name="message"> The message to normalize. </param>
+    /// <returns> The input message, or a fallback error message when the input is <see langword="null" />, empty, or whitespace. </returns>
+    private static string NormalizeMessage (string message)
+    {
+        return string.IsNullOrWhiteSpace(message) ? "An unknown error occurred." : message;
     }
 }

--- a/src/Ucli/Cli/ErrorCodes.cs
+++ b/src/Ucli/Cli/ErrorCodes.cs
@@ -1,15 +1,17 @@
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Defines machine-readable error code values written to CLI JSON results. </summary>
+internal static class ErrorCodes
 {
-    /// <summary> Defines machine-readable error code values written to CLI JSON results. </summary>
-    internal static class ErrorCodes
-    {
-        /// <summary> Gets the error code used when a command exists but is not implemented yet. </summary>
-        public const string CommandNotImplemented = "COMMAND_NOT_IMPLEMENTED";
+    /// <summary> Gets the error code used when a command exists but is not implemented yet. </summary>
+    public const string CommandNotImplemented = "COMMAND_NOT_IMPLEMENTED";
 
-        /// <summary> Gets the error code used when command arguments are invalid. </summary>
-        public const string InvalidArgument = "INVALID_ARGUMENT";
+    /// <summary> Gets the error code used when command arguments are invalid. </summary>
+    public const string InvalidArgument = "INVALID_ARGUMENT";
 
-        /// <summary> Gets the error code used when an unexpected runtime failure occurs. </summary>
-        public const string InternalError = "INTERNAL_ERROR";
-    }
+    /// <summary> Gets the error code used when command execution is canceled. </summary>
+    public const string Canceled = "CANCELED";
+
+    /// <summary> Gets the error code used when an unexpected runtime failure occurs. </summary>
+    public const string InternalError = "INTERNAL_ERROR";
 }

--- a/src/Ucli/Cli/InitCommand.cs
+++ b/src/Ucli/Cli/InitCommand.cs
@@ -26,7 +26,7 @@ namespace MackySoft.Ucli.Cli
         /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
         /// <returns> The exit code contained in the emitted command result. </returns>
         [Command(CommandName)]
-        public int Init (
+        public async Task<int> Init (
             bool force = false,
             string? projectPath = null,
             CancellationToken cancellationToken = default)
@@ -35,7 +35,7 @@ namespace MackySoft.Ucli.Cli
 
             CommandExecutionState.MarkStarted();
 
-            var executionResult = initService.Execute(force, projectPath, cancellationToken);
+            var executionResult = await initService.Execute(force, projectPath, cancellationToken).ConfigureAwait(false);
             var result = CreateCommandResult(executionResult);
             CommandResultWriter.WriteToStandardOutput(result);
             return result.ExitCode;

--- a/src/Ucli/Cli/OperationCatalogWarmupFilter.cs
+++ b/src/Ucli/Cli/OperationCatalogWarmupFilter.cs
@@ -1,0 +1,36 @@
+using ConsoleAppFramework;
+using MackySoft.Ucli.Operations;
+
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Loads the operation catalog before command execution to fail early on registry configuration errors. </summary>
+internal sealed class OperationCatalogWarmupFilter : ConsoleAppFilter
+{
+    private readonly IOperationCatalog operationCatalog;
+
+    /// <summary> Initializes a new instance of the <see cref="OperationCatalogWarmupFilter" /> class. </summary>
+    /// <param name="operationCatalog"> The operation catalog used for startup warmup. </param>
+    /// <param name="next"> The next filter in the command pipeline. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationCatalog" /> is <see langword="null" />. </exception>
+    public OperationCatalogWarmupFilter (
+        IOperationCatalog operationCatalog,
+        ConsoleAppFilter next)
+        : base(next)
+    {
+        this.operationCatalog = operationCatalog ?? throw new ArgumentNullException(nameof(operationCatalog));
+    }
+
+    /// <summary> Ensures operation metadata is loaded before command handlers run. </summary>
+    /// <param name="context"> The command execution context. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that completes after warmup and downstream filter execution. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
+    public override async Task InvokeAsync (ConsoleAppContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await operationCatalog.GetAll(cancellationToken).ConfigureAwait(false);
+        await Next.InvokeAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Ucli/Cli/StatusCommand.cs
+++ b/src/Ucli/Cli/StatusCommand.cs
@@ -11,16 +11,12 @@ namespace MackySoft.Ucli.Cli
         /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
         /// <param name="projectPath"> --projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
         /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
         /// <returns> The exit code contained in the emitted command result. </returns>
         [Command(CommandName)]
         public int Status (
             string? projectPath = null,
-            string? mode = null,
-            CancellationToken cancellationToken = default)
+            string? mode = null)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             CommandExecutionState.MarkStarted();
 
             var result = CommandResult.NotImplemented(CommandName);

--- a/src/Ucli/Configuration/IUcliConfigStore.cs
+++ b/src/Ucli/Configuration/IUcliConfigStore.cs
@@ -15,8 +15,8 @@ namespace MackySoft.Ucli.Configuration
         /// <summary> Loads config values for a UnityProject. </summary>
         /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
-        UcliConfigLoadResult Load (
+        /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+        ValueTask<UcliConfigLoadResult> Load (
             string unityProjectRoot,
             CancellationToken cancellationToken = default);
 
@@ -24,9 +24,9 @@ namespace MackySoft.Ucli.Configuration
         /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
         /// <param name="config"> The config values to persist. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The config-save result. </returns>
+        /// <returns> A task that resolves to the config-save result. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        UcliConfigSaveResult Save (
+        ValueTask<UcliConfigSaveResult> Save (
             string unityProjectRoot,
             UcliConfig config,
             CancellationToken cancellationToken = default);

--- a/src/Ucli/Configuration/UcliConfigStore.cs
+++ b/src/Ucli/Configuration/UcliConfigStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using MackySoft.Ucli.Foundation;
 
 namespace MackySoft.Ucli.Configuration
@@ -33,8 +34,8 @@ namespace MackySoft.Ucli.Configuration
         /// <summary> Loads configuration values for a UnityProject root. </summary>
         /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
-        public UcliConfigLoadResult Load (
+        /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+        public async ValueTask<UcliConfigLoadResult> Load (
             string unityProjectRoot,
             CancellationToken cancellationToken = default)
         {
@@ -64,7 +65,7 @@ namespace MackySoft.Ucli.Configuration
             string json;
             try
             {
-                json = File.ReadAllText(configPath);
+                json = await File.ReadAllTextAsync(configPath, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsPathFormatException(ex))
             {
@@ -107,9 +108,9 @@ namespace MackySoft.Ucli.Configuration
         /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
         /// <param name="config"> The config values to persist. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The config-save result. </returns>
+        /// <returns> A task that resolves to the config-save result. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        public UcliConfigSaveResult Save (
+        public async ValueTask<UcliConfigSaveResult> Save (
             string unityProjectRoot,
             UcliConfig config,
             CancellationToken cancellationToken = default)
@@ -161,7 +162,7 @@ namespace MackySoft.Ucli.Configuration
             try
             {
                 Directory.CreateDirectory(configDirectoryPath);
-                File.WriteAllText(configPath, json + Environment.NewLine);
+                await File.WriteAllTextAsync(configPath, json + Environment.NewLine, cancellationToken).ConfigureAwait(false);
                 return UcliConfigSaveResult.Success();
             }
             catch (Exception ex) when (IsPathFormatException(ex))
@@ -217,7 +218,14 @@ namespace MackySoft.Ucli.Configuration
                         $"Config operationAllowlist contains an empty pattern: {configPath}."));
                 }
 
-                normalizedAllowlist.Add(pattern.Trim());
+                var normalizedPattern = pattern.Trim();
+                if (!TryValidateRegexPattern(normalizedPattern, out var patternErrorMessage))
+                {
+                    return ConfigParseResult.Failure(CreateInvalidArgument(
+                        $"Config operationAllowlist contains an invalid regex pattern: {normalizedPattern}. {patternErrorMessage}"));
+                }
+
+                normalizedAllowlist.Add(normalizedPattern);
             }
 
             var config = new UcliConfig(
@@ -255,9 +263,36 @@ namespace MackySoft.Ucli.Configuration
                     return ConfigValidationResult.Failure(CreateInvalidArgument(
                         $"Config operationAllowlist contains an empty pattern: {configPath}."));
                 }
+
+                if (!TryValidateRegexPattern(pattern, out var patternErrorMessage))
+                {
+                    return ConfigValidationResult.Failure(CreateInvalidArgument(
+                        $"Config operationAllowlist contains an invalid regex pattern: {pattern}. {patternErrorMessage}"));
+                }
             }
 
             return ConfigValidationResult.Success();
+        }
+
+        /// <summary> Validates whether a value can be compiled as a regular expression pattern. </summary>
+        /// <param name="pattern"> The regex pattern string to validate. </param>
+        /// <param name="errorMessage"> The parser error message when the pattern is invalid. </param>
+        /// <returns> <see langword="true" /> when the pattern is valid; otherwise <see langword="false" />. </returns>
+        private static bool TryValidateRegexPattern (
+            string pattern,
+            out string? errorMessage)
+        {
+            try
+            {
+                new Regex(pattern, RegexOptions.CultureInvariant);
+                errorMessage = null;
+                return true;
+            }
+            catch (ArgumentException exception)
+            {
+                errorMessage = exception.Message;
+                return false;
+            }
         }
 
         /// <summary> Converts typed config values into serializable JSON DTO values. </summary>

--- a/src/Ucli/Context/IInitStatusContextResolver.cs
+++ b/src/Ucli/Context/IInitStatusContextResolver.cs
@@ -6,8 +6,8 @@ namespace MackySoft.Ucli.Context
         /// <summary> Resolves UnityProject and config values into an execution context. </summary>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The context-resolution result that contains either a fully resolved context or a structured error. </returns>
-        InitStatusContextResolutionResult Resolve (
+        /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
+        ValueTask<InitStatusContextResolutionResult> Resolve (
             string? projectPath,
             CancellationToken cancellationToken = default);
     }

--- a/src/Ucli/Context/InitStatusContextResolver.cs
+++ b/src/Ucli/Context/InitStatusContextResolver.cs
@@ -24,21 +24,21 @@ namespace MackySoft.Ucli.Context
         /// <summary> Resolves UnityProject and config values into a shared init/status context. </summary>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The context-resolution result that contains either a fully resolved context or a structured error. </returns>
-        public InitStatusContextResolutionResult Resolve (
+        /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
+        public async ValueTask<InitStatusContextResolutionResult> Resolve (
             string? projectPath,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var unityProjectResult = unityProjectResolver.Resolve(projectPath, cancellationToken);
+            var unityProjectResult = unityProjectResolver.Resolve(projectPath);
             if (!unityProjectResult.IsSuccess)
             {
                 return InitStatusContextResolutionResult.Failure(unityProjectResult.Error!);
             }
 
             var unityProjectContext = unityProjectResult.Context!;
-            var configLoadResult = configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken);
+            var configLoadResult = await configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken).ConfigureAwait(false);
             if (!configLoadResult.IsSuccess)
             {
                 return InitStatusContextResolutionResult.Failure(configLoadResult.Error!);

--- a/src/Ucli/Init/IInitService.cs
+++ b/src/Ucli/Init/IInitService.cs
@@ -7,8 +7,8 @@ namespace MackySoft.Ucli.Init
         /// <param name="force"> Whether existing files can be overwritten. </param>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The initialization execution result that contains either generated file paths or a structured error. </returns>
-        InitExecutionResult Execute (
+        /// <returns> A task that resolves to the initialization execution result that contains either generated file paths or a structured error. </returns>
+        ValueTask<InitExecutionResult> Execute (
             bool force,
             string? projectPath,
             CancellationToken cancellationToken = default);

--- a/src/Ucli/Init/InitService.cs
+++ b/src/Ucli/Init/InitService.cs
@@ -35,15 +35,15 @@ namespace MackySoft.Ucli.Init
         /// <param name="force"> Whether existing files can be overwritten. </param>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
         /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> The init execution result that contains generated file paths on success or a structured error on failure. </returns>
-        public InitExecutionResult Execute (
+        /// <returns> A task that resolves to the init execution result that contains generated file paths on success or a structured error on failure. </returns>
+        public async ValueTask<InitExecutionResult> Execute (
             bool force,
             string? projectPath,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var unityProjectResult = unityProjectResolver.Resolve(projectPath, cancellationToken);
+            var unityProjectResult = unityProjectResolver.Resolve(projectPath);
             if (!unityProjectResult.IsSuccess)
             {
                 return InitExecutionResult.Failure(unityProjectResult.Error!);
@@ -68,7 +68,7 @@ namespace MackySoft.Ucli.Init
                 // NOTE:
                 // Keep init and status using the same context pipeline.
                 // This ensures config parse/validation behavior stays consistent across command foundations.
-                var contextResult = contextResolver.Resolve(projectPath, cancellationToken);
+                var contextResult = await contextResolver.Resolve(projectPath, cancellationToken).ConfigureAwait(false);
                 if (!contextResult.IsSuccess)
                 {
                     return InitExecutionResult.Failure(contextResult.Error!);
@@ -93,7 +93,7 @@ namespace MackySoft.Ucli.Init
             cancellationToken.ThrowIfCancellationRequested();
 
             var defaultConfig = UcliConfig.CreateDefault();
-            var configSaveResult = configStore.Save(unityProjectRoot, defaultConfig, cancellationToken);
+            var configSaveResult = await configStore.Save(unityProjectRoot, defaultConfig, cancellationToken).ConfigureAwait(false);
             if (!configSaveResult.IsSuccess)
             {
                 return InitExecutionResult.Failure(configSaveResult.Error!);
@@ -101,7 +101,7 @@ namespace MackySoft.Ucli.Init
 
             try
             {
-                File.WriteAllText(gitIgnorePath, GitIgnoreContents + Environment.NewLine);
+                await File.WriteAllTextAsync(gitIgnorePath, GitIgnoreContents + Environment.NewLine, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsPathFormatException(ex))
             {

--- a/src/Ucli/Operations/IOperationAuthorizationService.cs
+++ b/src/Ucli/Operations/IOperationAuthorizationService.cs
@@ -1,0 +1,17 @@
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Evaluates whether one operation can be executed under current configuration. </summary>
+internal interface IOperationAuthorizationService
+{
+    /// <summary> Asynchronously evaluates operation policy and allowlist constraints for one operation. </summary>
+    /// <param name="operation"> The operation descriptor to evaluate. </param>
+    /// <param name="config"> The configuration values that define execution constraints. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the authorization evaluation result. </returns>
+    ValueTask<OperationAuthorizationResult> Authorize (
+        UcliOperationDescriptor operation,
+        UcliConfig config,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Operations/IOperationCatalog.cs
+++ b/src/Ucli/Operations/IOperationCatalog.cs
@@ -1,0 +1,19 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Provides lookup and listing over registered operation metadata. </summary>
+internal interface IOperationCatalog
+{
+    /// <summary> Asynchronously gets one operation descriptor by operation name. </summary>
+    /// <param name="name"> The operation name to resolve. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns>
+    /// <para> A task that resolves to the operation descriptor. </para>
+    /// <para> Returns <see langword="null" /> when the operation does not exist. </para>
+    /// </returns>
+    ValueTask<UcliOperationDescriptor?> Get (string name, CancellationToken cancellationToken = default);
+
+    /// <summary> Asynchronously gets all registered operation descriptors. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the descriptor list ordered by operation name. </returns>
+    ValueTask<IReadOnlyList<UcliOperationDescriptor>> GetAll (CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Operations/IOperationCatalogProvider.cs
+++ b/src/Ucli/Operations/IOperationCatalogProvider.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Provides operation descriptor values to the operation catalog. </summary>
+internal interface IOperationCatalogProvider
+{
+    /// <summary> Asynchronously gets operation descriptor values used for catalog construction. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the operation descriptor collection. </returns>
+    ValueTask<IReadOnlyList<UcliOperationDescriptor>> GetOperations (CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Operations/IRequestStaticValidator.cs
+++ b/src/Ucli/Operations/IRequestStaticValidator.cs
@@ -1,0 +1,17 @@
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Performs static pre-execution validation for JSON request structures. </summary>
+internal interface IRequestStaticValidator
+{
+    /// <summary> Asynchronously validates one normalized request against structure and operation authorization constraints. </summary>
+    /// <param name="request"> The normalized request. </param>
+    /// <param name="config"> The configuration values used for operation authorization checks. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the aggregated validation result. </returns>
+    ValueTask<ValidationResult> Validate (
+        ValidateRequest request,
+        UcliConfig config,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
+++ b/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
@@ -1,0 +1,51 @@
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Provides temporary in-memory operation metadata for foundation-stage development. </summary>
+internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvider
+{
+    private const string DefaultArgsSchemaJson = """{"type":"object"}""";
+
+    private static readonly IReadOnlyList<UcliOperationDescriptor> Operations =
+    [
+        new UcliOperationDescriptor("ucli.asset.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.asset.schema", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.asset.set", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.assets.find", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.comp.ensure", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.comp.schema", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.comp.set", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.cs.invoke", UcliOperationKind.Mutation, OperationPolicy.Dangerous, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.go.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.go.describe", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.prefab.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.prefab.open", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.prefab.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.project.refresh", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.project.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.resolve", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.scene.open", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.scene.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.scene.tree", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+
+        new UcliOperationDescriptor("ucli.scenes.findComponents", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+    ];
+
+    /// <summary> Asynchronously gets operation descriptor values used for catalog construction. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the operation descriptor collection. </returns>
+    public ValueTask<IReadOnlyList<UcliOperationDescriptor>> GetOperations (CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(Operations);
+    }
+}

--- a/src/Ucli/Operations/OperationAuthorizationResult.cs
+++ b/src/Ucli/Operations/OperationAuthorizationResult.cs
@@ -1,0 +1,41 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Represents authorization result for one operation execution attempt. </summary>
+/// <param name="IsAllowed"> Whether execution is allowed under current configuration. </param>
+/// <param name="ErrorCode"> The machine-readable denial code when <paramref name="IsAllowed" /> is <see langword="false" />. </param>
+/// <param name="Message"> The human-readable authorization detail. </param>
+internal sealed record OperationAuthorizationResult (
+    bool IsAllowed,
+    string? ErrorCode,
+    string Message)
+{
+    /// <summary> Creates an allowed authorization result. </summary>
+    /// <returns> The allowed authorization result. </returns>
+    public static OperationAuthorizationResult Allowed ()
+    {
+        return new OperationAuthorizationResult(
+            IsAllowed: true,
+            ErrorCode: null,
+            Message: "Operation is allowed.");
+    }
+
+    /// <summary> Creates a denied authorization result. </summary>
+    /// <param name="errorCode"> The machine-readable denial code. </param>
+    /// <param name="message"> The human-readable denial message. </param>
+    /// <returns> The denied authorization result. </returns>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="errorCode" /> is <see langword="null" />, empty, or whitespace. </exception>
+    public static OperationAuthorizationResult Denied (
+        string errorCode,
+        string message)
+    {
+        if (string.IsNullOrWhiteSpace(errorCode))
+        {
+            throw new ArgumentException("Error code must not be null, empty, or whitespace.", nameof(errorCode));
+        }
+
+        return new OperationAuthorizationResult(
+            IsAllowed: false,
+            ErrorCode: errorCode,
+            Message: message);
+    }
+}

--- a/src/Ucli/Operations/OperationAuthorizationService.cs
+++ b/src/Ucli/Operations/OperationAuthorizationService.cs
@@ -70,8 +70,9 @@ internal sealed class OperationAuthorizationService : IOperationAuthorizationSer
             return AllowlistMatchResult.NotMatched();
         }
 
-        foreach (var pattern in allowlistPatterns)
+        for (var i = 0; i < allowlistPatterns.Count; i++)
         {
+            var pattern = allowlistPatterns[i];
             if (string.IsNullOrWhiteSpace(pattern))
             {
                 continue;

--- a/src/Ucli/Operations/OperationAuthorizationService.cs
+++ b/src/Ucli/Operations/OperationAuthorizationService.cs
@@ -1,0 +1,127 @@
+using System.Text.RegularExpressions;
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Evaluates operation authorization using operationPolicy and operationAllowlist constraints. </summary>
+internal sealed class OperationAuthorizationService : IOperationAuthorizationService
+{
+    /// <summary> Asynchronously evaluates operation policy and allowlist constraints for one operation. </summary>
+    /// <param name="operation"> The operation descriptor to evaluate. </param>
+    /// <param name="config"> The configuration values that define execution constraints. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the authorization evaluation result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> or <paramref name="config" /> is <see langword="null" />. </exception>
+    public ValueTask<OperationAuthorizationResult> Authorize (
+        UcliOperationDescriptor operation,
+        UcliConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!IsPolicyAllowed(operation.Policy, config.OperationPolicy))
+        {
+            return ValueTask.FromResult(OperationAuthorizationResult.Denied(
+                ValidationErrorCodes.OperationNotAllowed,
+                $"Operation '{operation.Name}' is blocked by operationPolicy='{config.OperationPolicy}'."));
+        }
+
+        var allowlistResult = TryMatchAllowlist(operation.Name, config.OperationAllowlist);
+        if (!allowlistResult.IsMatched)
+        {
+            if (allowlistResult.InvalidPattern is not null)
+            {
+                return ValueTask.FromResult(OperationAuthorizationResult.Denied(
+                    ValidationErrorCodes.OperationNotAllowed,
+                    $"Operation allowlist contains invalid regex pattern: {allowlistResult.InvalidPattern}."));
+            }
+
+            return ValueTask.FromResult(OperationAuthorizationResult.Denied(
+                ValidationErrorCodes.OperationNotAllowed,
+                $"Operation '{operation.Name}' does not match operationAllowlist."));
+        }
+
+        return ValueTask.FromResult(OperationAuthorizationResult.Allowed());
+    }
+
+    /// <summary> Determines whether required operation policy is within configured allowance. </summary>
+    /// <param name="requiredPolicy"> The required policy for one operation. </param>
+    /// <param name="configuredPolicy"> The configured upper bound policy. </param>
+    /// <returns> <see langword="true" /> when operation is allowed by policy level; otherwise <see langword="false" />. </returns>
+    private static bool IsPolicyAllowed (
+        OperationPolicy requiredPolicy,
+        OperationPolicy configuredPolicy)
+    {
+        return requiredPolicy <= configuredPolicy;
+    }
+
+    /// <summary> Attempts to match operation name against allowlist patterns. </summary>
+    /// <param name="operationName"> The operation name. </param>
+    /// <param name="allowlistPatterns"> The configured allowlist patterns. </param>
+    /// <returns> The allowlist match result. </returns>
+    private static AllowlistMatchResult TryMatchAllowlist (
+        string operationName,
+        IReadOnlyList<string> allowlistPatterns)
+    {
+        if (allowlistPatterns is null || allowlistPatterns.Count == 0)
+        {
+            return AllowlistMatchResult.NotMatched();
+        }
+
+        foreach (var pattern in allowlistPatterns)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (Regex.IsMatch(operationName, pattern, RegexOptions.CultureInvariant))
+                {
+                    return AllowlistMatchResult.Matched();
+                }
+            }
+            catch (ArgumentException)
+            {
+                return AllowlistMatchResult.WithInvalidPattern(pattern);
+            }
+        }
+
+        return AllowlistMatchResult.NotMatched();
+    }
+
+    /// <summary> Represents the result of allowlist regex matching. </summary>
+    /// <param name="IsMatched"> Whether any allowlist pattern matched. </param>
+    /// <param name="InvalidPattern"> The invalid pattern when regex parsing failed. </param>
+    private readonly record struct AllowlistMatchResult (
+        bool IsMatched,
+        string? InvalidPattern)
+    {
+        /// <summary> Creates a matched result. </summary>
+        /// <returns> A matched result. </returns>
+        public static AllowlistMatchResult Matched ()
+        {
+            return new AllowlistMatchResult(IsMatched: true, InvalidPattern: null);
+        }
+
+        /// <summary> Creates a not-matched result. </summary>
+        /// <returns> A not-matched result. </returns>
+        public static AllowlistMatchResult NotMatched ()
+        {
+            return new AllowlistMatchResult(IsMatched: false, InvalidPattern: null);
+        }
+
+        /// <summary> Creates an invalid-pattern result. </summary>
+        /// <param name="pattern"> The invalid regex pattern. </param>
+        /// <returns> An invalid-pattern result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="pattern" /> is <see langword="null" />. </exception>
+        public static AllowlistMatchResult WithInvalidPattern (string pattern)
+        {
+            ArgumentNullException.ThrowIfNull(pattern);
+            return new AllowlistMatchResult(IsMatched: false, InvalidPattern: pattern);
+        }
+    }
+}

--- a/src/Ucli/Operations/OperationCatalog.cs
+++ b/src/Ucli/Operations/OperationCatalog.cs
@@ -103,8 +103,9 @@ internal sealed class OperationCatalog : IOperationCatalog
         }
 
         var operationsByName = new Dictionary<string, UcliOperationDescriptor>(StringComparer.Ordinal);
-        foreach (var operation in loadedOperations)
+        for (var i = 0; i < loadedOperations.Count; i++)
         {
+            var operation = loadedOperations[i];
             cancellationToken.ThrowIfCancellationRequested();
 
             if (operation is null)

--- a/src/Ucli/Operations/OperationCatalog.cs
+++ b/src/Ucli/Operations/OperationCatalog.cs
@@ -1,0 +1,139 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Provides operation lookup and listing backed by one provider snapshot. </summary>
+internal sealed class OperationCatalog : IOperationCatalog
+{
+    private readonly IOperationCatalogProvider provider;
+
+    private readonly object syncRoot = new();
+
+    private Task<CatalogSnapshot>? snapshotTask;
+
+    /// <summary> Initializes a new instance of the <see cref="OperationCatalog" /> class. </summary>
+    /// <param name="provider"> The operation metadata provider. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="provider" /> is <see langword="null" />. </exception>
+    public OperationCatalog (IOperationCatalogProvider provider)
+    {
+        this.provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    /// <summary> Asynchronously gets one operation descriptor by operation name. </summary>
+    /// <param name="name"> The operation name to resolve. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns>
+    /// <para> A task that resolves to the operation descriptor. </para>
+    /// <para> Returns <see langword="null" /> when the operation does not exist. </para>
+    /// </returns>
+    /// <exception cref="InvalidOperationException"> Thrown when provider data includes duplicated or invalid operation names. </exception>
+    public async ValueTask<UcliOperationDescriptor?> Get (string name, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+
+        var snapshot = await GetSnapshot(cancellationToken).ConfigureAwait(false);
+        if (snapshot.OperationsByName.TryGetValue(name, out var descriptor))
+        {
+            return descriptor;
+        }
+
+        return null;
+    }
+
+    /// <summary> Asynchronously gets all registered operation descriptors. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the descriptor list ordered by operation name. </returns>
+    /// <exception cref="InvalidOperationException"> Thrown when provider data includes duplicated or invalid operation names. </exception>
+    public async ValueTask<IReadOnlyList<UcliOperationDescriptor>> GetAll (CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var snapshot = await GetSnapshot(cancellationToken).ConfigureAwait(false);
+        return snapshot.SortedOperations;
+    }
+
+    /// <summary> Gets or creates the immutable catalog snapshot. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the loaded catalog snapshot. </returns>
+    private async ValueTask<CatalogSnapshot> GetSnapshot (CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        Task<CatalogSnapshot> initializationTask;
+        lock (syncRoot)
+        {
+            snapshotTask ??= BuildSnapshot(cancellationToken);
+            initializationTask = snapshotTask;
+        }
+
+        try
+        {
+            return await initializationTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            if (initializationTask.IsFaulted || initializationTask.IsCanceled)
+            {
+                lock (syncRoot)
+                {
+                    if (ReferenceEquals(snapshotTask, initializationTask))
+                    {
+                        snapshotTask = null;
+                    }
+                }
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary> Builds the immutable catalog snapshot from provider data. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the built catalog snapshot. </returns>
+    /// <exception cref="InvalidOperationException"> Thrown when provider data includes duplicated or invalid operation names. </exception>
+    private async Task<CatalogSnapshot> BuildSnapshot (CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var loadedOperations = await provider.GetOperations(cancellationToken).ConfigureAwait(false);
+        if (loadedOperations is null)
+        {
+            throw new InvalidOperationException("Operation catalog provider returned null.");
+        }
+
+        var operationsByName = new Dictionary<string, UcliOperationDescriptor>(StringComparer.Ordinal);
+        foreach (var operation in loadedOperations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (operation is null)
+            {
+                throw new InvalidOperationException("Operation catalog provider contains a null descriptor.");
+            }
+
+            if (string.IsNullOrWhiteSpace(operation.Name))
+            {
+                throw new InvalidOperationException("Operation name must not be null, empty, or whitespace.");
+            }
+
+            if (!operationsByName.TryAdd(operation.Name, operation))
+            {
+                throw new InvalidOperationException($"Operation name is duplicated: {operation.Name}.");
+            }
+        }
+
+        var sortedOperations = operationsByName
+            .Values
+            .OrderBy(static operation => operation.Name, StringComparer.Ordinal)
+            .ToArray();
+        return new CatalogSnapshot(sortedOperations, operationsByName);
+    }
+
+    /// <summary> Represents one immutable lookup snapshot for catalog data. </summary>
+    /// <param name="SortedOperations"> The ordered descriptor list. </param>
+    /// <param name="OperationsByName"> The descriptor lookup by operation name. </param>
+    private readonly record struct CatalogSnapshot (
+        IReadOnlyList<UcliOperationDescriptor> SortedOperations,
+        Dictionary<string, UcliOperationDescriptor> OperationsByName);
+}

--- a/src/Ucli/Operations/RequestStaticValidator.cs
+++ b/src/Ucli/Operations/RequestStaticValidator.cs
@@ -69,6 +69,19 @@ internal sealed class RequestStaticValidator : IRequestStaticValidator
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (operationRequest is null)
+            {
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OpIdRequired,
+                    Message: "opId is required.",
+                    OpId: null));
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OpNameRequired,
+                    Message: "op is required.",
+                    OpId: null));
+                continue;
+            }
+
             var normalizedOpId = Normalize(operationRequest.OpId);
             if (normalizedOpId is null)
             {

--- a/src/Ucli/Operations/RequestStaticValidator.cs
+++ b/src/Ucli/Operations/RequestStaticValidator.cs
@@ -1,0 +1,135 @@
+using MackySoft.Ucli.Cli;
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Performs static request validation for protocol, structure, and operation authorization. </summary>
+internal sealed class RequestStaticValidator : IRequestStaticValidator
+{
+    private readonly IOperationCatalog operationCatalog;
+
+    private readonly IOperationAuthorizationService operationAuthorizationService;
+
+    /// <summary> Initializes a new instance of the <see cref="RequestStaticValidator" /> class. </summary>
+    /// <param name="operationCatalog"> The operation catalog dependency. </param>
+    /// <param name="operationAuthorizationService"> The operation authorization dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationCatalog" /> or <paramref name="operationAuthorizationService" /> is <see langword="null" />. </exception>
+    public RequestStaticValidator (
+        IOperationCatalog operationCatalog,
+        IOperationAuthorizationService operationAuthorizationService)
+    {
+        this.operationCatalog = operationCatalog ?? throw new ArgumentNullException(nameof(operationCatalog));
+        this.operationAuthorizationService = operationAuthorizationService ?? throw new ArgumentNullException(nameof(operationAuthorizationService));
+    }
+
+    /// <summary> Asynchronously validates one normalized request against structure and operation authorization constraints. </summary>
+    /// <param name="request"> The normalized request. </param>
+    /// <param name="config"> The configuration values used for operation authorization checks. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the aggregated validation result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> or <paramref name="config" /> is <see langword="null" />. </exception>
+    public async ValueTask<ValidationResult> Validate (
+        ValidateRequest request,
+        UcliConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var errors = new List<ValidationError>();
+        if (request.ProtocolVersion != CliProtocol.CurrentVersion)
+        {
+            errors.Add(new ValidationError(
+                Code: ValidationErrorCodes.ProtocolVersionMismatch,
+                Message: $"protocolVersion must be {CliProtocol.CurrentVersion}. Actual: {request.ProtocolVersion}.",
+                OpId: null));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.RequestId)
+            || !Guid.TryParse(request.RequestId, out _))
+        {
+            errors.Add(new ValidationError(
+                Code: ValidationErrorCodes.RequestIdInvalid,
+                Message: "requestId must be a valid UUID.",
+                OpId: null));
+        }
+
+        if (request.Ops is null || request.Ops.Count == 0)
+        {
+            errors.Add(new ValidationError(
+                Code: ValidationErrorCodes.OpsRequired,
+                Message: "ops must contain at least one operation.",
+                OpId: null));
+            return new ValidationResult(errors);
+        }
+
+        var usedOpIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var operationRequest in request.Ops)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var normalizedOpId = Normalize(operationRequest.OpId);
+            if (normalizedOpId is null)
+            {
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OpIdRequired,
+                    Message: "opId is required.",
+                    OpId: null));
+            }
+            else if (!usedOpIds.Add(normalizedOpId))
+            {
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OpIdDuplicated,
+                    Message: $"opId '{normalizedOpId}' is duplicated.",
+                    OpId: normalizedOpId));
+            }
+
+            var normalizedOperationName = Normalize(operationRequest.Op);
+            if (normalizedOperationName is null)
+            {
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OpNameRequired,
+                    Message: "op is required.",
+                    OpId: normalizedOpId));
+                continue;
+            }
+
+            var descriptor = await operationCatalog.Get(normalizedOperationName, cancellationToken).ConfigureAwait(false);
+            if (descriptor is null)
+            {
+                errors.Add(new ValidationError(
+                    Code: ValidationErrorCodes.OperationNotFound,
+                    Message: $"Operation '{normalizedOperationName}' is not registered.",
+                    OpId: normalizedOpId));
+                continue;
+            }
+
+            var authorizationResult = await operationAuthorizationService
+                .Authorize(descriptor, config, cancellationToken)
+                .ConfigureAwait(false);
+            if (!authorizationResult.IsAllowed)
+            {
+                errors.Add(new ValidationError(
+                    Code: authorizationResult.ErrorCode ?? ValidationErrorCodes.OperationNotAllowed,
+                    Message: authorizationResult.Message,
+                    OpId: normalizedOpId));
+            }
+        }
+
+        return new ValidationResult(errors);
+    }
+
+    /// <summary> Normalizes a string value by trimming whitespace and converting empty strings to <see langword="null" />. </summary>
+    /// <param name="value"> The input value. </param>
+    /// <returns> The normalized value, or <see langword="null" /> when empty. </returns>
+    private static string? Normalize (string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+}

--- a/src/Ucli/Operations/UcliOperationDescriptor.cs
+++ b/src/Ucli/Operations/UcliOperationDescriptor.cs
@@ -1,0 +1,14 @@
+using MackySoft.Ucli.Configuration;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Represents one operation metadata entry resolved from the catalog provider. </summary>
+/// <param name="Name"> The unique operation name. </param>
+/// <param name="Kind"> The operation kind. </param>
+/// <param name="Policy"> The required operation policy. </param>
+/// <param name="ArgsSchemaJson"> The operation argument schema as JSON text. </param>
+internal sealed record UcliOperationDescriptor (
+    string Name,
+    UcliOperationKind Kind,
+    OperationPolicy Policy,
+    string ArgsSchemaJson);

--- a/src/Ucli/Operations/UcliOperationKind.cs
+++ b/src/Ucli/Operations/UcliOperationKind.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Defines high-level operation kinds exposed by the operation catalog. </summary>
+internal enum UcliOperationKind
+{
+    /// <summary> Represents read-only operations. </summary>
+    Query = 0,
+
+    /// <summary> Represents state-changing operations. </summary>
+    Mutation = 1,
+}

--- a/src/Ucli/Operations/ValidateRequest.cs
+++ b/src/Ucli/Operations/ValidateRequest.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Represents normalized request values for static validation. </summary>
+/// <param name="ProtocolVersion"> The request protocol version. </param>
+/// <param name="RequestId"> The request identifier. </param>
+/// <param name="Ops"> The requested operation list. </param>
+internal sealed record ValidateRequest (
+    int ProtocolVersion,
+    string? RequestId,
+    IReadOnlyList<ValidateRequestOperation>? Ops);
+
+/// <summary> Represents one operation element in a normalized validation request. </summary>
+/// <param name="OpId"> The operation identifier. </param>
+/// <param name="Op"> The operation name. </param>
+/// <param name="Args"> The operation arguments. </param>
+internal sealed record ValidateRequestOperation (
+    string? OpId,
+    string? Op,
+    JsonElement Args);

--- a/src/Ucli/Operations/ValidateRequest.cs
+++ b/src/Ucli/Operations/ValidateRequest.cs
@@ -5,11 +5,11 @@ namespace MackySoft.Ucli.Operations;
 /// <summary> Represents normalized request values for static validation. </summary>
 /// <param name="ProtocolVersion"> The request protocol version. </param>
 /// <param name="RequestId"> The request identifier. </param>
-/// <param name="Ops"> The requested operation list. </param>
+/// <param name="Ops"> The requested operation list. A malformed payload can include <see langword="null" /> elements. </param>
 internal sealed record ValidateRequest (
     int ProtocolVersion,
     string? RequestId,
-    IReadOnlyList<ValidateRequestOperation>? Ops);
+    IReadOnlyList<ValidateRequestOperation?>? Ops);
 
 /// <summary> Represents one operation element in a normalized validation request. </summary>
 /// <param name="OpId"> The operation identifier. </param>

--- a/src/Ucli/Operations/ValidationError.cs
+++ b/src/Ucli/Operations/ValidationError.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Represents one validation error entry for static request validation. </summary>
+/// <param name="Code"> The machine-readable validation code. </param>
+/// <param name="Message"> The validation detail message. </param>
+/// <param name="OpId"> The operation identifier related to this error, or <see langword="null" /> when not associated. </param>
+internal sealed record ValidationError (
+    string Code,
+    string Message,
+    string? OpId);

--- a/src/Ucli/Operations/ValidationErrorCodes.cs
+++ b/src/Ucli/Operations/ValidationErrorCodes.cs
@@ -1,0 +1,29 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Defines machine-readable validation error codes for static request validation. </summary>
+internal static class ValidationErrorCodes
+{
+    /// <summary> Gets the error code used when protocolVersion differs from supported value. </summary>
+    public const string ProtocolVersionMismatch = "PROTOCOL_VERSION_MISMATCH";
+
+    /// <summary> Gets the error code used when requestId is not a valid UUID. </summary>
+    public const string RequestIdInvalid = "REQUEST_ID_INVALID";
+
+    /// <summary> Gets the error code used when ops is missing or empty. </summary>
+    public const string OpsRequired = "OPS_REQUIRED";
+
+    /// <summary> Gets the error code used when opId is missing. </summary>
+    public const string OpIdRequired = "OP_ID_REQUIRED";
+
+    /// <summary> Gets the error code used when opId appears multiple times. </summary>
+    public const string OpIdDuplicated = "OP_ID_DUPLICATED";
+
+    /// <summary> Gets the error code used when op name is missing. </summary>
+    public const string OpNameRequired = "OP_NAME_REQUIRED";
+
+    /// <summary> Gets the error code used when op name is not registered. </summary>
+    public const string OperationNotFound = "OPERATION_NOT_FOUND";
+
+    /// <summary> Gets the error code used when operation is blocked by authorization rules. </summary>
+    public const string OperationNotAllowed = "OPERATION_NOT_ALLOWED";
+}

--- a/src/Ucli/Operations/ValidationResult.cs
+++ b/src/Ucli/Operations/ValidationResult.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Operations;
+
+/// <summary> Represents the aggregated static-validation result. </summary>
+/// <param name="Errors"> The collected validation errors. </param>
+internal sealed record ValidationResult (
+    IReadOnlyList<ValidationError> Errors)
+{
+    /// <summary> Gets a value indicating whether validation has no errors. </summary>
+    public bool IsValid => Errors.Count == 0;
+
+    /// <summary> Creates a successful validation result with no errors. </summary>
+    /// <returns> The successful validation result. </returns>
+    public static ValidationResult Success ()
+    {
+        return new ValidationResult(Array.Empty<ValidationError>());
+    }
+}

--- a/src/Ucli/Program.cs
+++ b/src/Ucli/Program.cs
@@ -4,6 +4,7 @@ using MackySoft.Ucli.Configuration;
 using MackySoft.Ucli.Context;
 using MackySoft.Ucli.Init;
 using MackySoft.Ucli.Ipc;
+using MackySoft.Ucli.Operations;
 using MackySoft.Ucli.UnityProject;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -44,6 +45,10 @@ namespace MackySoft.Ucli
                     services.AddSingleton<IInitService, InitService>();
                     services.AddSingleton<IIpcEndpointResolver, IpcEndpointResolver>();
                     services.AddSingleton<IUnityIpcClient, UnityIpcClient>();
+                    services.AddSingleton<IOperationCatalogProvider, InMemoryOperationCatalogProvider>();
+                    services.AddSingleton<IOperationCatalog, OperationCatalog>();
+                    services.AddSingleton<IOperationAuthorizationService, OperationAuthorizationService>();
+                    services.AddSingleton<IRequestStaticValidator, RequestStaticValidator>();
                 });
             app.Add<InitCommand>();
             app.Add<StatusCommand>();

--- a/src/Ucli/Program.cs
+++ b/src/Ucli/Program.cs
@@ -8,148 +8,159 @@ using MackySoft.Ucli.Operations;
 using MackySoft.Ucli.UnityProject;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace MackySoft.Ucli
+namespace MackySoft.Ucli;
+
+internal static class Program
 {
-    internal static class Program
+    private const string HelpCommandName = "help";
+
+    private const string InternalErrorMessage = "An unexpected internal error occurred.";
+
+    private const string CanceledMessage = "Command execution was canceled.";
+
+    /// <summary> Executes the CLI command pipeline and emits JSON command results. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns> The process exit code determined by command execution. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static async Task<int> Main (string[] args)
     {
-        private const string HelpCommandName = "help";
+        ArgumentNullException.ThrowIfNull(args);
 
-        /// <summary> Executes the CLI command pipeline and emits JSON command results. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns> The process exit code determined by command execution. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static async Task<int> Main (string[] args)
+        ParseErrorBuffer.Clear();
+        CommandExecutionState.Reset();
+
+        ConsoleApp.LogError = message =>
         {
-            ArgumentNullException.ThrowIfNull(args);
+            ParseErrorBuffer.Add(message);
+            Console.Error.WriteLine(message);
+        };
 
-            ParseErrorBuffer.Clear();
-            CommandExecutionState.Reset();
-
-            ConsoleApp.LogError = message =>
-            {
-                ParseErrorBuffer.Add(message);
-                Console.Error.WriteLine(message);
-            };
-
-            if (TryHandleUnknownCommand(args))
-            {
-                return Environment.ExitCode;
-            }
-
-            var app = ConsoleApp.Create()
-                .ConfigureServices(services =>
-                {
-                    services.AddSingleton<IUnityProjectResolver, UnityProjectResolver>();
-                    services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
-                    services.AddSingleton<IInitStatusContextResolver, InitStatusContextResolver>();
-                    services.AddSingleton<IInitService, InitService>();
-                    services.AddSingleton<IIpcEndpointResolver, IpcEndpointResolver>();
-                    services.AddSingleton<IUnityIpcClient, UnityIpcClient>();
-                    services.AddSingleton<IOperationCatalogProvider, InMemoryOperationCatalogProvider>();
-                    services.AddSingleton<IOperationCatalog, OperationCatalog>();
-                    services.AddSingleton<IOperationAuthorizationService, OperationAuthorizationService>();
-                    services.AddSingleton<IRequestStaticValidator, RequestStaticValidator>();
-                });
-            app.Add<InitCommand>();
-            app.Add<StatusCommand>();
-
-            try
-            {
-                await app.RunAsync(args);
-            }
-            catch (Exception exception)
-            {
-                var internalErrorResult = CommandResult.InternalError(CliProtocol.RootCommand, exception.Message);
-                CommandResultWriter.WriteToStandardOutput(internalErrorResult);
-                Environment.ExitCode = internalErrorResult.ExitCode;
-                return Environment.ExitCode;
-            }
-
-            // NOTE:
-            // ConsoleAppFramework can fail before command handlers start when parsing options.
-            // Emit JSON contract output in that path to keep stdout machine-readable.
-            if (!CommandExecutionState.HasStarted && ParseErrorBuffer.HasAny)
-            {
-                var commandName = ResolveCommandName(args);
-                var parseErrorMessage = string.Join(" ", ParseErrorBuffer.Messages);
-                var parseErrorResult = CommandResult.InvalidArgument(commandName, parseErrorMessage);
-                CommandResultWriter.WriteToStandardOutput(parseErrorResult);
-                Environment.ExitCode = parseErrorResult.ExitCode;
-            }
-
+        if (TryHandleUnknownCommand(args))
+        {
             return Environment.ExitCode;
         }
 
-        /// <summary> Handles unknown command names before framework dispatch starts. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns>
-        /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
-        /// <para> Otherwise, <see langword="false" />. </para>
-        /// </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static bool TryHandleUnknownCommand (string[] args)
+        var app = ConsoleApp.Create()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IUnityProjectResolver, UnityProjectResolver>();
+                services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
+                services.AddSingleton<IInitStatusContextResolver, InitStatusContextResolver>();
+                services.AddSingleton<IInitService, InitService>();
+                services.AddSingleton<IIpcEndpointResolver, IpcEndpointResolver>();
+                services.AddSingleton<IUnityIpcClient, UnityIpcClient>();
+                services.AddSingleton<IOperationCatalogProvider, InMemoryOperationCatalogProvider>();
+                services.AddSingleton<IOperationCatalog, OperationCatalog>();
+                services.AddSingleton<IOperationAuthorizationService, OperationAuthorizationService>();
+                services.AddSingleton<IRequestStaticValidator, RequestStaticValidator>();
+            });
+        app.UseFilter<OperationCatalogWarmupFilter>();
+        app.Add<InitCommand>();
+        app.Add<StatusCommand>();
+
+        try
         {
-            ArgumentNullException.ThrowIfNull(args);
-
-            if (args.Length == 0)
-            {
-                return false;
-            }
-
-            var firstArgument = args[0];
-            if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            if (IsRegisteredCommand(firstArgument)
-                || string.Equals(firstArgument, HelpCommandName, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var result = CommandResult.InvalidArgument(
-                command: CliProtocol.RootCommand,
-                message: $"Command '{firstArgument}' is not recognized.");
-            CommandResultWriter.WriteToStandardOutput(result);
-            Environment.ExitCode = result.ExitCode;
-            return true;
+            await app.RunAsync(args);
+        }
+        catch (OperationCanceledException)
+        {
+            var canceledResult = CommandResult.Canceled(CliProtocol.RootCommand, CanceledMessage);
+            CommandResultWriter.WriteToStandardOutput(canceledResult);
+            Environment.ExitCode = canceledResult.ExitCode;
+            return Environment.ExitCode;
+        }
+        catch (Exception)
+        {
+            var internalErrorResult = CommandResult.InternalError(CliProtocol.RootCommand, InternalErrorMessage);
+            CommandResultWriter.WriteToStandardOutput(internalErrorResult);
+            Environment.ExitCode = internalErrorResult.ExitCode;
+            return Environment.ExitCode;
         }
 
-        /// <summary> Resolves the command name used for parse error results. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns>
-        /// <para> The normalized command name for parse errors. </para>
-        /// <para> Returns <see cref="CliProtocol.RootCommand" /> when no known command can be identified. </para>
-        /// </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static string ResolveCommandName (string[] args)
+        // NOTE:
+        // ConsoleAppFramework can fail before command handlers start when parsing options.
+        // Emit JSON contract output in that path to keep stdout machine-readable.
+        if (!CommandExecutionState.HasStarted && ParseErrorBuffer.HasAny)
         {
-            ArgumentNullException.ThrowIfNull(args);
+            var commandName = ResolveCommandName(args);
+            var parseErrorMessage = string.Join(" ", ParseErrorBuffer.Messages);
+            var parseErrorResult = CommandResult.InvalidArgument(commandName, parseErrorMessage);
+            CommandResultWriter.WriteToStandardOutput(parseErrorResult);
+            Environment.ExitCode = parseErrorResult.ExitCode;
+        }
 
-            if (args.Length == 0)
-            {
-                return CliProtocol.RootCommand;
-            }
+        return Environment.ExitCode;
+    }
 
-            var firstArgument = args[0];
-            if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
-            {
-                return CliProtocol.RootCommand;
-            }
+    /// <summary> Handles unknown command names before framework dispatch starts. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns>
+    /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
+    /// <para> Otherwise, <see langword="false" />. </para>
+    /// </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static bool TryHandleUnknownCommand (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
 
-            if (IsRegisteredCommand(firstArgument))
-            {
-                return firstArgument;
-            }
+        if (args.Length == 0)
+        {
+            return false;
+        }
 
+        var firstArgument = args[0];
+        if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (IsRegisteredCommand(firstArgument)
+            || string.Equals(firstArgument, HelpCommandName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var result = CommandResult.InvalidArgument(
+            command: CliProtocol.RootCommand,
+            message: $"Command '{firstArgument}' is not recognized.");
+        CommandResultWriter.WriteToStandardOutput(result);
+        Environment.ExitCode = result.ExitCode;
+        return true;
+    }
+
+    /// <summary> Resolves the command name used for parse error results. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns>
+    /// <para> The normalized command name for parse errors. </para>
+    /// <para> Returns <see cref="CliProtocol.RootCommand" /> when no known command can be identified. </para>
+    /// </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static string ResolveCommandName (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length == 0)
+        {
             return CliProtocol.RootCommand;
         }
 
-        private static bool IsRegisteredCommand (string commandName)
+        var firstArgument = args[0];
+        if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
         {
-            return string.Equals(commandName, InitCommand.CommandName, StringComparison.Ordinal)
-                || string.Equals(commandName, StatusCommand.CommandName, StringComparison.Ordinal);
+            return CliProtocol.RootCommand;
         }
+
+        if (IsRegisteredCommand(firstArgument))
+        {
+            return firstArgument;
+        }
+
+        return CliProtocol.RootCommand;
+    }
+
+    private static bool IsRegisteredCommand (string commandName)
+    {
+        return string.Equals(commandName, InitCommand.CommandName, StringComparison.Ordinal)
+            || string.Equals(commandName, StatusCommand.CommandName, StringComparison.Ordinal);
     }
 }

--- a/src/Ucli/UnityProject/IUnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/IUnityProjectResolver.cs
@@ -5,10 +5,7 @@ namespace MackySoft.Ucli.UnityProject
     {
         /// <summary> Resolves the UnityProject context from an optional <c>--projectPath</c> argument. </summary>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
         /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
-        UnityProjectResolutionResult Resolve (
-            string? projectPath,
-            CancellationToken cancellationToken = default);
+        UnityProjectResolutionResult Resolve (string? projectPath);
     }
 }

--- a/src/Ucli/UnityProject/UnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/UnityProjectResolver.cs
@@ -15,14 +15,9 @@ namespace MackySoft.Ucli.UnityProject
 
         /// <summary> Resolves UnityProject context from command options and validates required project markers. </summary>
         /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
         /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
-        public UnityProjectResolutionResult Resolve (
-            string? projectPath,
-            CancellationToken cancellationToken = default)
+        public UnityProjectResolutionResult Resolve (string? projectPath)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             var pathSource = string.IsNullOrWhiteSpace(projectPath)
                 ? UnityProjectPathSource.CurrentDirectory
                 : UnityProjectPathSource.CommandOption;
@@ -151,25 +146,25 @@ namespace MackySoft.Ucli.UnityProject
             /// <summary> Gets a value indicating whether path normalization succeeded. </summary>
             public bool IsSuccess => !string.IsNullOrWhiteSpace(Path) && Error is null;
 
-        /// <summary> Creates a successful path normalization result. </summary>
-        /// <param name="path"> The normalized absolute path. </param>
-        /// <returns> The successful result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="path" /> is <see langword="null" />. </exception>
-        public static PathNormalizationResult Success (string path)
-        {
-            ArgumentNullException.ThrowIfNull(path);
-            return new PathNormalizationResult(path, null);
-        }
+            /// <summary> Creates a successful path normalization result. </summary>
+            /// <param name="path"> The normalized absolute path. </param>
+            /// <returns> The successful result. </returns>
+            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="path" /> is <see langword="null" />. </exception>
+            public static PathNormalizationResult Success (string path)
+            {
+                ArgumentNullException.ThrowIfNull(path);
+                return new PathNormalizationResult(path, null);
+            }
 
-        /// <summary> Creates a failed path normalization result. </summary>
-        /// <param name="error"> The structured error. </param>
-        /// <returns> The failed result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static PathNormalizationResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new PathNormalizationResult(null, error);
-        }
+            /// <summary> Creates a failed path normalization result. </summary>
+            /// <param name="error"> The structured error. </param>
+            /// <returns> The failed result. </returns>
+            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+            public static PathNormalizationResult Failure (ExecutionError error)
+            {
+                ArgumentNullException.ThrowIfNull(error);
+                return new PathNormalizationResult(null, error);
+            }
         }
     }
 }

--- a/tests/Ucli.Tests/CommandResultTests.cs
+++ b/tests/Ucli.Tests/CommandResultTests.cs
@@ -9,6 +9,8 @@ namespace MackySoft.Ucli.Tests
 
         private const string UnhandledExceptionMessage = "Unhandled exception.";
 
+        private const string CanceledMessage = "Command execution was canceled.";
+
         public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
         {
             {
@@ -24,6 +26,13 @@ namespace MackySoft.Ucli.Tests
                 (int)CliExitCode.InvalidArgument,
                 ErrorCodes.InvalidArgument,
                 UnknownOptionMessage
+            },
+            {
+                CommandResult.Canceled(StatusCommand.CommandName, CanceledMessage),
+                StatusCommand.CommandName,
+                (int)CliExitCode.ToolError,
+                ErrorCodes.Canceled,
+                CanceledMessage
             },
             {
                 CommandResult.InternalError(StatusCommand.CommandName, UnhandledExceptionMessage),

--- a/tests/Ucli.Tests/InitStatusContextResolverTests.cs
+++ b/tests/Ucli.Tests/InitStatusContextResolverTests.cs
@@ -10,13 +10,13 @@ public sealed class InitStatusContextResolverTests
 {
     [Fact]
     [Trait("Size", "Small")]
-    public void Resolve_ReturnsContextWithDefaultConfig_WhenConfigFileDoesNotExist ()
+    public async Task Resolve_ReturnsContextWithDefaultConfig_WhenConfigFileDoesNotExist ()
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "default-config");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         var resolver = CreateResolver();
 
-        var result = resolver.Resolve(unityProjectPath);
+        var result = await resolver.Resolve(unityProjectPath, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         Assert.Null(result.Error);
@@ -29,12 +29,12 @@ public sealed class InitStatusContextResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Resolve_ReturnsContextWithFileConfig_WhenConfigFileExists ()
+    public async Task Resolve_ReturnsContextWithFileConfig_WhenConfigFileExists ()
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "file-config");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         var configStore = new UcliConfigStore();
-        var saveResult = configStore.Save(
+        var saveResult = await configStore.Save(
             unityProjectPath,
             new UcliConfig(
                 SchemaVersion: 1,
@@ -44,12 +44,13 @@ public sealed class InitStatusContextResolverTests
                 [
                     "^ucli\\.",
                     "^extension\\.",
-                ]));
+                ]),
+            CancellationToken.None);
         Assert.True(saveResult.IsSuccess);
 
         var resolver = new InitStatusContextResolver(new UnityProjectResolver(), configStore);
 
-        var result = resolver.Resolve(unityProjectPath);
+        var result = await resolver.Resolve(unityProjectPath, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         var context = Assert.IsType<InitStatusContext>(result.Context);
@@ -61,13 +62,13 @@ public sealed class InitStatusContextResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Resolve_ReturnsInvalidArgument_WhenUnityProjectIsInvalid ()
+    public async Task Resolve_ReturnsInvalidArgument_WhenUnityProjectIsInvalid ()
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "invalid-unity-project");
         var invalidPath = scope.GetPath("MissingUnityProject");
         var resolver = CreateResolver();
 
-        var result = resolver.Resolve(invalidPath);
+        var result = await resolver.Resolve(invalidPath, CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.Context);
@@ -77,7 +78,7 @@ public sealed class InitStatusContextResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Resolve_ReturnsInvalidArgument_WhenConfigFileIsInvalid ()
+    public async Task Resolve_ReturnsInvalidArgument_WhenConfigFileIsInvalid ()
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "invalid-config");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
@@ -87,7 +88,7 @@ public sealed class InitStatusContextResolverTests
         scope.WriteFile(relativeConfigPath, "{");
         var resolver = new InitStatusContextResolver(new UnityProjectResolver(), configStore);
 
-        var result = resolver.Resolve(unityProjectPath);
+        var result = await resolver.Resolve(unityProjectPath, CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.Context);

--- a/tests/Ucli.Tests/Operations/OperationAuthorizationServiceTests.cs
+++ b/tests/Ucli.Tests/Operations/OperationAuthorizationServiceTests.cs
@@ -1,0 +1,113 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Operations;
+
+public sealed class OperationAuthorizationServiceTests
+{
+    private const string ArgsSchemaJson = """{"type":"object"}""";
+
+    public static TheoryData<string, string, string, string, string> AllowedAuthorizationCases => new()
+    {
+        { "ucli.scene.open", "query", "safe", "safe", "^ucli\\." },
+        { "ucli.cs.invoke", "mutation", "dangerous", "dangerous", "^ucli\\." },
+    };
+
+    public static TheoryData<string, string, string, string, string, string?> DeniedAuthorizationCases => new()
+    {
+        { "ucli.scene.save", "mutation", "advanced", "safe", "^ucli\\.", null },
+        { "ucli.scene.open", "query", "safe", "safe", "^myorg\\.", null },
+        { "ucli.scene.open", "query", "safe", "safe", "[", "invalid regex" },
+    };
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(AllowedAuthorizationCases))]
+    public async Task Authorize_ReturnsAllowed_WhenPolicyAndAllowlistPermitOperation (
+        string operationName,
+        string operationKind,
+        string requiredPolicy,
+        string configuredPolicy,
+        string allowlistPattern)
+    {
+        var service = new OperationAuthorizationService();
+        var operation = CreateOperation(
+            operationName,
+            ParseOperationKind(operationKind),
+            ParseOperationPolicy(requiredPolicy));
+        var config = CreateConfig(ParseOperationPolicy(configuredPolicy), allowlistPattern);
+
+        var result = await service.Authorize(operation, config, CancellationToken.None);
+
+        Assert.True(result.IsAllowed);
+        Assert.Null(result.ErrorCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(DeniedAuthorizationCases))]
+    public async Task Authorize_ReturnsDenied_WhenOperationIsDisallowed (
+        string operationName,
+        string operationKind,
+        string requiredPolicy,
+        string configuredPolicy,
+        string allowlistPattern,
+        string? expectedMessageContains)
+    {
+        var service = new OperationAuthorizationService();
+        var operation = CreateOperation(
+            operationName,
+            ParseOperationKind(operationKind),
+            ParseOperationPolicy(requiredPolicy));
+        var config = CreateConfig(ParseOperationPolicy(configuredPolicy), allowlistPattern);
+
+        var result = await service.Authorize(operation, config, CancellationToken.None);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(ValidationErrorCodes.OperationNotAllowed, result.ErrorCode);
+        if (!string.IsNullOrWhiteSpace(expectedMessageContains))
+        {
+            Assert.Contains(expectedMessageContains, result.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static UcliOperationDescriptor CreateOperation (
+        string name,
+        UcliOperationKind kind,
+        OperationPolicy policy)
+    {
+        return new UcliOperationDescriptor(name, kind, policy, ArgsSchemaJson);
+    }
+
+    private static UcliConfig CreateConfig (
+        OperationPolicy operationPolicy,
+        params string[] allowlistPatterns)
+    {
+        return new UcliConfig(
+            SchemaVersion: UcliContractConstants.Config.SchemaVersion,
+            OperationPolicy: operationPolicy,
+            PlanTokenMode: PlanTokenMode.Optional,
+            OperationAllowlist: allowlistPatterns);
+    }
+
+    private static UcliOperationKind ParseOperationKind (string operationKind)
+    {
+        return operationKind switch
+        {
+            "query" => UcliOperationKind.Query,
+            "mutation" => UcliOperationKind.Mutation,
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, "Unsupported operation kind case."),
+        };
+    }
+
+    private static OperationPolicy ParseOperationPolicy (string operationPolicy)
+    {
+        return operationPolicy switch
+        {
+            "safe" => OperationPolicy.Safe,
+            "advanced" => OperationPolicy.Advanced,
+            "dangerous" => OperationPolicy.Dangerous,
+            _ => throw new ArgumentOutOfRangeException(nameof(operationPolicy), operationPolicy, "Unsupported operation policy case."),
+        };
+    }
+}

--- a/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
+++ b/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
@@ -1,0 +1,85 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Operations;
+
+public sealed class OperationCatalogTests
+{
+    private const string ArgsSchemaJson = """{"type":"object"}""";
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Get_ReturnsRegisteredOperation ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var descriptor = await catalog.Get("ucli.scene.open", CancellationToken.None);
+
+        Assert.NotNull(descriptor);
+        Assert.Equal("ucli.scene.open", descriptor.Name);
+        Assert.Equal(UcliOperationKind.Query, descriptor.Kind);
+        Assert.Equal(OperationPolicy.Safe, descriptor.Policy);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task GetAll_ReturnsOperationsOrderedByName ()
+    {
+        var provider = new TestOperationCatalogProvider(
+        [
+            new UcliOperationDescriptor("ucli.z", UcliOperationKind.Query, OperationPolicy.Safe, ArgsSchemaJson),
+            new UcliOperationDescriptor("ucli.a", UcliOperationKind.Query, OperationPolicy.Safe, ArgsSchemaJson),
+            new UcliOperationDescriptor("ucli.m", UcliOperationKind.Query, OperationPolicy.Safe, ArgsSchemaJson),
+        ]);
+        var catalog = new OperationCatalog(provider);
+
+        var listed = await catalog.GetAll(CancellationToken.None);
+
+        Assert.Equal(3, listed.Count);
+        Assert.Equal("ucli.a", listed[0].Name);
+        Assert.Equal("ucli.m", listed[1].Name);
+        Assert.Equal("ucli.z", listed[2].Name);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task GetAll_ThrowsInvalidOperationException_WhenOperationNameIsDuplicated ()
+    {
+        var provider = new TestOperationCatalogProvider(
+        [
+            new UcliOperationDescriptor("ucli.scene.open", UcliOperationKind.Query, OperationPolicy.Safe, ArgsSchemaJson),
+            new UcliOperationDescriptor("ucli.scene.open", UcliOperationKind.Query, OperationPolicy.Safe, ArgsSchemaJson),
+        ]);
+        var catalog = new OperationCatalog(provider);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await catalog.GetAll(CancellationToken.None));
+        Assert.Contains("duplicated", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Get_ReturnsNull_WhenOperationDoesNotExist ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var found = await catalog.Get("ucli.unknown.operation", CancellationToken.None);
+
+        Assert.Null(found);
+    }
+
+    private sealed class TestOperationCatalogProvider : IOperationCatalogProvider
+    {
+        private readonly IReadOnlyList<UcliOperationDescriptor> operations;
+
+        public TestOperationCatalogProvider (IReadOnlyList<UcliOperationDescriptor> operations)
+        {
+            this.operations = operations ?? throw new ArgumentNullException(nameof(operations));
+        }
+
+        public ValueTask<IReadOnlyList<UcliOperationDescriptor>> GetOperations (CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(operations);
+        }
+    }
+}

--- a/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
+++ b/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
@@ -34,6 +34,24 @@ public sealed class RequestStaticValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Validate_AddsRequiredErrors_WhenOpsContainsNullElement ()
+    {
+        var validator = CreateValidator();
+        var request = CreateRequest(
+            ops:
+            [
+                null,
+            ]);
+
+        var result = await validator.Validate(request, CreateConfig(OperationPolicy.Safe, "^ucli\\."), CancellationToken.None);
+
+        Assert.False(result.IsValid);
+        AssertContainsError(result, ValidationErrorCodes.OpIdRequired);
+        AssertContainsError(result, ValidationErrorCodes.OpNameRequired);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Validate_ReturnsValidResult_WhenRequestSatisfiesAllChecks ()
     {
         var validator = CreateValidator();
@@ -60,7 +78,7 @@ public sealed class RequestStaticValidatorTests
     private static ValidateRequest CreateRequest (
         int protocolVersion = CliProtocol.CurrentVersion,
         string? requestId = null,
-        IReadOnlyList<ValidateRequestOperation>? ops = null)
+        IReadOnlyList<ValidateRequestOperation?>? ops = null)
     {
         return new ValidateRequest(
             ProtocolVersion: protocolVersion,

--- a/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
+++ b/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
@@ -1,0 +1,126 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Ucli.Cli;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Operations;
+
+public sealed class RequestStaticValidatorTests
+{
+    public static TheoryData<string, string> InvalidRequestCases => new()
+    {
+        { "protocol-version-mismatch", ValidationErrorCodes.ProtocolVersionMismatch },
+        { "request-id-invalid", ValidationErrorCodes.RequestIdInvalid },
+        { "ops-required", ValidationErrorCodes.OpsRequired },
+        { "op-id-duplicated", ValidationErrorCodes.OpIdDuplicated },
+        { "operation-not-found", ValidationErrorCodes.OperationNotFound },
+        { "operation-not-allowed", ValidationErrorCodes.OperationNotAllowed },
+    };
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(InvalidRequestCases))]
+    public async Task Validate_AddsExpectedError_WhenRequestIsInvalid (
+        string scenario,
+        string expectedErrorCode)
+    {
+        var validator = CreateValidator();
+        var request = CreateInvalidRequest(scenario);
+
+        var result = await validator.Validate(request, CreateConfig(OperationPolicy.Safe, "^ucli\\."), CancellationToken.None);
+
+        AssertContainsError(result, expectedErrorCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Validate_ReturnsValidResult_WhenRequestSatisfiesAllChecks ()
+    {
+        var validator = CreateValidator();
+        var request = CreateRequest(
+            ops:
+            [
+                new ValidateRequestOperation("op-1", "ucli.scene.open", CreateArgs()),
+                new ValidateRequestOperation("op-2", "ucli.scene.tree", CreateArgs()),
+            ]);
+
+        var result = await validator.Validate(request, CreateConfig(OperationPolicy.Safe, "^ucli\\."), CancellationToken.None);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    private static IRequestStaticValidator CreateValidator ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+        var authorizationService = new OperationAuthorizationService();
+        return new RequestStaticValidator(catalog, authorizationService);
+    }
+
+    private static ValidateRequest CreateRequest (
+        int protocolVersion = CliProtocol.CurrentVersion,
+        string? requestId = null,
+        IReadOnlyList<ValidateRequestOperation>? ops = null)
+    {
+        return new ValidateRequest(
+            ProtocolVersion: protocolVersion,
+            RequestId: requestId ?? Guid.NewGuid().ToString(),
+            Ops: ops ??
+            [
+                new ValidateRequestOperation("op-1", "ucli.scene.open", CreateArgs()),
+            ]);
+    }
+
+    private static ValidateRequest CreateInvalidRequest (string scenario)
+    {
+        return scenario switch
+        {
+            "protocol-version-mismatch" => CreateRequest(protocolVersion: CliProtocol.CurrentVersion + 1),
+            "request-id-invalid" => CreateRequest(requestId: "invalid-request-id"),
+            "ops-required" => new ValidateRequest(
+                ProtocolVersion: CliProtocol.CurrentVersion,
+                RequestId: Guid.NewGuid().ToString(),
+                Ops: null),
+            "op-id-duplicated" => CreateRequest(
+                ops:
+                [
+                    new ValidateRequestOperation("dup", "ucli.scene.open", CreateArgs()),
+                    new ValidateRequestOperation("dup", "ucli.scene.tree", CreateArgs()),
+                ]),
+            "operation-not-found" => CreateRequest(
+                ops:
+                [
+                    new ValidateRequestOperation("op-1", "ucli.unknown", CreateArgs()),
+                ]),
+            "operation-not-allowed" => CreateRequest(
+                ops:
+                [
+                    new ValidateRequestOperation("op-1", "ucli.scene.save", CreateArgs()),
+                ]),
+            _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, "Unsupported invalid request scenario."),
+        };
+    }
+
+    private static UcliConfig CreateConfig (
+        OperationPolicy operationPolicy,
+        params string[] allowlistPatterns)
+    {
+        return new UcliConfig(
+            SchemaVersion: UcliContractConstants.Config.SchemaVersion,
+            OperationPolicy: operationPolicy,
+            PlanTokenMode: PlanTokenMode.Optional,
+            OperationAllowlist: allowlistPatterns);
+    }
+
+    private static JsonElement CreateArgs ()
+    {
+        return JsonSerializer.SerializeToElement(new { });
+    }
+
+    private static void AssertContainsError (ValidationResult result, string errorCode)
+    {
+        Assert.Contains(
+            result.Errors,
+            error => string.Equals(error.Code, errorCode, StringComparison.Ordinal));
+    }
+}

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -9,13 +9,13 @@ public sealed class UcliConfigStoreTests
 {
     [Fact]
     [Trait("Size", "Small")]
-    public void Load_ReturnsDefaultConfig_WhenConfigFileDoesNotExist ()
+    public async Task Load_ReturnsDefaultConfig_WhenConfigFileDoesNotExist ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "load-default");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         var configStore = new UcliConfigStore();
 
-        var result = configStore.Load(unityProjectPath);
+        var result = await configStore.Load(unityProjectPath, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         Assert.Null(result.Error);
@@ -29,7 +29,7 @@ public sealed class UcliConfigStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Save_ThenLoad_RoundTripsConfigValues ()
+    public async Task Save_ThenLoad_RoundTripsConfigValues ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "save-round-trip");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
@@ -44,12 +44,12 @@ public sealed class UcliConfigStoreTests
                 "^mylab\\.",
             ]);
 
-        var saveResult = configStore.Save(unityProjectPath, config);
+        var saveResult = await configStore.Save(unityProjectPath, config, CancellationToken.None);
 
         Assert.True(saveResult.IsSuccess);
         Assert.Null(saveResult.Error);
 
-        var loadResult = configStore.Load(unityProjectPath);
+        var loadResult = await configStore.Load(unityProjectPath, CancellationToken.None);
         Assert.True(loadResult.IsSuccess);
         Assert.Equal(ConfigSource.File, loadResult.Source);
         var loadedConfig = Assert.IsType<UcliConfig>(loadResult.Config);
@@ -69,7 +69,7 @@ public sealed class UcliConfigStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Load_ReturnsInvalidArgument_WhenConfigJsonIsMalformed ()
+    public async Task Load_ReturnsInvalidArgument_WhenConfigJsonIsMalformed ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "malformed-json");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
@@ -78,7 +78,7 @@ public sealed class UcliConfigStoreTests
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         scope.WriteFile(relativeConfigPath, "{");
 
-        var result = configStore.Load(unityProjectPath);
+        var result = await configStore.Load(unityProjectPath, CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.Config);
@@ -89,7 +89,7 @@ public sealed class UcliConfigStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Load_ReturnsInvalidArgument_WhenSchemaVersionDoesNotMatch ()
+    public async Task Load_ReturnsInvalidArgument_WhenSchemaVersionDoesNotMatch ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "schema-version-mismatch");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
@@ -108,12 +108,66 @@ public sealed class UcliConfigStoreTests
             relativeConfigPath,
             invalidSchemaConfigJson);
 
-        var result = configStore.Load(unityProjectPath);
+        var result = await configStore.Load(unityProjectPath, CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Null(result.Config);
         var error = Assert.IsType<ExecutionError>(result.Error);
         Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
         Assert.Contains("schemaVersion", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Load_ReturnsInvalidArgument_WhenOperationAllowlistPatternIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-allowlist-load");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var configPath = configStore.GetConfigPath(unityProjectPath);
+        var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
+        var invalidAllowlistConfigJson = JsonSerializer.Serialize(
+            new
+            {
+                schemaVersion = UcliContractConstants.Config.SchemaVersion,
+                operationPolicy = UcliContractConstants.Config.OperationPolicySafe,
+                planTokenMode = UcliContractConstants.Config.PlanTokenModeOptional,
+                operationAllowlist = new[] { "[" },
+            });
+        scope.WriteFile(relativeConfigPath, invalidAllowlistConfigJson);
+
+        var result = await configStore.Load(unityProjectPath, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Config);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("operationAllowlist", error.Message, StringComparison.Ordinal);
+        Assert.Contains("regex", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Save_ReturnsInvalidArgument_WhenOperationAllowlistPatternIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-allowlist-save");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var configStore = new UcliConfigStore();
+        var invalidConfig = new UcliConfig(
+            SchemaVersion: UcliContractConstants.Config.SchemaVersion,
+            OperationPolicy: OperationPolicy.Safe,
+            PlanTokenMode: PlanTokenMode.Optional,
+            OperationAllowlist:
+            [
+                "[",
+            ]);
+
+        var saveResult = await configStore.Save(unityProjectPath, invalidConfig, CancellationToken.None);
+
+        Assert.False(saveResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(saveResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("operationAllowlist", error.Message, StringComparison.Ordinal);
+        Assert.Contains("regex", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- Implements Issue #13 foundation only: operation catalog/provider, authorization, static request validator, and validation DTO/error contracts.
- Adds temporary in-memory operation catalog metadata and keeps args schema as placeholder object schema.
- Aligns synchronous/asynchronous boundaries so I/O paths are async and non-I/O resolver paths remain synchronous.

## Scope
- Added Operations layer: `src/Ucli/Operations/*`.
- Registered operation services in DI: `src/Ucli/Program.cs`.
- Added operation allowlist regex validation on config load/save and updated init/context/config flow contracts.
- Added/updated unit tests: `tests/Ucli.Tests/Operations/*`, `tests/Ucli.Tests/UcliConfigStoreTests.cs`, `tests/Ucli.Tests/InitStatusContextResolverTests.cs`.

## Verification
- Gate level: Standard
- Diff budget: WAIVED (31 files changed, +1156/-91)
- Split waived reason: operation registry/validation/config-check/DI/test contracts are a single foundation unit; splitting introduces contract drift or non-buildable intermediate states.
- Spec drift: Skipped (`docs/agents/feature_issue-13-op-registry-validate-ops-foundation/spec.md` not found)
- Format: PASS (`dotnet format` targeted include + `--verify-no-changes`)
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal`)
- Coverage: N/A

## Risks / Rollback
- Risk: contract changes in config/init/context paths may affect command execution flow.
- Rollback: revert `aa09e53` and `c5494ed`.

## Checklist
- [x] op registry/validate/ops foundation implemented
- [x] JSON contract and error contract implemented
- [x] target unit tests added
- [x] Split waived decision for oversized diff

Closes #13
