### PR TITLE
[v1.0][F5] リクエスト入力正規化の基盤を実装

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -124,7 +124,7 @@ csharp_style_prefer_readonly_struct_member = true
 csharp_prefer_braces = true
 csharp_prefer_simple_using_statement = true
 csharp_prefer_system_threading_lock = true
-csharp_style_namespace_declarations = block_scoped
+csharp_style_namespace_declarations = file_scoped
 csharp_style_prefer_method_group_conversion = true
 csharp_style_prefer_primary_constructors = true
 csharp_style_prefer_top_level_statements = true
@@ -280,3 +280,6 @@ dotnet_naming_style.camel_case.required_prefix =
 dotnet_naming_style.camel_case.required_suffix = 
 dotnet_naming_style.camel_case.word_separator = 
 dotnet_naming_style.camel_case.capitalization = camel_case
+
+[src/Ucli.Unity/**/*.cs]
+csharp_style_namespace_declarations = block_scoped

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -388,7 +388,20 @@ public sealed record TypeRef(string Name, string? Assembly = null, bool ExpectUn
 - `op`：op名（例：`ucli.scene.open`）
 - `args`：op引数（`ops describe` が返すschemaで検証）
 - `as`：後続参照用の変数名（任意）
-- `expect`：件数・成功条件（特に `resolve/query` 系で誤爆防止）
+- `expect`：opの主要アウトプットに対する共通制約（任意）
+
+### `expect`（共通制約）
+- `expect` は各opが返す主要アウトプットに対して評価する
+- 形式（任意項目）:
+  - `nonNull`：`true` の場合、主要アウトプットが `null` でないことを要求する
+  - `count`：件数の完全一致（`>= 0` の整数）
+  - `min`：件数下限（`>= 0` の整数）
+  - `max`：件数上限（`>= 0` の整数）
+- ルール:
+  - `count` と `min`/`max` の同時指定は禁止
+  - `min` と `max` を同時指定する場合は `min <= max` を必須とする
+  - `expect` は空オブジェクトを許可しない（少なくとも1項目を指定する）
+  - 非コレクション出力に `count`/`min`/`max` を指定した場合は入力不正とする
 
 ### 参照表現
 - 変数参照：`{ "var": "<name>" }`（例：`{ "var": "go" }`）
@@ -491,6 +504,7 @@ CWDがUnityプロジェクトと判定可能な場合はそれを使う。そう
   - `--force`：既存設定を上書き
 - `ucli validate`：JSONリクエストの静的検証（スキーマ/必須項目/許可op等）
   - 保証範囲：形式・スキーマ・許可判定まで（実在確認や差分見積りは含まない）
+  - Unity実体への接続や解決は行わない（ローカル静的検証のみ）
   - `--noReadIndex`：readIndexを使わずに検証する
   - `--requireFreshReadIndex`：`fresh` なreadIndexが得られない場合は失敗する
 - `ucli plan`：対象解決・差分見積り（実変更なし、または最小）を返す

--- a/src/Ucli.Contracts/Ipc/IpcErrorCodes.cs
+++ b/src/Ucli.Contracts/Ipc/IpcErrorCodes.cs
@@ -3,6 +3,9 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 /// <summary> Defines machine-readable error code values shared by IPC requests and responses. </summary>
 public static class IpcErrorCodes
 {
+    /// <summary> Gets the error code emitted when request arguments are invalid. </summary>
+    public const string InvalidArgument = "INVALID_ARGUMENT";
+
     /// <summary> Gets the error code emitted when protocol versions are incompatible. </summary>
     public const string ProtocolVersionMismatch = "PROTOCOL_VERSION_MISMATCH";
 

--- a/src/Ucli.Contracts/Ipc/IpcExecuteCommandNames.cs
+++ b/src/Ucli.Contracts/Ipc/IpcExecuteCommandNames.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Defines IPC command names used by request contracts and execution dispatch. </summary>
+public static class IpcExecuteCommandNames
+{
+    /// <summary> Gets the command name used for static request validation. </summary>
+    public const string Validate = "validate";
+
+    /// <summary> Gets the command name used for planning execution. </summary>
+    public const string Plan = "plan";
+
+    /// <summary> Gets the command name used for call execution. </summary>
+    public const string Call = "call";
+
+    /// <summary> Gets the command name used for object resolution. </summary>
+    public const string Resolve = "resolve";
+
+    /// <summary> Gets the command name used for read-only query execution. </summary>
+    public const string Query = "query";
+
+    /// <summary> Gets the command name used for refresh execution. </summary>
+    public const string Refresh = "refresh";
+
+    private static readonly HashSet<string> KnownCommandNames = new(StringComparer.Ordinal)
+    {
+        Validate,
+        Plan,
+        Call,
+        Resolve,
+        Query,
+        Refresh,
+    };
+
+    private static readonly HashSet<string> OperationPipelineCommandNames = new(StringComparer.Ordinal)
+    {
+        Plan,
+        Call,
+        Resolve,
+        Query,
+        Refresh,
+    };
+
+    /// <summary> Determines whether the command name is recognized by protocol contracts. </summary>
+    /// <param name="commandName"> The command name to check. </param>
+    /// <returns> <see langword="true" /> when recognized; otherwise <see langword="false" />. </returns>
+    public static bool IsKnown (string? commandName)
+    {
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return false;
+        }
+
+        return KnownCommandNames.Contains(commandName);
+    }
+
+    /// <summary> Determines whether the command requires operation-pipeline execution. </summary>
+    /// <param name="commandName"> The command name to check. </param>
+    /// <returns> <see langword="true" /> when command is handled by operation-pipeline execution; otherwise <see langword="false" />. </returns>
+    public static bool IsOperationPipelineCommand (string? commandName)
+    {
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return false;
+        }
+
+        return OperationPipelineCommandNames.Contains(commandName);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: af0e875d8df1845079f9127275f69745
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility/IsExternalInit.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility/IsExternalInit.cs
@@ -1,0 +1,6 @@
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility/IsExternalInit.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility/IsExternalInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8445f82a06cda4cc097e7a1a2c909482
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70b19308b29cd4fce88e0885b5551e7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e154db0101edf4a6b97f57f442431a3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs
@@ -4,194 +4,204 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
-
-/// <summary> Writes canonical JSON payload bytes used for request-digest material. </summary>
-internal static class CanonicalRequestWriter
+namespace MackySoft.Ucli.Unity.Execution.Requests
 {
-    /// <summary> Compares JSON properties by ordinal property-name order for canonical output. </summary>
-    private static readonly IComparer<JsonProperty> JsonPropertyNameComparer = Comparer<JsonProperty>.Create(
-        static (x, y) => StringComparer.Ordinal.Compare(x.Name, y.Name));
-
-    /// <summary> Writes canonical UTF-8 payload bytes for request digest material. </summary>
-    /// <param name="protocolVersion"> The request protocol version. </param>
-    /// <param name="operations"> The normalized operation sequence. </param>
-    /// <returns> Canonical UTF-8 payload bytes containing only <c>protocolVersion</c> and <c>ops</c>. </returns>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" />. </exception>
-    public static ReadOnlyMemory<byte> WriteDigestPayload (
-        int protocolVersion,
-        IReadOnlyList<NormalizedOperation> operations)
+    /// <summary> Writes canonical JSON payload bytes used for request-digest material. </summary>
+    internal static class CanonicalRequestWriter
     {
-        ArgumentNullException.ThrowIfNull(operations);
+        /// <summary> Compares JSON properties by ordinal property-name order for canonical output. </summary>
+        private static readonly IComparer<JsonProperty> JsonPropertyNameComparer = Comparer<JsonProperty>.Create(
+            static (x, y) => StringComparer.Ordinal.Compare(x.Name, y.Name));
 
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        /// <summary> Writes canonical UTF-8 payload bytes for request digest material. </summary>
+        /// <param name="protocolVersion"> The request protocol version. </param>
+        /// <param name="operations"> The normalized operation sequence. </param>
+        /// <returns> Canonical UTF-8 payload bytes containing only <c>protocolVersion</c> and <c>ops</c>. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" />. </exception>
+        public static ReadOnlyMemory<byte> WriteDigestPayload (
+            int protocolVersion,
+            IReadOnlyList<NormalizedOperation> operations)
         {
-            Indented = false,
-        });
+            if (operations == null)
+            {
+                throw new ArgumentNullException(nameof(operations));
+            }
 
-        writer.WriteStartObject();
-        writer.WritePropertyName("ops");
-        writer.WriteStartArray();
-        for (var i = 0; i < operations.Count; i++)
-        {
-            WriteOperation(writer, operations[i]);
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+            {
+                Indented = false,
+            });
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("ops");
+            writer.WriteStartArray();
+            for (var i = 0; i < operations.Count; i++)
+            {
+                WriteOperation(writer, operations[i]);
+            }
+
+            writer.WriteEndArray();
+            writer.WriteNumber("protocolVersion", protocolVersion);
+            writer.WriteEndObject();
+            writer.Flush();
+            return stream.ToArray();
         }
 
-        writer.WriteEndArray();
-        writer.WriteNumber("protocolVersion", protocolVersion);
-        writer.WriteEndObject();
-        writer.Flush();
-        return stream.ToArray();
-    }
-
-    /// <summary> Writes one canonical operation object. </summary>
-    /// <param name="writer"> The target writer. </param>
-    /// <param name="operation"> The operation model. </param>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> is <see langword="null" />. </exception>
-    private static void WriteOperation (
-        Utf8JsonWriter writer,
-        NormalizedOperation operation)
-    {
-        ArgumentNullException.ThrowIfNull(operation);
-
-        writer.WriteStartObject();
-        writer.WritePropertyName("args");
-        WriteCanonicalJsonValue(writer, operation.Args);
-
-        if (operation.As is not null)
+        /// <summary> Writes one canonical operation object. </summary>
+        /// <param name="writer"> The target writer. </param>
+        /// <param name="operation"> The operation model. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> is <see langword="null" />. </exception>
+        private static void WriteOperation (
+            Utf8JsonWriter writer,
+            NormalizedOperation operation)
         {
-            writer.WriteString("as", operation.As);
+            if (operation == null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("args");
+            WriteCanonicalJsonValue(writer, operation.Args);
+
+            if (operation.As is not null)
+            {
+                writer.WriteString("as", operation.As);
+            }
+
+            if (operation.Expect is not null)
+            {
+                writer.WritePropertyName("expect");
+                WriteExpectation(writer, operation.Expect);
+            }
+
+            writer.WriteString("id", operation.Id);
+            writer.WriteString("op", operation.Op);
+            writer.WriteEndObject();
         }
 
-        if (operation.Expect is not null)
+        /// <summary> Writes one canonical expectation object. </summary>
+        /// <param name="writer"> The target writer. </param>
+        /// <param name="expectation"> The expectation model. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="expectation" /> is <see langword="null" />. </exception>
+        private static void WriteExpectation (
+            Utf8JsonWriter writer,
+            NormalizedExpectation expectation)
         {
-            writer.WritePropertyName("expect");
-            WriteExpectation(writer, operation.Expect);
+            if (expectation == null)
+            {
+                throw new ArgumentNullException(nameof(expectation));
+            }
+
+            writer.WriteStartObject();
+            if (expectation.Count.HasValue)
+            {
+                writer.WriteNumber("count", expectation.Count.Value);
+            }
+
+            if (expectation.Max.HasValue)
+            {
+                writer.WriteNumber("max", expectation.Max.Value);
+            }
+
+            if (expectation.Min.HasValue)
+            {
+                writer.WriteNumber("min", expectation.Min.Value);
+            }
+
+            if (expectation.NonNull.HasValue)
+            {
+                writer.WriteBoolean("nonNull", expectation.NonNull.Value);
+            }
+
+            writer.WriteEndObject();
         }
 
-        writer.WriteString("id", operation.Id);
-        writer.WriteString("op", operation.Op);
-        writer.WriteEndObject();
-    }
-
-    /// <summary> Writes one canonical expectation object. </summary>
-    /// <param name="writer"> The target writer. </param>
-    /// <param name="expectation"> The expectation model. </param>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="expectation" /> is <see langword="null" />. </exception>
-    private static void WriteExpectation (
-        Utf8JsonWriter writer,
-        NormalizedExpectation expectation)
-    {
-        ArgumentNullException.ThrowIfNull(expectation);
-
-        writer.WriteStartObject();
-        if (expectation.Count.HasValue)
+        /// <summary> Writes one canonical JSON value recursively. </summary>
+        /// <param name="writer"> The target writer. </param>
+        /// <param name="value"> The JSON value to canonicalize. </param>
+        private static void WriteCanonicalJsonValue (
+            Utf8JsonWriter writer,
+            JsonElement value)
         {
-            writer.WriteNumber("count", expectation.Count.Value);
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    WriteCanonicalObject(writer, value);
+                    return;
+
+                case JsonValueKind.Array:
+                    writer.WriteStartArray();
+                    foreach (var arrayItem in value.EnumerateArray())
+                    {
+                        WriteCanonicalJsonValue(writer, arrayItem);
+                    }
+
+                    writer.WriteEndArray();
+                    return;
+
+                default:
+                    value.WriteTo(writer);
+                    return;
+            }
         }
 
-        if (expectation.Max.HasValue)
+        /// <summary> Writes one object with properties sorted by ordinal key order. </summary>
+        /// <param name="writer"> The target writer. </param>
+        /// <param name="value"> The object JSON value. </param>
+        private static void WriteCanonicalObject (
+            Utf8JsonWriter writer,
+            JsonElement value)
         {
-            writer.WriteNumber("max", expectation.Max.Value);
-        }
-
-        if (expectation.Min.HasValue)
-        {
-            writer.WriteNumber("min", expectation.Min.Value);
-        }
-
-        if (expectation.NonNull.HasValue)
-        {
-            writer.WriteBoolean("nonNull", expectation.NonNull.Value);
-        }
-
-        writer.WriteEndObject();
-    }
-
-    /// <summary> Writes one canonical JSON value recursively. </summary>
-    /// <param name="writer"> The target writer. </param>
-    /// <param name="value"> The JSON value to canonicalize. </param>
-    private static void WriteCanonicalJsonValue (
-        Utf8JsonWriter writer,
-        JsonElement value)
-    {
-        switch (value.ValueKind)
-        {
-            case JsonValueKind.Object:
-                WriteCanonicalObject(writer, value);
+            var propertyCount = CountObjectProperties(value);
+            if (propertyCount == 0)
+            {
+                writer.WriteStartObject();
+                writer.WriteEndObject();
                 return;
+            }
 
-            case JsonValueKind.Array:
-                writer.WriteStartArray();
-                foreach (var arrayItem in value.EnumerateArray())
+            var properties = ArrayPool<JsonProperty>.Shared.Rent(propertyCount);
+            try
+            {
+                var index = 0;
+                foreach (var property in value.EnumerateObject())
                 {
-                    WriteCanonicalJsonValue(writer, arrayItem);
+                    properties[index] = property;
+                    index++;
                 }
 
-                writer.WriteEndArray();
-                return;
+                Array.Sort(properties, 0, propertyCount, JsonPropertyNameComparer);
 
-            default:
-                value.WriteTo(writer);
-                return;
-        }
-    }
+                writer.WriteStartObject();
+                for (var i = 0; i < propertyCount; i++)
+                {
+                    var property = properties[i];
+                    writer.WritePropertyName(property.Name);
+                    WriteCanonicalJsonValue(writer, property.Value);
+                }
 
-    /// <summary> Writes one object with properties sorted by ordinal key order. </summary>
-    /// <param name="writer"> The target writer. </param>
-    /// <param name="value"> The object JSON value. </param>
-    private static void WriteCanonicalObject (
-        Utf8JsonWriter writer,
-        JsonElement value)
-    {
-        var propertyCount = CountObjectProperties(value);
-        if (propertyCount == 0)
-        {
-            writer.WriteStartObject();
-            writer.WriteEndObject();
-            return;
-        }
-
-        var properties = ArrayPool<JsonProperty>.Shared.Rent(propertyCount);
-        try
-        {
-            var index = 0;
-            foreach (var property in value.EnumerateObject())
+                writer.WriteEndObject();
+            }
+            finally
             {
-                properties[index] = property;
-                index++;
+                ArrayPool<JsonProperty>.Shared.Return(properties, clearArray: false);
+            }
+        }
+
+        /// <summary> Counts object properties without allocating intermediate buffers. </summary>
+        /// <param name="value"> The object JSON value. </param>
+        /// <returns> The property count. </returns>
+        private static int CountObjectProperties (JsonElement value)
+        {
+            var count = 0;
+            foreach (var _ in value.EnumerateObject())
+            {
+                count++;
             }
 
-            Array.Sort(properties, 0, propertyCount, JsonPropertyNameComparer);
-
-            writer.WriteStartObject();
-            for (var i = 0; i < propertyCount; i++)
-            {
-                var property = properties[i];
-                writer.WritePropertyName(property.Name);
-                WriteCanonicalJsonValue(writer, property.Value);
-            }
-
-            writer.WriteEndObject();
+            return count;
         }
-        finally
-        {
-            ArrayPool<JsonProperty>.Shared.Return(properties, clearArray: false);
-        }
-    }
-
-    /// <summary> Counts object properties without allocating intermediate buffers. </summary>
-    /// <param name="value"> The object JSON value. </param>
-    /// <returns> The property count. </returns>
-    private static int CountObjectProperties (JsonElement value)
-    {
-        var count = 0;
-        foreach (var _ in value.EnumerateObject())
-        {
-            count++;
-        }
-
-        return count;
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Writes canonical JSON payload bytes used for request-digest material. </summary>
+internal static class CanonicalRequestWriter
+{
+    /// <summary> Compares JSON properties by ordinal property-name order for canonical output. </summary>
+    private static readonly IComparer<JsonProperty> JsonPropertyNameComparer = Comparer<JsonProperty>.Create(
+        static (x, y) => StringComparer.Ordinal.Compare(x.Name, y.Name));
+
+    /// <summary> Writes canonical UTF-8 payload bytes for request digest material. </summary>
+    /// <param name="protocolVersion"> The request protocol version. </param>
+    /// <param name="operations"> The normalized operation sequence. </param>
+    /// <returns> Canonical UTF-8 payload bytes containing only <c>protocolVersion</c> and <c>ops</c>. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" />. </exception>
+    public static ReadOnlyMemory<byte> WriteDigestPayload (
+        int protocolVersion,
+        IReadOnlyList<NormalizedOperation> operations)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Indented = false,
+        });
+
+        writer.WriteStartObject();
+        writer.WritePropertyName("ops");
+        writer.WriteStartArray();
+        for (var i = 0; i < operations.Count; i++)
+        {
+            WriteOperation(writer, operations[i]);
+        }
+
+        writer.WriteEndArray();
+        writer.WriteNumber("protocolVersion", protocolVersion);
+        writer.WriteEndObject();
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    /// <summary> Writes one canonical operation object. </summary>
+    /// <param name="writer"> The target writer. </param>
+    /// <param name="operation"> The operation model. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> is <see langword="null" />. </exception>
+    private static void WriteOperation (
+        Utf8JsonWriter writer,
+        NormalizedOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        writer.WriteStartObject();
+        writer.WritePropertyName("args");
+        WriteCanonicalJsonValue(writer, operation.Args);
+
+        if (operation.As is not null)
+        {
+            writer.WriteString("as", operation.As);
+        }
+
+        if (operation.Expect is not null)
+        {
+            writer.WritePropertyName("expect");
+            WriteExpectation(writer, operation.Expect);
+        }
+
+        writer.WriteString("id", operation.Id);
+        writer.WriteString("op", operation.Op);
+        writer.WriteEndObject();
+    }
+
+    /// <summary> Writes one canonical expectation object. </summary>
+    /// <param name="writer"> The target writer. </param>
+    /// <param name="expectation"> The expectation model. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="expectation" /> is <see langword="null" />. </exception>
+    private static void WriteExpectation (
+        Utf8JsonWriter writer,
+        NormalizedExpectation expectation)
+    {
+        ArgumentNullException.ThrowIfNull(expectation);
+
+        writer.WriteStartObject();
+        if (expectation.Count.HasValue)
+        {
+            writer.WriteNumber("count", expectation.Count.Value);
+        }
+
+        if (expectation.Max.HasValue)
+        {
+            writer.WriteNumber("max", expectation.Max.Value);
+        }
+
+        if (expectation.Min.HasValue)
+        {
+            writer.WriteNumber("min", expectation.Min.Value);
+        }
+
+        if (expectation.NonNull.HasValue)
+        {
+            writer.WriteBoolean("nonNull", expectation.NonNull.Value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    /// <summary> Writes one canonical JSON value recursively. </summary>
+    /// <param name="writer"> The target writer. </param>
+    /// <param name="value"> The JSON value to canonicalize. </param>
+    private static void WriteCanonicalJsonValue (
+        Utf8JsonWriter writer,
+        JsonElement value)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                WriteCanonicalObject(writer, value);
+                return;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var arrayItem in value.EnumerateArray())
+                {
+                    WriteCanonicalJsonValue(writer, arrayItem);
+                }
+
+                writer.WriteEndArray();
+                return;
+
+            default:
+                value.WriteTo(writer);
+                return;
+        }
+    }
+
+    /// <summary> Writes one object with properties sorted by ordinal key order. </summary>
+    /// <param name="writer"> The target writer. </param>
+    /// <param name="value"> The object JSON value. </param>
+    private static void WriteCanonicalObject (
+        Utf8JsonWriter writer,
+        JsonElement value)
+    {
+        var propertyCount = CountObjectProperties(value);
+        if (propertyCount == 0)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+            return;
+        }
+
+        var properties = ArrayPool<JsonProperty>.Shared.Rent(propertyCount);
+        try
+        {
+            var index = 0;
+            foreach (var property in value.EnumerateObject())
+            {
+                properties[index] = property;
+                index++;
+            }
+
+            Array.Sort(properties, 0, propertyCount, JsonPropertyNameComparer);
+
+            writer.WriteStartObject();
+            for (var i = 0; i < propertyCount; i++)
+            {
+                var property = properties[i];
+                writer.WritePropertyName(property.Name);
+                WriteCanonicalJsonValue(writer, property.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+        finally
+        {
+            ArrayPool<JsonProperty>.Shared.Return(properties, clearArray: false);
+        }
+    }
+
+    /// <summary> Counts object properties without allocating intermediate buffers. </summary>
+    /// <param name="value"> The object JSON value. </param>
+    /// <returns> The property count. </returns>
+    private static int CountObjectProperties (JsonElement value)
+    {
+        var count = 0;
+        foreach (var _ in value.EnumerateObject())
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/CanonicalRequestWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b4fdfc52f93e4855972f14c716d940e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs
@@ -1,10 +1,13 @@
-namespace MackySoft.Ucli.Unity.Execution.Requests;
+#nullable enable
 
-/// <summary> Represents one structured normalization error. </summary>
-/// <param name="Code"> The machine-readable error code. </param>
-/// <param name="Message"> The user-facing error message. </param>
-/// <param name="OpId"> The related operation identifier when available; otherwise <see langword="null" />. </param>
-internal sealed record ExecuteRequestNormalizationError (
-    string Code,
-    string Message,
-    string? OpId);
+namespace MackySoft.Ucli.Unity.Execution.Requests
+{
+    /// <summary> Represents one structured normalization error. </summary>
+    /// <param name="Code"> The machine-readable error code. </param>
+    /// <param name="Message"> The user-facing error message. </param>
+    /// <param name="OpId"> The related operation identifier when available; otherwise <see langword="null" />. </param>
+    internal sealed record ExecuteRequestNormalizationError (
+        string Code,
+        string Message,
+        string? OpId);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Represents one structured normalization error. </summary>
+/// <param name="Code"> The machine-readable error code. </param>
+/// <param name="Message"> The user-facing error message. </param>
+/// <param name="OpId"> The related operation identifier when available; otherwise <see langword="null" />. </param>
+internal sealed record ExecuteRequestNormalizationError (
+    string Code,
+    string Message,
+    string? OpId);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationError.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8662d06d907c483c91c562b41c4a799
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs
@@ -1,40 +1,49 @@
 using System;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
+#nullable enable
 
-/// <summary> Represents the result of execute-request normalization. </summary>
-/// <param name="Request"> The normalized request on success; otherwise <see langword="null" />. </param>
-/// <param name="Error"> The normalization error on failure; otherwise <see langword="null" />. </param>
-internal sealed record ExecuteRequestNormalizationResult (
-    NormalizedExecuteRequest? Request,
-    ExecuteRequestNormalizationError? Error)
+namespace MackySoft.Ucli.Unity.Execution.Requests
 {
-    /// <summary> Gets a value indicating whether normalization succeeded. </summary>
-    public bool IsSuccess => Request is not null && Error is null;
-
-    /// <summary> Creates a successful normalization result. </summary>
-    /// <param name="request"> The normalized request. </param>
-    /// <returns> The successful result. </returns>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
-    public static ExecuteRequestNormalizationResult Success (NormalizedExecuteRequest request)
+    /// <summary> Represents the result of execute-request normalization. </summary>
+    /// <param name="Request"> The normalized request on success; otherwise <see langword="null" />. </param>
+    /// <param name="Error"> The normalization error on failure; otherwise <see langword="null" />. </param>
+    internal sealed record ExecuteRequestNormalizationResult (
+        NormalizedExecuteRequest? Request,
+        ExecuteRequestNormalizationError? Error)
     {
-        ArgumentNullException.ThrowIfNull(request);
+        /// <summary> Gets a value indicating whether normalization succeeded. </summary>
+        public bool IsSuccess => Request is not null && Error is null;
 
-        return new ExecuteRequestNormalizationResult(
-            Request: request,
-            Error: null);
-    }
+        /// <summary> Creates a successful normalization result. </summary>
+        /// <param name="request"> The normalized request. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+        public static ExecuteRequestNormalizationResult Success (NormalizedExecuteRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
 
-    /// <summary> Creates a failed normalization result. </summary>
-    /// <param name="error"> The normalization error. </param>
-    /// <returns> The failed result. </returns>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-    public static ExecuteRequestNormalizationResult Failure (ExecuteRequestNormalizationError error)
-    {
-        ArgumentNullException.ThrowIfNull(error);
+            return new ExecuteRequestNormalizationResult(
+                Request: request,
+                Error: null);
+        }
 
-        return new ExecuteRequestNormalizationResult(
-            Request: null,
-            Error: error);
+        /// <summary> Creates a failed normalization result. </summary>
+        /// <param name="error"> The normalization error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static ExecuteRequestNormalizationResult Failure (ExecuteRequestNormalizationError error)
+        {
+            if (error == null)
+            {
+                throw new ArgumentNullException(nameof(error));
+            }
+
+            return new ExecuteRequestNormalizationResult(
+                Request: null,
+                Error: error);
+        }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Represents the result of execute-request normalization. </summary>
+/// <param name="Request"> The normalized request on success; otherwise <see langword="null" />. </param>
+/// <param name="Error"> The normalization error on failure; otherwise <see langword="null" />. </param>
+internal sealed record ExecuteRequestNormalizationResult (
+    NormalizedExecuteRequest? Request,
+    ExecuteRequestNormalizationError? Error)
+{
+    /// <summary> Gets a value indicating whether normalization succeeded. </summary>
+    public bool IsSuccess => Request is not null && Error is null;
+
+    /// <summary> Creates a successful normalization result. </summary>
+    /// <param name="request"> The normalized request. </param>
+    /// <returns> The successful result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+    public static ExecuteRequestNormalizationResult Success (NormalizedExecuteRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new ExecuteRequestNormalizationResult(
+            Request: request,
+            Error: null);
+    }
+
+    /// <summary> Creates a failed normalization result. </summary>
+    /// <param name="error"> The normalization error. </param>
+    /// <returns> The failed result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static ExecuteRequestNormalizationResult Failure (ExecuteRequestNormalizationError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        return new ExecuteRequestNormalizationResult(
+            Request: null,
+            Error: error);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizationResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79825237ab520474ab6cc2cd34bd04ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs
@@ -1,0 +1,600 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Validates and normalizes execute request payloads into strict contract models. </summary>
+internal sealed class ExecuteRequestNormalizer : IExecuteRequestNormalizer
+{
+    private static readonly HashSet<string> AllowedRequestProperties = new(StringComparer.Ordinal)
+    {
+        "protocolVersion",
+        "requestId",
+        "ops",
+    };
+
+    private static readonly HashSet<string> AllowedOperationProperties = new(StringComparer.Ordinal)
+    {
+        "id",
+        "op",
+        "args",
+        "as",
+        "expect",
+    };
+
+    private static readonly HashSet<string> AllowedExpectationProperties = new(StringComparer.Ordinal)
+    {
+        "nonNull",
+        "count",
+        "min",
+        "max",
+    };
+
+    /// <summary> Validates and normalizes one execute request payload. </summary>
+    /// <param name="request"> The execute request payload. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+    /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+    public ExecuteRequestNormalizationResult Normalize (
+        IpcExecuteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!IpcExecuteCommandNames.IsOperationPipelineCommand(request.Command))
+        {
+            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                message: $"Execute command is not supported: {request.Command}.",
+                opId: null));
+        }
+
+        if (request.Arguments.ValueKind != JsonValueKind.Object)
+        {
+            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                message: "Request arguments must be a JSON object.",
+                opId: null));
+        }
+
+        var unknownRequestProperty = FindUnknownProperty(request.Arguments, AllowedRequestProperties);
+        if (unknownRequestProperty is not null)
+        {
+            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                message: $"Request contains an unknown property: {unknownRequestProperty}.",
+                opId: null));
+        }
+
+        if (!TryReadProtocolVersion(request.Arguments, out var protocolVersion, out var protocolVersionError))
+        {
+            return ExecuteRequestNormalizationResult.Failure(protocolVersionError!);
+        }
+
+        if (!TryReadRequestId(request.Arguments, out var requestId, out var requestIdError))
+        {
+            return ExecuteRequestNormalizationResult.Failure(requestIdError!);
+        }
+
+        if (!TryReadOperations(request.Arguments, cancellationToken, out var operations, out var operationsError))
+        {
+            return ExecuteRequestNormalizationResult.Failure(operationsError!);
+        }
+
+        var canonicalPayload = CanonicalRequestWriter.WriteDigestPayload(protocolVersion, operations);
+        var normalizedRequest = new NormalizedExecuteRequest(
+            ProtocolVersion: protocolVersion,
+            RequestId: requestId,
+            Ops: operations,
+            CanonicalDigestPayloadUtf8: canonicalPayload);
+        return ExecuteRequestNormalizationResult.Success(normalizedRequest);
+    }
+
+    /// <summary> Reads and validates protocol version. </summary>
+    /// <param name="requestArguments"> The request arguments object. </param>
+    /// <param name="protocolVersion"> The parsed protocol version on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when protocol version is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadProtocolVersion (
+        JsonElement requestArguments,
+        out int protocolVersion,
+        out ExecuteRequestNormalizationError? error)
+    {
+        protocolVersion = default;
+        error = null;
+
+        if (!requestArguments.TryGetProperty("protocolVersion", out var protocolVersionElement))
+        {
+            error = CreateInvalidArgument("Request property 'protocolVersion' is required.", null);
+            return false;
+        }
+
+        if (!protocolVersionElement.TryGetInt32(out protocolVersion))
+        {
+            error = CreateInvalidArgument("Request property 'protocolVersion' must be an integer.", null);
+            return false;
+        }
+
+        if (protocolVersion != IpcProtocol.CurrentVersion)
+        {
+            error = new ExecuteRequestNormalizationError(
+                Code: IpcErrorCodes.ProtocolVersionMismatch,
+                Message: $"Protocol version mismatch. Expected {IpcProtocol.CurrentVersion}, actual {protocolVersion}.",
+                OpId: null);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads and validates request identifier. </summary>
+    /// <param name="requestArguments"> The request arguments object. </param>
+    /// <param name="requestId"> The normalized request identifier on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when request identifier is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadRequestId (
+        JsonElement requestArguments,
+        out string requestId,
+        out ExecuteRequestNormalizationError? error)
+    {
+        requestId = string.Empty;
+        error = null;
+
+        if (!requestArguments.TryGetProperty("requestId", out var requestIdElement))
+        {
+            error = CreateInvalidArgument("Request property 'requestId' is required.", null);
+            return false;
+        }
+
+        if (requestIdElement.ValueKind != JsonValueKind.String)
+        {
+            error = CreateInvalidArgument("Request property 'requestId' must be a UUID string.", null);
+            return false;
+        }
+
+        var rawRequestId = requestIdElement.GetString()!;
+        if (HasOuterWhitespace(rawRequestId) || string.IsNullOrWhiteSpace(rawRequestId))
+        {
+            error = CreateInvalidArgument("Request property 'requestId' must not contain leading or trailing whitespace.", null);
+            return false;
+        }
+
+        if (!Guid.TryParseExact(rawRequestId, "D", out var parsedRequestId))
+        {
+            error = CreateInvalidArgument("Request property 'requestId' must be UUID format 'D'.", null);
+            return false;
+        }
+
+        requestId = parsedRequestId.ToString("D");
+        return true;
+    }
+
+    /// <summary> Reads and validates operation list. </summary>
+    /// <param name="requestArguments"> The request arguments object. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+    /// <param name="operations"> The normalized operation list on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when operation list is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperations (
+        JsonElement requestArguments,
+        CancellationToken cancellationToken,
+        out List<NormalizedOperation> operations,
+        out ExecuteRequestNormalizationError? error)
+    {
+        operations = new List<NormalizedOperation>();
+        error = null;
+
+        if (!requestArguments.TryGetProperty("ops", out var operationsElement))
+        {
+            error = CreateInvalidArgument("Request property 'ops' is required.", null);
+            return false;
+        }
+
+        if (operationsElement.ValueKind != JsonValueKind.Array)
+        {
+            error = CreateInvalidArgument("Request property 'ops' must be an array.", null);
+            return false;
+        }
+
+        var duplicatedOpIdDetector = new HashSet<string>(StringComparer.Ordinal);
+        var operationIndex = 0;
+        foreach (var operationElement in operationsElement.EnumerateArray())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (operationElement.ValueKind != JsonValueKind.Object)
+            {
+                error = CreateInvalidArgument($"Operation at index {operationIndex} must be an object.", null);
+                return false;
+            }
+
+            var unknownOperationProperty = FindUnknownProperty(operationElement, AllowedOperationProperties);
+            if (unknownOperationProperty is not null)
+            {
+                error = CreateInvalidArgument(
+                    $"Operation at index {operationIndex} contains an unknown property: {unknownOperationProperty}.",
+                    null);
+                return false;
+            }
+
+            if (!TryReadOperationId(operationElement, operationIndex, out var operationId, out error))
+            {
+                return false;
+            }
+
+            if (!duplicatedOpIdDetector.Add(operationId))
+            {
+                error = CreateInvalidArgument($"Operation id is duplicated: {operationId}.", operationId);
+                return false;
+            }
+
+            if (!TryReadOperationName(operationElement, operationId, out var operationName, out error))
+            {
+                return false;
+            }
+
+            if (!TryReadOperationArgs(operationElement, operationId, out var operationArgs, out error))
+            {
+                return false;
+            }
+
+            if (!TryReadOperationAs(operationElement, operationId, out var operationAs, out error))
+            {
+                return false;
+            }
+
+            if (!TryReadExpectation(operationElement, operationId, out var expectation, out error))
+            {
+                return false;
+            }
+
+            operations.Add(new NormalizedOperation(
+                Id: operationId,
+                Op: operationName,
+                Args: operationArgs.Clone(),
+                As: operationAs,
+                Expect: expectation));
+            operationIndex++;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads and validates operation identifier. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="operationId"> The operation identifier on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when operation identifier is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperationId (
+        JsonElement operationElement,
+        int operationIndex,
+        out string operationId,
+        out ExecuteRequestNormalizationError? error)
+    {
+        operationId = string.Empty;
+        error = null;
+
+        if (!operationElement.TryGetProperty("id", out var operationIdElement))
+        {
+            error = CreateInvalidArgument($"Operation at index {operationIndex} requires property 'id'.", null);
+            return false;
+        }
+
+        if (operationIdElement.ValueKind != JsonValueKind.String)
+        {
+            error = CreateInvalidArgument($"Operation at index {operationIndex} property 'id' must be a string.", null);
+            return false;
+        }
+
+        operationId = operationIdElement.GetString()!;
+        if (string.IsNullOrWhiteSpace(operationId) || HasOuterWhitespace(operationId))
+        {
+            error = CreateInvalidArgument($"Operation at index {operationIndex} property 'id' must not be empty or contain outer whitespace.", null);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads and validates operation name. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="operationName"> The operation name on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when operation name is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperationName (
+        JsonElement operationElement,
+        string operationId,
+        out string operationName,
+        out ExecuteRequestNormalizationError? error)
+    {
+        operationName = string.Empty;
+        error = null;
+
+        if (!operationElement.TryGetProperty("op", out var operationNameElement))
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' requires property 'op'.", operationId);
+            return false;
+        }
+
+        if (operationNameElement.ValueKind != JsonValueKind.String)
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'op' must be a string.", operationId);
+            return false;
+        }
+
+        operationName = operationNameElement.GetString()!;
+        if (string.IsNullOrWhiteSpace(operationName) || HasOuterWhitespace(operationName))
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'op' must not be empty or contain outer whitespace.", operationId);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads and validates operation arguments. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="operationArgs"> The operation arguments on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when operation arguments are valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperationArgs (
+        JsonElement operationElement,
+        string operationId,
+        out JsonElement operationArgs,
+        out ExecuteRequestNormalizationError? error)
+    {
+        operationArgs = default;
+        error = null;
+
+        if (!operationElement.TryGetProperty("args", out operationArgs))
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' requires property 'args'.", operationId);
+            return false;
+        }
+
+        if (operationArgs.ValueKind != JsonValueKind.Object)
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'args' must be an object.", operationId);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads and validates operation alias. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="operationAs"> The alias value on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when alias value is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperationAs (
+        JsonElement operationElement,
+        string operationId,
+        out string? operationAs,
+        out ExecuteRequestNormalizationError? error)
+    {
+        operationAs = null;
+        error = null;
+
+        if (!operationElement.TryGetProperty("as", out var operationAsElement))
+        {
+            return true;
+        }
+
+        if (operationAsElement.ValueKind != JsonValueKind.String)
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'as' must be a string when specified.", operationId);
+            return false;
+        }
+
+        var alias = operationAsElement.GetString()!;
+        if (string.IsNullOrWhiteSpace(alias) || HasOuterWhitespace(alias))
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'as' must not be empty or contain outer whitespace.", operationId);
+            return false;
+        }
+
+        operationAs = alias;
+        return true;
+    }
+
+    /// <summary> Reads and validates shared expectation constraints. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="expectation"> The normalized expectation on success. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when expectation contract is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadExpectation (
+        JsonElement operationElement,
+        string operationId,
+        out NormalizedExpectation? expectation,
+        out ExecuteRequestNormalizationError? error)
+    {
+        expectation = null;
+        error = null;
+
+        if (!operationElement.TryGetProperty("expect", out var expectationElement))
+        {
+            return true;
+        }
+
+        if (expectationElement.ValueKind != JsonValueKind.Object)
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'expect' must be an object when specified.", operationId);
+            return false;
+        }
+
+        var unknownExpectationProperty = FindUnknownProperty(expectationElement, AllowedExpectationProperties);
+        if (unknownExpectationProperty is not null)
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect' contains an unknown property: {unknownExpectationProperty}.",
+                operationId);
+            return false;
+        }
+
+        if (!expectationElement.EnumerateObject().MoveNext())
+        {
+            error = CreateInvalidArgument($"Operation '{operationId}' property 'expect' must contain at least one constraint.", operationId);
+            return false;
+        }
+
+        var nonNull = TryReadOptionalBooleanConstraint(expectationElement, "nonNull", operationId, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var count = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "count", operationId, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var min = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "min", operationId, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var max = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "max", operationId, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        if (count.HasValue && (min.HasValue || max.HasValue))
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect' cannot combine 'count' with 'min' or 'max'.",
+                operationId);
+            return false;
+        }
+
+        if (min.HasValue && max.HasValue && min.Value > max.Value)
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect' requires 'min' to be less than or equal to 'max'.",
+                operationId);
+            return false;
+        }
+
+        expectation = new NormalizedExpectation(
+            NonNull: nonNull,
+            Count: count,
+            Min: min,
+            Max: max);
+        return true;
+    }
+
+    /// <summary> Reads one optional boolean expectation constraint. </summary>
+    /// <param name="expectationElement"> The expectation object. </param>
+    /// <param name="propertyName"> The property to parse. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> The parsed value, or <see langword="null" /> when property is absent. </returns>
+    private static bool? TryReadOptionalBooleanConstraint (
+        JsonElement expectationElement,
+        string propertyName,
+        string operationId,
+        out ExecuteRequestNormalizationError? error)
+    {
+        error = null;
+        if (!expectationElement.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return null;
+        }
+
+        if (propertyElement.ValueKind != JsonValueKind.True && propertyElement.ValueKind != JsonValueKind.False)
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect.{propertyName}' must be a boolean.",
+                operationId);
+            return null;
+        }
+
+        return propertyElement.GetBoolean();
+    }
+
+    /// <summary> Reads one optional non-negative integer expectation constraint. </summary>
+    /// <param name="expectationElement"> The expectation object. </param>
+    /// <param name="propertyName"> The property to parse. </param>
+    /// <param name="operationId"> The operation identifier. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> The parsed value, or <see langword="null" /> when property is absent. </returns>
+    private static int? TryReadOptionalNonNegativeIntegerConstraint (
+        JsonElement expectationElement,
+        string propertyName,
+        string operationId,
+        out ExecuteRequestNormalizationError? error)
+    {
+        error = null;
+        if (!expectationElement.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return null;
+        }
+
+        if (!propertyElement.TryGetInt32(out var parsedValue))
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect.{propertyName}' must be an integer.",
+                operationId);
+            return null;
+        }
+
+        if (parsedValue < 0)
+        {
+            error = CreateInvalidArgument(
+                $"Operation '{operationId}' property 'expect.{propertyName}' must be greater than or equal to 0.",
+                operationId);
+            return null;
+        }
+
+        return parsedValue;
+    }
+
+    /// <summary> Finds the first unknown property in a JSON object. </summary>
+    /// <param name="jsonObject"> The object to inspect. </param>
+    /// <param name="allowedProperties"> The allowed property set. </param>
+    /// <returns> The unknown property name, or <see langword="null" /> when all properties are allowed. </returns>
+    private static string? FindUnknownProperty (
+        JsonElement jsonObject,
+        HashSet<string> allowedProperties)
+    {
+        foreach (var property in jsonObject.EnumerateObject())
+        {
+            if (!allowedProperties.Contains(property.Name))
+            {
+                return property.Name;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary> Determines whether string contains leading or trailing whitespace. </summary>
+    /// <param name="value"> The string to inspect. </param>
+    /// <returns> <see langword="true" /> when leading or trailing whitespace exists; otherwise <see langword="false" />. </returns>
+    private static bool HasOuterWhitespace (string value)
+    {
+        return value.Length != value.Trim().Length;
+    }
+
+    /// <summary> Creates one invalid-argument normalization error. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <param name="opId"> The related operation identifier. </param>
+    /// <returns> The normalization error. </returns>
+    private static ExecuteRequestNormalizationError CreateInvalidArgument (
+        string message,
+        string? opId)
+    {
+        return new ExecuteRequestNormalizationError(
+            Code: IpcErrorCodes.InvalidArgument,
+            Message: message,
+            OpId: opId);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs
@@ -4,92 +4,98 @@ using System.Text.Json;
 using System.Threading;
 using MackySoft.Ucli.Contracts.Ipc;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
+#nullable enable
 
-/// <summary> Validates and normalizes execute request payloads into strict contract models. </summary>
-internal sealed class ExecuteRequestNormalizer : IExecuteRequestNormalizer
+namespace MackySoft.Ucli.Unity.Execution.Requests
 {
-    private static readonly HashSet<string> AllowedRequestProperties = new(StringComparer.Ordinal)
+    /// <summary> Validates and normalizes execute request payloads into strict contract models. </summary>
+    internal sealed class ExecuteRequestNormalizer : IExecuteRequestNormalizer
     {
-        "protocolVersion",
-        "requestId",
-        "ops",
-    };
-
-    private static readonly HashSet<string> AllowedOperationProperties = new(StringComparer.Ordinal)
-    {
-        "id",
-        "op",
-        "args",
-        "as",
-        "expect",
-    };
-
-    private static readonly HashSet<string> AllowedExpectationProperties = new(StringComparer.Ordinal)
-    {
-        "nonNull",
-        "count",
-        "min",
-        "max",
-    };
-
-    /// <summary> Validates and normalizes one execute request payload. </summary>
-    /// <param name="request"> The execute request payload. </param>
-    /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
-    /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
-    public ExecuteRequestNormalizationResult Normalize (
-        IpcExecuteRequest request,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (!IpcExecuteCommandNames.IsOperationPipelineCommand(request.Command))
+        private static readonly HashSet<string> AllowedRequestProperties = new(StringComparer.Ordinal)
         {
-            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
-                message: $"Execute command is not supported: {request.Command}.",
-                opId: null));
-        }
+            "protocolVersion",
+            "requestId",
+            "ops",
+        };
 
-        if (request.Arguments.ValueKind != JsonValueKind.Object)
+        private static readonly HashSet<string> AllowedOperationProperties = new(StringComparer.Ordinal)
         {
-            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
-                message: "Request arguments must be a JSON object.",
-                opId: null));
-        }
+            "id",
+            "op",
+            "args",
+            "as",
+            "expect",
+        };
 
-        var unknownRequestProperty = FindUnknownProperty(request.Arguments, AllowedRequestProperties);
-        if (unknownRequestProperty is not null)
+        private static readonly HashSet<string> AllowedExpectationProperties = new(StringComparer.Ordinal)
         {
-            return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
-                message: $"Request contains an unknown property: {unknownRequestProperty}.",
-                opId: null));
-        }
+            "nonNull",
+            "count",
+            "min",
+            "max",
+        };
 
-        if (!TryReadProtocolVersion(request.Arguments, out var protocolVersion, out var protocolVersionError))
+        /// <summary> Validates and normalizes one execute request payload. </summary>
+        /// <param name="request"> The execute request payload. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+        /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+        public ExecuteRequestNormalizationResult Normalize (
+            IpcExecuteRequest request,
+            CancellationToken cancellationToken = default)
         {
-            return ExecuteRequestNormalizationResult.Failure(protocolVersionError!);
-        }
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
 
-        if (!TryReadRequestId(request.Arguments, out var requestId, out var requestIdError))
-        {
-            return ExecuteRequestNormalizationResult.Failure(requestIdError!);
-        }
+            cancellationToken.ThrowIfCancellationRequested();
 
-        if (!TryReadOperations(request.Arguments, cancellationToken, out var operations, out var operationsError))
-        {
-            return ExecuteRequestNormalizationResult.Failure(operationsError!);
-        }
+            if (!IpcExecuteCommandNames.IsOperationPipelineCommand(request.Command))
+            {
+                return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                    message: $"Execute command is not supported: {request.Command}.",
+                    opId: null));
+            }
 
-        var canonicalPayload = CanonicalRequestWriter.WriteDigestPayload(protocolVersion, operations);
-        var normalizedRequest = new NormalizedExecuteRequest(
-            ProtocolVersion: protocolVersion,
-            RequestId: requestId,
-            Ops: operations,
-            CanonicalDigestPayloadUtf8: canonicalPayload);
-        return ExecuteRequestNormalizationResult.Success(normalizedRequest);
-    }
+            if (request.Arguments.ValueKind != JsonValueKind.Object)
+            {
+                return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                    message: "Request arguments must be a JSON object.",
+                    opId: null));
+            }
+
+            var unknownRequestProperty = FindUnknownProperty(request.Arguments, AllowedRequestProperties);
+            if (unknownRequestProperty is not null)
+            {
+                return ExecuteRequestNormalizationResult.Failure(CreateInvalidArgument(
+                    message: $"Request contains an unknown property: {unknownRequestProperty}.",
+                    opId: null));
+            }
+
+            if (!TryReadProtocolVersion(request.Arguments, out var protocolVersion, out var protocolVersionError))
+            {
+                return ExecuteRequestNormalizationResult.Failure(protocolVersionError!);
+            }
+
+            if (!TryReadRequestId(request.Arguments, out var requestId, out var requestIdError))
+            {
+                return ExecuteRequestNormalizationResult.Failure(requestIdError!);
+            }
+
+            if (!TryReadOperations(request.Arguments, cancellationToken, out var operations, out var operationsError))
+            {
+                return ExecuteRequestNormalizationResult.Failure(operationsError!);
+            }
+
+            var canonicalPayload = CanonicalRequestWriter.WriteDigestPayload(protocolVersion, operations);
+            var normalizedRequest = new NormalizedExecuteRequest(
+                ProtocolVersion: protocolVersion,
+                RequestId: requestId,
+                Ops: operations,
+                CanonicalDigestPayloadUtf8: canonicalPayload);
+            return ExecuteRequestNormalizationResult.Success(normalizedRequest);
+        }
 
     /// <summary> Reads and validates protocol version. </summary>
     /// <param name="requestArguments"> The request arguments object. </param>
@@ -538,7 +544,7 @@ internal sealed class ExecuteRequestNormalizer : IExecuteRequestNormalizer
             return null;
         }
 
-        if (!propertyElement.TryGetInt32(out var parsedValue))
+        if (propertyElement.ValueKind != JsonValueKind.Number || !propertyElement.TryGetInt32(out var parsedValue))
         {
             error = CreateInvalidArgument(
                 $"Operation '{operationId}' property 'expect.{propertyName}' must be an integer.",
@@ -588,13 +594,14 @@ internal sealed class ExecuteRequestNormalizer : IExecuteRequestNormalizer
     /// <param name="message"> The error message. </param>
     /// <param name="opId"> The related operation identifier. </param>
     /// <returns> The normalization error. </returns>
-    private static ExecuteRequestNormalizationError CreateInvalidArgument (
-        string message,
-        string? opId)
-    {
-        return new ExecuteRequestNormalizationError(
-            Code: IpcErrorCodes.InvalidArgument,
-            Message: message,
-            OpId: opId);
+        private static ExecuteRequestNormalizationError CreateInvalidArgument (
+            string message,
+            string? opId)
+        {
+            return new ExecuteRequestNormalizationError(
+                Code: IpcErrorCodes.InvalidArgument,
+                Message: message,
+                OpId: opId);
+        }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d7c9ed0c28464b639d26866418539dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs
@@ -1,16 +1,17 @@
 using System.Threading;
 using MackySoft.Ucli.Contracts.Ipc;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
-
-/// <summary> Normalizes one execute request into a strict request contract used by execution pipelines. </summary>
-internal interface IExecuteRequestNormalizer
+namespace MackySoft.Ucli.Unity.Execution.Requests
 {
-    /// <summary> Validates and normalizes one execute request payload. </summary>
-    /// <param name="request"> The execute request payload. </param>
-    /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
-    /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
-    ExecuteRequestNormalizationResult Normalize (
-        IpcExecuteRequest request,
-        CancellationToken cancellationToken = default);
+    /// <summary> Normalizes one execute request into a strict request contract used by execution pipelines. </summary>
+    internal interface IExecuteRequestNormalizer
+    {
+        /// <summary> Validates and normalizes one execute request payload. </summary>
+        /// <param name="request"> The execute request payload. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+        /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
+        ExecuteRequestNormalizationResult Normalize (
+            IpcExecuteRequest request,
+            CancellationToken cancellationToken = default);
+    }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Normalizes one execute request into a strict request contract used by execution pipelines. </summary>
+internal interface IExecuteRequestNormalizer
+{
+    /// <summary> Validates and normalizes one execute request payload. </summary>
+    /// <param name="request"> The execute request payload. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+    /// <returns> The normalization result that contains either normalized request data or one structured error. </returns>
+    ExecuteRequestNormalizationResult Normalize (
+        IpcExecuteRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/IExecuteRequestNormalizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2cd6745c86f6486aa21cb406382b909
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Represents one normalized execute request used by execution pipelines. </summary>
+/// <param name="ProtocolVersion"> The validated protocol version. </param>
+/// <param name="RequestId"> The normalized request identifier. </param>
+/// <param name="Ops"> The normalized operation list. </param>
+/// <param name="CanonicalDigestPayloadUtf8"> The canonical UTF-8 JSON payload used as request-digest material. </param>
+internal sealed record NormalizedExecuteRequest (
+    int ProtocolVersion,
+    string RequestId,
+    IReadOnlyList<NormalizedOperation> Ops,
+    ReadOnlyMemory<byte> CanonicalDigestPayloadUtf8);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
-
-/// <summary> Represents one normalized execute request used by execution pipelines. </summary>
-/// <param name="ProtocolVersion"> The validated protocol version. </param>
-/// <param name="RequestId"> The normalized request identifier. </param>
-/// <param name="Ops"> The normalized operation list. </param>
-/// <param name="CanonicalDigestPayloadUtf8"> The canonical UTF-8 JSON payload used as request-digest material. </param>
-internal sealed record NormalizedExecuteRequest (
-    int ProtocolVersion,
-    string RequestId,
-    IReadOnlyList<NormalizedOperation> Ops,
-    ReadOnlyMemory<byte> CanonicalDigestPayloadUtf8);
+namespace MackySoft.Ucli.Unity.Execution.Requests
+{
+    /// <summary> Represents one normalized execute request used by execution pipelines. </summary>
+    /// <param name="ProtocolVersion"> The validated protocol version. </param>
+    /// <param name="RequestId"> The normalized request identifier. </param>
+    /// <param name="Ops"> The normalized operation list. </param>
+    /// <param name="CanonicalDigestPayloadUtf8"> The canonical UTF-8 JSON payload used as request-digest material. </param>
+    internal sealed record NormalizedExecuteRequest (
+        int ProtocolVersion,
+        string RequestId,
+        IReadOnlyList<NormalizedOperation> Ops,
+        ReadOnlyMemory<byte> CanonicalDigestPayloadUtf8);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExecuteRequest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bf479e16c203498693bdf2edf0fd539
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Represents normalized shared expectation constraints for one operation output. </summary>
+/// <param name="NonNull"> The optional non-null constraint flag. </param>
+/// <param name="Count"> The optional exact-count constraint. </param>
+/// <param name="Min"> The optional minimum-count constraint. </param>
+/// <param name="Max"> The optional maximum-count constraint. </param>
+internal sealed record NormalizedExpectation (
+    bool? NonNull,
+    int? Count,
+    int? Min,
+    int? Max);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs
@@ -1,12 +1,13 @@
-namespace MackySoft.Ucli.Unity.Execution.Requests;
-
-/// <summary> Represents normalized shared expectation constraints for one operation output. </summary>
-/// <param name="NonNull"> The optional non-null constraint flag. </param>
-/// <param name="Count"> The optional exact-count constraint. </param>
-/// <param name="Min"> The optional minimum-count constraint. </param>
-/// <param name="Max"> The optional maximum-count constraint. </param>
-internal sealed record NormalizedExpectation (
-    bool? NonNull,
-    int? Count,
-    int? Min,
-    int? Max);
+namespace MackySoft.Ucli.Unity.Execution.Requests
+{
+    /// <summary> Represents normalized shared expectation constraints for one operation output. </summary>
+    /// <param name="NonNull"> The optional non-null constraint flag. </param>
+    /// <param name="Count"> The optional exact-count constraint. </param>
+    /// <param name="Min"> The optional minimum-count constraint. </param>
+    /// <param name="Max"> The optional maximum-count constraint. </param>
+    internal sealed record NormalizedExpectation (
+        bool? NonNull,
+        int? Count,
+        int? Min,
+        int? Max);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedExpectation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a71174e46f9a94a8786f830685e3635d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Unity.Execution.Requests;
+
+/// <summary> Represents one normalized operation entry. </summary>
+/// <param name="Id"> The operation identifier. </param>
+/// <param name="Op"> The operation name. </param>
+/// <param name="Args"> The normalized operation arguments JSON object. </param>
+/// <param name="As"> The optional alias exposed to later operations. </param>
+/// <param name="Expect"> The optional shared expectation constraints. </param>
+internal sealed record NormalizedOperation (
+    string Id,
+    string Op,
+    JsonElement Args,
+    string? As,
+    NormalizedExpectation? Expect);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs
@@ -1,16 +1,19 @@
 using System.Text.Json;
 
-namespace MackySoft.Ucli.Unity.Execution.Requests;
+#nullable enable
 
-/// <summary> Represents one normalized operation entry. </summary>
-/// <param name="Id"> The operation identifier. </param>
-/// <param name="Op"> The operation name. </param>
-/// <param name="Args"> The normalized operation arguments JSON object. </param>
-/// <param name="As"> The optional alias exposed to later operations. </param>
-/// <param name="Expect"> The optional shared expectation constraints. </param>
-internal sealed record NormalizedOperation (
-    string Id,
-    string Op,
-    JsonElement Args,
-    string? As,
-    NormalizedExpectation? Expect);
+namespace MackySoft.Ucli.Unity.Execution.Requests
+{
+    /// <summary> Represents one normalized operation entry. </summary>
+    /// <param name="Id"> The operation identifier. </param>
+    /// <param name="Op"> The operation name. </param>
+    /// <param name="Args"> The normalized operation arguments JSON object. </param>
+    /// <param name="As"> The optional alias exposed to later operations. </param>
+    /// <param name="Expect"> The optional shared expectation constraints. </param>
+    internal sealed record NormalizedOperation (
+        string Id,
+        string Op,
+        JsonElement Args,
+        string? As,
+        NormalizedExpectation? Expect);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/NormalizedOperation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2bf1f54cfedf4938bbd8f35b3b2b702
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/NuGet.config
+++ b/src/Ucli.Unity/Assets/NuGet.config
@@ -2,8 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PrivateNuGet" value="https://nuget.pkg.github.com/mackysoft/index.json" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
+    <add key="LocalNuGet" value="../Packages/nuget-local-source" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" enableCredentialProvider="false" />
+    <add key="PrivateNuGet" value="https://nuget.pkg.github.com/mackysoft/index.json" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
   </packageSources>
 
   <disabledPackageSources />

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs
@@ -1,0 +1,582 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using NUnit.Framework;
+
+namespace MackySoft.Ucli.Unity.Tests;
+
+public sealed class ExecuteRequestNormalizerTests
+{
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenRequestIsValid_ReturnsNormalizedRequestAndCanonicalPayload ()
+    {
+        var request = CreateExecuteRequest(
+            IpcExecuteCommandNames.Plan,
+            """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "resolve",
+                  "op": "ucli.resolve",
+                  "args": {
+                    "scene": "Assets/Scenes/Main.unity",
+                    "hierarchyPath": "Root/Enemies/Spawner"
+                  },
+                  "expect": {
+                    "nonNull": true,
+                    "min": 1,
+                    "max": 1
+                  }
+                }
+              ]
+            }
+            """);
+        var normalizer = new ExecuteRequestNormalizer();
+
+        var result = normalizer.Normalize(request);
+
+        Assert.That(result.IsSuccess, Is.True);
+        Assert.That(result.Error, Is.Null);
+        var normalizedRequest = result.Request!;
+        Assert.That(normalizedRequest.ProtocolVersion, Is.EqualTo(IpcProtocol.CurrentVersion));
+        Assert.That(normalizedRequest.RequestId, Is.EqualTo("9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62"));
+        Assert.That(normalizedRequest.Ops.Count, Is.EqualTo(1));
+
+        var canonicalPayload = Encoding.UTF8.GetString(normalizedRequest.CanonicalDigestPayloadUtf8.ToArray());
+        Assert.That(canonicalPayload, Does.Not.Contain("requestId"));
+        Assert.That(canonicalPayload, Does.Contain("\"protocolVersion\":1"));
+        Assert.That(canonicalPayload, Does.Contain("\"ops\""));
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenCommandIsValidate_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+            IpcExecuteCommandNames.Validate,
+            """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": []
+            }
+            """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenRequestJsonKeyOrderDiffers_ProducesStableCanonicalPayload ()
+    {
+        var requestA = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "setSpawner",
+                      "op": "ucli.comp.set",
+                      "args": {
+                        "mode": "atomic",
+                        "target": { "var": "spawner" },
+                        "sets": [ { "path": "spawnInterval", "value": 3.0 } ]
+                      }
+                    }
+                  ]
+                }
+                """);
+        var requestB = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "op": "ucli.comp.set",
+                      "args": {
+                        "target": { "var": "spawner" },
+                        "sets": [ { "value": 3.0, "path": "spawnInterval" } ],
+                        "mode": "atomic"
+                      },
+                      "id": "setSpawner"
+                    }
+                  ],
+                  "protocolVersion": 1
+                }
+                """);
+        var normalizer = new ExecuteRequestNormalizer();
+
+        var resultA = normalizer.Normalize(requestA);
+        var resultB = normalizer.Normalize(requestB);
+
+        Assert.That(resultA.IsSuccess, Is.True);
+        Assert.That(resultB.IsSuccess, Is.True);
+        Assert.That(resultA.Request!.CanonicalDigestPayloadUtf8.Span.SequenceEqual(resultB.Request!.CanonicalDigestPayloadUtf8.Span), Is.True);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenProtocolVersionMismatches_ReturnsProtocolVersionMismatchError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Call,
+                """
+                {
+                  "protocolVersion": 999,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": []
+                }
+                """);
+        var normalizer = new ExecuteRequestNormalizer();
+
+        var result = normalizer.Normalize(request);
+
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.ProtocolVersionMismatch));
+        Assert.That(result.Error.OpId, Is.Null);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenRequestIdIsInvalid_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Call,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "invalid",
+                  "ops": []
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenTopLevelContainsUnknownProperty_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Resolve,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [],
+                  "unknown": true
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenOperationContainsUnknownProperty_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Query,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "q1",
+                      "op": "ucli.query",
+                      "args": {},
+                      "unknown": 1
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result);
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenOperationIdIsDuplicated_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Refresh,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    { "id": "same", "op": "ucli.project.refresh", "args": {} },
+                    { "id": "same", "op": "ucli.project.refresh", "args": {} }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "same");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenArgsPropertyIsMissing_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "missingArgs",
+                      "op": "ucli.scene.open"
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "missingArgs");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenArgsPropertyIsNotObject_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "argsType",
+                      "op": "ucli.scene.open",
+                      "args": []
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "argsType");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectObjectIsEmpty_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectEmpty",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {}
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectEmpty");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectIsNotObject_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectType",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": true
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectType");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectContainsUnknownProperty_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectUnknown",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "nonNull": true,
+                        "unknown": 1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectUnknown");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectNonNullIsNotBoolean_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectNonNullType",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "nonNull": 1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectNonNullType");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectContainsCountAndMinMax_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectCount",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "count": 1,
+                        "min": 1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectCount");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectCountIsNegative_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectCountNegative",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "count": -1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectCountNegative");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectCountIsNotInteger_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectCountType",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "count": "1"
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectCountType");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectMinGreaterThanMax_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectRange",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "min": 5,
+                        "max": 2
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectRange");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectMaxIsNegative_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectMaxNegative",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "max": -1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectMaxNegative");
+    }
+
+    [Test]
+    [Category("Size.Small")]
+    public void Normalize_WhenExpectContainsNegativeConstraint_ReturnsInvalidArgumentError ()
+    {
+        var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                """
+                {
+                  "protocolVersion": 1,
+                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                  "ops": [
+                    {
+                      "id": "expectNegative",
+                      "op": "ucli.resolve",
+                      "args": {},
+                      "expect": {
+                        "min": -1
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        var result = new ExecuteRequestNormalizer().Normalize(request);
+
+        AssertInvalidArgument(result, "expectNegative");
+    }
+
+    private static void AssertInvalidArgument (
+        ExecuteRequestNormalizationResult result,
+        string? expectedOpId = null)
+    {
+        Assert.That(result.IsSuccess, Is.False);
+        Assert.That(result.Request, Is.Null);
+        Assert.That(result.Error, Is.Not.Null);
+        Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+        Assert.That(result.Error.OpId, Is.EqualTo(expectedOpId));
+    }
+
+    private static IpcExecuteRequest CreateExecuteRequest (string command, string argumentsJson)
+    {
+        using var document = JsonDocument.Parse(argumentsJson);
+        return new IpcExecuteRequest(
+            Command: command,
+            Arguments: document.RootElement.Clone());
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs
@@ -5,578 +5,586 @@ using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using NUnit.Framework;
 
-namespace MackySoft.Ucli.Unity.Tests;
-
-public sealed class ExecuteRequestNormalizerTests
+namespace MackySoft.Ucli.Unity.Tests
 {
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenRequestIsValid_ReturnsNormalizedRequestAndCanonicalPayload ()
+    public sealed class ExecuteRequestNormalizerTests
     {
-        var request = CreateExecuteRequest(
-            IpcExecuteCommandNames.Plan,
-            """
-            {
-              "protocolVersion": 1,
-              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-              "ops": [
-                {
-                  "id": "resolve",
-                  "op": "ucli.resolve",
-                  "args": {
-                    "scene": "Assets/Scenes/Main.unity",
-                    "hierarchyPath": "Root/Enemies/Spawner"
-                  },
-                  "expect": {
-                    "nonNull": true,
-                    "min": 1,
-                    "max": 1
-                  }
-                }
-              ]
-            }
-            """);
-        var normalizer = new ExecuteRequestNormalizer();
+        private const string k_RequestId = "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62";
 
-        var result = normalizer.Normalize(request);
-
-        Assert.That(result.IsSuccess, Is.True);
-        Assert.That(result.Error, Is.Null);
-        var normalizedRequest = result.Request!;
-        Assert.That(normalizedRequest.ProtocolVersion, Is.EqualTo(IpcProtocol.CurrentVersion));
-        Assert.That(normalizedRequest.RequestId, Is.EqualTo("9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62"));
-        Assert.That(normalizedRequest.Ops.Count, Is.EqualTo(1));
-
-        var canonicalPayload = Encoding.UTF8.GetString(normalizedRequest.CanonicalDigestPayloadUtf8.ToArray());
-        Assert.That(canonicalPayload, Does.Not.Contain("requestId"));
-        Assert.That(canonicalPayload, Does.Contain("\"protocolVersion\":1"));
-        Assert.That(canonicalPayload, Does.Contain("\"ops\""));
-    }
-
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenCommandIsValidate_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
-            IpcExecuteCommandNames.Validate,
-            """
-            {
-              "protocolVersion": 1,
-              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-              "ops": []
-            }
-            """);
-
-        var result = new ExecuteRequestNormalizer().Normalize(request);
-
-        AssertInvalidArgument(result);
-    }
-
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenRequestJsonKeyOrderDiffers_ProducesStableCanonicalPayload ()
-    {
-        var requestA = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenRequestIsValid_ReturnsNormalizedRequestAndCanonicalPayload ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "setSpawner",
-                      "op": "ucli.comp.set",
-                      "args": {
-                        "mode": "atomic",
-                        "target": { "var": "spawner" },
-                        "sets": [ { "path": "spawnInterval", "value": 3.0 } ]
-                      }
+                        new
+                        {
+                            id = "resolve",
+                            op = "ucli.resolve",
+                            args = new
+                            {
+                                scene = "Assets/Scenes/Main.unity",
+                                hierarchyPath = "Root/Enemies/Spawner"
+                            },
+                            expect = new
+                            {
+                                nonNull = true,
+                                min = 1,
+                                max = 1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
-        var requestB = CreateExecuteRequest(
+                });
+            var normalizer = new ExecuteRequestNormalizer();
+
+            var result = normalizer.Normalize(request);
+
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Error, Is.Null);
+            var normalizedRequest = result.Request!;
+            Assert.That(normalizedRequest.ProtocolVersion, Is.EqualTo(IpcProtocol.CurrentVersion));
+            Assert.That(normalizedRequest.RequestId, Is.EqualTo("9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62"));
+            Assert.That(normalizedRequest.Ops.Count, Is.EqualTo(1));
+
+            var canonicalPayload = Encoding.UTF8.GetString(normalizedRequest.CanonicalDigestPayloadUtf8.ToArray());
+            Assert.That(canonicalPayload, Does.Not.Contain("requestId"));
+            Assert.That(canonicalPayload, Does.Contain("\"protocolVersion\":1"));
+            Assert.That(canonicalPayload, Does.Contain("\"ops\""));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenCommandIsValidate_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Validate,
+                new
+                {
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = Array.Empty<object>()
+                });
+
+            var result = new ExecuteRequestNormalizer().Normalize(request);
+
+            AssertInvalidArgument(result);
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenRequestJsonKeyOrderDiffers_ProducesStableCanonicalPayload ()
+        {
+            var requestA = CreateExecuteRequestFromJson(
                 IpcExecuteCommandNames.Plan,
-                """
-                {
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
-                    {
-                      "op": "ucli.comp.set",
-                      "args": {
-                        "target": { "var": "spawner" },
-                        "sets": [ { "value": 3.0, "path": "spawnInterval" } ],
-                        "mode": "atomic"
-                      },
-                      "id": "setSpawner"
-                    }
-                  ],
-                  "protocolVersion": 1
-                }
-                """);
-        var normalizer = new ExecuteRequestNormalizer();
+                "{\"protocolVersion\":1,\"requestId\":\"9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62\",\"ops\":[{\"id\":\"setSpawner\",\"op\":\"ucli.comp.set\",\"args\":{\"mode\":\"atomic\",\"target\":{\"var\":\"spawner\"},\"sets\":[{\"path\":\"spawnInterval\",\"value\":3.0}]}}]}");
+            var requestB = CreateExecuteRequestFromJson(
+                IpcExecuteCommandNames.Plan,
+                "{\"requestId\":\"9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62\",\"ops\":[{\"op\":\"ucli.comp.set\",\"args\":{\"target\":{\"var\":\"spawner\"},\"sets\":[{\"value\":3.0,\"path\":\"spawnInterval\"}],\"mode\":\"atomic\"},\"id\":\"setSpawner\"}],\"protocolVersion\":1}");
+            var normalizer = new ExecuteRequestNormalizer();
 
-        var resultA = normalizer.Normalize(requestA);
-        var resultB = normalizer.Normalize(requestB);
+            var resultA = normalizer.Normalize(requestA);
+            var resultB = normalizer.Normalize(requestB);
 
-        Assert.That(resultA.IsSuccess, Is.True);
-        Assert.That(resultB.IsSuccess, Is.True);
-        Assert.That(resultA.Request!.CanonicalDigestPayloadUtf8.Span.SequenceEqual(resultB.Request!.CanonicalDigestPayloadUtf8.Span), Is.True);
-    }
+            Assert.That(resultA.IsSuccess, Is.True);
+            Assert.That(resultB.IsSuccess, Is.True);
+            Assert.That(resultA.Request!.CanonicalDigestPayloadUtf8.Span.SequenceEqual(resultB.Request!.CanonicalDigestPayloadUtf8.Span), Is.True);
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenProtocolVersionMismatches_ReturnsProtocolVersionMismatchError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenProtocolVersionMismatches_ReturnsProtocolVersionMismatchError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Call,
-                """
+                new
                 {
-                  "protocolVersion": 999,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": []
-                }
-                """);
-        var normalizer = new ExecuteRequestNormalizer();
+                    protocolVersion = 999,
+                    requestId = k_RequestId,
+                    ops = Array.Empty<object>()
+                });
+            var normalizer = new ExecuteRequestNormalizer();
 
-        var result = normalizer.Normalize(request);
+            var result = normalizer.Normalize(request);
 
-        Assert.That(result.IsSuccess, Is.False);
-        Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.ProtocolVersionMismatch));
-        Assert.That(result.Error.OpId, Is.Null);
-    }
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.ProtocolVersionMismatch));
+            Assert.That(result.Error.OpId, Is.Null);
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenRequestIdIsInvalid_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenRequestIdIsInvalid_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Call,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "invalid",
-                  "ops": []
-                }
-                """);
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = "invalid",
+                    ops = Array.Empty<object>()
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result);
-    }
+            AssertInvalidArgument(result);
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenTopLevelContainsUnknownProperty_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenTopLevelContainsUnknownProperty_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Resolve,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [],
-                  "unknown": true
-                }
-                """);
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = Array.Empty<object>(),
+                    unknown = true
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result);
-    }
+            AssertInvalidArgument(result);
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenOperationContainsUnknownProperty_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenOperationContainsUnknownProperty_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Query,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "q1",
-                      "op": "ucli.query",
-                      "args": {},
-                      "unknown": 1
+                        new
+                        {
+                            id = "q1",
+                            op = "ucli.query",
+                            args = new { },
+                            unknown = 1
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result);
-    }
+            AssertInvalidArgument(result);
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenOperationIdIsDuplicated_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenOperationIdIsDuplicated_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Refresh,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
-                    { "id": "same", "op": "ucli.project.refresh", "args": {} },
-                    { "id": "same", "op": "ucli.project.refresh", "args": {} }
-                  ]
-                }
-                """);
-
-        var result = new ExecuteRequestNormalizer().Normalize(request);
-
-        AssertInvalidArgument(result, "same");
-    }
-
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenArgsPropertyIsMissing_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
-                IpcExecuteCommandNames.Plan,
-                """
-                {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "missingArgs",
-                      "op": "ucli.scene.open"
+                        new
+                        {
+                            id = "same",
+                            op = "ucli.project.refresh",
+                            args = new { }
+                        },
+                        new
+                        {
+                            id = "same",
+                            op = "ucli.project.refresh",
+                            args = new { }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "missingArgs");
-    }
+            AssertInvalidArgument(result, "same");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenArgsPropertyIsNotObject_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenArgsPropertyIsMissing_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "argsType",
-                      "op": "ucli.scene.open",
-                      "args": []
+                        new
+                        {
+                            id = "missingArgs",
+                            op = "ucli.scene.open"
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "argsType");
-    }
+            AssertInvalidArgument(result, "missingArgs");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectObjectIsEmpty_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenArgsPropertyIsNotObject_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectEmpty",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {}
+                        new
+                        {
+                            id = "argsType",
+                            op = "ucli.scene.open",
+                            args = Array.Empty<object>()
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectEmpty");
-    }
+            AssertInvalidArgument(result, "argsType");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectIsNotObject_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectObjectIsEmpty_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectType",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": true
+                        new
+                        {
+                            id = "expectEmpty",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new { }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectType");
-    }
+            AssertInvalidArgument(result, "expectEmpty");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectContainsUnknownProperty_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectIsNotObject_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectUnknown",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "nonNull": true,
-                        "unknown": 1
-                      }
+                        new
+                        {
+                            id = "expectType",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = true
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectUnknown");
-    }
+            AssertInvalidArgument(result, "expectType");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectNonNullIsNotBoolean_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectContainsUnknownProperty_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectNonNullType",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "nonNull": 1
-                      }
+                        new
+                        {
+                            id = "expectUnknown",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                nonNull = true,
+                                unknown = 1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectNonNullType");
-    }
+            AssertInvalidArgument(result, "expectUnknown");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectContainsCountAndMinMax_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectNonNullIsNotBoolean_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectCount",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "count": 1,
-                        "min": 1
-                      }
+                        new
+                        {
+                            id = "expectNonNullType",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                nonNull = 1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectCount");
-    }
+            AssertInvalidArgument(result, "expectNonNullType");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectCountIsNegative_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectContainsCountAndMinMax_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectCountNegative",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "count": -1
-                      }
+                        new
+                        {
+                            id = "expectCount",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                count = 1,
+                                min = 1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectCountNegative");
-    }
+            AssertInvalidArgument(result, "expectCount");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectCountIsNotInteger_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectCountIsNegative_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectCountType",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "count": "1"
-                      }
+                        new
+                        {
+                            id = "expectCountNegative",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                count = -1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectCountType");
-    }
+            AssertInvalidArgument(result, "expectCountNegative");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectMinGreaterThanMax_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectCountIsNotInteger_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectRange",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "min": 5,
-                        "max": 2
-                      }
+                        new
+                        {
+                            id = "expectCountType",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                count = "1"
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectRange");
-    }
+            AssertInvalidArgument(result, "expectCountType");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectMaxIsNegative_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectMinGreaterThanMax_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectMaxNegative",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "max": -1
-                      }
+                        new
+                        {
+                            id = "expectRange",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                min = 5,
+                                max = 2
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectMaxNegative");
-    }
+            AssertInvalidArgument(result, "expectRange");
+        }
 
-    [Test]
-    [Category("Size.Small")]
-    public void Normalize_WhenExpectContainsNegativeConstraint_ReturnsInvalidArgumentError ()
-    {
-        var request = CreateExecuteRequest(
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectMaxIsNegative_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
                 IpcExecuteCommandNames.Plan,
-                """
+                new
                 {
-                  "protocolVersion": 1,
-                  "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
-                  "ops": [
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
                     {
-                      "id": "expectNegative",
-                      "op": "ucli.resolve",
-                      "args": {},
-                      "expect": {
-                        "min": -1
-                      }
+                        new
+                        {
+                            id = "expectMaxNegative",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                max = -1
+                            }
+                        }
                     }
-                  ]
-                }
-                """);
+                });
 
-        var result = new ExecuteRequestNormalizer().Normalize(request);
+            var result = new ExecuteRequestNormalizer().Normalize(request);
 
-        AssertInvalidArgument(result, "expectNegative");
-    }
+            AssertInvalidArgument(result, "expectMaxNegative");
+        }
 
-    private static void AssertInvalidArgument (
-        ExecuteRequestNormalizationResult result,
-        string? expectedOpId = null)
-    {
-        Assert.That(result.IsSuccess, Is.False);
-        Assert.That(result.Request, Is.Null);
-        Assert.That(result.Error, Is.Not.Null);
-        Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
-        Assert.That(result.Error.OpId, Is.EqualTo(expectedOpId));
-    }
+        [Test]
+        [Category("Size.Small")]
+        public void Normalize_WhenExpectContainsNegativeConstraint_ReturnsInvalidArgumentError ()
+        {
+            var request = CreateExecuteRequest(
+                IpcExecuteCommandNames.Plan,
+                new
+                {
+                    protocolVersion = IpcProtocol.CurrentVersion,
+                    requestId = k_RequestId,
+                    ops = new[]
+                    {
+                        new
+                        {
+                            id = "expectNegative",
+                            op = "ucli.resolve",
+                            args = new { },
+                            expect = new
+                            {
+                                min = -1
+                            }
+                        }
+                    }
+                });
 
-    private static IpcExecuteRequest CreateExecuteRequest (string command, string argumentsJson)
-    {
-        using var document = JsonDocument.Parse(argumentsJson);
-        return new IpcExecuteRequest(
-            Command: command,
-            Arguments: document.RootElement.Clone());
+            var result = new ExecuteRequestNormalizer().Normalize(request);
+
+            AssertInvalidArgument(result, "expectNegative");
+        }
+
+        private static void AssertInvalidArgument (
+            ExecuteRequestNormalizationResult result,
+            string expectedOpId = null)
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Request, Is.Null);
+            Assert.That(result.Error, Is.Not.Null);
+            Assert.That(result.Error!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(result.Error.OpId, Is.EqualTo(expectedOpId));
+        }
+
+        private static IpcExecuteRequest CreateExecuteRequest (string command, object arguments)
+        {
+            var argumentsJson = JsonSerializer.Serialize(arguments);
+
+            return CreateExecuteRequestFromJson(command, argumentsJson);
+        }
+
+        private static IpcExecuteRequest CreateExecuteRequestFromJson (string command, string argumentsJson)
+        {
+            using var document = JsonDocument.Parse(argumentsJson);
+            return new IpcExecuteRequest(
+                Command: command,
+                Arguments: document.RootElement.Clone());
+        }
     }
 }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestNormalizerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de5588105739947b99e49d029429fd95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/MackySoft.Ucli.Unity.Tests.Editor.asmdef
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/MackySoft.Ucli.Unity.Tests.Editor.asmdef
@@ -10,8 +10,14 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "MackySoft.Ucli.Contracts.dll",
+        "System.Text.Json.dll",
+        "System.Text.Encodings.Web.dll",
+        "Microsoft.Bcl.AsyncInterfaces.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll"
+    ],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.1.0" manuallyInstalled="true" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
-  <package id="System.Text.Encodings.Web" version="8.0.0" />
-  <package id="System.Text.Json" version="8.0.5" />
+  <package id="MackySoft.Ucli.Contracts" version="0.1.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="netstandard2.0" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="netstandard2.0" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="netstandard2.0" />
 </packages>

--- a/src/Ucli/Cli/CliExitCode.cs
+++ b/src/Ucli/Cli/CliExitCode.cs
@@ -1,15 +1,14 @@
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Defines process exit codes emitted by the CLI runtime. </summary>
+internal enum CliExitCode
 {
-    /// <summary> Defines process exit codes emitted by the CLI runtime. </summary>
-    internal enum CliExitCode
-    {
-        /// <summary> Indicates successful command completion. </summary>
-        Success = 0,
+    /// <summary> Indicates successful command completion. </summary>
+    Success = 0,
 
-        /// <summary> Indicates that command arguments could not be parsed or validated. </summary>
-        InvalidArgument = 3,
+    /// <summary> Indicates that command arguments could not be parsed or validated. </summary>
+    InvalidArgument = 3,
 
-        /// <summary> Indicates that command execution failed because of a tool-level error. </summary>
-        ToolError = 4,
-    }
+    /// <summary> Indicates that command execution failed because of a tool-level error. </summary>
+    ToolError = 4,
 }

--- a/src/Ucli/Cli/CliProtocol.cs
+++ b/src/Ucli/Cli/CliProtocol.cs
@@ -1,18 +1,17 @@
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Defines protocol constants shared by all CLI JSON results. </summary>
+internal static class CliProtocol
 {
-    /// <summary> Defines protocol constants shared by all CLI JSON results. </summary>
-    internal static class CliProtocol
-    {
-        /// <summary> Gets the protocol version written to the <c>protocolVersion</c> field. </summary>
-        public const int CurrentVersion = 1;
+    /// <summary> Gets the protocol version written to the <c>protocolVersion</c> field. </summary>
+    public const int CurrentVersion = 1;
 
-        /// <summary> Gets the command name used when no subcommand can be identified. </summary>
-        public const string RootCommand = "root";
+    /// <summary> Gets the command name used when no subcommand can be identified. </summary>
+    public const string RootCommand = "root";
 
-        /// <summary> Gets the <c>status</c> value used for successful command execution. </summary>
-        public const string StatusOk = "ok";
+    /// <summary> Gets the <c>status</c> value used for successful command execution. </summary>
+    public const string StatusOk = "ok";
 
-        /// <summary> Gets the <c>status</c> value used for failed command execution. </summary>
-        public const string StatusError = "error";
-    }
+    /// <summary> Gets the <c>status</c> value used for failed command execution. </summary>
+    public const string StatusError = "error";
 }

--- a/src/Ucli/Cli/CommandError.cs
+++ b/src/Ucli/Cli/CommandError.cs
@@ -1,11 +1,10 @@
-namespace MackySoft.Ucli.Cli
-{
-    /// <summary> Represents a single error entry in the CLI JSON result payload. </summary>
-    /// <param name="Code"> A machine-readable error code. </param>
-    /// <param name="Message"> A human-readable error message for the current failure. </param>
-    /// <param name="OpId"> The operation identifier associated with this error, or <see langword="null" /> when not available. </param>
-    internal sealed record CommandError (
-        string Code,
-        string Message,
-        string? OpId);
-}
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Represents a single error entry in the CLI JSON result payload. </summary>
+/// <param name="Code"> A machine-readable error code. </param>
+/// <param name="Message"> A human-readable error message for the current failure. </param>
+/// <param name="OpId"> The operation identifier associated with this error, or <see langword="null" /> when not available. </param>
+internal sealed record CommandError (
+    string Code,
+    string Message,
+    string? OpId);

--- a/src/Ucli/Cli/CommandExecutionState.cs
+++ b/src/Ucli/Cli/CommandExecutionState.cs
@@ -1,21 +1,20 @@
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Tracks whether any command handler has started during the current process execution. </summary>
+internal static class CommandExecutionState
 {
-    /// <summary> Tracks whether any command handler has started during the current process execution. </summary>
-    internal static class CommandExecutionState
+    /// <summary> Gets a value indicating whether command handler execution has started. </summary>
+    public static bool HasStarted { get; private set; }
+
+    /// <summary> Marks the process state as started when command handler execution begins. </summary>
+    public static void MarkStarted ()
     {
-        /// <summary> Gets a value indicating whether command handler execution has started. </summary>
-        public static bool HasStarted { get; private set; }
+        HasStarted = true;
+    }
 
-        /// <summary> Marks the process state as started when command handler execution begins. </summary>
-        public static void MarkStarted ()
-        {
-            HasStarted = true;
-        }
-
-        /// <summary> Resets the process state before a new command invocation flow. </summary>
-        public static void Reset ()
-        {
-            HasStarted = false;
-        }
+    /// <summary> Resets the process state before a new command invocation flow. </summary>
+    public static void Reset ()
+    {
+        HasStarted = false;
     }
 }

--- a/src/Ucli/Cli/CommandResultWriter.cs
+++ b/src/Ucli/Cli/CommandResultWriter.cs
@@ -1,24 +1,23 @@
 using System.Text.Json;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Serializes command results and writes them to standard output as JSON. </summary>
+internal static class CommandResultWriter
 {
-    /// <summary> Serializes command results and writes them to standard output as JSON. </summary>
-    internal static class CommandResultWriter
+    private static readonly JsonSerializerOptions SerializerOptions = new()
     {
-        private static readonly JsonSerializerOptions SerializerOptions = new()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = true,
-        };
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
 
-        /// <summary> Writes the specified command result to standard output in JSON format. </summary>
-        /// <param name="result"> The command result to serialize. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="result" /> is <see langword="null" />. </exception>
-        public static void WriteToStandardOutput (CommandResult result)
-        {
-            ArgumentNullException.ThrowIfNull(result);
+    /// <summary> Writes the specified command result to standard output in JSON format. </summary>
+    /// <param name="result"> The command result to serialize. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="result" /> is <see langword="null" />. </exception>
+    public static void WriteToStandardOutput (CommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
 
-            Console.Out.WriteLine(JsonSerializer.Serialize(result, SerializerOptions));
-        }
+        Console.Out.WriteLine(JsonSerializer.Serialize(result, SerializerOptions));
     }
 }

--- a/src/Ucli/Cli/InitCommand.cs
+++ b/src/Ucli/Cli/InitCommand.cs
@@ -2,72 +2,68 @@ using ConsoleAppFramework;
 using MackySoft.Ucli.Foundation;
 using MackySoft.Ucli.Init;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Provides the <c>init</c> CLI command entry point. </summary>
+internal sealed class InitCommand
 {
-    /// <summary> Provides the <c>init</c> CLI command entry point. </summary>
-    internal sealed class InitCommand
+    private readonly IInitService initService;
+
+    /// <summary> Initializes a new instance of the <see cref="InitCommand" /> class. </summary>
+    /// <param name="initService"> The init service dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="initService" /> is <see langword="null" />. </exception>
+    public InitCommand (IInitService initService)
     {
-        /// <summary> Gets the command name used by this command handler. </summary>
-        internal const string CommandName = "init";
+        this.initService = initService ?? throw new ArgumentNullException(nameof(initService));
+    }
 
-        private readonly IInitService initService;
+    /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
+    /// <param name="force"> Whether existing template files can be overwritten. </param>
+    /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.Init)]
+    public int Init (
+        bool force = false,
+        string? projectPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
-        /// <summary> Initializes a new instance of the <see cref="InitCommand" /> class. </summary>
-        /// <param name="initService"> The init service dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="initService" /> is <see langword="null" />. </exception>
-        public InitCommand (IInitService initService)
+        CommandExecutionState.MarkStarted();
+
+        var executionResult = initService.Execute(force, projectPath, cancellationToken);
+        var result = CreateCommandResult(executionResult);
+        CommandResultWriter.WriteToStandardOutput(result);
+        return result.ExitCode;
+    }
+
+    /// <summary> Creates the command-level JSON result from an init service execution result. </summary>
+    /// <param name="executionResult"> The init service execution result. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="executionResult" /> is <see langword="null" />. </exception>
+    private static CommandResult CreateCommandResult (InitExecutionResult executionResult)
+    {
+        ArgumentNullException.ThrowIfNull(executionResult);
+
+        if (executionResult.IsSuccess)
         {
-            this.initService = initService ?? throw new ArgumentNullException(nameof(initService));
+            var output = executionResult.Output!;
+            return CommandResult.Success(
+                command: UcliCommandNames.Init,
+                message: "uCLI initialization completed.",
+                payload: new
+                {
+                    projectPath = output.ProjectPath,
+                    projectFingerprint = output.ProjectFingerprint,
+                    configPath = output.ConfigPath,
+                    gitignorePath = output.GitIgnorePath,
+                });
         }
 
-        /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
-        /// <param name="force"> Whether existing template files can be overwritten. </param>
-        /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
-        /// <returns> The exit code contained in the emitted command result. </returns>
-        [Command(CommandName)]
-        public int Init (
-            bool force = false,
-            string? projectPath = null,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            CommandExecutionState.MarkStarted();
-
-            var executionResult = initService.Execute(force, projectPath, cancellationToken);
-            var result = CreateCommandResult(executionResult);
-            CommandResultWriter.WriteToStandardOutput(result);
-            return result.ExitCode;
-        }
-
-        /// <summary> Creates the command-level JSON result from an init service execution result. </summary>
-        /// <param name="executionResult"> The init service execution result. </param>
-        /// <returns> The command result serialized to stdout. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="executionResult" /> is <see langword="null" />. </exception>
-        private static CommandResult CreateCommandResult (InitExecutionResult executionResult)
-        {
-            ArgumentNullException.ThrowIfNull(executionResult);
-
-            if (executionResult.IsSuccess)
-            {
-                var output = executionResult.Output!;
-                return CommandResult.Success(
-                    command: CommandName,
-                    message: "uCLI initialization completed.",
-                    payload: new
-                    {
-                        projectPath = output.ProjectPath,
-                        projectFingerprint = output.ProjectFingerprint,
-                        configPath = output.ConfigPath,
-                        gitignorePath = output.GitIgnorePath,
-                    });
-            }
-
-            var error = executionResult.Error!;
-            return error.Kind == ExecutionErrorKind.InvalidArgument
-                ? CommandResult.InvalidArgument(CommandName, error.Message)
-                : CommandResult.InternalError(CommandName, error.Message);
-        }
+        var error = executionResult.Error!;
+        return error.Kind == ExecutionErrorKind.InvalidArgument
+            ? CommandResult.InvalidArgument(UcliCommandNames.Init, error.Message)
+            : CommandResult.InternalError(UcliCommandNames.Init, error.Message);
     }
 }

--- a/src/Ucli/Cli/InitCommand.cs
+++ b/src/Ucli/Cli/InitCommand.cs
@@ -2,72 +2,71 @@ using ConsoleAppFramework;
 using MackySoft.Ucli.Foundation;
 using MackySoft.Ucli.Init;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Provides the <c>init</c> CLI command entry point. </summary>
+internal sealed class InitCommand
 {
-    /// <summary> Provides the <c>init</c> CLI command entry point. </summary>
-    internal sealed class InitCommand
+    /// <summary> Gets the command name used by this command handler. </summary>
+    internal const string CommandName = "init";
+
+    private readonly IInitService initService;
+
+    /// <summary> Initializes a new instance of the <see cref="InitCommand" /> class. </summary>
+    /// <param name="initService"> The init service dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="initService" /> is <see langword="null" />. </exception>
+    public InitCommand (IInitService initService)
     {
-        /// <summary> Gets the command name used by this command handler. </summary>
-        internal const string CommandName = "init";
+        this.initService = initService ?? throw new ArgumentNullException(nameof(initService));
+    }
 
-        private readonly IInitService initService;
+    /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
+    /// <param name="force"> Whether existing template files can be overwritten. </param>
+    /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(CommandName)]
+    public async Task<int> Init (
+        bool force = false,
+        string? projectPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
-        /// <summary> Initializes a new instance of the <see cref="InitCommand" /> class. </summary>
-        /// <param name="initService"> The init service dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="initService" /> is <see langword="null" />. </exception>
-        public InitCommand (IInitService initService)
+        CommandExecutionState.MarkStarted();
+
+        var executionResult = await initService.Execute(force, projectPath, cancellationToken).ConfigureAwait(false);
+        var result = CreateCommandResult(executionResult);
+        CommandResultWriter.WriteToStandardOutput(result);
+        return result.ExitCode;
+    }
+
+    /// <summary> Creates the command-level JSON result from an init service execution result. </summary>
+    /// <param name="executionResult"> The init service execution result. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="executionResult" /> is <see langword="null" />. </exception>
+    private static CommandResult CreateCommandResult (InitExecutionResult executionResult)
+    {
+        ArgumentNullException.ThrowIfNull(executionResult);
+
+        if (executionResult.IsSuccess)
         {
-            this.initService = initService ?? throw new ArgumentNullException(nameof(initService));
+            var output = executionResult.Output!;
+            return CommandResult.Success(
+                command: CommandName,
+                message: "uCLI initialization completed.",
+                payload: new
+                {
+                    projectPath = output.ProjectPath,
+                    projectFingerprint = output.ProjectFingerprint,
+                    configPath = output.ConfigPath,
+                    gitignorePath = output.GitIgnorePath,
+                });
         }
 
-        /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
-        /// <param name="force"> Whether existing template files can be overwritten. </param>
-        /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
-        /// <returns> The exit code contained in the emitted command result. </returns>
-        [Command(CommandName)]
-        public async Task<int> Init (
-            bool force = false,
-            string? projectPath = null,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            CommandExecutionState.MarkStarted();
-
-            var executionResult = await initService.Execute(force, projectPath, cancellationToken).ConfigureAwait(false);
-            var result = CreateCommandResult(executionResult);
-            CommandResultWriter.WriteToStandardOutput(result);
-            return result.ExitCode;
-        }
-
-        /// <summary> Creates the command-level JSON result from an init service execution result. </summary>
-        /// <param name="executionResult"> The init service execution result. </param>
-        /// <returns> The command result serialized to stdout. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="executionResult" /> is <see langword="null" />. </exception>
-        private static CommandResult CreateCommandResult (InitExecutionResult executionResult)
-        {
-            ArgumentNullException.ThrowIfNull(executionResult);
-
-            if (executionResult.IsSuccess)
-            {
-                var output = executionResult.Output!;
-                return CommandResult.Success(
-                    command: CommandName,
-                    message: "uCLI initialization completed.",
-                    payload: new
-                    {
-                        projectPath = output.ProjectPath,
-                        projectFingerprint = output.ProjectFingerprint,
-                        configPath = output.ConfigPath,
-                        gitignorePath = output.GitIgnorePath,
-                    });
-            }
-
-            var error = executionResult.Error!;
-            return error.Kind == ExecutionErrorKind.InvalidArgument
-                ? CommandResult.InvalidArgument(CommandName, error.Message)
-                : CommandResult.InternalError(CommandName, error.Message);
-        }
+        var error = executionResult.Error!;
+        return error.Kind == ExecutionErrorKind.InvalidArgument
+            ? CommandResult.InvalidArgument(CommandName, error.Message)
+            : CommandResult.InternalError(CommandName, error.Message);
     }
 }

--- a/src/Ucli/Cli/ParseErrorBuffer.cs
+++ b/src/Ucli/Cli/ParseErrorBuffer.cs
@@ -1,35 +1,34 @@
 using System.Collections.Concurrent;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Buffers argument parse error messages emitted before command handlers start. </summary>
+internal static class ParseErrorBuffer
 {
-    /// <summary> Buffers argument parse error messages emitted before command handlers start. </summary>
-    internal static class ParseErrorBuffer
+    private static readonly ConcurrentQueue<string> MessagesCore = new();
+
+    /// <summary> Gets the buffered parse error messages. </summary>
+    /// <returns> A snapshot enumeration of messages currently stored in the buffer. </returns>
+    public static IEnumerable<string> Messages => MessagesCore;
+
+    /// <summary> Gets a value indicating whether at least one parse error message is buffered. </summary>
+    public static bool HasAny => !MessagesCore.IsEmpty;
+
+    /// <summary> Adds a parse error message to the buffer. </summary>
+    /// <param name="message"> The parse error message to store. Must not be <see langword="null" />. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message" /> is <see langword="null" />. </exception>
+    public static void Add (string message)
     {
-        private static readonly ConcurrentQueue<string> MessagesCore = new();
+        ArgumentNullException.ThrowIfNull(message);
 
-        /// <summary> Gets the buffered parse error messages. </summary>
-        /// <returns> A snapshot enumeration of messages currently stored in the buffer. </returns>
-        public static IEnumerable<string> Messages => MessagesCore;
+        MessagesCore.Enqueue(message);
+    }
 
-        /// <summary> Gets a value indicating whether at least one parse error message is buffered. </summary>
-        public static bool HasAny => !MessagesCore.IsEmpty;
-
-        /// <summary> Adds a parse error message to the buffer. </summary>
-        /// <param name="message"> The parse error message to store. Must not be <see langword="null" />. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="message" /> is <see langword="null" />. </exception>
-        public static void Add (string message)
+    /// <summary> Removes all buffered parse error messages. </summary>
+    public static void Clear ()
+    {
+        while (MessagesCore.TryDequeue(out _))
         {
-            ArgumentNullException.ThrowIfNull(message);
-
-            MessagesCore.Enqueue(message);
-        }
-
-        /// <summary> Removes all buffered parse error messages. </summary>
-        public static void Clear ()
-        {
-            while (MessagesCore.TryDequeue(out _))
-            {
-            }
         }
     }
 }

--- a/src/Ucli/Cli/Requests/IRequestInputReader.cs
+++ b/src/Ucli/Cli/Requests/IRequestInputReader.cs
@@ -1,0 +1,13 @@
+namespace MackySoft.Ucli.Cli.Requests;
+
+/// <summary> Reads JSON request input from one configured source. </summary>
+internal interface IRequestInputReader
+{
+    /// <summary> Reads request JSON from <c>--requestPath</c> or standard input according to input rules. </summary>
+    /// <param name="requestPath"> The optional request file path specified by <c>--requestPath</c>. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result containing either request JSON and source metadata, or a structured error. </returns>
+    ValueTask<RequestInputReadResult> ReadAsync (
+        string? requestPath,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Cli/Requests/RequestInputReadResult.cs
+++ b/src/Ucli/Cli/Requests/RequestInputReadResult.cs
@@ -1,0 +1,50 @@
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Cli.Requests;
+
+/// <summary> Represents the result of reading JSON request input. </summary>
+/// <param name="Json"> The raw JSON request content, or <see langword="null" /> when reading fails. </param>
+/// <param name="Source"> The input source that produced <paramref name="Json" />, or <see langword="null" /> on failure. </param>
+/// <param name="Error"> The structured read error, or <see langword="null" /> on success. </param>
+internal sealed record RequestInputReadResult (
+    string? Json,
+    RequestInputSource? Source,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether request input was read successfully. </summary>
+    public bool IsSuccess => Json is not null && Source is not null && Error is null;
+
+    /// <summary> Creates a successful request-input read result. </summary>
+    /// <param name="json"> The raw JSON request content. </param>
+    /// <param name="source"> The input source that provided request JSON. </param>
+    /// <returns> The successful read result. </returns>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="json" /> is empty or whitespace. </exception>
+    public static RequestInputReadResult Success (
+        string json,
+        RequestInputSource source)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new ArgumentException("Request JSON must not be empty.", nameof(json));
+        }
+
+        return new RequestInputReadResult(
+            Json: json,
+            Source: source,
+            Error: null);
+    }
+
+    /// <summary> Creates a failed request-input read result. </summary>
+    /// <param name="error"> The structured read error. </param>
+    /// <returns> The failed read result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static RequestInputReadResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        return new RequestInputReadResult(
+            Json: null,
+            Source: null,
+            Error: error);
+    }
+}

--- a/src/Ucli/Cli/Requests/RequestInputReader.cs
+++ b/src/Ucli/Cli/Requests/RequestInputReader.cs
@@ -1,0 +1,191 @@
+using System.Security;
+using System.Text.Json;
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Cli.Requests;
+
+/// <summary> Reads JSON request input from one source and validates basic input constraints. </summary>
+internal sealed class RequestInputReader : IRequestInputReader
+{
+    private readonly Func<bool> isStandardInputRedirected;
+    private readonly Func<CancellationToken, Task<string>> readStandardInputAsync;
+    private readonly Func<string, CancellationToken, Task<string>> readRequestFileAsync;
+
+    /// <summary> Initializes a new instance of the <see cref="RequestInputReader" /> class. </summary>
+    public RequestInputReader ()
+        : this(
+            isStandardInputRedirected: static () => Console.IsInputRedirected,
+            readStandardInputAsync: static cancellationToken => Console.In.ReadToEndAsync(cancellationToken),
+            readRequestFileAsync: static (path, cancellationToken) => File.ReadAllTextAsync(path, cancellationToken))
+    {
+    }
+
+    /// <summary> Initializes a new instance of the <see cref="RequestInputReader" /> class for tests. </summary>
+    /// <param name="isStandardInputRedirected"> Delegate that reports whether standard input is redirected. </param>
+    /// <param name="readStandardInputAsync"> Delegate that reads standard input content. </param>
+    /// <param name="readRequestFileAsync"> Delegate that reads request file content. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when any delegate is <see langword="null" />. </exception>
+    internal RequestInputReader (
+        Func<bool> isStandardInputRedirected,
+        Func<CancellationToken, Task<string>> readStandardInputAsync,
+        Func<string, CancellationToken, Task<string>> readRequestFileAsync)
+    {
+        this.isStandardInputRedirected = isStandardInputRedirected ?? throw new ArgumentNullException(nameof(isStandardInputRedirected));
+        this.readStandardInputAsync = readStandardInputAsync ?? throw new ArgumentNullException(nameof(readStandardInputAsync));
+        this.readRequestFileAsync = readRequestFileAsync ?? throw new ArgumentNullException(nameof(readRequestFileAsync));
+    }
+
+    /// <summary> Reads JSON request input from one source under strict source-selection rules. </summary>
+    /// <param name="requestPath"> The optional request file path specified by <c>--requestPath</c>. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result containing either request JSON and source metadata, or a structured error. </returns>
+    public async ValueTask<RequestInputReadResult> ReadAsync (
+        string? requestPath,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var hasRequestPath = !string.IsNullOrWhiteSpace(requestPath);
+        var hasRedirectedStandardInput = isStandardInputRedirected();
+
+        if (hasRequestPath && hasRedirectedStandardInput)
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                "Request input source is ambiguous. Specify either --requestPath or redirected standard input."));
+        }
+
+        if (hasRequestPath)
+        {
+            return await ReadFromRequestPathAsync(requestPath!, cancellationToken);
+        }
+
+        if (!hasRedirectedStandardInput)
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                "Request input was not provided. Use redirected standard input or --requestPath."));
+        }
+
+        return await ReadFromStandardInputAsync(cancellationToken);
+    }
+
+    /// <summary> Reads and validates request JSON from standard input. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result. </returns>
+    private async ValueTask<RequestInputReadResult> ReadFromStandardInputAsync (CancellationToken cancellationToken)
+    {
+        string json;
+        try
+        {
+            json = await readStandardInputAsync(cancellationToken);
+        }
+        catch (IOException exception)
+        {
+            return RequestInputReadResult.Failure(CreateInternalError(
+                $"Failed to read request JSON from standard input. {exception.Message}"));
+        }
+
+        return ValidateJson(json, RequestInputSource.StandardInput, "standard input");
+    }
+
+    /// <summary> Reads and validates request JSON from a request file path. </summary>
+    /// <param name="requestPath"> The request file path. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result. </returns>
+    private async ValueTask<RequestInputReadResult> ReadFromRequestPathAsync (
+        string requestPath,
+        CancellationToken cancellationToken)
+    {
+        string json;
+        try
+        {
+            json = await readRequestFileAsync(requestPath, cancellationToken);
+        }
+        catch (Exception exception) when (IsPathFormatException(exception))
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                $"Request path is invalid: {requestPath}."));
+        }
+        catch (FileNotFoundException)
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                $"Request file was not found: {requestPath}."));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                $"Request directory was not found: {requestPath}."));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return RequestInputReadResult.Failure(CreateInternalError(
+                $"Failed to read request JSON from file: {requestPath}. {exception.Message}"));
+        }
+
+        return ValidateJson(json, RequestInputSource.RequestPath, $"request file '{requestPath}'");
+    }
+
+    /// <summary> Validates that request input is non-empty and JSON-parseable. </summary>
+    /// <param name="json"> The JSON content to validate. </param>
+    /// <param name="source"> The source where the input was read from. </param>
+    /// <param name="sourceLabel"> The source label used in error messages. </param>
+    /// <returns> The read result. </returns>
+    private static RequestInputReadResult ValidateJson (
+        string json,
+        RequestInputSource source,
+        string sourceLabel)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                $"Request JSON from {sourceLabel} must not be empty."));
+        }
+
+        try
+        {
+            using var _ = JsonDocument.Parse(json);
+        }
+        catch (JsonException exception)
+        {
+            return RequestInputReadResult.Failure(CreateInvalidArgument(
+                $"Request JSON from {sourceLabel} is invalid. {exception.Message}"));
+        }
+
+        return RequestInputReadResult.Success(json, source);
+    }
+
+    /// <summary> Determines whether an exception indicates unsupported or malformed path syntax. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when the exception represents invalid path syntax; otherwise, <see langword="false" />. </returns>
+    private static bool IsPathFormatException (Exception exception)
+    {
+        return exception is ArgumentException
+            || exception is NotSupportedException
+            || exception is PathTooLongException;
+    }
+
+    /// <summary> Determines whether an exception indicates I/O access failure. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when the exception represents I/O access failure; otherwise, <see langword="false" />. </returns>
+    private static bool IsIoFailure (Exception exception)
+    {
+        return exception is IOException
+            || exception is UnauthorizedAccessException
+            || exception is SecurityException;
+    }
+
+    /// <summary> Creates an invalid-argument error for request input failures. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured invalid-argument error. </returns>
+    private static ExecutionError CreateInvalidArgument (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+    }
+
+    /// <summary> Creates an internal error for request input failures. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured internal error. </returns>
+    private static ExecutionError CreateInternalError (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InternalError, message);
+    }
+}

--- a/src/Ucli/Cli/Requests/RequestInputSource.cs
+++ b/src/Ucli/Cli/Requests/RequestInputSource.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Cli.Requests;
+
+/// <summary> Identifies the source used to read one JSON request input. </summary>
+internal enum RequestInputSource
+{
+    /// <summary> Indicates standard input was used. </summary>
+    StandardInput = 0,
+
+    /// <summary> Indicates a request file path was used. </summary>
+    RequestPath = 1,
+}

--- a/src/Ucli/Cli/StatusCommand.cs
+++ b/src/Ucli/Cli/StatusCommand.cs
@@ -1,31 +1,27 @@
 using ConsoleAppFramework;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Provides the <c>status</c> CLI command entry point. </summary>
+internal sealed class StatusCommand
 {
-    /// <summary> Provides the <c>status</c> CLI command entry point. </summary>
-    internal sealed class StatusCommand
+    /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
+    /// <param name="projectPath"> --projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
+    /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.Status)]
+    public int Status (
+        string? projectPath = null,
+        string? mode = null,
+        CancellationToken cancellationToken = default)
     {
-        /// <summary> Gets the command name used by this command handler. </summary>
-        internal const string CommandName = "status";
+        cancellationToken.ThrowIfCancellationRequested();
 
-        /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
-        /// <param name="projectPath"> --projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
-        /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
-        /// <returns> The exit code contained in the emitted command result. </returns>
-        [Command(CommandName)]
-        public int Status (
-            string? projectPath = null,
-            string? mode = null,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        CommandExecutionState.MarkStarted();
 
-            CommandExecutionState.MarkStarted();
-
-            var result = CommandResult.NotImplemented(CommandName);
-            CommandResultWriter.WriteToStandardOutput(result);
-            return result.ExitCode;
-        }
+        var result = CommandResult.NotImplemented(UcliCommandNames.Status);
+        CommandResultWriter.WriteToStandardOutput(result);
+        return result.ExitCode;
     }
 }

--- a/src/Ucli/Cli/StatusCommand.cs
+++ b/src/Ucli/Cli/StatusCommand.cs
@@ -1,27 +1,26 @@
 using ConsoleAppFramework;
 
-namespace MackySoft.Ucli.Cli
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Provides the <c>status</c> CLI command entry point. </summary>
+internal sealed class StatusCommand
 {
-    /// <summary> Provides the <c>status</c> CLI command entry point. </summary>
-    internal sealed class StatusCommand
+    /// <summary> Gets the command name used by this command handler. </summary>
+    internal const string CommandName = "status";
+
+    /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
+    /// <param name="projectPath"> --projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
+    /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(CommandName)]
+    public int Status (
+        string? projectPath = null,
+        string? mode = null)
     {
-        /// <summary> Gets the command name used by this command handler. </summary>
-        internal const string CommandName = "status";
+        CommandExecutionState.MarkStarted();
 
-        /// <summary> Writes the placeholder result for the <c>status</c> command. </summary>
-        /// <param name="projectPath"> --projectPath, Reserved option for target UnityProject path selection. The current implementation ignores this value. </param>
-        /// <param name="mode"> Reserved option for status output mode selection. The current implementation ignores this value. </param>
-        /// <returns> The exit code contained in the emitted command result. </returns>
-        [Command(CommandName)]
-        public int Status (
-            string? projectPath = null,
-            string? mode = null)
-        {
-            CommandExecutionState.MarkStarted();
-
-            var result = CommandResult.NotImplemented(CommandName);
-            CommandResultWriter.WriteToStandardOutput(result);
-            return result.ExitCode;
-        }
+        var result = CommandResult.NotImplemented(CommandName);
+        CommandResultWriter.WriteToStandardOutput(result);
+        return result.ExitCode;
     }
 }

--- a/src/Ucli/Cli/UcliCommandNames.cs
+++ b/src/Ucli/Cli/UcliCommandNames.cs
@@ -1,0 +1,28 @@
+namespace MackySoft.Ucli.Cli;
+
+/// <summary> Defines CLI command-name constants and lookup helpers. </summary>
+internal static class UcliCommandNames
+{
+    /// <summary> Gets the command name for help. </summary>
+    public const string Help = "help";
+
+    /// <summary> Gets the command name for init. </summary>
+    public const string Init = "init";
+
+    /// <summary> Gets the command name for status. </summary>
+    public const string Status = "status";
+
+    private static readonly HashSet<string> RegisteredCommandNames = new(StringComparer.Ordinal)
+    {
+        Init,
+        Status,
+    };
+
+    /// <summary> Determines whether the specified command name is registered in the CLI host. </summary>
+    /// <param name="commandName"> The command name to check. </param>
+    /// <returns> <see langword="true" /> when the command is registered; otherwise <see langword="false" />. </returns>
+    public static bool IsRegistered (string? commandName)
+    {
+        return !string.IsNullOrWhiteSpace(commandName) && RegisteredCommandNames.Contains(commandName);
+    }
+}

--- a/src/Ucli/Configuration/ConfigSource.cs
+++ b/src/Ucli/Configuration/ConfigSource.cs
@@ -1,12 +1,11 @@
-namespace MackySoft.Ucli.Configuration
-{
-    /// <summary> Identifies where <see cref="UcliConfig" /> values were loaded from. </summary>
-    internal enum ConfigSource
-    {
-        /// <summary> The configuration file was not found and default values were applied. </summary>
-        Default = 0,
+namespace MackySoft.Ucli.Configuration;
 
-        /// <summary> The configuration file was loaded from disk. </summary>
-        File = 1,
-    }
+/// <summary> Identifies where <see cref="UcliConfig" /> values were loaded from. </summary>
+internal enum ConfigSource
+{
+    /// <summary> The configuration file was not found and default values were applied. </summary>
+    Default = 0,
+
+    /// <summary> The configuration file was loaded from disk. </summary>
+    File = 1,
 }

--- a/src/Ucli/Configuration/IUcliConfigStore.cs
+++ b/src/Ucli/Configuration/IUcliConfigStore.cs
@@ -1,34 +1,33 @@
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Provides read/write access to <c>.ucli/config.json</c>. </summary>
+internal interface IUcliConfigStore
 {
-    /// <summary> Provides read/write access to <c>.ucli/config.json</c>. </summary>
-    internal interface IUcliConfigStore
-    {
-        /// <summary> Resolves the absolute path to the config file under a UnityProject root. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
-        /// <returns> The absolute config path. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
-        /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
-        /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
-        /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
-        string GetConfigPath (string unityProjectRoot);
+    /// <summary> Resolves the absolute path to the config file under a UnityProject root. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
+    /// <returns> The absolute config path. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
+    /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
+    /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
+    string GetConfigPath (string unityProjectRoot);
 
-        /// <summary> Loads config values for a UnityProject. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
-        ValueTask<UcliConfigLoadResult> Load (
-            string unityProjectRoot,
-            CancellationToken cancellationToken = default);
+    /// <summary> Loads config values for a UnityProject. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+    ValueTask<UcliConfigLoadResult> Load (
+        string unityProjectRoot,
+        CancellationToken cancellationToken = default);
 
-        /// <summary> Saves config values for a UnityProject. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
-        /// <param name="config"> The config values to persist. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the config-save result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        ValueTask<UcliConfigSaveResult> Save (
-            string unityProjectRoot,
-            UcliConfig config,
-            CancellationToken cancellationToken = default);
-    }
+    /// <summary> Saves config values for a UnityProject. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+    /// <param name="config"> The config values to persist. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the config-save result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+    ValueTask<UcliConfigSaveResult> Save (
+        string unityProjectRoot,
+        UcliConfig config,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Ucli/Configuration/OperationPolicy.cs
+++ b/src/Ucli/Configuration/OperationPolicy.cs
@@ -1,15 +1,14 @@
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Defines allowed operation safety levels configured in <c>.ucli/config.json</c>. </summary>
+internal enum OperationPolicy
 {
-    /// <summary> Defines allowed operation safety levels configured in <c>.ucli/config.json</c>. </summary>
-    internal enum OperationPolicy
-    {
-        /// <summary> Allows only safe operations. </summary>
-        Safe = 0,
+    /// <summary> Allows only safe operations. </summary>
+    Safe = 0,
 
-        /// <summary> Allows safe and advanced operations. </summary>
-        Advanced = 1,
+    /// <summary> Allows safe and advanced operations. </summary>
+    Advanced = 1,
 
-        /// <summary> Allows safe, advanced, and dangerous operations. </summary>
-        Dangerous = 2,
-    }
+    /// <summary> Allows safe, advanced, and dangerous operations. </summary>
+    Dangerous = 2,
 }

--- a/src/Ucli/Configuration/PlanTokenMode.cs
+++ b/src/Ucli/Configuration/PlanTokenMode.cs
@@ -1,12 +1,11 @@
-namespace MackySoft.Ucli.Configuration
-{
-    /// <summary> Defines plan-token requirements configured in <c>.ucli/config.json</c>. </summary>
-    internal enum PlanTokenMode
-    {
-        /// <summary> Allows command execution with or without a plan token. </summary>
-        Optional = 0,
+namespace MackySoft.Ucli.Configuration;
 
-        /// <summary> Requires command execution to include a plan token. </summary>
-        Required = 1,
-    }
+/// <summary> Defines plan-token requirements configured in <c>.ucli/config.json</c>. </summary>
+internal enum PlanTokenMode
+{
+    /// <summary> Allows command execution with or without a plan token. </summary>
+    Optional = 0,
+
+    /// <summary> Requires command execution to include a plan token. </summary>
+    Required = 1,
 }

--- a/src/Ucli/Configuration/UcliConfig.cs
+++ b/src/Ucli/Configuration/UcliConfig.cs
@@ -1,31 +1,30 @@
-namespace MackySoft.Ucli.Configuration
-{
-    /// <summary> Represents parsed values from <c>.ucli/config.json</c>. </summary>
-    /// <param name="SchemaVersion"> The config schema version. </param>
-    /// <param name="OperationPolicy"> The allowed operation safety level. </param>
-    /// <param name="PlanTokenMode"> The plan token requirement level. </param>
-    /// <param name="OperationAllowlist"> The operation-name allowlist patterns. </param>
-    internal sealed record UcliConfig (
-        int SchemaVersion,
-        OperationPolicy OperationPolicy,
-        PlanTokenMode PlanTokenMode,
-        IReadOnlyList<string> OperationAllowlist)
-    {
-        private const int CurrentSchemaVersion = 1;
-        private const string DefaultAllowlistPattern = "^ucli\\.";
+namespace MackySoft.Ucli.Configuration;
 
-        /// <summary> Creates default configuration values for missing config files. </summary>
-        /// <returns> The default config instance. </returns>
-        public static UcliConfig CreateDefault ()
-        {
-            return new UcliConfig(
-                SchemaVersion: CurrentSchemaVersion,
-                OperationPolicy: OperationPolicy.Safe,
-                PlanTokenMode: PlanTokenMode.Optional,
-                OperationAllowlist:
-                [
-                    DefaultAllowlistPattern,
-                ]);
-        }
+/// <summary> Represents parsed values from <c>.ucli/config.json</c>. </summary>
+/// <param name="SchemaVersion"> The config schema version. </param>
+/// <param name="OperationPolicy"> The allowed operation safety level. </param>
+/// <param name="PlanTokenMode"> The plan token requirement level. </param>
+/// <param name="OperationAllowlist"> The operation-name allowlist patterns. </param>
+internal sealed record UcliConfig (
+    int SchemaVersion,
+    OperationPolicy OperationPolicy,
+    PlanTokenMode PlanTokenMode,
+    IReadOnlyList<string> OperationAllowlist)
+{
+    private const int CurrentSchemaVersion = 1;
+    private const string DefaultAllowlistPattern = "^ucli\\.";
+
+    /// <summary> Creates default configuration values for missing config files. </summary>
+    /// <returns> The default config instance. </returns>
+    public static UcliConfig CreateDefault ()
+    {
+        return new UcliConfig(
+            SchemaVersion: CurrentSchemaVersion,
+            OperationPolicy: OperationPolicy.Safe,
+            PlanTokenMode: PlanTokenMode.Optional,
+            OperationAllowlist:
+            [
+                DefaultAllowlistPattern,
+            ]);
     }
 }

--- a/src/Ucli/Configuration/UcliConfigLoadResult.cs
+++ b/src/Ucli/Configuration/UcliConfigLoadResult.cs
@@ -1,38 +1,37 @@
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Represents the result of loading <see cref="UcliConfig" /> values. </summary>
+/// <param name="Config"> The loaded config, or <see langword="null" /> on failure. </param>
+/// <param name="Source"> The source used for config values. </param>
+/// <param name="Error"> The structured load error, or <see langword="null" /> on success. </param>
+internal sealed record UcliConfigLoadResult (
+    UcliConfig? Config,
+    ConfigSource Source,
+    ExecutionError? Error)
 {
-    /// <summary> Represents the result of loading <see cref="UcliConfig" /> values. </summary>
-    /// <param name="Config"> The loaded config, or <see langword="null" /> on failure. </param>
-    /// <param name="Source"> The source used for config values. </param>
-    /// <param name="Error"> The structured load error, or <see langword="null" /> on success. </param>
-    internal sealed record UcliConfigLoadResult (
-        UcliConfig? Config,
-        ConfigSource Source,
-        ExecutionError? Error)
+    /// <summary> Gets a value indicating whether config load succeeded. </summary>
+    public bool IsSuccess => Config is not null && Error is null;
+
+    /// <summary> Creates a successful config-load result. </summary>
+    /// <param name="config"> The loaded config values. </param>
+    /// <param name="source"> The source used for the loaded values. </param>
+    /// <returns> The successful result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+    public static UcliConfigLoadResult Success (UcliConfig config, ConfigSource source)
     {
-        /// <summary> Gets a value indicating whether config load succeeded. </summary>
-        public bool IsSuccess => Config is not null && Error is null;
+        ArgumentNullException.ThrowIfNull(config);
+        return new UcliConfigLoadResult(config, source, null);
+    }
 
-        /// <summary> Creates a successful config-load result. </summary>
-        /// <param name="config"> The loaded config values. </param>
-        /// <param name="source"> The source used for the loaded values. </param>
-        /// <returns> The successful result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        public static UcliConfigLoadResult Success (UcliConfig config, ConfigSource source)
-        {
-            ArgumentNullException.ThrowIfNull(config);
-            return new UcliConfigLoadResult(config, source, null);
-        }
-
-        /// <summary> Creates a failed config-load result. </summary>
-        /// <param name="error"> The structured load error. </param>
-        /// <returns> The failed result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static UcliConfigLoadResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new UcliConfigLoadResult(null, ConfigSource.Default, error);
-        }
+    /// <summary> Creates a failed config-load result. </summary>
+    /// <param name="error"> The structured load error. </param>
+    /// <returns> The failed result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static UcliConfigLoadResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new UcliConfigLoadResult(null, ConfigSource.Default, error);
     }
 }

--- a/src/Ucli/Configuration/UcliConfigSaveResult.cs
+++ b/src/Ucli/Configuration/UcliConfigSaveResult.cs
@@ -1,30 +1,29 @@
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Represents the result of persisting <see cref="UcliConfig" /> values. </summary>
+/// <param name="Error"> The structured save error, or <see langword="null" /> on success. </param>
+internal sealed record UcliConfigSaveResult (
+    ExecutionError? Error)
 {
-    /// <summary> Represents the result of persisting <see cref="UcliConfig" /> values. </summary>
-    /// <param name="Error"> The structured save error, or <see langword="null" /> on success. </param>
-    internal sealed record UcliConfigSaveResult (
-        ExecutionError? Error)
+    /// <summary> Gets a value indicating whether config save succeeded. </summary>
+    public bool IsSuccess => Error is null;
+
+    /// <summary> Creates a successful config-save result. </summary>
+    /// <returns> The successful result. </returns>
+    public static UcliConfigSaveResult Success ()
     {
-        /// <summary> Gets a value indicating whether config save succeeded. </summary>
-        public bool IsSuccess => Error is null;
+        return new UcliConfigSaveResult(Error: null);
+    }
 
-        /// <summary> Creates a successful config-save result. </summary>
-        /// <returns> The successful result. </returns>
-        public static UcliConfigSaveResult Success ()
-        {
-            return new UcliConfigSaveResult(Error: null);
-        }
-
-        /// <summary> Creates a failed config-save result. </summary>
-        /// <param name="error"> The structured save error. </param>
-        /// <returns> The failed result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static UcliConfigSaveResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new UcliConfigSaveResult(Error: error);
-        }
+    /// <summary> Creates a failed config-save result. </summary>
+    /// <param name="error"> The structured save error. </param>
+    /// <returns> The failed result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static UcliConfigSaveResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new UcliConfigSaveResult(Error: error);
     }
 }

--- a/src/Ucli/Configuration/UcliConfigStore.cs
+++ b/src/Ucli/Configuration/UcliConfigStore.cs
@@ -2,494 +2,493 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Provides filesystem-backed access to <c>.ucli/config.json</c>. </summary>
+internal sealed class UcliConfigStore : IUcliConfigStore
 {
-    /// <summary> Provides filesystem-backed access to <c>.ucli/config.json</c>. </summary>
-    internal sealed class UcliConfigStore : IUcliConfigStore
+    private const string UcliDirectoryName = ".ucli";
+    private const string ConfigFileName = "config.json";
+    private const int SupportedSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
     {
-        private const string UcliDirectoryName = ".ucli";
-        private const string ConfigFileName = "config.json";
-        private const int SupportedSchemaVersion = 1;
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
 
-        private static readonly JsonSerializerOptions SerializerOptions = new()
+    /// <summary> Resolves the absolute path to <c>.ucli/config.json</c> for a UnityProject root. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
+    /// <returns> The absolute config path. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
+    /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
+    /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
+    public string GetConfigPath (string unityProjectRoot)
+    {
+        var fullPath = Path.GetFullPath(unityProjectRoot);
+        return Path.Combine(fullPath, UcliDirectoryName, ConfigFileName);
+    }
+
+    /// <summary> Loads configuration values for a UnityProject root. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
+    public async ValueTask<UcliConfigLoadResult> Load (
+        string unityProjectRoot,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(unityProjectRoot))
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            PropertyNameCaseInsensitive = true,
-            WriteIndented = true,
+            return UcliConfigLoadResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
+        }
+
+        string configPath;
+        try
+        {
+            configPath = GetConfigPath(unityProjectRoot);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                $"UnityProject root path is invalid: {unityProjectRoot}"));
+        }
+
+        if (!File.Exists(configPath))
+        {
+            return UcliConfigLoadResult.Success(UcliConfig.CreateDefault(), ConfigSource.Default);
+        }
+
+        string json;
+        try
+        {
+            json = await File.ReadAllTextAsync(configPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                $"Config path is invalid: {configPath}"));
+        }
+        catch (Exception ex) when (IsIoFailure(ex))
+        {
+            return UcliConfigLoadResult.Failure(CreateInternalError(
+                $"Failed to read config file: {configPath}. {ex.Message}"));
+        }
+
+        UcliConfigDocument? document;
+        try
+        {
+            document = JsonSerializer.Deserialize<UcliConfigDocument>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                $"Config JSON is invalid: {configPath}. {ex.Message}"));
+        }
+
+        if (document is null)
+        {
+            return UcliConfigLoadResult.Failure(CreateInvalidArgument(
+                $"Config JSON is invalid: {configPath}."));
+        }
+
+        var parseResult = TryConvertToConfig(document, configPath);
+        if (!parseResult.IsSuccess)
+        {
+            return UcliConfigLoadResult.Failure(parseResult.Error!);
+        }
+
+        return UcliConfigLoadResult.Success(parseResult.Config!, ConfigSource.File);
+    }
+
+    /// <summary> Saves configuration values to <c>.ucli/config.json</c>. </summary>
+    /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
+    /// <param name="config"> The config values to persist. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the config-save result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+    public async ValueTask<UcliConfigSaveResult> Save (
+        string unityProjectRoot,
+        UcliConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(unityProjectRoot))
+        {
+            return UcliConfigSaveResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
+        }
+
+        ArgumentNullException.ThrowIfNull(config);
+
+        string configPath;
+        try
+        {
+            configPath = GetConfigPath(unityProjectRoot);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                $"UnityProject root path is invalid: {unityProjectRoot}"));
+        }
+
+        var configValidationResult = ValidateConfig(config, configPath);
+        if (!configValidationResult.IsSuccess)
+        {
+            return UcliConfigSaveResult.Failure(configValidationResult.Error!);
+        }
+
+        var json = JsonSerializer.Serialize(ToDocument(config), SerializerOptions);
+        string? configDirectoryPath = null;
+        try
+        {
+            configDirectoryPath = Path.GetDirectoryName(configPath);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                $"Config path is invalid: {configPath}. {ex.Message}"));
+        }
+
+        if (string.IsNullOrWhiteSpace(configDirectoryPath))
+        {
+            return UcliConfigSaveResult.Failure(CreateInternalError(
+                $"Config directory path could not be determined: {configPath}"));
+        }
+
+        try
+        {
+            Directory.CreateDirectory(configDirectoryPath);
+            await File.WriteAllTextAsync(configPath, json + Environment.NewLine, cancellationToken).ConfigureAwait(false);
+            return UcliConfigSaveResult.Success();
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return UcliConfigSaveResult.Failure(CreateInvalidArgument(
+                $"Config path is invalid: {configPath}. {ex.Message}"));
+        }
+        catch (Exception ex) when (IsIoFailure(ex))
+        {
+            return UcliConfigSaveResult.Failure(CreateInternalError(
+                $"Failed to write config file: {configPath}. {ex.Message}"));
+        }
+    }
+
+    /// <summary> Converts deserialized config JSON into a validated <see cref="UcliConfig" /> instance. </summary>
+    /// <param name="document"> The deserialized config document. </param>
+    /// <param name="configPath"> The source config path. </param>
+    /// <returns> The conversion result. </returns>
+    private static ConfigParseResult TryConvertToConfig (
+        UcliConfigDocument document,
+        string configPath)
+    {
+        if (document.SchemaVersion != SupportedSchemaVersion)
+        {
+            return ConfigParseResult.Failure(CreateInvalidArgument(
+                $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {document.SchemaVersion}."));
+        }
+
+        if (!TryParseOperationPolicy(document.OperationPolicy, out var operationPolicy))
+        {
+            return ConfigParseResult.Failure(CreateInvalidArgument(
+                $"Config operationPolicy is invalid: {document.OperationPolicy}."));
+        }
+
+        if (!TryParsePlanTokenMode(document.PlanTokenMode, out var planTokenMode))
+        {
+            return ConfigParseResult.Failure(CreateInvalidArgument(
+                $"Config planTokenMode is invalid: {document.PlanTokenMode}."));
+        }
+
+        if (document.OperationAllowlist is null)
+        {
+            return ConfigParseResult.Failure(CreateInvalidArgument(
+                $"Config operationAllowlist must be an array: {configPath}."));
+        }
+
+        var normalizedAllowlist = new List<string>(document.OperationAllowlist.Length);
+        foreach (var pattern in document.OperationAllowlist)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist contains an empty pattern: {configPath}."));
+            }
+
+            var normalizedPattern = pattern.Trim();
+            if (!TryValidateRegexPattern(normalizedPattern, out var patternErrorMessage))
+            {
+                return ConfigParseResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist contains an invalid regex pattern: {normalizedPattern}. {patternErrorMessage}"));
+            }
+
+            normalizedAllowlist.Add(normalizedPattern);
+        }
+
+        var config = new UcliConfig(
+            SchemaVersion: document.SchemaVersion,
+            OperationPolicy: operationPolicy,
+            PlanTokenMode: planTokenMode,
+            OperationAllowlist: normalizedAllowlist);
+        return ConfigParseResult.Success(config);
+    }
+
+    /// <summary> Validates configuration values before writing them to disk. </summary>
+    /// <param name="config"> The config values to validate. </param>
+    /// <param name="configPath"> The destination config path. </param>
+    /// <returns> The validation result. </returns>
+    private static ConfigValidationResult ValidateConfig (
+        UcliConfig config,
+        string configPath)
+    {
+        if (config.SchemaVersion != SupportedSchemaVersion)
+        {
+            return ConfigValidationResult.Failure(CreateInvalidArgument(
+                $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {config.SchemaVersion}."));
+        }
+
+        if (config.OperationAllowlist is null)
+        {
+            return ConfigValidationResult.Failure(CreateInvalidArgument(
+                $"Config operationAllowlist must not be null: {configPath}."));
+        }
+
+        foreach (var pattern in config.OperationAllowlist)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                return ConfigValidationResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist contains an empty pattern: {configPath}."));
+            }
+
+            if (!TryValidateRegexPattern(pattern, out var patternErrorMessage))
+            {
+                return ConfigValidationResult.Failure(CreateInvalidArgument(
+                    $"Config operationAllowlist contains an invalid regex pattern: {pattern}. {patternErrorMessage}"));
+            }
+        }
+
+        return ConfigValidationResult.Success();
+    }
+
+    /// <summary> Validates whether a value can be compiled as a regular expression pattern. </summary>
+    /// <param name="pattern"> The regex pattern string to validate. </param>
+    /// <param name="errorMessage"> The parser error message when the pattern is invalid. </param>
+    /// <returns> <see langword="true" /> when the pattern is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryValidateRegexPattern (
+        string pattern,
+        out string? errorMessage)
+    {
+        try
+        {
+            new Regex(pattern, RegexOptions.CultureInvariant);
+            errorMessage = null;
+            return true;
+        }
+        catch (ArgumentException exception)
+        {
+            errorMessage = exception.Message;
+            return false;
+        }
+    }
+
+    /// <summary> Converts typed config values into serializable JSON DTO values. </summary>
+    /// <param name="config"> The typed config values. </param>
+    /// <returns> The serializable DTO. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
+    private static UcliConfigDocument ToDocument (UcliConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return new UcliConfigDocument(
+            SchemaVersion: config.SchemaVersion,
+            OperationPolicy: ToStringValue(config.OperationPolicy),
+            PlanTokenMode: ToStringValue(config.PlanTokenMode),
+            OperationAllowlist: config.OperationAllowlist.ToArray());
+    }
+
+    /// <summary> Converts <see cref="OperationPolicy" /> to the config string value. </summary>
+    /// <param name="operationPolicy"> The operation policy value. </param>
+    /// <returns> The config string representation. </returns>
+    /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="operationPolicy" /> is outside supported values. </exception>
+    private static string ToStringValue (OperationPolicy operationPolicy)
+    {
+        return operationPolicy switch
+        {
+            OperationPolicy.Safe => UcliConfigValueConstants.OperationPolicySafe,
+            OperationPolicy.Advanced => UcliConfigValueConstants.OperationPolicyAdvanced,
+            OperationPolicy.Dangerous => UcliConfigValueConstants.OperationPolicyDangerous,
+            _ => throw new ArgumentOutOfRangeException(nameof(operationPolicy), operationPolicy, "Unsupported operationPolicy."),
         };
+    }
 
-        /// <summary> Resolves the absolute path to <c>.ucli/config.json</c> for a UnityProject root. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path used as the base directory. Must not be <see langword="null" />. </param>
-        /// <returns> The absolute config path. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectRoot" /> is <see langword="null" />. </exception>
-        /// <exception cref="ArgumentException"> Thrown when <paramref name="unityProjectRoot" /> contains invalid path characters. </exception>
-        /// <exception cref="NotSupportedException"> Thrown when <paramref name="unityProjectRoot" /> uses an unsupported path format. </exception>
-        /// <exception cref="PathTooLongException"> Thrown when <paramref name="unityProjectRoot" /> exceeds platform path limits. </exception>
-        public string GetConfigPath (string unityProjectRoot)
+    /// <summary> Converts <see cref="PlanTokenMode" /> to the config string value. </summary>
+    /// <param name="planTokenMode"> The plan token mode value. </param>
+    /// <returns> The config string representation. </returns>
+    /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="planTokenMode" /> is outside supported values. </exception>
+    private static string ToStringValue (PlanTokenMode planTokenMode)
+    {
+        return planTokenMode switch
         {
-            var fullPath = Path.GetFullPath(unityProjectRoot);
-            return Path.Combine(fullPath, UcliDirectoryName, ConfigFileName);
+            PlanTokenMode.Optional => UcliConfigValueConstants.PlanTokenModeOptional,
+            PlanTokenMode.Required => UcliConfigValueConstants.PlanTokenModeRequired,
+            _ => throw new ArgumentOutOfRangeException(nameof(planTokenMode), planTokenMode, "Unsupported planTokenMode."),
+        };
+    }
+
+    /// <summary> Parses operation-policy config values. </summary>
+    /// <param name="value"> The config string value. </param>
+    /// <param name="operationPolicy"> The parsed enum value. </param>
+    /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
+    private static bool TryParseOperationPolicy (string? value, out OperationPolicy operationPolicy)
+    {
+        if (string.Equals(value, UcliConfigValueConstants.OperationPolicySafe, StringComparison.OrdinalIgnoreCase))
+        {
+            operationPolicy = OperationPolicy.Safe;
+            return true;
         }
 
-        /// <summary> Loads configuration values for a UnityProject root. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the config-load result. When <c>.ucli/config.json</c> does not exist, default config values are returned with <see cref="ConfigSource.Default" />. </returns>
-        public async ValueTask<UcliConfigLoadResult> Load (
-            string unityProjectRoot,
-            CancellationToken cancellationToken = default)
+        if (string.Equals(value, UcliConfigValueConstants.OperationPolicyAdvanced, StringComparison.OrdinalIgnoreCase))
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (string.IsNullOrWhiteSpace(unityProjectRoot))
-            {
-                return UcliConfigLoadResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
-            }
-
-            string configPath;
-            try
-            {
-                configPath = GetConfigPath(unityProjectRoot);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
-                    $"UnityProject root path is invalid: {unityProjectRoot}"));
-            }
-
-            if (!File.Exists(configPath))
-            {
-                return UcliConfigLoadResult.Success(UcliConfig.CreateDefault(), ConfigSource.Default);
-            }
-
-            string json;
-            try
-            {
-                json = await File.ReadAllTextAsync(configPath, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
-                    $"Config path is invalid: {configPath}"));
-            }
-            catch (Exception ex) when (IsIoFailure(ex))
-            {
-                return UcliConfigLoadResult.Failure(CreateInternalError(
-                    $"Failed to read config file: {configPath}. {ex.Message}"));
-            }
-
-            UcliConfigDocument? document;
-            try
-            {
-                document = JsonSerializer.Deserialize<UcliConfigDocument>(json, SerializerOptions);
-            }
-            catch (JsonException ex)
-            {
-                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
-                    $"Config JSON is invalid: {configPath}. {ex.Message}"));
-            }
-
-            if (document is null)
-            {
-                return UcliConfigLoadResult.Failure(CreateInvalidArgument(
-                    $"Config JSON is invalid: {configPath}."));
-            }
-
-            var parseResult = TryConvertToConfig(document, configPath);
-            if (!parseResult.IsSuccess)
-            {
-                return UcliConfigLoadResult.Failure(parseResult.Error!);
-            }
-
-            return UcliConfigLoadResult.Success(parseResult.Config!, ConfigSource.File);
+            operationPolicy = OperationPolicy.Advanced;
+            return true;
         }
 
-        /// <summary> Saves configuration values to <c>.ucli/config.json</c>. </summary>
-        /// <param name="unityProjectRoot"> The UnityProject root path from command context. <see langword="null" />, empty, and whitespace values return an invalid-argument result. </param>
-        /// <param name="config"> The config values to persist. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the config-save result. </returns>
+        if (string.Equals(value, UcliConfigValueConstants.OperationPolicyDangerous, StringComparison.OrdinalIgnoreCase))
+        {
+            operationPolicy = OperationPolicy.Dangerous;
+            return true;
+        }
+
+        operationPolicy = default;
+        return false;
+    }
+
+    /// <summary> Parses plan-token-mode config values. </summary>
+    /// <param name="value"> The config string value. </param>
+    /// <param name="planTokenMode"> The parsed enum value. </param>
+    /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
+    private static bool TryParsePlanTokenMode (string? value, out PlanTokenMode planTokenMode)
+    {
+        if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeOptional, StringComparison.OrdinalIgnoreCase))
+        {
+            planTokenMode = PlanTokenMode.Optional;
+            return true;
+        }
+
+        if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeRequired, StringComparison.OrdinalIgnoreCase))
+        {
+            planTokenMode = PlanTokenMode.Required;
+            return true;
+        }
+
+        planTokenMode = default;
+        return false;
+    }
+
+    /// <summary> Creates an invalid-argument error. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured invalid-argument error. </returns>
+    private static ExecutionError CreateInvalidArgument (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+    }
+
+    /// <summary> Creates an internal-error value. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured internal-error value. </returns>
+    private static ExecutionError CreateInternalError (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InternalError, message);
+    }
+
+    /// <summary> Determines whether an exception should be treated as invalid path formatting. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when invalid path formatting is detected; otherwise <see langword="false" />. </returns>
+    private static bool IsPathFormatException (Exception exception)
+    {
+        return exception is ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+    }
+
+    /// <summary> Determines whether an exception should be treated as an internal I/O failure. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
+    private static bool IsIoFailure (Exception exception)
+    {
+        return exception is IOException
+            or UnauthorizedAccessException;
+    }
+
+    /// <summary> Serializable JSON DTO for config values. </summary>
+    /// <param name="SchemaVersion"> The config schema version. </param>
+    /// <param name="OperationPolicy"> The operation-policy value. </param>
+    /// <param name="PlanTokenMode"> The plan-token-mode value. </param>
+    /// <param name="OperationAllowlist"> The operation-name allowlist. </param>
+    private sealed record UcliConfigDocument (
+        int SchemaVersion,
+        string OperationPolicy,
+        string PlanTokenMode,
+        string[] OperationAllowlist);
+
+    /// <summary> Represents result values from config parse operations. </summary>
+    /// <param name="Config"> The parsed config instance. </param>
+    /// <param name="Error"> The parse error, when parse fails. </param>
+    private readonly record struct ConfigParseResult (
+        UcliConfig? Config,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether parse succeeded. </summary>
+        public bool IsSuccess => Config is not null && Error is null;
+
+        /// <summary> Creates a successful parse result. </summary>
+        /// <param name="config"> The parsed config instance. </param>
+        /// <returns> The successful parse result. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        public async ValueTask<UcliConfigSaveResult> Save (
-            string unityProjectRoot,
-            UcliConfig config,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (string.IsNullOrWhiteSpace(unityProjectRoot))
-            {
-                return UcliConfigSaveResult.Failure(CreateInvalidArgument("UnityProject root path must not be empty."));
-            }
-
-            ArgumentNullException.ThrowIfNull(config);
-
-            string configPath;
-            try
-            {
-                configPath = GetConfigPath(unityProjectRoot);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
-                    $"UnityProject root path is invalid: {unityProjectRoot}"));
-            }
-
-            var configValidationResult = ValidateConfig(config, configPath);
-            if (!configValidationResult.IsSuccess)
-            {
-                return UcliConfigSaveResult.Failure(configValidationResult.Error!);
-            }
-
-            var json = JsonSerializer.Serialize(ToDocument(config), SerializerOptions);
-            string? configDirectoryPath = null;
-            try
-            {
-                configDirectoryPath = Path.GetDirectoryName(configPath);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
-                    $"Config path is invalid: {configPath}. {ex.Message}"));
-            }
-
-            if (string.IsNullOrWhiteSpace(configDirectoryPath))
-            {
-                return UcliConfigSaveResult.Failure(CreateInternalError(
-                    $"Config directory path could not be determined: {configPath}"));
-            }
-
-            try
-            {
-                Directory.CreateDirectory(configDirectoryPath);
-                await File.WriteAllTextAsync(configPath, json + Environment.NewLine, cancellationToken).ConfigureAwait(false);
-                return UcliConfigSaveResult.Success();
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return UcliConfigSaveResult.Failure(CreateInvalidArgument(
-                    $"Config path is invalid: {configPath}. {ex.Message}"));
-            }
-            catch (Exception ex) when (IsIoFailure(ex))
-            {
-                return UcliConfigSaveResult.Failure(CreateInternalError(
-                    $"Failed to write config file: {configPath}. {ex.Message}"));
-            }
-        }
-
-        /// <summary> Converts deserialized config JSON into a validated <see cref="UcliConfig" /> instance. </summary>
-        /// <param name="document"> The deserialized config document. </param>
-        /// <param name="configPath"> The source config path. </param>
-        /// <returns> The conversion result. </returns>
-        private static ConfigParseResult TryConvertToConfig (
-            UcliConfigDocument document,
-            string configPath)
-        {
-            if (document.SchemaVersion != SupportedSchemaVersion)
-            {
-                return ConfigParseResult.Failure(CreateInvalidArgument(
-                    $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {document.SchemaVersion}."));
-            }
-
-            if (!TryParseOperationPolicy(document.OperationPolicy, out var operationPolicy))
-            {
-                return ConfigParseResult.Failure(CreateInvalidArgument(
-                    $"Config operationPolicy is invalid: {document.OperationPolicy}."));
-            }
-
-            if (!TryParsePlanTokenMode(document.PlanTokenMode, out var planTokenMode))
-            {
-                return ConfigParseResult.Failure(CreateInvalidArgument(
-                    $"Config planTokenMode is invalid: {document.PlanTokenMode}."));
-            }
-
-            if (document.OperationAllowlist is null)
-            {
-                return ConfigParseResult.Failure(CreateInvalidArgument(
-                    $"Config operationAllowlist must be an array: {configPath}."));
-            }
-
-            var normalizedAllowlist = new List<string>(document.OperationAllowlist.Length);
-            foreach (var pattern in document.OperationAllowlist)
-            {
-                if (string.IsNullOrWhiteSpace(pattern))
-                {
-                    return ConfigParseResult.Failure(CreateInvalidArgument(
-                        $"Config operationAllowlist contains an empty pattern: {configPath}."));
-                }
-
-                var normalizedPattern = pattern.Trim();
-                if (!TryValidateRegexPattern(normalizedPattern, out var patternErrorMessage))
-                {
-                    return ConfigParseResult.Failure(CreateInvalidArgument(
-                        $"Config operationAllowlist contains an invalid regex pattern: {normalizedPattern}. {patternErrorMessage}"));
-                }
-
-                normalizedAllowlist.Add(normalizedPattern);
-            }
-
-            var config = new UcliConfig(
-                SchemaVersion: document.SchemaVersion,
-                OperationPolicy: operationPolicy,
-                PlanTokenMode: planTokenMode,
-                OperationAllowlist: normalizedAllowlist);
-            return ConfigParseResult.Success(config);
-        }
-
-        /// <summary> Validates configuration values before writing them to disk. </summary>
-        /// <param name="config"> The config values to validate. </param>
-        /// <param name="configPath"> The destination config path. </param>
-        /// <returns> The validation result. </returns>
-        private static ConfigValidationResult ValidateConfig (
-            UcliConfig config,
-            string configPath)
-        {
-            if (config.SchemaVersion != SupportedSchemaVersion)
-            {
-                return ConfigValidationResult.Failure(CreateInvalidArgument(
-                    $"Config schemaVersion must be {SupportedSchemaVersion}. Actual: {config.SchemaVersion}."));
-            }
-
-            if (config.OperationAllowlist is null)
-            {
-                return ConfigValidationResult.Failure(CreateInvalidArgument(
-                    $"Config operationAllowlist must not be null: {configPath}."));
-            }
-
-            foreach (var pattern in config.OperationAllowlist)
-            {
-                if (string.IsNullOrWhiteSpace(pattern))
-                {
-                    return ConfigValidationResult.Failure(CreateInvalidArgument(
-                        $"Config operationAllowlist contains an empty pattern: {configPath}."));
-                }
-
-                if (!TryValidateRegexPattern(pattern, out var patternErrorMessage))
-                {
-                    return ConfigValidationResult.Failure(CreateInvalidArgument(
-                        $"Config operationAllowlist contains an invalid regex pattern: {pattern}. {patternErrorMessage}"));
-                }
-            }
-
-            return ConfigValidationResult.Success();
-        }
-
-        /// <summary> Validates whether a value can be compiled as a regular expression pattern. </summary>
-        /// <param name="pattern"> The regex pattern string to validate. </param>
-        /// <param name="errorMessage"> The parser error message when the pattern is invalid. </param>
-        /// <returns> <see langword="true" /> when the pattern is valid; otherwise <see langword="false" />. </returns>
-        private static bool TryValidateRegexPattern (
-            string pattern,
-            out string? errorMessage)
-        {
-            try
-            {
-                new Regex(pattern, RegexOptions.CultureInvariant);
-                errorMessage = null;
-                return true;
-            }
-            catch (ArgumentException exception)
-            {
-                errorMessage = exception.Message;
-                return false;
-            }
-        }
-
-        /// <summary> Converts typed config values into serializable JSON DTO values. </summary>
-        /// <param name="config"> The typed config values. </param>
-        /// <returns> The serializable DTO. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-        private static UcliConfigDocument ToDocument (UcliConfig config)
+        public static ConfigParseResult Success (UcliConfig config)
         {
             ArgumentNullException.ThrowIfNull(config);
-
-            return new UcliConfigDocument(
-                SchemaVersion: config.SchemaVersion,
-                OperationPolicy: ToStringValue(config.OperationPolicy),
-                PlanTokenMode: ToStringValue(config.PlanTokenMode),
-                OperationAllowlist: config.OperationAllowlist.ToArray());
+            return new ConfigParseResult(config, null);
         }
 
-        /// <summary> Converts <see cref="OperationPolicy" /> to the config string value. </summary>
-        /// <param name="operationPolicy"> The operation policy value. </param>
-        /// <returns> The config string representation. </returns>
-        /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="operationPolicy" /> is outside supported values. </exception>
-        private static string ToStringValue (OperationPolicy operationPolicy)
+        /// <summary> Creates a failed parse result. </summary>
+        /// <param name="error"> The parse error. </param>
+        /// <returns> The failed parse result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static ConfigParseResult Failure (ExecutionError error)
         {
-            return operationPolicy switch
-            {
-                OperationPolicy.Safe => UcliConfigValueConstants.OperationPolicySafe,
-                OperationPolicy.Advanced => UcliConfigValueConstants.OperationPolicyAdvanced,
-                OperationPolicy.Dangerous => UcliConfigValueConstants.OperationPolicyDangerous,
-                _ => throw new ArgumentOutOfRangeException(nameof(operationPolicy), operationPolicy, "Unsupported operationPolicy."),
-            };
+            ArgumentNullException.ThrowIfNull(error);
+            return new ConfigParseResult(null, error);
+        }
+    }
+
+    /// <summary> Represents result values from config validation before save. </summary>
+    /// <param name="Error"> The validation error, when validation fails. </param>
+    private readonly record struct ConfigValidationResult (
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether validation succeeded. </summary>
+        public bool IsSuccess => Error is null;
+
+        /// <summary> Creates a successful validation result. </summary>
+        /// <returns> The successful validation result. </returns>
+        public static ConfigValidationResult Success ()
+        {
+            return new ConfigValidationResult(Error: null);
         }
 
-        /// <summary> Converts <see cref="PlanTokenMode" /> to the config string value. </summary>
-        /// <param name="planTokenMode"> The plan token mode value. </param>
-        /// <returns> The config string representation. </returns>
-        /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="planTokenMode" /> is outside supported values. </exception>
-        private static string ToStringValue (PlanTokenMode planTokenMode)
+        /// <summary> Creates a failed validation result. </summary>
+        /// <param name="error"> The validation error. </param>
+        /// <returns> The failed validation result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static ConfigValidationResult Failure (ExecutionError error)
         {
-            return planTokenMode switch
-            {
-                PlanTokenMode.Optional => UcliConfigValueConstants.PlanTokenModeOptional,
-                PlanTokenMode.Required => UcliConfigValueConstants.PlanTokenModeRequired,
-                _ => throw new ArgumentOutOfRangeException(nameof(planTokenMode), planTokenMode, "Unsupported planTokenMode."),
-            };
-        }
-
-        /// <summary> Parses operation-policy config values. </summary>
-        /// <param name="value"> The config string value. </param>
-        /// <param name="operationPolicy"> The parsed enum value. </param>
-        /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
-        private static bool TryParseOperationPolicy (string? value, out OperationPolicy operationPolicy)
-        {
-            if (string.Equals(value, UcliConfigValueConstants.OperationPolicySafe, StringComparison.OrdinalIgnoreCase))
-            {
-                operationPolicy = OperationPolicy.Safe;
-                return true;
-            }
-
-            if (string.Equals(value, UcliConfigValueConstants.OperationPolicyAdvanced, StringComparison.OrdinalIgnoreCase))
-            {
-                operationPolicy = OperationPolicy.Advanced;
-                return true;
-            }
-
-            if (string.Equals(value, UcliConfigValueConstants.OperationPolicyDangerous, StringComparison.OrdinalIgnoreCase))
-            {
-                operationPolicy = OperationPolicy.Dangerous;
-                return true;
-            }
-
-            operationPolicy = default;
-            return false;
-        }
-
-        /// <summary> Parses plan-token-mode config values. </summary>
-        /// <param name="value"> The config string value. </param>
-        /// <param name="planTokenMode"> The parsed enum value. </param>
-        /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
-        private static bool TryParsePlanTokenMode (string? value, out PlanTokenMode planTokenMode)
-        {
-            if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeOptional, StringComparison.OrdinalIgnoreCase))
-            {
-                planTokenMode = PlanTokenMode.Optional;
-                return true;
-            }
-
-            if (string.Equals(value, UcliConfigValueConstants.PlanTokenModeRequired, StringComparison.OrdinalIgnoreCase))
-            {
-                planTokenMode = PlanTokenMode.Required;
-                return true;
-            }
-
-            planTokenMode = default;
-            return false;
-        }
-
-        /// <summary> Creates an invalid-argument error. </summary>
-        /// <param name="message"> The error message. </param>
-        /// <returns> The structured invalid-argument error. </returns>
-        private static ExecutionError CreateInvalidArgument (string message)
-        {
-            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
-        }
-
-        /// <summary> Creates an internal-error value. </summary>
-        /// <param name="message"> The error message. </param>
-        /// <returns> The structured internal-error value. </returns>
-        private static ExecutionError CreateInternalError (string message)
-        {
-            return new ExecutionError(ExecutionErrorKind.InternalError, message);
-        }
-
-        /// <summary> Determines whether an exception should be treated as invalid path formatting. </summary>
-        /// <param name="exception"> The exception to classify. </param>
-        /// <returns> <see langword="true" /> when invalid path formatting is detected; otherwise <see langword="false" />. </returns>
-        private static bool IsPathFormatException (Exception exception)
-        {
-            return exception is ArgumentException
-                or NotSupportedException
-                or PathTooLongException;
-        }
-
-        /// <summary> Determines whether an exception should be treated as an internal I/O failure. </summary>
-        /// <param name="exception"> The exception to classify. </param>
-        /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
-        private static bool IsIoFailure (Exception exception)
-        {
-            return exception is IOException
-                or UnauthorizedAccessException;
-        }
-
-        /// <summary> Serializable JSON DTO for config values. </summary>
-        /// <param name="SchemaVersion"> The config schema version. </param>
-        /// <param name="OperationPolicy"> The operation-policy value. </param>
-        /// <param name="PlanTokenMode"> The plan-token-mode value. </param>
-        /// <param name="OperationAllowlist"> The operation-name allowlist. </param>
-        private sealed record UcliConfigDocument (
-            int SchemaVersion,
-            string OperationPolicy,
-            string PlanTokenMode,
-            string[] OperationAllowlist);
-
-        /// <summary> Represents result values from config parse operations. </summary>
-        /// <param name="Config"> The parsed config instance. </param>
-        /// <param name="Error"> The parse error, when parse fails. </param>
-        private readonly record struct ConfigParseResult (
-            UcliConfig? Config,
-            ExecutionError? Error)
-        {
-            /// <summary> Gets a value indicating whether parse succeeded. </summary>
-            public bool IsSuccess => Config is not null && Error is null;
-
-            /// <summary> Creates a successful parse result. </summary>
-            /// <param name="config"> The parsed config instance. </param>
-            /// <returns> The successful parse result. </returns>
-            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="config" /> is <see langword="null" />. </exception>
-            public static ConfigParseResult Success (UcliConfig config)
-            {
-                ArgumentNullException.ThrowIfNull(config);
-                return new ConfigParseResult(config, null);
-            }
-
-            /// <summary> Creates a failed parse result. </summary>
-            /// <param name="error"> The parse error. </param>
-            /// <returns> The failed parse result. </returns>
-            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-            public static ConfigParseResult Failure (ExecutionError error)
-            {
-                ArgumentNullException.ThrowIfNull(error);
-                return new ConfigParseResult(null, error);
-            }
-        }
-
-        /// <summary> Represents result values from config validation before save. </summary>
-        /// <param name="Error"> The validation error, when validation fails. </param>
-        private readonly record struct ConfigValidationResult (
-            ExecutionError? Error)
-        {
-            /// <summary> Gets a value indicating whether validation succeeded. </summary>
-            public bool IsSuccess => Error is null;
-
-            /// <summary> Creates a successful validation result. </summary>
-            /// <returns> The successful validation result. </returns>
-            public static ConfigValidationResult Success ()
-            {
-                return new ConfigValidationResult(Error: null);
-            }
-
-            /// <summary> Creates a failed validation result. </summary>
-            /// <param name="error"> The validation error. </param>
-            /// <returns> The failed validation result. </returns>
-            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-            public static ConfigValidationResult Failure (ExecutionError error)
-            {
-                ArgumentNullException.ThrowIfNull(error);
-                return new ConfigValidationResult(Error: error);
-            }
+            ArgumentNullException.ThrowIfNull(error);
+            return new ConfigValidationResult(Error: error);
         }
     }
 }

--- a/src/Ucli/Configuration/UcliConfigValueConstants.cs
+++ b/src/Ucli/Configuration/UcliConfigValueConstants.cs
@@ -1,21 +1,20 @@
-namespace MackySoft.Ucli.Configuration
+namespace MackySoft.Ucli.Configuration;
+
+/// <summary> Defines string literals used in <c>.ucli/config.json</c> enum-like fields. </summary>
+internal static class UcliConfigValueConstants
 {
-    /// <summary> Defines string literals used in <c>.ucli/config.json</c> enum-like fields. </summary>
-    internal static class UcliConfigValueConstants
-    {
-        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Safe" />. </summary>
-        public const string OperationPolicySafe = "safe";
+    /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Safe" />. </summary>
+    public const string OperationPolicySafe = "safe";
 
-        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Advanced" />. </summary>
-        public const string OperationPolicyAdvanced = "advanced";
+    /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Advanced" />. </summary>
+    public const string OperationPolicyAdvanced = "advanced";
 
-        /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Dangerous" />. </summary>
-        public const string OperationPolicyDangerous = "dangerous";
+    /// <summary> Gets the operation policy value for <see cref="OperationPolicy.Dangerous" />. </summary>
+    public const string OperationPolicyDangerous = "dangerous";
 
-        /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Optional" />. </summary>
-        public const string PlanTokenModeOptional = "optional";
+    /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Optional" />. </summary>
+    public const string PlanTokenModeOptional = "optional";
 
-        /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Required" />. </summary>
-        public const string PlanTokenModeRequired = "required";
-    }
+    /// <summary> Gets the plan token mode value for <see cref="PlanTokenMode.Required" />. </summary>
+    public const string PlanTokenModeRequired = "required";
 }

--- a/src/Ucli/Context/IInitStatusContextResolver.cs
+++ b/src/Ucli/Context/IInitStatusContextResolver.cs
@@ -1,14 +1,13 @@
-namespace MackySoft.Ucli.Context
+namespace MackySoft.Ucli.Context;
+
+/// <summary> Resolves foundation context shared by <c>init</c> and future <c>status</c> implementations. </summary>
+internal interface IInitStatusContextResolver
 {
-    /// <summary> Resolves foundation context shared by <c>init</c> and future <c>status</c> implementations. </summary>
-    internal interface IInitStatusContextResolver
-    {
-        /// <summary> Resolves UnityProject and config values into an execution context. </summary>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
-        ValueTask<InitStatusContextResolutionResult> Resolve (
-            string? projectPath,
-            CancellationToken cancellationToken = default);
-    }
+    /// <summary> Resolves UnityProject and config values into an execution context. </summary>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
+    ValueTask<InitStatusContextResolutionResult> Resolve (
+        string? projectPath,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Ucli/Context/InitStatusContext.cs
+++ b/src/Ucli/Context/InitStatusContext.cs
@@ -1,14 +1,13 @@
 using MackySoft.Ucli.Configuration;
 using MackySoft.Ucli.UnityProject;
 
-namespace MackySoft.Ucli.Context
-{
-    /// <summary> Represents shared foundation values for init/status command execution. </summary>
-    /// <param name="UnityProject"> The resolved UnityProject context. </param>
-    /// <param name="Config"> The loaded config values. </param>
-    /// <param name="ConfigSource"> The source where config values were loaded from. </param>
-    internal sealed record InitStatusContext (
-        ResolvedUnityProjectContext UnityProject,
-        UcliConfig Config,
-        ConfigSource ConfigSource);
-}
+namespace MackySoft.Ucli.Context;
+
+/// <summary> Represents shared foundation values for init/status command execution. </summary>
+/// <param name="UnityProject"> The resolved UnityProject context. </param>
+/// <param name="Config"> The loaded config values. </param>
+/// <param name="ConfigSource"> The source where config values were loaded from. </param>
+internal sealed record InitStatusContext (
+    ResolvedUnityProjectContext UnityProject,
+    UcliConfig Config,
+    ConfigSource ConfigSource);

--- a/src/Ucli/Context/InitStatusContextResolutionResult.cs
+++ b/src/Ucli/Context/InitStatusContextResolutionResult.cs
@@ -1,35 +1,34 @@
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.Context
+namespace MackySoft.Ucli.Context;
+
+/// <summary> Represents the result of resolving <see cref="InitStatusContext" /> values. </summary>
+/// <param name="Context"> The resolved context, or <see langword="null" /> on failure. </param>
+/// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
+internal sealed record InitStatusContextResolutionResult (
+    InitStatusContext? Context,
+    ExecutionError? Error)
 {
-    /// <summary> Represents the result of resolving <see cref="InitStatusContext" /> values. </summary>
-    /// <param name="Context"> The resolved context, or <see langword="null" /> on failure. </param>
-    /// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
-    internal sealed record InitStatusContextResolutionResult (
-        InitStatusContext? Context,
-        ExecutionError? Error)
+    /// <summary> Gets a value indicating whether context resolution succeeded. </summary>
+    public bool IsSuccess => Context is not null && Error is null;
+
+    /// <summary> Creates a successful context-resolution result. </summary>
+    /// <param name="context"> The resolved context value. </param>
+    /// <returns> The successful result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
+    public static InitStatusContextResolutionResult Success (InitStatusContext context)
     {
-        /// <summary> Gets a value indicating whether context resolution succeeded. </summary>
-        public bool IsSuccess => Context is not null && Error is null;
+        ArgumentNullException.ThrowIfNull(context);
+        return new InitStatusContextResolutionResult(context, null);
+    }
 
-        /// <summary> Creates a successful context-resolution result. </summary>
-        /// <param name="context"> The resolved context value. </param>
-        /// <returns> The successful result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
-        public static InitStatusContextResolutionResult Success (InitStatusContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return new InitStatusContextResolutionResult(context, null);
-        }
-
-        /// <summary> Creates a failed context-resolution result. </summary>
-        /// <param name="error"> The structured resolution error. </param>
-        /// <returns> The failed result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static InitStatusContextResolutionResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new InitStatusContextResolutionResult(null, error);
-        }
+    /// <summary> Creates a failed context-resolution result. </summary>
+    /// <param name="error"> The structured resolution error. </param>
+    /// <returns> The failed result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static InitStatusContextResolutionResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new InitStatusContextResolutionResult(null, error);
     }
 }

--- a/src/Ucli/Context/InitStatusContextResolver.cs
+++ b/src/Ucli/Context/InitStatusContextResolver.cs
@@ -1,54 +1,53 @@
 using MackySoft.Ucli.Configuration;
 using MackySoft.Ucli.UnityProject;
 
-namespace MackySoft.Ucli.Context
+namespace MackySoft.Ucli.Context;
+
+/// <summary> Resolves shared foundation context for init/status command pipelines. </summary>
+internal sealed class InitStatusContextResolver : IInitStatusContextResolver
 {
-    /// <summary> Resolves shared foundation context for init/status command pipelines. </summary>
-    internal sealed class InitStatusContextResolver : IInitStatusContextResolver
+    private readonly IUnityProjectResolver unityProjectResolver;
+    private readonly IUcliConfigStore configStore;
+
+    /// <summary> Initializes a new instance of the <see cref="InitStatusContextResolver" /> class. </summary>
+    /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
+    /// <param name="configStore"> The config-store dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" /> or <paramref name="configStore" /> is <see langword="null" />. </exception>
+    public InitStatusContextResolver (
+        IUnityProjectResolver unityProjectResolver,
+        IUcliConfigStore configStore)
     {
-        private readonly IUnityProjectResolver unityProjectResolver;
-        private readonly IUcliConfigStore configStore;
+        this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
+        this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+    }
 
-        /// <summary> Initializes a new instance of the <see cref="InitStatusContextResolver" /> class. </summary>
-        /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
-        /// <param name="configStore"> The config-store dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" /> or <paramref name="configStore" /> is <see langword="null" />. </exception>
-        public InitStatusContextResolver (
-            IUnityProjectResolver unityProjectResolver,
-            IUcliConfigStore configStore)
+    /// <summary> Resolves UnityProject and config values into a shared init/status context. </summary>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
+    public async ValueTask<InitStatusContextResolutionResult> Resolve (
+        string? projectPath,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var unityProjectResult = unityProjectResolver.Resolve(projectPath);
+        if (!unityProjectResult.IsSuccess)
         {
-            this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
-            this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+            return InitStatusContextResolutionResult.Failure(unityProjectResult.Error!);
         }
 
-        /// <summary> Resolves UnityProject and config values into a shared init/status context. </summary>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the context-resolution result that contains either a fully resolved context or a structured error. </returns>
-        public async ValueTask<InitStatusContextResolutionResult> Resolve (
-            string? projectPath,
-            CancellationToken cancellationToken = default)
+        var unityProjectContext = unityProjectResult.Context!;
+        var configLoadResult = await configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken).ConfigureAwait(false);
+        if (!configLoadResult.IsSuccess)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var unityProjectResult = unityProjectResolver.Resolve(projectPath);
-            if (!unityProjectResult.IsSuccess)
-            {
-                return InitStatusContextResolutionResult.Failure(unityProjectResult.Error!);
-            }
-
-            var unityProjectContext = unityProjectResult.Context!;
-            var configLoadResult = await configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken).ConfigureAwait(false);
-            if (!configLoadResult.IsSuccess)
-            {
-                return InitStatusContextResolutionResult.Failure(configLoadResult.Error!);
-            }
-
-            var context = new InitStatusContext(
-                UnityProject: unityProjectContext,
-                Config: configLoadResult.Config!,
-                ConfigSource: configLoadResult.Source);
-            return InitStatusContextResolutionResult.Success(context);
+            return InitStatusContextResolutionResult.Failure(configLoadResult.Error!);
         }
+
+        var context = new InitStatusContext(
+            UnityProject: unityProjectContext,
+            Config: configLoadResult.Config!,
+            ConfigSource: configLoadResult.Source);
+        return InitStatusContextResolutionResult.Success(context);
     }
 }

--- a/src/Ucli/Foundation/ExecutionError.cs
+++ b/src/Ucli/Foundation/ExecutionError.cs
@@ -1,9 +1,8 @@
-namespace MackySoft.Ucli.Foundation
-{
-    /// <summary> Represents a structured error returned from foundation services. </summary>
-    /// <param name="Kind"> The classification used to map the error to the CLI contract. </param>
-    /// <param name="Message"> The user-facing error message. </param>
-    internal sealed record ExecutionError (
-        ExecutionErrorKind Kind,
-        string Message);
-}
+namespace MackySoft.Ucli.Foundation;
+
+/// <summary> Represents a structured error returned from foundation services. </summary>
+/// <param name="Kind"> The classification used to map the error to the CLI contract. </param>
+/// <param name="Message"> The user-facing error message. </param>
+internal sealed record ExecutionError (
+    ExecutionErrorKind Kind,
+    string Message);

--- a/src/Ucli/Foundation/ExecutionErrorKind.cs
+++ b/src/Ucli/Foundation/ExecutionErrorKind.cs
@@ -1,12 +1,11 @@
-namespace MackySoft.Ucli.Foundation
-{
-    /// <summary> Defines high-level error categories used by foundation services. </summary>
-    internal enum ExecutionErrorKind
-    {
-        /// <summary> Indicates an invalid argument or invalid contract input. </summary>
-        InvalidArgument = 0,
+namespace MackySoft.Ucli.Foundation;
 
-        /// <summary> Indicates an unexpected infrastructure or runtime failure. </summary>
-        InternalError = 1,
-    }
+/// <summary> Defines high-level error categories used by foundation services. </summary>
+internal enum ExecutionErrorKind
+{
+    /// <summary> Indicates an invalid argument or invalid contract input. </summary>
+    InvalidArgument = 0,
+
+    /// <summary> Indicates an unexpected infrastructure or runtime failure. </summary>
+    InternalError = 1,
 }

--- a/src/Ucli/Init/IInitService.cs
+++ b/src/Ucli/Init/IInitService.cs
@@ -1,16 +1,15 @@
-namespace MackySoft.Ucli.Init
+namespace MackySoft.Ucli.Init;
+
+/// <summary> Executes initialization flow for generating the <c>.ucli</c> template files. </summary>
+internal interface IInitService
 {
-    /// <summary> Executes initialization flow for generating the <c>.ucli</c> template files. </summary>
-    internal interface IInitService
-    {
-        /// <summary> Executes initialization for a target UnityProject. </summary>
-        /// <param name="force"> Whether existing files can be overwritten. </param>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the initialization execution result that contains either generated file paths or a structured error. </returns>
-        ValueTask<InitExecutionResult> Execute (
-            bool force,
-            string? projectPath,
-            CancellationToken cancellationToken = default);
-    }
+    /// <summary> Executes initialization for a target UnityProject. </summary>
+    /// <param name="force"> Whether existing files can be overwritten. </param>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the initialization execution result that contains either generated file paths or a structured error. </returns>
+    ValueTask<InitExecutionResult> Execute (
+        bool force,
+        string? projectPath,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Ucli/Init/InitExecutionOutput.cs
+++ b/src/Ucli/Init/InitExecutionOutput.cs
@@ -1,13 +1,12 @@
-namespace MackySoft.Ucli.Init
-{
-    /// <summary> Represents output values produced by a successful init execution. </summary>
-    /// <param name="ProjectPath"> The resolved UnityProject root path. </param>
-    /// <param name="ProjectFingerprint"> The resolved UnityProject fingerprint. </param>
-    /// <param name="ConfigPath"> The path of the generated config file. </param>
-    /// <param name="GitIgnorePath"> The path of the generated <c>.ucli/.gitignore</c> file. </param>
-    internal sealed record InitExecutionOutput (
-        string ProjectPath,
-        string ProjectFingerprint,
-        string ConfigPath,
-        string GitIgnorePath);
-}
+namespace MackySoft.Ucli.Init;
+
+/// <summary> Represents output values produced by a successful init execution. </summary>
+/// <param name="ProjectPath"> The resolved UnityProject root path. </param>
+/// <param name="ProjectFingerprint"> The resolved UnityProject fingerprint. </param>
+/// <param name="ConfigPath"> The path of the generated config file. </param>
+/// <param name="GitIgnorePath"> The path of the generated <c>.ucli/.gitignore</c> file. </param>
+internal sealed record InitExecutionOutput (
+    string ProjectPath,
+    string ProjectFingerprint,
+    string ConfigPath,
+    string GitIgnorePath);

--- a/src/Ucli/Init/InitExecutionResult.cs
+++ b/src/Ucli/Init/InitExecutionResult.cs
@@ -1,35 +1,34 @@
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.Init
+namespace MackySoft.Ucli.Init;
+
+/// <summary> Represents the result of init execution. </summary>
+/// <param name="Output"> The init output values on success. </param>
+/// <param name="Error"> The structured init error on failure. </param>
+internal sealed record InitExecutionResult (
+    InitExecutionOutput? Output,
+    ExecutionError? Error)
 {
-    /// <summary> Represents the result of init execution. </summary>
-    /// <param name="Output"> The init output values on success. </param>
-    /// <param name="Error"> The structured init error on failure. </param>
-    internal sealed record InitExecutionResult (
-        InitExecutionOutput? Output,
-        ExecutionError? Error)
+    /// <summary> Gets a value indicating whether init execution succeeded. </summary>
+    public bool IsSuccess => Output is not null && Error is null;
+
+    /// <summary> Creates a successful init-execution result. </summary>
+    /// <param name="output"> The init output values. </param>
+    /// <returns> The successful result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="output" /> is <see langword="null" />. </exception>
+    public static InitExecutionResult Success (InitExecutionOutput output)
     {
-        /// <summary> Gets a value indicating whether init execution succeeded. </summary>
-        public bool IsSuccess => Output is not null && Error is null;
+        ArgumentNullException.ThrowIfNull(output);
+        return new InitExecutionResult(output, null);
+    }
 
-        /// <summary> Creates a successful init-execution result. </summary>
-        /// <param name="output"> The init output values. </param>
-        /// <returns> The successful result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="output" /> is <see langword="null" />. </exception>
-        public static InitExecutionResult Success (InitExecutionOutput output)
-        {
-            ArgumentNullException.ThrowIfNull(output);
-            return new InitExecutionResult(output, null);
-        }
-
-        /// <summary> Creates a failed init-execution result. </summary>
-        /// <param name="error"> The structured init error. </param>
-        /// <returns> The failed result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static InitExecutionResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new InitExecutionResult(null, error);
-        }
+    /// <summary> Creates a failed init-execution result. </summary>
+    /// <param name="error"> The structured init error. </param>
+    /// <returns> The failed result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static InitExecutionResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new InitExecutionResult(null, error);
     }
 }

--- a/src/Ucli/Init/InitService.cs
+++ b/src/Ucli/Init/InitService.cs
@@ -3,180 +3,179 @@ using MackySoft.Ucli.Context;
 using MackySoft.Ucli.Foundation;
 using MackySoft.Ucli.UnityProject;
 
-namespace MackySoft.Ucli.Init
+namespace MackySoft.Ucli.Init;
+
+/// <summary> Implements init flow that generates the <c>.ucli</c> template files. </summary>
+internal sealed class InitService : IInitService
 {
-    /// <summary> Implements init flow that generates the <c>.ucli</c> template files. </summary>
-    internal sealed class InitService : IInitService
+    private const string UcliDirectoryName = ".ucli";
+    private const string GitIgnoreFileName = ".gitignore";
+    private const string GitIgnoreContents = "local/";
+
+    private readonly IUnityProjectResolver unityProjectResolver;
+    private readonly IInitStatusContextResolver contextResolver;
+    private readonly IUcliConfigStore configStore;
+
+    /// <summary> Initializes a new instance of the <see cref="InitService" /> class. </summary>
+    /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
+    /// <param name="contextResolver"> The init/status context resolver dependency. </param>
+    /// <param name="configStore"> The config store dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" />, <paramref name="contextResolver" />, or <paramref name="configStore" /> is <see langword="null" />. </exception>
+    public InitService (
+        IUnityProjectResolver unityProjectResolver,
+        IInitStatusContextResolver contextResolver,
+        IUcliConfigStore configStore)
     {
-        private const string UcliDirectoryName = ".ucli";
-        private const string GitIgnoreFileName = ".gitignore";
-        private const string GitIgnoreContents = "local/";
+        this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
+        this.contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
+        this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+    }
 
-        private readonly IUnityProjectResolver unityProjectResolver;
-        private readonly IInitStatusContextResolver contextResolver;
-        private readonly IUcliConfigStore configStore;
+    /// <summary> Executes initialization to create or overwrite <c>.ucli/config.json</c> and <c>.ucli/.gitignore</c>. </summary>
+    /// <param name="force"> Whether existing files can be overwritten. </param>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the init execution result that contains generated file paths on success or a structured error on failure. </returns>
+    public async ValueTask<InitExecutionResult> Execute (
+        bool force,
+        string? projectPath,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
 
-        /// <summary> Initializes a new instance of the <see cref="InitService" /> class. </summary>
-        /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
-        /// <param name="contextResolver"> The init/status context resolver dependency. </param>
-        /// <param name="configStore"> The config store dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" />, <paramref name="contextResolver" />, or <paramref name="configStore" /> is <see langword="null" />. </exception>
-        public InitService (
-            IUnityProjectResolver unityProjectResolver,
-            IInitStatusContextResolver contextResolver,
-            IUcliConfigStore configStore)
+        var unityProjectResult = unityProjectResolver.Resolve(projectPath);
+        if (!unityProjectResult.IsSuccess)
         {
-            this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
-            this.contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
-            this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+            return InitExecutionResult.Failure(unityProjectResult.Error!);
         }
 
-        /// <summary> Executes initialization to create or overwrite <c>.ucli/config.json</c> and <c>.ucli/.gitignore</c>. </summary>
-        /// <param name="force"> Whether existing files can be overwritten. </param>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
-        /// <returns> A task that resolves to the init execution result that contains generated file paths on success or a structured error on failure. </returns>
-        public async ValueTask<InitExecutionResult> Execute (
-            bool force,
-            string? projectPath,
-            CancellationToken cancellationToken = default)
+        var unityProjectContext = unityProjectResult.Context!;
+        var unityProjectRoot = unityProjectContext.UnityProjectRoot;
+        var ucliDirectoryPath = Path.Combine(unityProjectRoot, UcliDirectoryName);
+        var configPath = unityProjectContext.ConfigPath;
+        var gitIgnorePath = Path.Combine(ucliDirectoryPath, GitIgnoreFileName);
+        var existingPaths = CollectExistingTemplatePaths(configPath, gitIgnorePath);
+
+        if (!force && existingPaths.Count > 0)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var unityProjectResult = unityProjectResolver.Resolve(projectPath);
-            if (!unityProjectResult.IsSuccess)
-            {
-                return InitExecutionResult.Failure(unityProjectResult.Error!);
-            }
-
-            var unityProjectContext = unityProjectResult.Context!;
-            var unityProjectRoot = unityProjectContext.UnityProjectRoot;
-            var ucliDirectoryPath = Path.Combine(unityProjectRoot, UcliDirectoryName);
-            var configPath = unityProjectContext.ConfigPath;
-            var gitIgnorePath = Path.Combine(ucliDirectoryPath, GitIgnoreFileName);
-            var existingPaths = CollectExistingTemplatePaths(configPath, gitIgnorePath);
-
-            if (!force && existingPaths.Count > 0)
-            {
-                var joinedPaths = string.Join(", ", existingPaths);
-                return InitExecutionResult.Failure(CreateInvalidArgument(
-                    $"Initialization failed because template files already exist. Use --force to overwrite: {joinedPaths}"));
-            }
-
-            if (!force)
-            {
-                // NOTE:
-                // Keep init and status using the same context pipeline.
-                // This ensures config parse/validation behavior stays consistent across command foundations.
-                var contextResult = await contextResolver.Resolve(projectPath, cancellationToken).ConfigureAwait(false);
-                if (!contextResult.IsSuccess)
-                {
-                    return InitExecutionResult.Failure(contextResult.Error!);
-                }
-            }
-
-            try
-            {
-                Directory.CreateDirectory(ucliDirectoryPath);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return InitExecutionResult.Failure(CreateInvalidArgument(
-                    $"UnityProject path is invalid: {unityProjectRoot}. {ex.Message}"));
-            }
-            catch (Exception ex) when (IsIoFailure(ex))
-            {
-                return InitExecutionResult.Failure(CreateInternalError(
-                    $"Failed to create .ucli directory: {ucliDirectoryPath}. {ex.Message}"));
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var defaultConfig = UcliConfig.CreateDefault();
-            var configSaveResult = await configStore.Save(unityProjectRoot, defaultConfig, cancellationToken).ConfigureAwait(false);
-            if (!configSaveResult.IsSuccess)
-            {
-                return InitExecutionResult.Failure(configSaveResult.Error!);
-            }
-
-            try
-            {
-                await File.WriteAllTextAsync(gitIgnorePath, GitIgnoreContents + Environment.NewLine, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return InitExecutionResult.Failure(CreateInvalidArgument(
-                    $"Git ignore path is invalid: {gitIgnorePath}. {ex.Message}"));
-            }
-            catch (Exception ex) when (IsIoFailure(ex))
-            {
-                return InitExecutionResult.Failure(CreateInternalError(
-                    $"Failed to write git ignore file: {gitIgnorePath}. {ex.Message}"));
-            }
-
-            var output = new InitExecutionOutput(
-                ProjectPath: unityProjectRoot,
-                ProjectFingerprint: unityProjectContext.ProjectFingerprint,
-                ConfigPath: configPath,
-                GitIgnorePath: gitIgnorePath);
-            return InitExecutionResult.Success(output);
+            var joinedPaths = string.Join(", ", existingPaths);
+            return InitExecutionResult.Failure(CreateInvalidArgument(
+                $"Initialization failed because template files already exist. Use --force to overwrite: {joinedPaths}"));
         }
 
-        /// <summary> Collects existing init-template files for precondition checks. </summary>
-        /// <param name="configPath"> The config file path. </param>
-        /// <param name="gitIgnorePath"> The git-ignore file path. </param>
-        /// <returns> Existing file paths that would be overwritten. </returns>
-        private static List<string> CollectExistingTemplatePaths (
-            string configPath,
-            string gitIgnorePath)
+        if (!force)
         {
-            var existingPaths = new List<string>(2);
-            if (File.Exists(configPath))
+            // NOTE:
+            // Keep init and status using the same context pipeline.
+            // This ensures config parse/validation behavior stays consistent across command foundations.
+            var contextResult = await contextResolver.Resolve(projectPath, cancellationToken).ConfigureAwait(false);
+            if (!contextResult.IsSuccess)
             {
-                existingPaths.Add(configPath);
+                return InitExecutionResult.Failure(contextResult.Error!);
             }
-
-            if (File.Exists(gitIgnorePath))
-            {
-                existingPaths.Add(gitIgnorePath);
-            }
-
-            return existingPaths;
         }
 
-        /// <summary> Creates an invalid-argument error value. </summary>
-        /// <param name="message"> The error message. </param>
-        /// <returns> The structured invalid-argument error. </returns>
-        private static ExecutionError CreateInvalidArgument (string message)
+        try
         {
-            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+            Directory.CreateDirectory(ucliDirectoryPath);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return InitExecutionResult.Failure(CreateInvalidArgument(
+                $"UnityProject path is invalid: {unityProjectRoot}. {ex.Message}"));
+        }
+        catch (Exception ex) when (IsIoFailure(ex))
+        {
+            return InitExecutionResult.Failure(CreateInternalError(
+                $"Failed to create .ucli directory: {ucliDirectoryPath}. {ex.Message}"));
         }
 
-        /// <summary> Creates an internal-error value. </summary>
-        /// <param name="message"> The error message. </param>
-        /// <returns> The structured internal-error value. </returns>
-        private static ExecutionError CreateInternalError (string message)
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var defaultConfig = UcliConfig.CreateDefault();
+        var configSaveResult = await configStore.Save(unityProjectRoot, defaultConfig, cancellationToken).ConfigureAwait(false);
+        if (!configSaveResult.IsSuccess)
         {
-            return new ExecutionError(ExecutionErrorKind.InternalError, message);
+            return InitExecutionResult.Failure(configSaveResult.Error!);
         }
 
-        /// <summary> Determines whether an exception indicates invalid path formatting. </summary>
-        /// <param name="exception"> The exception to classify. </param>
-        /// <returns> <see langword="true" /> when it is a path-format exception; otherwise <see langword="false" />. </returns>
-        private static bool IsPathFormatException (Exception exception)
+        try
         {
-            return exception is ArgumentException
-                or NotSupportedException
-                or PathTooLongException;
+            await File.WriteAllTextAsync(gitIgnorePath, GitIgnoreContents + Environment.NewLine, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return InitExecutionResult.Failure(CreateInvalidArgument(
+                $"Git ignore path is invalid: {gitIgnorePath}. {ex.Message}"));
+        }
+        catch (Exception ex) when (IsIoFailure(ex))
+        {
+            return InitExecutionResult.Failure(CreateInternalError(
+                $"Failed to write git ignore file: {gitIgnorePath}. {ex.Message}"));
         }
 
-        /// <summary> Determines whether an exception indicates a filesystem I/O failure. </summary>
-        /// <param name="exception"> The exception to classify. </param>
-        /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
-        private static bool IsIoFailure (Exception exception)
+        var output = new InitExecutionOutput(
+            ProjectPath: unityProjectRoot,
+            ProjectFingerprint: unityProjectContext.ProjectFingerprint,
+            ConfigPath: configPath,
+            GitIgnorePath: gitIgnorePath);
+        return InitExecutionResult.Success(output);
+    }
+
+    /// <summary> Collects existing init-template files for precondition checks. </summary>
+    /// <param name="configPath"> The config file path. </param>
+    /// <param name="gitIgnorePath"> The git-ignore file path. </param>
+    /// <returns> Existing file paths that would be overwritten. </returns>
+    private static List<string> CollectExistingTemplatePaths (
+        string configPath,
+        string gitIgnorePath)
+    {
+        var existingPaths = new List<string>(2);
+        if (File.Exists(configPath))
         {
-            return exception is IOException
-                or UnauthorizedAccessException;
+            existingPaths.Add(configPath);
         }
+
+        if (File.Exists(gitIgnorePath))
+        {
+            existingPaths.Add(gitIgnorePath);
+        }
+
+        return existingPaths;
+    }
+
+    /// <summary> Creates an invalid-argument error value. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured invalid-argument error. </returns>
+    private static ExecutionError CreateInvalidArgument (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+    }
+
+    /// <summary> Creates an internal-error value. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured internal-error value. </returns>
+    private static ExecutionError CreateInternalError (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InternalError, message);
+    }
+
+    /// <summary> Determines whether an exception indicates invalid path formatting. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when it is a path-format exception; otherwise <see langword="false" />. </returns>
+    private static bool IsPathFormatException (Exception exception)
+    {
+        return exception is ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+    }
+
+    /// <summary> Determines whether an exception indicates a filesystem I/O failure. </summary>
+    /// <param name="exception"> The exception to classify. </param>
+    /// <returns> <see langword="true" /> when it is an I/O failure; otherwise <see langword="false" />. </returns>
+    private static bool IsIoFailure (Exception exception)
+    {
+        return exception is IOException
+            or UnauthorizedAccessException;
     }
 }

--- a/src/Ucli/Program.cs
+++ b/src/Ucli/Program.cs
@@ -7,144 +7,140 @@ using MackySoft.Ucli.Ipc;
 using MackySoft.Ucli.UnityProject;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace MackySoft.Ucli
+namespace MackySoft.Ucli;
+
+internal static class Program
 {
-    internal static class Program
+    /// <summary> Executes the CLI command pipeline and emits JSON command results. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns> The process exit code determined by command execution. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static async Task<int> Main (string[] args)
     {
-        private const string HelpCommandName = "help";
+        ArgumentNullException.ThrowIfNull(args);
 
-        /// <summary> Executes the CLI command pipeline and emits JSON command results. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns> The process exit code determined by command execution. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static async Task<int> Main (string[] args)
+        ParseErrorBuffer.Clear();
+        CommandExecutionState.Reset();
+
+        ConsoleApp.LogError = message =>
         {
-            ArgumentNullException.ThrowIfNull(args);
+            ParseErrorBuffer.Add(message);
+            Console.Error.WriteLine(message);
+        };
 
-            ParseErrorBuffer.Clear();
-            CommandExecutionState.Reset();
-
-            ConsoleApp.LogError = message =>
-            {
-                ParseErrorBuffer.Add(message);
-                Console.Error.WriteLine(message);
-            };
-
-            if (TryHandleUnknownCommand(args))
-            {
-                return Environment.ExitCode;
-            }
-
-            var app = ConsoleApp.Create()
-                .ConfigureServices(services =>
-                {
-                    services.AddSingleton<IUnityProjectResolver, UnityProjectResolver>();
-                    services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
-                    services.AddSingleton<IInitStatusContextResolver, InitStatusContextResolver>();
-                    services.AddSingleton<IInitService, InitService>();
-                    services.AddSingleton<IIpcEndpointResolver, IpcEndpointResolver>();
-                    services.AddSingleton<IUnityIpcClient, UnityIpcClient>();
-                });
-            app.Add<InitCommand>();
-            app.Add<StatusCommand>();
-
-            try
-            {
-                await app.RunAsync(args);
-            }
-            catch (Exception exception)
-            {
-                var internalErrorResult = CommandResult.InternalError(CliProtocol.RootCommand, exception.Message);
-                CommandResultWriter.WriteToStandardOutput(internalErrorResult);
-                Environment.ExitCode = internalErrorResult.ExitCode;
-                return Environment.ExitCode;
-            }
-
-            // NOTE:
-            // ConsoleAppFramework can fail before command handlers start when parsing options.
-            // Emit JSON contract output in that path to keep stdout machine-readable.
-            if (!CommandExecutionState.HasStarted && ParseErrorBuffer.HasAny)
-            {
-                var commandName = ResolveCommandName(args);
-                var parseErrorMessage = string.Join(" ", ParseErrorBuffer.Messages);
-                var parseErrorResult = CommandResult.InvalidArgument(commandName, parseErrorMessage);
-                CommandResultWriter.WriteToStandardOutput(parseErrorResult);
-                Environment.ExitCode = parseErrorResult.ExitCode;
-            }
-
+        if (TryHandleUnknownCommand(args))
+        {
             return Environment.ExitCode;
         }
 
-        /// <summary> Handles unknown command names before framework dispatch starts. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns>
-        /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
-        /// <para> Otherwise, <see langword="false" />. </para>
-        /// </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static bool TryHandleUnknownCommand (string[] args)
+        var app = ConsoleApp.Create()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<IUnityProjectResolver, UnityProjectResolver>();
+                services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
+                services.AddSingleton<IInitStatusContextResolver, InitStatusContextResolver>();
+                services.AddSingleton<IInitService, InitService>();
+                services.AddSingleton<IIpcEndpointResolver, IpcEndpointResolver>();
+                services.AddSingleton<IUnityIpcClient, UnityIpcClient>();
+            });
+        app.Add<InitCommand>();
+        app.Add<StatusCommand>();
+
+        try
         {
-            ArgumentNullException.ThrowIfNull(args);
-
-            if (args.Length == 0)
-            {
-                return false;
-            }
-
-            var firstArgument = args[0];
-            if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            if (IsRegisteredCommand(firstArgument)
-                || string.Equals(firstArgument, HelpCommandName, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            var result = CommandResult.InvalidArgument(
-                command: CliProtocol.RootCommand,
-                message: $"Command '{firstArgument}' is not recognized.");
-            CommandResultWriter.WriteToStandardOutput(result);
-            Environment.ExitCode = result.ExitCode;
-            return true;
+            await app.RunAsync(args);
+        }
+        catch (Exception exception)
+        {
+            var internalErrorResult = CommandResult.InternalError(CliProtocol.RootCommand, exception.Message);
+            CommandResultWriter.WriteToStandardOutput(internalErrorResult);
+            Environment.ExitCode = internalErrorResult.ExitCode;
+            return Environment.ExitCode;
         }
 
-        /// <summary> Resolves the command name used for parse error results. </summary>
-        /// <param name="args"> The command-line arguments passed to the process. </param>
-        /// <returns>
-        /// <para> The normalized command name for parse errors. </para>
-        /// <para> Returns <see cref="CliProtocol.RootCommand" /> when no known command can be identified. </para>
-        /// </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
-        private static string ResolveCommandName (string[] args)
+        // NOTE:
+        // ConsoleAppFramework can fail before command handlers start when parsing options.
+        // Emit JSON contract output in that path to keep stdout machine-readable.
+        if (!CommandExecutionState.HasStarted && ParseErrorBuffer.HasAny)
         {
-            ArgumentNullException.ThrowIfNull(args);
+            var commandName = ResolveCommandName(args);
+            var parseErrorMessage = string.Join(" ", ParseErrorBuffer.Messages);
+            var parseErrorResult = CommandResult.InvalidArgument(commandName, parseErrorMessage);
+            CommandResultWriter.WriteToStandardOutput(parseErrorResult);
+            Environment.ExitCode = parseErrorResult.ExitCode;
+        }
 
-            if (args.Length == 0)
-            {
-                return CliProtocol.RootCommand;
-            }
+        return Environment.ExitCode;
+    }
 
-            var firstArgument = args[0];
-            if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
-            {
-                return CliProtocol.RootCommand;
-            }
+    /// <summary> Handles unknown command names before framework dispatch starts. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns>
+    /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
+    /// <para> Otherwise, <see langword="false" />. </para>
+    /// </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static bool TryHandleUnknownCommand (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
 
-            if (IsRegisteredCommand(firstArgument))
-            {
-                return firstArgument;
-            }
+        if (args.Length == 0)
+        {
+            return false;
+        }
 
+        var firstArgument = args[0];
+        if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (IsRegisteredCommand(firstArgument)
+            || string.Equals(firstArgument, UcliCommandNames.Help, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var result = CommandResult.InvalidArgument(
+            command: CliProtocol.RootCommand,
+            message: $"Command '{firstArgument}' is not recognized.");
+        CommandResultWriter.WriteToStandardOutput(result);
+        Environment.ExitCode = result.ExitCode;
+        return true;
+    }
+
+    /// <summary> Resolves the command name used for parse error results. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <returns>
+    /// <para> The normalized command name for parse errors. </para>
+    /// <para> Returns <see cref="CliProtocol.RootCommand" /> when no known command can be identified. </para>
+    /// </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    private static string ResolveCommandName (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length == 0)
+        {
             return CliProtocol.RootCommand;
         }
 
-        private static bool IsRegisteredCommand (string commandName)
+        var firstArgument = args[0];
+        if (string.IsNullOrWhiteSpace(firstArgument) || firstArgument.StartsWith("-", StringComparison.Ordinal))
         {
-            return string.Equals(commandName, InitCommand.CommandName, StringComparison.Ordinal)
-                || string.Equals(commandName, StatusCommand.CommandName, StringComparison.Ordinal);
+            return CliProtocol.RootCommand;
         }
+
+        if (IsRegisteredCommand(firstArgument))
+        {
+            return firstArgument;
+        }
+
+        return CliProtocol.RootCommand;
+    }
+
+    private static bool IsRegisteredCommand (string commandName)
+    {
+        return UcliCommandNames.IsRegistered(commandName);
     }
 }

--- a/src/Ucli/UnityProject/IUnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/IUnityProjectResolver.cs
@@ -1,11 +1,10 @@
-namespace MackySoft.Ucli.UnityProject
+namespace MackySoft.Ucli.UnityProject;
+
+/// <summary> Resolves and validates a UnityProject path for CLI command execution. </summary>
+internal interface IUnityProjectResolver
 {
-    /// <summary> Resolves and validates a UnityProject path for CLI command execution. </summary>
-    internal interface IUnityProjectResolver
-    {
-        /// <summary> Resolves the UnityProject context from an optional <c>--projectPath</c> argument. </summary>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
-        UnityProjectResolutionResult Resolve (string? projectPath);
-    }
+    /// <summary> Resolves the UnityProject context from an optional <c>--projectPath</c> argument. </summary>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
+    UnityProjectResolutionResult Resolve (string? projectPath);
 }

--- a/src/Ucli/UnityProject/ResolvedUnityProjectContext.cs
+++ b/src/Ucli/UnityProject/ResolvedUnityProjectContext.cs
@@ -1,13 +1,12 @@
-namespace MackySoft.Ucli.UnityProject
-{
-    /// <summary> Represents a resolved UnityProject context shared by command foundation services. </summary>
-    /// <param name="UnityProjectRoot"> The normalized absolute UnityProject root path. </param>
-    /// <param name="ProjectFingerprint"> The deterministic fingerprint for project identity checks. </param>
-    /// <param name="PathSource"> The path source used during resolution. </param>
-    /// <param name="ConfigPath"> The absolute path to <c>.ucli/config.json</c>. </param>
-    internal sealed record ResolvedUnityProjectContext (
-        string UnityProjectRoot,
-        string ProjectFingerprint,
-        UnityProjectPathSource PathSource,
-        string ConfigPath);
-}
+namespace MackySoft.Ucli.UnityProject;
+
+/// <summary> Represents a resolved UnityProject context shared by command foundation services. </summary>
+/// <param name="UnityProjectRoot"> The normalized absolute UnityProject root path. </param>
+/// <param name="ProjectFingerprint"> The deterministic fingerprint for project identity checks. </param>
+/// <param name="PathSource"> The path source used during resolution. </param>
+/// <param name="ConfigPath"> The absolute path to <c>.ucli/config.json</c>. </param>
+internal sealed record ResolvedUnityProjectContext (
+    string UnityProjectRoot,
+    string ProjectFingerprint,
+    UnityProjectPathSource PathSource,
+    string ConfigPath);

--- a/src/Ucli/UnityProject/UnityProjectPathSource.cs
+++ b/src/Ucli/UnityProject/UnityProjectPathSource.cs
@@ -1,12 +1,11 @@
-namespace MackySoft.Ucli.UnityProject
-{
-    /// <summary> Identifies where the UnityProject path was obtained during resolution. </summary>
-    internal enum UnityProjectPathSource
-    {
-        /// <summary> The resolver used the current working directory. </summary>
-        CurrentDirectory = 0,
+namespace MackySoft.Ucli.UnityProject;
 
-        /// <summary> The resolver used the explicit <c>--projectPath</c> option value. </summary>
-        CommandOption = 1,
-    }
+/// <summary> Identifies where the UnityProject path was obtained during resolution. </summary>
+internal enum UnityProjectPathSource
+{
+    /// <summary> The resolver used the current working directory. </summary>
+    CurrentDirectory = 0,
+
+    /// <summary> The resolver used the explicit <c>--projectPath</c> option value. </summary>
+    CommandOption = 1,
 }

--- a/src/Ucli/UnityProject/UnityProjectResolutionResult.cs
+++ b/src/Ucli/UnityProject/UnityProjectResolutionResult.cs
@@ -1,35 +1,34 @@
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.UnityProject
+namespace MackySoft.Ucli.UnityProject;
+
+/// <summary> Represents the result of UnityProject path resolution. </summary>
+/// <param name="Context"> The resolved UnityProject context, or <see langword="null" /> on failure. </param>
+/// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
+internal sealed record UnityProjectResolutionResult (
+    ResolvedUnityProjectContext? Context,
+    ExecutionError? Error)
 {
-    /// <summary> Represents the result of UnityProject path resolution. </summary>
-    /// <param name="Context"> The resolved UnityProject context, or <see langword="null" /> on failure. </param>
-    /// <param name="Error"> The structured resolution error, or <see langword="null" /> on success. </param>
-    internal sealed record UnityProjectResolutionResult (
-        ResolvedUnityProjectContext? Context,
-        ExecutionError? Error)
+    /// <summary> Gets a value indicating whether the resolution succeeded. </summary>
+    public bool IsSuccess => Context is not null && Error is null;
+
+    /// <summary> Creates a successful UnityProject resolution result. </summary>
+    /// <param name="context"> The resolved UnityProject context. </param>
+    /// <returns> The successful resolution result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
+    public static UnityProjectResolutionResult Success (ResolvedUnityProjectContext context)
     {
-        /// <summary> Gets a value indicating whether the resolution succeeded. </summary>
-        public bool IsSuccess => Context is not null && Error is null;
+        ArgumentNullException.ThrowIfNull(context);
+        return new UnityProjectResolutionResult(context, null);
+    }
 
-        /// <summary> Creates a successful UnityProject resolution result. </summary>
-        /// <param name="context"> The resolved UnityProject context. </param>
-        /// <returns> The successful resolution result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> is <see langword="null" />. </exception>
-        public static UnityProjectResolutionResult Success (ResolvedUnityProjectContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            return new UnityProjectResolutionResult(context, null);
-        }
-
-        /// <summary> Creates a failed UnityProject resolution result. </summary>
-        /// <param name="error"> The structured resolution error. </param>
-        /// <returns> The failed resolution result. </returns>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-        public static UnityProjectResolutionResult Failure (ExecutionError error)
-        {
-            ArgumentNullException.ThrowIfNull(error);
-            return new UnityProjectResolutionResult(null, error);
-        }
+    /// <summary> Creates a failed UnityProject resolution result. </summary>
+    /// <param name="error"> The structured resolution error. </param>
+    /// <returns> The failed resolution result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static UnityProjectResolutionResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new UnityProjectResolutionResult(null, error);
     }
 }

--- a/src/Ucli/UnityProject/UnityProjectResolver.cs
+++ b/src/Ucli/UnityProject/UnityProjectResolver.cs
@@ -2,169 +2,168 @@ using System.Security.Cryptography;
 using System.Text;
 using MackySoft.Ucli.Foundation;
 
-namespace MackySoft.Ucli.UnityProject
+namespace MackySoft.Ucli.UnityProject;
+
+/// <summary> Resolves UnityProject identity information from command inputs. </summary>
+internal sealed class UnityProjectResolver : IUnityProjectResolver
 {
-    /// <summary> Resolves UnityProject identity information from command inputs. </summary>
-    internal sealed class UnityProjectResolver : IUnityProjectResolver
+    private const string ProjectSettingsDirectoryName = "ProjectSettings";
+    private const string ProjectVersionFileName = "ProjectVersion.txt";
+
+    private const string UcliDirectoryName = ".ucli";
+    private const string ConfigFileName = "config.json";
+
+    /// <summary> Resolves UnityProject context from command options and validates required project markers. </summary>
+    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
+    /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
+    public UnityProjectResolutionResult Resolve (string? projectPath)
     {
-        private const string ProjectSettingsDirectoryName = "ProjectSettings";
-        private const string ProjectVersionFileName = "ProjectVersion.txt";
-
-        private const string UcliDirectoryName = ".ucli";
-        private const string ConfigFileName = "config.json";
-
-        /// <summary> Resolves UnityProject context from command options and validates required project markers. </summary>
-        /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
-        /// <returns> The resolution result containing either a validated UnityProject context or a structured error. </returns>
-        public UnityProjectResolutionResult Resolve (string? projectPath)
+        var pathSource = string.IsNullOrWhiteSpace(projectPath)
+            ? UnityProjectPathSource.CurrentDirectory
+            : UnityProjectPathSource.CommandOption;
+        var pathCandidate = pathSource == UnityProjectPathSource.CurrentDirectory
+            ? Environment.CurrentDirectory
+            : projectPath!;
+        var fullPathResult = TryNormalizePath(pathCandidate);
+        if (!fullPathResult.IsSuccess)
         {
-            var pathSource = string.IsNullOrWhiteSpace(projectPath)
-                ? UnityProjectPathSource.CurrentDirectory
-                : UnityProjectPathSource.CommandOption;
-            var pathCandidate = pathSource == UnityProjectPathSource.CurrentDirectory
-                ? Environment.CurrentDirectory
-                : projectPath!;
-            var fullPathResult = TryNormalizePath(pathCandidate);
-            if (!fullPathResult.IsSuccess)
-            {
-                return UnityProjectResolutionResult.Failure(fullPathResult.Error!);
-            }
-
-            var unityProjectRoot = fullPathResult.Path!;
-            if (!Directory.Exists(unityProjectRoot))
-            {
-                return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
-                    $"UnityProject path does not exist: {unityProjectRoot}"));
-            }
-
-            var projectVersionPath = Path.Combine(
-                unityProjectRoot,
-                ProjectSettingsDirectoryName,
-                ProjectVersionFileName);
-            if (!File.Exists(projectVersionPath))
-            {
-                return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
-                    $"UnityProject is invalid. Missing file: {projectVersionPath}"));
-            }
-
-            var projectFingerprint = CreateProjectFingerprint(unityProjectRoot);
-            var configPath = Path.Combine(unityProjectRoot, UcliDirectoryName, ConfigFileName);
-            return UnityProjectResolutionResult.Success(new ResolvedUnityProjectContext(
-                UnityProjectRoot: unityProjectRoot,
-                ProjectFingerprint: projectFingerprint,
-                PathSource: pathSource,
-                ConfigPath: configPath));
+            return UnityProjectResolutionResult.Failure(fullPathResult.Error!);
         }
 
-        /// <summary> Creates a deterministic SHA-256 fingerprint for the normalized UnityProject root path. </summary>
-        /// <param name="unityProjectRoot"> The normalized absolute UnityProject root path. </param>
-        /// <returns> The lowercase hexadecimal SHA-256 string. </returns>
-        private static string CreateProjectFingerprint (string unityProjectRoot)
+        var unityProjectRoot = fullPathResult.Path!;
+        if (!Directory.Exists(unityProjectRoot))
         {
-            var normalizedPath = NormalizeForFingerprint(unityProjectRoot);
-            var normalizedBytes = Encoding.UTF8.GetBytes(normalizedPath);
-            var hashBytes = SHA256.HashData(normalizedBytes);
-            return Convert.ToHexString(hashBytes).ToLowerInvariant();
+            return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
+                $"UnityProject path does not exist: {unityProjectRoot}"));
         }
 
-        /// <summary> Normalizes a UnityProject path value to improve fingerprint stability. </summary>
-        /// <param name="unityProjectRoot"> The input UnityProject root path. </param>
-        /// <returns> The normalized path value used as fingerprint input. </returns>
-        private static string NormalizeForFingerprint (string unityProjectRoot)
+        var projectVersionPath = Path.Combine(
+            unityProjectRoot,
+            ProjectSettingsDirectoryName,
+            ProjectVersionFileName);
+        if (!File.Exists(projectVersionPath))
         {
-            var fullPath = Path.GetFullPath(unityProjectRoot);
-            fullPath = fullPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            var pathRoot = Path.GetPathRoot(fullPath);
-            if (!string.IsNullOrEmpty(pathRoot) && string.Equals(fullPath, pathRoot, PathComparison))
-            {
-                return NormalizeCase(fullPath);
-            }
-
-            var trimmedPath = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            return NormalizeCase(trimmedPath);
+            return UnityProjectResolutionResult.Failure(CreateInvalidArgument(
+                $"UnityProject is invalid. Missing file: {projectVersionPath}"));
         }
 
-        /// <summary> Normalizes path casing for platforms with case-insensitive paths. </summary>
-        /// <param name="path"> The path value to normalize. </param>
-        /// <returns> The normalized path string. </returns>
-        private static string NormalizeCase (string path)
+        var projectFingerprint = CreateProjectFingerprint(unityProjectRoot);
+        var configPath = Path.Combine(unityProjectRoot, UcliDirectoryName, ConfigFileName);
+        return UnityProjectResolutionResult.Success(new ResolvedUnityProjectContext(
+            UnityProjectRoot: unityProjectRoot,
+            ProjectFingerprint: projectFingerprint,
+            PathSource: pathSource,
+            ConfigPath: configPath));
+    }
+
+    /// <summary> Creates a deterministic SHA-256 fingerprint for the normalized UnityProject root path. </summary>
+    /// <param name="unityProjectRoot"> The normalized absolute UnityProject root path. </param>
+    /// <returns> The lowercase hexadecimal SHA-256 string. </returns>
+    private static string CreateProjectFingerprint (string unityProjectRoot)
+    {
+        var normalizedPath = NormalizeForFingerprint(unityProjectRoot);
+        var normalizedBytes = Encoding.UTF8.GetBytes(normalizedPath);
+        var hashBytes = SHA256.HashData(normalizedBytes);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    /// <summary> Normalizes a UnityProject path value to improve fingerprint stability. </summary>
+    /// <param name="unityProjectRoot"> The input UnityProject root path. </param>
+    /// <returns> The normalized path value used as fingerprint input. </returns>
+    private static string NormalizeForFingerprint (string unityProjectRoot)
+    {
+        var fullPath = Path.GetFullPath(unityProjectRoot);
+        fullPath = fullPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        var pathRoot = Path.GetPathRoot(fullPath);
+        if (!string.IsNullOrEmpty(pathRoot) && string.Equals(fullPath, pathRoot, PathComparison))
         {
-            return OperatingSystem.IsWindows()
-                ? path.ToUpperInvariant()
-                : path;
+            return NormalizeCase(fullPath);
         }
 
-        /// <summary> Attempts to normalize a path into an absolute path while converting path format errors to structured output. </summary>
-        /// <param name="pathValue"> The input path value. </param>
-        /// <returns> The normalization result. </returns>
-        private static PathNormalizationResult TryNormalizePath (string pathValue)
+        var trimmedPath = fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return NormalizeCase(trimmedPath);
+    }
+
+    /// <summary> Normalizes path casing for platforms with case-insensitive paths. </summary>
+    /// <param name="path"> The path value to normalize. </param>
+    /// <returns> The normalized path string. </returns>
+    private static string NormalizeCase (string path)
+    {
+        return OperatingSystem.IsWindows()
+            ? path.ToUpperInvariant()
+            : path;
+    }
+
+    /// <summary> Attempts to normalize a path into an absolute path while converting path format errors to structured output. </summary>
+    /// <param name="pathValue"> The input path value. </param>
+    /// <returns> The normalization result. </returns>
+    private static PathNormalizationResult TryNormalizePath (string pathValue)
+    {
+        try
         {
-            try
-            {
-                var fullPath = Path.GetFullPath(pathValue);
-                return PathNormalizationResult.Success(fullPath);
-            }
-            catch (Exception ex) when (IsPathFormatException(ex))
-            {
-                return PathNormalizationResult.Failure(CreateInvalidArgument(
-                    $"UnityProject path is invalid: {pathValue}"));
-            }
+            var fullPath = Path.GetFullPath(pathValue);
+            return PathNormalizationResult.Success(fullPath);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return PathNormalizationResult.Failure(CreateInvalidArgument(
+                $"UnityProject path is invalid: {pathValue}"));
+        }
+    }
+
+    /// <summary> Determines whether an exception represents invalid input path formatting. </summary>
+    /// <param name="exception"> The exception to inspect. </param>
+    /// <returns>
+    /// <para> <see langword="true" /> when the exception should be mapped to <c>INVALID_ARGUMENT</c>. </para>
+    /// <para> Otherwise, <see langword="false" />. </para>
+    /// </returns>
+    private static bool IsPathFormatException (Exception exception)
+    {
+        return exception is ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+    }
+
+    /// <summary> Creates an invalid-argument foundation error. </summary>
+    /// <param name="message"> The error message. </param>
+    /// <returns> The structured invalid-argument error. </returns>
+    private static ExecutionError CreateInvalidArgument (string message)
+    {
+        return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
+    }
+
+    /// <summary> Gets the path comparison mode for the current operating system. </summary>
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    /// <summary> Represents the result of path normalization. </summary>
+    /// <param name="Path"> The normalized absolute path. </param>
+    /// <param name="Error"> The structured error when normalization fails. </param>
+    private readonly record struct PathNormalizationResult (
+        string? Path,
+        ExecutionError? Error)
+    {
+        /// <summary> Gets a value indicating whether path normalization succeeded. </summary>
+        public bool IsSuccess => !string.IsNullOrWhiteSpace(Path) && Error is null;
+
+        /// <summary> Creates a successful path normalization result. </summary>
+        /// <param name="path"> The normalized absolute path. </param>
+        /// <returns> The successful result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="path" /> is <see langword="null" />. </exception>
+        public static PathNormalizationResult Success (string path)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            return new PathNormalizationResult(path, null);
         }
 
-        /// <summary> Determines whether an exception represents invalid input path formatting. </summary>
-        /// <param name="exception"> The exception to inspect. </param>
-        /// <returns>
-        /// <para> <see langword="true" /> when the exception should be mapped to <c>INVALID_ARGUMENT</c>. </para>
-        /// <para> Otherwise, <see langword="false" />. </para>
-        /// </returns>
-        private static bool IsPathFormatException (Exception exception)
+        /// <summary> Creates a failed path normalization result. </summary>
+        /// <param name="error"> The structured error. </param>
+        /// <returns> The failed result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+        public static PathNormalizationResult Failure (ExecutionError error)
         {
-            return exception is ArgumentException
-                or NotSupportedException
-                or PathTooLongException;
-        }
-
-        /// <summary> Creates an invalid-argument foundation error. </summary>
-        /// <param name="message"> The error message. </param>
-        /// <returns> The structured invalid-argument error. </returns>
-        private static ExecutionError CreateInvalidArgument (string message)
-        {
-            return new ExecutionError(ExecutionErrorKind.InvalidArgument, message);
-        }
-
-        /// <summary> Gets the path comparison mode for the current operating system. </summary>
-        private static StringComparison PathComparison =>
-            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-        /// <summary> Represents the result of path normalization. </summary>
-        /// <param name="Path"> The normalized absolute path. </param>
-        /// <param name="Error"> The structured error when normalization fails. </param>
-        private readonly record struct PathNormalizationResult (
-            string? Path,
-            ExecutionError? Error)
-        {
-            /// <summary> Gets a value indicating whether path normalization succeeded. </summary>
-            public bool IsSuccess => !string.IsNullOrWhiteSpace(Path) && Error is null;
-
-            /// <summary> Creates a successful path normalization result. </summary>
-            /// <param name="path"> The normalized absolute path. </param>
-            /// <returns> The successful result. </returns>
-            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="path" /> is <see langword="null" />. </exception>
-            public static PathNormalizationResult Success (string path)
-            {
-                ArgumentNullException.ThrowIfNull(path);
-                return new PathNormalizationResult(path, null);
-            }
-
-            /// <summary> Creates a failed path normalization result. </summary>
-            /// <param name="error"> The structured error. </param>
-            /// <returns> The failed result. </returns>
-            /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-            public static PathNormalizationResult Failure (ExecutionError error)
-            {
-                ArgumentNullException.ThrowIfNull(error);
-                return new PathNormalizationResult(null, error);
-            }
+            ArgumentNullException.ThrowIfNull(error);
+            return new PathNormalizationResult(null, error);
         }
     }
 }

--- a/tests/Ucli.Tests/Cli/Requests/RequestInputReaderTests.cs
+++ b/tests/Ucli.Tests/Cli/Requests/RequestInputReaderTests.cs
@@ -1,0 +1,156 @@
+using System.Security;
+using MackySoft.Ucli.Cli.Requests;
+using MackySoft.Ucli.Foundation;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class RequestInputReaderTests
+{
+    private static readonly (Exception Exception, ExecutionErrorKind ExpectedErrorKind)[] RequestPathReadExceptionCases =
+    [
+        (new ArgumentException("bad path"), ExecutionErrorKind.InvalidArgument),
+        (new NotSupportedException("bad path"), ExecutionErrorKind.InvalidArgument),
+        (new PathTooLongException("bad path"), ExecutionErrorKind.InvalidArgument),
+        (new FileNotFoundException("missing"), ExecutionErrorKind.InvalidArgument),
+        (new DirectoryNotFoundException("missing"), ExecutionErrorKind.InvalidArgument),
+        (new UnauthorizedAccessException("denied"), ExecutionErrorKind.InternalError),
+        (new IOException("io failure"), ExecutionErrorKind.InternalError),
+        (new SecurityException("denied"), ExecutionErrorKind.InternalError),
+    ];
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsInvalidArgument_WhenRequestPathAndRedirectedStandardInputAreBothProvided ()
+    {
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult("""{"from":"stdin"}"""),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"from":"file"}"""));
+
+        var result = await reader.ReadAsync("request.json");
+
+        AssertFailure(result, ExecutionErrorKind.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReadsRequestPath_WhenOnlyRequestPathIsSpecified ()
+    {
+        const string expectedJson = """{"source":"file"}""";
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => false,
+            readStandardInputAsync: static _ => Task.FromResult("""{"source":"stdin"}"""),
+            readRequestFileAsync: static (_, _) => Task.FromResult(expectedJson));
+
+        var result = await reader.ReadAsync("request.json");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedJson, result.Json);
+        Assert.Equal(RequestInputSource.RequestPath, result.Source);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReadsStandardInput_WhenRedirectedAndRequestPathIsNotSpecified ()
+    {
+        const string expectedJson = """{"source":"stdin"}""";
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult(expectedJson),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"source":"file"}"""));
+
+        var result = await reader.ReadAsync(null);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedJson, result.Json);
+        Assert.Equal(RequestInputSource.StandardInput, result.Source);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsInvalidArgument_WhenInputSourceIsMissing ()
+    {
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => false,
+            readStandardInputAsync: static _ => Task.FromResult("""{"source":"stdin"}"""),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"source":"file"}"""));
+
+        var result = await reader.ReadAsync(null);
+
+        AssertFailure(result, ExecutionErrorKind.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsInvalidArgument_WhenRequestJsonIsEmpty ()
+    {
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => false,
+            readStandardInputAsync: static _ => Task.FromResult("""{"source":"stdin"}"""),
+            readRequestFileAsync: static (_, _) => Task.FromResult("   "));
+
+        var result = await reader.ReadAsync("request.json");
+
+        AssertFailure(result, ExecutionErrorKind.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsInvalidArgument_WhenRequestJsonIsMalformed ()
+    {
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult("{"),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"source":"file"}"""));
+
+        var result = await reader.ReadAsync(null);
+
+        AssertFailure(result, ExecutionErrorKind.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsExpectedErrorKind_WhenReadingRequestFileThrows ()
+    {
+        foreach ((Exception exception, ExecutionErrorKind expectedErrorKind) in RequestPathReadExceptionCases)
+        {
+            var reader = new RequestInputReader(
+                isStandardInputRedirected: static () => false,
+                readStandardInputAsync: static _ => Task.FromResult("""{"source":"stdin"}"""),
+                readRequestFileAsync: (_, _) => Task.FromException<string>(exception));
+
+            RequestInputReadResult result = await reader.ReadAsync("request.json");
+
+            AssertFailure(result, expectedErrorKind);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadAsync_ReturnsInternalError_WhenStandardInputReadFails ()
+    {
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromException<string>(new IOException("stdin failure")),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"source":"file"}"""));
+
+        var result = await reader.ReadAsync(null);
+
+        AssertFailure(result, ExecutionErrorKind.InternalError);
+    }
+
+    private static void AssertFailure (
+        RequestInputReadResult result,
+        ExecutionErrorKind expectedErrorKind)
+    {
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Json);
+        Assert.Null(result.Source);
+
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(expectedErrorKind, error.Kind);
+        Assert.False(string.IsNullOrWhiteSpace(error.Message));
+    }
+}

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -3,340 +3,339 @@ using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Cli;
 
-namespace MackySoft.Ucli.Tests
+namespace MackySoft.Ucli.Tests;
+
+public sealed class CliOutputContractTests
 {
-    public sealed class CliOutputContractTests
+    private const string ConfigFileName = "config.json";
+
+    private const string GitIgnoreFileName = ".gitignore";
+
+    private const string LegacyConfigJson = """{"schemaVersion":999}""";
+
+    private const string LegacyGitIgnoreContent = "legacy/";
+
+    private const string UcliDirectoryName = ".ucli";
+
+    private const string UnityProjectDirectoryName = "UnityProject";
+
+    private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Status_ReturnsNotImplementedErrorAsSingleJson ()
     {
-        private const string ConfigFileName = "config.json";
+        var result = await RunToolAsync(UcliCommandNames.Status);
 
-        private const string GitIgnoreFileName = ".gitignore";
-
-        private const string LegacyConfigJson = """{"schemaVersion":999}""";
-
-        private const string LegacyGitIgnoreContent = "legacy/";
-
-        private const string UcliDirectoryName = ".ucli";
-
-        private const string UnityProjectDirectoryName = "UnityProject";
-
-        private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
-
-        private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(15);
-
-        [Fact]
-        [Trait("Size", "Medium")]
-        public async Task Status_ReturnsNotImplementedErrorAsSingleJson ()
-        {
-            var result = await RunToolAsync(StatusCommand.CommandName);
-
-            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-            Assert.Equal((int)CliExitCode.ToolError, result.ExitCode);
-            AssertCommandResultCommon(
-                outputJson.RootElement,
-                command: StatusCommand.CommandName,
-                status: CliProtocol.StatusError,
-                exitCode: (int)CliExitCode.ToolError);
-            AssertSingleError(
-                outputJson.RootElement,
-                expectedCode: ErrorCodes.CommandNotImplemented);
-        }
-
-        [Theory]
-        [Trait("Size", "Medium")]
-        [InlineData(false, "init-success")]
-        [InlineData(true, "init-force-success")]
-        public async Task Init_ReturnsSuccessJsonContractAsSingleJson (bool force, string scopeName)
-        {
-            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-            var (unityProjectPath, configPath, gitIgnorePath) = CreateUnityProjectPaths(scope);
-            if (force)
-            {
-                PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
-            }
-
-            var result = await RunInitAsync(unityProjectPath, force);
-
-            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-            Assert.Equal((int)CliExitCode.Success, result.ExitCode);
-            AssertCommandResultCommon(
-                outputJson.RootElement,
-                command: InitCommand.CommandName,
-                status: CliProtocol.StatusOk,
-                exitCode: (int)CliExitCode.Success);
-            AssertNoErrors(outputJson.RootElement);
-            JsonAssert.For(outputJson.RootElement)
-                .HasProperty("payload", payload => payload
-                    .HasString("projectPath", unityProjectPath)
-                    .HasValueKind("projectFingerprint", JsonValueKind.String)
-                    .HasString("configPath", configPath)
-                    .HasString("gitignorePath", gitIgnorePath));
-        }
-
-        [Theory]
-        [Trait("Size", "Medium")]
-        [InlineData(true, "init-config-file")]
-        [InlineData(false, "init-gitignore-file")]
-        public async Task Init_WithProjectPath_CreatesTemplateFiles (bool isConfigFile, string scopeName)
-        {
-            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-            var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
-            var templateFilePath = isConfigFile
-                ? GetConfigPath(unityProjectPath)
-                : GetGitIgnorePath(unityProjectPath);
-
-            await RunInitAsync(unityProjectPath);
-
-            FileSystemAssert.ForFile(templateFilePath).Exists();
-        }
-
-        [Theory]
-        [Trait("Size", "Medium")]
-        [InlineData(false, "init-default-config-values")]
-        [InlineData(true, "init-force-config-overwrite")]
-        public async Task Init_WritesDefaultConfigValues (bool force, string scopeName)
-        {
-            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-            var (unityProjectPath, configPath, _) = CreateUnityProjectPaths(scope);
-            if (force)
-            {
-                PrepareLegacyTemplateFiles(scope, configPath, GetGitIgnorePath(unityProjectPath));
-            }
-
-            await RunInitAsync(unityProjectPath, force);
-
-            AssertDefaultConfigValues(configPath);
-        }
-
-        [Theory]
-        [Trait("Size", "Medium")]
-        [InlineData(false, "init-gitignore-contents")]
-        [InlineData(true, "init-force-gitignore-overwrite")]
-        public async Task Init_WritesLocalOnlyGitIgnoreContents (bool force, string scopeName)
-        {
-            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-            var (unityProjectPath, _, gitIgnorePath) = CreateUnityProjectPaths(scope);
-            if (force)
-            {
-                PrepareLegacyTemplateFiles(scope, GetConfigPath(unityProjectPath), gitIgnorePath);
-            }
-
-            await RunInitAsync(unityProjectPath, force);
-
-            Assert.Equal(UcliContractConstants.LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
-        }
-
-        [Theory]
-        [Trait("Size", "Medium")]
-        [InlineData(true, LegacyConfigJson, "init-existing-config")]
-        [InlineData(false, LegacyGitIgnoreContent, "init-existing-gitignore")]
-        public async Task Init_WithoutForce_WhenTemplateFileExists_ReturnsInvalidArgumentErrorAsSingleJson (
-            bool isConfigFile,
-            string existingContent,
-            string scopeName)
-        {
-            using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-            var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
-            var existingTemplateFilePath = isConfigFile
-                ? GetConfigPath(unityProjectPath)
-                : GetGitIgnorePath(unityProjectPath);
-            WriteFileUnderScope(scope, existingTemplateFilePath, existingContent);
-
-            var result = await RunInitAsync(unityProjectPath);
-
-            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-            Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-            AssertCommandResultCommon(
-                outputJson.RootElement,
-                command: InitCommand.CommandName,
-                status: CliProtocol.StatusError,
-                exitCode: (int)CliExitCode.InvalidArgument);
-            AssertSingleError(
-                outputJson.RootElement,
-                expectedCode: ErrorCodes.InvalidArgument);
-        }
-
-        [Fact]
-        [Trait("Size", "Medium")]
-        public async Task Status_WithUnknownOption_ReturnsInvalidArgumentErrorAsSingleJson ()
-        {
-            var result = await RunToolAsync(StatusCommand.CommandName, UcliContractConstants.CliOption.Unknown);
-
-            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-            Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-            AssertCommandResultCommon(
-                outputJson.RootElement,
-                command: StatusCommand.CommandName,
-                status: CliProtocol.StatusError,
-                exitCode: (int)CliExitCode.InvalidArgument);
-            AssertSingleError(
-                outputJson.RootElement,
-                expectedCode: ErrorCodes.InvalidArgument);
-            Assert.Contains(UnknownOptionMessage, result.StdErr, StringComparison.Ordinal);
-        }
-
-        [Fact]
-        [Trait("Size", "Medium")]
-        public async Task UnknownCommand_ReturnsInvalidArgumentErrorAsSingleJson ()
-        {
-            var result = await RunToolAsync("unknown");
-
-            using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-            Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-            AssertCommandResultCommon(
-                outputJson.RootElement,
-                command: CliProtocol.RootCommand,
-                status: CliProtocol.StatusError,
-                exitCode: (int)CliExitCode.InvalidArgument);
-            AssertSingleError(
-                outputJson.RootElement,
-                expectedCode: ErrorCodes.InvalidArgument);
-        }
-
-        private static void AssertCommandResultCommon (
-            JsonElement root,
-            string command,
-            string status,
-            int exitCode)
-        {
-            JsonAssert.For(root)
-                .HasInt32("protocolVersion", CliProtocol.CurrentVersion)
-                .HasString("command", command)
-                .HasString("status", status)
-                .HasInt32("exitCode", exitCode)
-                .HasValueKind("message", JsonValueKind.String)
-                .HasValueKind("payload", JsonValueKind.Object)
-                .HasValueKind("errors", JsonValueKind.Array);
-        }
-
-        private static void AssertNoErrors (JsonElement root)
-        {
-            JsonAssert.For(root)
-                .HasArrayLength("errors", 0);
-        }
-
-        private static void AssertSingleError (JsonElement root, string expectedCode)
-        {
-            JsonAssert.For(root)
-                .HasArrayLength("errors", 1)
-                .HasProperty("errors", 0, error => error
-                    .HasString("code", expectedCode)
-                    .HasValueKind("message", JsonValueKind.String)
-                    .IsNull("opId"));
-        }
-
-        private static async Task<CommandExecutionResult> RunToolAsync (params string[] args)
-        {
-            // NOTE:
-            // This test validates the process-level CLI contract (stdout JSON, stderr, exit code).
-            // Resolving command instances directly would bypass Program and parser error paths.
-            var toolPath = typeof(CommandResult).Assembly.Location;
-            Assert.True(File.Exists(toolPath), $"CLI assembly was not found: {toolPath}");
-
-            using var process = new Process();
-            var startInfo = process.StartInfo;
-            startInfo.FileName = "dotnet";
-            startInfo.UseShellExecute = false;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
-            startInfo.CreateNoWindow = true;
-            startInfo.ArgumentList.Add(toolPath);
-            foreach (var arg in args)
-            {
-                startInfo.ArgumentList.Add(arg);
-            }
-
-            var started = process.Start();
-            Assert.True(started, "Failed to start ucli process.");
-
-            var stdOutTask = process.StandardOutput.ReadToEndAsync();
-            var stdErrTask = process.StandardError.ReadToEndAsync();
-
-            using var timeoutCts = new CancellationTokenSource(ProcessTimeout);
-            try
-            {
-                await process.WaitForExitAsync(timeoutCts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-
-                throw new TimeoutException($"ucli process timed out after {ProcessTimeout.TotalSeconds} seconds.");
-            }
-
-            return new CommandExecutionResult(
-                ExitCode: process.ExitCode,
-                StdOut: await stdOutTask,
-                StdErr: await stdErrTask);
-        }
-
-        private static async Task<CommandExecutionResult> RunInitAsync (string unityProjectPath, bool force = false)
-        {
-            if (force)
-            {
-                return await RunToolAsync(
-                    InitCommand.CommandName,
-                    UcliContractConstants.CliOption.ProjectPath,
-                    unityProjectPath,
-                    UcliContractConstants.CliOption.Force);
-            }
-
-            return await RunToolAsync(InitCommand.CommandName, UcliContractConstants.CliOption.ProjectPath, unityProjectPath);
-        }
-
-        private static (string UnityProjectPath, string ConfigPath, string GitIgnorePath) CreateUnityProjectPaths (TestDirectoryScope scope)
-        {
-            var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, UnityProjectDirectoryName);
-            var configPath = GetConfigPath(unityProjectPath);
-            var gitIgnorePath = GetGitIgnorePath(unityProjectPath);
-            return (unityProjectPath, configPath, gitIgnorePath);
-        }
-
-        private static string GetConfigPath (string unityProjectPath)
-        {
-            return Path.Combine(unityProjectPath, UcliDirectoryName, ConfigFileName);
-        }
-
-        private static string GetGitIgnorePath (string unityProjectPath)
-        {
-            return Path.Combine(unityProjectPath, UcliDirectoryName, GitIgnoreFileName);
-        }
-
-        private static void AssertDefaultConfigValues (string configPath)
-        {
-            using var configJson = JsonDocument.Parse(File.ReadAllText(configPath));
-            JsonAssert.For(configJson.RootElement)
-                .HasInt32("schemaVersion", UcliContractConstants.Config.SchemaVersion)
-                .HasString("operationPolicy", UcliContractConstants.Config.OperationPolicySafe)
-                .HasString("planTokenMode", UcliContractConstants.Config.PlanTokenModeOptional)
-                .HasArrayLength("operationAllowlist", 1)
-                .HasProperty("operationAllowlist", 0, static allowlistValue => allowlistValue
-                    .HasString(UcliContractConstants.Config.DefaultOperationAllowlistPattern));
-        }
-
-        private static void PrepareLegacyTemplateFiles (
-            TestDirectoryScope scope,
-            string configPath,
-            string gitIgnorePath)
-        {
-            WriteFileUnderScope(scope, configPath, LegacyConfigJson);
-            WriteFileUnderScope(scope, gitIgnorePath, LegacyGitIgnoreContent);
-        }
-
-        private static void WriteFileUnderScope (
-            TestDirectoryScope scope,
-            string absolutePath,
-            string contents)
-        {
-            var relativePath = Path.GetRelativePath(scope.FullPath, absolutePath);
-            scope.WriteFile(relativePath, contents);
-        }
-
-        private readonly record struct CommandExecutionResult (
-            int ExitCode,
-            string StdOut,
-            string StdErr);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.ToolError, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: UcliCommandNames.Status,
+            status: CliProtocol.StatusError,
+            exitCode: (int)CliExitCode.ToolError);
+        AssertSingleError(
+            outputJson.RootElement,
+            expectedCode: ErrorCodes.CommandNotImplemented);
     }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(false, "init-success")]
+    [InlineData(true, "init-force-success")]
+    public async Task Init_ReturnsSuccessJsonContractAsSingleJson (bool force, string scopeName)
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+        var (unityProjectPath, configPath, gitIgnorePath) = CreateUnityProjectPaths(scope);
+        if (force)
+        {
+            PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
+        }
+
+        var result = await RunInitAsync(unityProjectPath, force);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: UcliCommandNames.Init,
+            status: CliProtocol.StatusOk,
+            exitCode: (int)CliExitCode.Success);
+        AssertNoErrors(outputJson.RootElement);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("projectPath", unityProjectPath)
+                .HasValueKind("projectFingerprint", JsonValueKind.String)
+                .HasString("configPath", configPath)
+                .HasString("gitignorePath", gitIgnorePath));
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(true, "init-config-file")]
+    [InlineData(false, "init-gitignore-file")]
+    public async Task Init_WithProjectPath_CreatesTemplateFiles (bool isConfigFile, string scopeName)
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+        var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
+        var templateFilePath = isConfigFile
+            ? GetConfigPath(unityProjectPath)
+            : GetGitIgnorePath(unityProjectPath);
+
+        await RunInitAsync(unityProjectPath);
+
+        FileSystemAssert.ForFile(templateFilePath).Exists();
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(false, "init-default-config-values")]
+    [InlineData(true, "init-force-config-overwrite")]
+    public async Task Init_WritesDefaultConfigValues (bool force, string scopeName)
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+        var (unityProjectPath, configPath, _) = CreateUnityProjectPaths(scope);
+        if (force)
+        {
+            PrepareLegacyTemplateFiles(scope, configPath, GetGitIgnorePath(unityProjectPath));
+        }
+
+        await RunInitAsync(unityProjectPath, force);
+
+        AssertDefaultConfigValues(configPath);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(false, "init-gitignore-contents")]
+    [InlineData(true, "init-force-gitignore-overwrite")]
+    public async Task Init_WritesLocalOnlyGitIgnoreContents (bool force, string scopeName)
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+        var (unityProjectPath, _, gitIgnorePath) = CreateUnityProjectPaths(scope);
+        if (force)
+        {
+            PrepareLegacyTemplateFiles(scope, GetConfigPath(unityProjectPath), gitIgnorePath);
+        }
+
+        await RunInitAsync(unityProjectPath, force);
+
+        Assert.Equal(UcliContractConstants.LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(true, LegacyConfigJson, "init-existing-config")]
+    [InlineData(false, LegacyGitIgnoreContent, "init-existing-gitignore")]
+    public async Task Init_WithoutForce_WhenTemplateFileExists_ReturnsInvalidArgumentErrorAsSingleJson (
+        bool isConfigFile,
+        string existingContent,
+        string scopeName)
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
+        var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
+        var existingTemplateFilePath = isConfigFile
+            ? GetConfigPath(unityProjectPath)
+            : GetGitIgnorePath(unityProjectPath);
+        WriteFileUnderScope(scope, existingTemplateFilePath, existingContent);
+
+        var result = await RunInitAsync(unityProjectPath);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: UcliCommandNames.Init,
+            status: CliProtocol.StatusError,
+            exitCode: (int)CliExitCode.InvalidArgument);
+        AssertSingleError(
+            outputJson.RootElement,
+            expectedCode: ErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Status_WithUnknownOption_ReturnsInvalidArgumentErrorAsSingleJson ()
+    {
+        var result = await RunToolAsync(UcliCommandNames.Status, UcliContractConstants.CliOption.Unknown);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: UcliCommandNames.Status,
+            status: CliProtocol.StatusError,
+            exitCode: (int)CliExitCode.InvalidArgument);
+        AssertSingleError(
+            outputJson.RootElement,
+            expectedCode: ErrorCodes.InvalidArgument);
+        Assert.Contains(UnknownOptionMessage, result.StdErr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task UnknownCommand_ReturnsInvalidArgumentErrorAsSingleJson ()
+    {
+        var result = await RunToolAsync("unknown");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: CliProtocol.RootCommand,
+            status: CliProtocol.StatusError,
+            exitCode: (int)CliExitCode.InvalidArgument);
+        AssertSingleError(
+            outputJson.RootElement,
+            expectedCode: ErrorCodes.InvalidArgument);
+    }
+
+    private static void AssertCommandResultCommon (
+        JsonElement root,
+        string command,
+        string status,
+        int exitCode)
+    {
+        JsonAssert.For(root)
+            .HasInt32("protocolVersion", CliProtocol.CurrentVersion)
+            .HasString("command", command)
+            .HasString("status", status)
+            .HasInt32("exitCode", exitCode)
+            .HasValueKind("message", JsonValueKind.String)
+            .HasValueKind("payload", JsonValueKind.Object)
+            .HasValueKind("errors", JsonValueKind.Array);
+    }
+
+    private static void AssertNoErrors (JsonElement root)
+    {
+        JsonAssert.For(root)
+            .HasArrayLength("errors", 0);
+    }
+
+    private static void AssertSingleError (JsonElement root, string expectedCode)
+    {
+        JsonAssert.For(root)
+            .HasArrayLength("errors", 1)
+            .HasProperty("errors", 0, error => error
+                .HasString("code", expectedCode)
+                .HasValueKind("message", JsonValueKind.String)
+                .IsNull("opId"));
+    }
+
+    private static async Task<CommandExecutionResult> RunToolAsync (params string[] args)
+    {
+        // NOTE:
+        // This test validates the process-level CLI contract (stdout JSON, stderr, exit code).
+        // Resolving command instances directly would bypass Program and parser error paths.
+        var toolPath = typeof(CommandResult).Assembly.Location;
+        Assert.True(File.Exists(toolPath), $"CLI assembly was not found: {toolPath}");
+
+        using var process = new Process();
+        var startInfo = process.StartInfo;
+        startInfo.FileName = "dotnet";
+        startInfo.UseShellExecute = false;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.CreateNoWindow = true;
+        startInfo.ArgumentList.Add(toolPath);
+        foreach (var arg in args)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        var started = process.Start();
+        Assert.True(started, "Failed to start ucli process.");
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+
+        using var timeoutCts = new CancellationTokenSource(ProcessTimeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            throw new TimeoutException($"ucli process timed out after {ProcessTimeout.TotalSeconds} seconds.");
+        }
+
+        return new CommandExecutionResult(
+            ExitCode: process.ExitCode,
+            StdOut: await stdOutTask,
+            StdErr: await stdErrTask);
+    }
+
+    private static async Task<CommandExecutionResult> RunInitAsync (string unityProjectPath, bool force = false)
+    {
+        if (force)
+        {
+            return await RunToolAsync(
+                UcliCommandNames.Init,
+                UcliContractConstants.CliOption.ProjectPath,
+                unityProjectPath,
+                UcliContractConstants.CliOption.Force);
+        }
+
+        return await RunToolAsync(UcliCommandNames.Init, UcliContractConstants.CliOption.ProjectPath, unityProjectPath);
+    }
+
+    private static (string UnityProjectPath, string ConfigPath, string GitIgnorePath) CreateUnityProjectPaths (TestDirectoryScope scope)
+    {
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, UnityProjectDirectoryName);
+        var configPath = GetConfigPath(unityProjectPath);
+        var gitIgnorePath = GetGitIgnorePath(unityProjectPath);
+        return (unityProjectPath, configPath, gitIgnorePath);
+    }
+
+    private static string GetConfigPath (string unityProjectPath)
+    {
+        return Path.Combine(unityProjectPath, UcliDirectoryName, ConfigFileName);
+    }
+
+    private static string GetGitIgnorePath (string unityProjectPath)
+    {
+        return Path.Combine(unityProjectPath, UcliDirectoryName, GitIgnoreFileName);
+    }
+
+    private static void AssertDefaultConfigValues (string configPath)
+    {
+        using var configJson = JsonDocument.Parse(File.ReadAllText(configPath));
+        JsonAssert.For(configJson.RootElement)
+            .HasInt32("schemaVersion", UcliContractConstants.Config.SchemaVersion)
+            .HasString("operationPolicy", UcliContractConstants.Config.OperationPolicySafe)
+            .HasString("planTokenMode", UcliContractConstants.Config.PlanTokenModeOptional)
+            .HasArrayLength("operationAllowlist", 1)
+            .HasProperty("operationAllowlist", 0, static allowlistValue => allowlistValue
+                .HasString(UcliContractConstants.Config.DefaultOperationAllowlistPattern));
+    }
+
+    private static void PrepareLegacyTemplateFiles (
+        TestDirectoryScope scope,
+        string configPath,
+        string gitIgnorePath)
+    {
+        WriteFileUnderScope(scope, configPath, LegacyConfigJson);
+        WriteFileUnderScope(scope, gitIgnorePath, LegacyGitIgnoreContent);
+    }
+
+    private static void WriteFileUnderScope (
+        TestDirectoryScope scope,
+        string absolutePath,
+        string contents)
+    {
+        var relativePath = Path.GetRelativePath(scope.FullPath, absolutePath);
+        scope.WriteFile(relativePath, contents);
+    }
+
+    private readonly record struct CommandExecutionResult (
+        int ExitCode,
+        string StdOut,
+        string StdErr);
 }

--- a/tests/Ucli.Tests/CommandResultTests.cs
+++ b/tests/Ucli.Tests/CommandResultTests.cs
@@ -1,17 +1,17 @@
 ﻿using System.Text.Json;
 using MackySoft.Ucli.Cli;
 
-namespace MackySoft.Ucli.Tests
+namespace MackySoft.Ucli.Tests;
+
+public sealed class CommandResultTests
 {
-    public sealed class CommandResultTests
-    {
-        private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+    private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
 
-        private const string UnhandledExceptionMessage = "Unhandled exception.";
+    private const string UnhandledExceptionMessage = "Unhandled exception.";
 
-        private const string CanceledMessage = "Command execution was canceled.";
+    private const string CanceledMessage = "Command execution was canceled.";
 
-        public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
+    public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
         {
             {
                 CommandResult.NotImplemented(StatusCommand.CommandName),
@@ -43,111 +43,110 @@ namespace MackySoft.Ucli.Tests
             },
         };
 
-        [Fact]
-        [Trait("Size", "Small")]
-        public void Success_CreatesContractCompliantResult ()
-        {
-            const string message = "Initialized.";
-            var payload = new { initialized = true };
-            var result = CommandResult.Success(InitCommand.CommandName, message, payload);
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Success_CreatesContractCompliantResult ()
+    {
+        const string message = "Initialized.";
+        var payload = new { initialized = true };
+        var result = CommandResult.Success(InitCommand.CommandName, message, payload);
 
-            AssertCommonContract(
-                result,
-                expectedCommand: InitCommand.CommandName,
-                expectedStatus: CliProtocol.StatusOk,
-                expectedExitCode: (int)CliExitCode.Success,
-                expectedMessage: message);
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Empty(result.Errors);
-        }
+        AssertCommonContract(
+            result,
+            expectedCommand: InitCommand.CommandName,
+            expectedStatus: CliProtocol.StatusOk,
+            expectedExitCode: (int)CliExitCode.Success,
+            expectedMessage: message);
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Empty(result.Errors);
+    }
 
-        [Theory]
-        [Trait("Size", "Small")]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void Success_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
-        {
-            var result = CommandResult.Success(whitespaceValue, whitespaceValue);
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Success_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
+    {
+        var result = CommandResult.Success(whitespaceValue, whitespaceValue);
 
-            AssertCommonContract(
-                result,
-                expectedCommand: CliProtocol.RootCommand,
-                expectedStatus: CliProtocol.StatusOk,
-                expectedExitCode: (int)CliExitCode.Success,
-                expectedMessage: "An unknown error occurred.");
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Empty(result.Errors);
-        }
+        AssertCommonContract(
+            result,
+            expectedCommand: CliProtocol.RootCommand,
+            expectedStatus: CliProtocol.StatusOk,
+            expectedExitCode: (int)CliExitCode.Success,
+            expectedMessage: "An unknown error occurred.");
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Empty(result.Errors);
+    }
 
-        [Theory]
-        [Trait("Size", "Small")]
-        [MemberData(nameof(ErrorCaseData))]
-        public void ErrorFactory_CreatesContractCompliantResult (
-            object actualResult,
-            string expectedCommand,
-            int expectedExitCode,
-            string expectedErrorCode,
-            string expectedMessage)
-        {
-            var result = Assert.IsType<CommandResult>(actualResult);
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(ErrorCaseData))]
+    public void ErrorFactory_CreatesContractCompliantResult (
+        object actualResult,
+        string expectedCommand,
+        int expectedExitCode,
+        string expectedErrorCode,
+        string expectedMessage)
+    {
+        var result = Assert.IsType<CommandResult>(actualResult);
 
-            AssertCommonContract(
-                result,
-                expectedCommand: expectedCommand,
-                expectedStatus: CliProtocol.StatusError,
-                expectedExitCode: expectedExitCode,
-                expectedMessage: expectedMessage);
-            AssertSingleError(
-                result,
-                expectedCode: expectedErrorCode,
-                expectedMessage: expectedMessage);
-        }
+        AssertCommonContract(
+            result,
+            expectedCommand: expectedCommand,
+            expectedStatus: CliProtocol.StatusError,
+            expectedExitCode: expectedExitCode,
+            expectedMessage: expectedMessage);
+        AssertSingleError(
+            result,
+            expectedCode: expectedErrorCode,
+            expectedMessage: expectedMessage);
+    }
 
-        [Theory]
-        [Trait("Size", "Small")]
-        [InlineData("")]
-        [InlineData(" ")]
-        public void InternalError_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
-        {
-            const string expectedMessage = "An unknown error occurred.";
-            var result = CommandResult.InternalError(whitespaceValue, whitespaceValue);
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void InternalError_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
+    {
+        const string expectedMessage = "An unknown error occurred.";
+        var result = CommandResult.InternalError(whitespaceValue, whitespaceValue);
 
-            AssertCommonContract(
-                result,
-                expectedCommand: CliProtocol.RootCommand,
-                expectedStatus: CliProtocol.StatusError,
-                expectedExitCode: (int)CliExitCode.ToolError,
-                expectedMessage: expectedMessage);
-            AssertSingleError(
-                result,
-                expectedCode: ErrorCodes.InternalError,
-                expectedMessage: expectedMessage);
-        }
+        AssertCommonContract(
+            result,
+            expectedCommand: CliProtocol.RootCommand,
+            expectedStatus: CliProtocol.StatusError,
+            expectedExitCode: (int)CliExitCode.ToolError,
+            expectedMessage: expectedMessage);
+        AssertSingleError(
+            result,
+            expectedCode: ErrorCodes.InternalError,
+            expectedMessage: expectedMessage);
+    }
 
-        private static void AssertCommonContract (
-            CommandResult result,
-            string expectedCommand,
-            string expectedStatus,
-            int expectedExitCode,
-            string expectedMessage)
-        {
-            Assert.Equal(CliProtocol.CurrentVersion, result.ProtocolVersion);
-            Assert.Equal(expectedCommand, result.Command);
-            Assert.Equal(expectedStatus, result.Status);
-            Assert.Equal(expectedExitCode, result.ExitCode);
-            Assert.Equal(expectedMessage, result.Message);
-        }
+    private static void AssertCommonContract (
+        CommandResult result,
+        string expectedCommand,
+        string expectedStatus,
+        int expectedExitCode,
+        string expectedMessage)
+    {
+        Assert.Equal(CliProtocol.CurrentVersion, result.ProtocolVersion);
+        Assert.Equal(expectedCommand, result.Command);
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.Equal(expectedMessage, result.Message);
+    }
 
-        private static void AssertSingleError (
-            CommandResult result,
-            string expectedCode,
-            string expectedMessage)
-        {
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Single(result.Errors);
-            Assert.Equal(expectedCode, result.Errors[0].Code);
-            Assert.Equal(expectedMessage, result.Errors[0].Message);
-            Assert.Null(result.Errors[0].OpId);
-        }
+    private static void AssertSingleError (
+        CommandResult result,
+        string expectedCode,
+        string expectedMessage)
+    {
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Single(result.Errors);
+        Assert.Equal(expectedCode, result.Errors[0].Code);
+        Assert.Equal(expectedMessage, result.Errors[0].Message);
+        Assert.Null(result.Errors[0].OpId);
     }
 }

--- a/tests/Ucli.Tests/CommandResultTests.cs
+++ b/tests/Ucli.Tests/CommandResultTests.cs
@@ -1,144 +1,143 @@
 ﻿using System.Text.Json;
 using MackySoft.Ucli.Cli;
 
-namespace MackySoft.Ucli.Tests
+namespace MackySoft.Ucli.Tests;
+
+public sealed class CommandResultTests
 {
-    public sealed class CommandResultTests
+    private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+
+    private const string UnhandledExceptionMessage = "Unhandled exception.";
+
+    public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
     {
-        private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
-
-        private const string UnhandledExceptionMessage = "Unhandled exception.";
-
-        public static TheoryData<object, string, int, string, string> ErrorCaseData => new()
         {
-            {
-                CommandResult.NotImplemented(StatusCommand.CommandName),
-                StatusCommand.CommandName,
-                (int)CliExitCode.ToolError,
-                ErrorCodes.CommandNotImplemented,
-                $"Command '{StatusCommand.CommandName}' is not implemented yet."
-            },
-            {
-                CommandResult.InvalidArgument(StatusCommand.CommandName, UnknownOptionMessage),
-                StatusCommand.CommandName,
-                (int)CliExitCode.InvalidArgument,
-                ErrorCodes.InvalidArgument,
-                UnknownOptionMessage
-            },
-            {
-                CommandResult.InternalError(StatusCommand.CommandName, UnhandledExceptionMessage),
-                StatusCommand.CommandName,
-                (int)CliExitCode.ToolError,
-                ErrorCodes.InternalError,
-                UnhandledExceptionMessage
-            },
-        };
-
-        [Fact]
-        [Trait("Size", "Small")]
-        public void Success_CreatesContractCompliantResult ()
+            CommandResult.NotImplemented(UcliCommandNames.Status),
+            UcliCommandNames.Status,
+            (int)CliExitCode.ToolError,
+            ErrorCodes.CommandNotImplemented,
+            $"Command '{UcliCommandNames.Status}' is not implemented yet."
+        },
         {
-            const string message = "Initialized.";
-            var payload = new { initialized = true };
-            var result = CommandResult.Success(InitCommand.CommandName, message, payload);
-
-            AssertCommonContract(
-                result,
-                expectedCommand: InitCommand.CommandName,
-                expectedStatus: CliProtocol.StatusOk,
-                expectedExitCode: (int)CliExitCode.Success,
-                expectedMessage: message);
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Empty(result.Errors);
-        }
-
-        [Theory]
-        [Trait("Size", "Small")]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void Success_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
+            CommandResult.InvalidArgument(UcliCommandNames.Status, UnknownOptionMessage),
+            UcliCommandNames.Status,
+            (int)CliExitCode.InvalidArgument,
+            ErrorCodes.InvalidArgument,
+            UnknownOptionMessage
+        },
         {
-            var result = CommandResult.Success(whitespaceValue, whitespaceValue);
+            CommandResult.InternalError(UcliCommandNames.Status, UnhandledExceptionMessage),
+            UcliCommandNames.Status,
+            (int)CliExitCode.ToolError,
+            ErrorCodes.InternalError,
+            UnhandledExceptionMessage
+        },
+    };
 
-            AssertCommonContract(
-                result,
-                expectedCommand: CliProtocol.RootCommand,
-                expectedStatus: CliProtocol.StatusOk,
-                expectedExitCode: (int)CliExitCode.Success,
-                expectedMessage: "An unknown error occurred.");
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Empty(result.Errors);
-        }
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Success_CreatesContractCompliantResult ()
+    {
+        const string message = "Initialized.";
+        var payload = new { initialized = true };
+        var result = CommandResult.Success(UcliCommandNames.Init, message, payload);
 
-        [Theory]
-        [Trait("Size", "Small")]
-        [MemberData(nameof(ErrorCaseData))]
-        public void ErrorFactory_CreatesContractCompliantResult (
-            object actualResult,
-            string expectedCommand,
-            int expectedExitCode,
-            string expectedErrorCode,
-            string expectedMessage)
-        {
-            var result = Assert.IsType<CommandResult>(actualResult);
+        AssertCommonContract(
+            result,
+            expectedCommand: UcliCommandNames.Init,
+            expectedStatus: CliProtocol.StatusOk,
+            expectedExitCode: (int)CliExitCode.Success,
+            expectedMessage: message);
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Empty(result.Errors);
+    }
 
-            AssertCommonContract(
-                result,
-                expectedCommand: expectedCommand,
-                expectedStatus: CliProtocol.StatusError,
-                expectedExitCode: expectedExitCode,
-                expectedMessage: expectedMessage);
-            AssertSingleError(
-                result,
-                expectedCode: expectedErrorCode,
-                expectedMessage: expectedMessage);
-        }
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Success_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
+    {
+        var result = CommandResult.Success(whitespaceValue, whitespaceValue);
 
-        [Theory]
-        [Trait("Size", "Small")]
-        [InlineData("")]
-        [InlineData(" ")]
-        public void InternalError_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
-        {
-            const string expectedMessage = "An unknown error occurred.";
-            var result = CommandResult.InternalError(whitespaceValue, whitespaceValue);
+        AssertCommonContract(
+            result,
+            expectedCommand: CliProtocol.RootCommand,
+            expectedStatus: CliProtocol.StatusOk,
+            expectedExitCode: (int)CliExitCode.Success,
+            expectedMessage: "An unknown error occurred.");
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Empty(result.Errors);
+    }
 
-            AssertCommonContract(
-                result,
-                expectedCommand: CliProtocol.RootCommand,
-                expectedStatus: CliProtocol.StatusError,
-                expectedExitCode: (int)CliExitCode.ToolError,
-                expectedMessage: expectedMessage);
-            AssertSingleError(
-                result,
-                expectedCode: ErrorCodes.InternalError,
-                expectedMessage: expectedMessage);
-        }
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(ErrorCaseData))]
+    public void ErrorFactory_CreatesContractCompliantResult (
+        object actualResult,
+        string expectedCommand,
+        int expectedExitCode,
+        string expectedErrorCode,
+        string expectedMessage)
+    {
+        var result = Assert.IsType<CommandResult>(actualResult);
 
-        private static void AssertCommonContract (
-            CommandResult result,
-            string expectedCommand,
-            string expectedStatus,
-            int expectedExitCode,
-            string expectedMessage)
-        {
-            Assert.Equal(CliProtocol.CurrentVersion, result.ProtocolVersion);
-            Assert.Equal(expectedCommand, result.Command);
-            Assert.Equal(expectedStatus, result.Status);
-            Assert.Equal(expectedExitCode, result.ExitCode);
-            Assert.Equal(expectedMessage, result.Message);
-        }
+        AssertCommonContract(
+            result,
+            expectedCommand: expectedCommand,
+            expectedStatus: CliProtocol.StatusError,
+            expectedExitCode: expectedExitCode,
+            expectedMessage: expectedMessage);
+        AssertSingleError(
+            result,
+            expectedCode: expectedErrorCode,
+            expectedMessage: expectedMessage);
+    }
 
-        private static void AssertSingleError (
-            CommandResult result,
-            string expectedCode,
-            string expectedMessage)
-        {
-            Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
-            Assert.Single(result.Errors);
-            Assert.Equal(expectedCode, result.Errors[0].Code);
-            Assert.Equal(expectedMessage, result.Errors[0].Message);
-            Assert.Null(result.Errors[0].OpId);
-        }
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void InternalError_NormalizesWhitespaceCommandAndMessage (string whitespaceValue)
+    {
+        const string expectedMessage = "An unknown error occurred.";
+        var result = CommandResult.InternalError(whitespaceValue, whitespaceValue);
+
+        AssertCommonContract(
+            result,
+            expectedCommand: CliProtocol.RootCommand,
+            expectedStatus: CliProtocol.StatusError,
+            expectedExitCode: (int)CliExitCode.ToolError,
+            expectedMessage: expectedMessage);
+        AssertSingleError(
+            result,
+            expectedCode: ErrorCodes.InternalError,
+            expectedMessage: expectedMessage);
+    }
+
+    private static void AssertCommonContract (
+        CommandResult result,
+        string expectedCommand,
+        string expectedStatus,
+        int expectedExitCode,
+        string expectedMessage)
+    {
+        Assert.Equal(CliProtocol.CurrentVersion, result.ProtocolVersion);
+        Assert.Equal(expectedCommand, result.Command);
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        Assert.Equal(expectedMessage, result.Message);
+    }
+
+    private static void AssertSingleError (
+        CommandResult result,
+        string expectedCode,
+        string expectedMessage)
+    {
+        Assert.Equal(JsonValueKind.Object, JsonSerializer.SerializeToElement(result.Payload).ValueKind);
+        Assert.Single(result.Errors);
+        Assert.Equal(expectedCode, result.Errors[0].Code);
+        Assert.Equal(expectedMessage, result.Errors[0].Message);
+        Assert.Null(result.Errors[0].OpId);
     }
 }

--- a/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
@@ -64,4 +64,45 @@ public sealed class IpcContractSerializationTests
         Assert.Equal(IpcErrorCodes.CommandNotImplemented, roundTrip.Errors[0].Code);
         Assert.Equal("Not implemented", roundTrip.Errors[0].Message);
     }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IpcErrorCodes_ContainsInvalidArgumentConstant ()
+    {
+        Assert.Equal("INVALID_ARGUMENT", IpcErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IpcExecuteCommandNames_ExposeExpectedCommandLiterals ()
+    {
+        Assert.Equal("validate", IpcExecuteCommandNames.Validate);
+        Assert.Equal("plan", IpcExecuteCommandNames.Plan);
+        Assert.Equal("call", IpcExecuteCommandNames.Call);
+        Assert.Equal("resolve", IpcExecuteCommandNames.Resolve);
+        Assert.Equal("query", IpcExecuteCommandNames.Query);
+        Assert.Equal("refresh", IpcExecuteCommandNames.Refresh);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IpcExecuteCommandNames_ClassifiesKnownAndOperationPipelineCommands ()
+    {
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Validate));
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Plan));
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Call));
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Resolve));
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Query));
+        Assert.True(IpcExecuteCommandNames.IsKnown(IpcExecuteCommandNames.Refresh));
+        Assert.False(IpcExecuteCommandNames.IsKnown("unknown"));
+
+        Assert.False(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Validate));
+        Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Plan));
+        Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Call));
+        Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Resolve));
+        Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Query));
+        Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Refresh));
+        Assert.False(IpcExecuteCommandNames.IsOperationPipelineCommand("unknown"));
+    }
+
 }


### PR DESCRIPTION
## Summary
- #14（F5）として、execute リクエスト入力の正規化基盤を実装しました。
- `validate` は静的検証専用、`plan/call/query/resolve/refresh` は op pipeline 対象という責務分離を反映しています。
- `expect` 共通制約（`nonNull` / `count` / `min` / `max`）と canonical digest 素材生成を契約化しました。

## Scope
- Contracts:
  - `IpcErrorCodes.InvalidArgument` を追加
  - `IpcExecuteCommandNames` を新設し、コマンド判定を集約
- CLI:
  - `Requests` 基盤（`IRequestInputReader`, `RequestInputReader`, `RequestInputReadResult`, `RequestInputSource`）を追加
  - `UcliCommandNames` を導入し、`InitCommand` / `StatusCommand` / `Program` のコマンド名参照を統一
- Unity:
  - `ExecuteRequestNormalizer` と正規化モデル（`NormalizedExecuteRequest`, `NormalizedOperation`, `NormalizedExpectation`）を追加
  - `CanonicalRequestWriter` を追加し、`protocolVersion + ops` の canonical UTF-8 payload を生成
- Tests/Docs:
  - .NET テスト（Contracts / RequestInputReader）を追加・更新
  - Unity EditMode テスト（Normalizer）を追加
  - `docs/uCLI.md` の `expect` 節を共通制約仕様へ更新

## Verification
- Gate level: Standard
- Diff budget: FAIL（24 files changed。Issue #14 で Split waived 記載済み）
- Spec drift: Skipped（`docs/agents/<branch>/spec.md` なし）
- Format: PASS（`dotnet format Ucli.slnx --verify-no-changes --no-restore`）
- Tests: PASS（`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore`）
- Coverage: N/A
- Unity EditMode tests: NOT RUN（ローカル Unity バッチ実行未実施）

## Risks / Rollback
- Risk: 正規化ロジックは新規導入のため、実行接続時に境界条件の抜けが顕在化する可能性があります。
- Rollback: 本PRのコミット `cea6206` をリバートすることで、#14着手前の状態へ戻せます。

## Checklist
- [ ] Unity EditMode テストをバッチ実行で確認する
- [ ] #15 で `expect` 実値評価（`EXPECTATION_FAILED`）を接続する

Closes #14
