### PR TITLE
chore(contracts): 0.2.0 参照へ更新

### DIFF
--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -38,9 +38,9 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
-- タグは `v` プレフィックスを付けない（例: `contracts/0.1.0`）。
+- タグは `v` プレフィックスを付けない（例: `contracts/0.2.0`）。
 
 ```bash
-git tag contracts/0.1.0
-git push origin contracts/0.1.0
+git tag contracts/0.2.0
+git push origin contracts/0.2.0
 ```

--- a/src/Ucli.Contracts/Ucli.Contracts.csproj
+++ b/src/Ucli.Contracts/Ucli.Contracts.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Contracts</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Description>Shared contract types for uCLI IPC protocol.</Description>
     <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;ipc</PackageTags>

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.1.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.2.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="netstandard2.0" />
   <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="netstandard2.0" />


### PR DESCRIPTION
## Summary
- src/Ucli.Contracts/Ucli.Contracts.csproj の Version を 0.2.0 に更新
- src/Ucli.Unity/Assets/packages.config の MackySoft.Ucli.Contracts 参照を 0.2.0 に更新
- docs/package-operations.md のタグ例を contracts/0.2.0 に更新

## Verification
- dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore

## Notes
- contracts/0.2.0 公開後の参照追従更新です。
