### PR TITLE
[v1.0][C1] Cmd-init を実装する

### DIFF
--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -497,10 +497,11 @@ public static class RebuildNavmesh
 ```
 
 ## コマンド
-CWDがUnityプロジェクトと判定可能な場合はそれを使う。そうでない場合は `--projectPath` 指定が必要。
+`ucli init` を除く Unity 依存コマンドは、CWDがUnityプロジェクトと判定可能な場合はそれを使う。そうでない場合は `--projectPath` 指定が必要。
 
 - `ucli init`：`.ucli` 雛形を作成する
-  - 生成対象：`.ucli/config.json`, `.ucli/.gitignore`
+  - 生成先：実行時CWD直下（`<cwd>/.ucli`）
+  - 生成対象：`.ucli/local/`, `.ucli/config.json`, `.ucli/.gitignore`
   - `--force`：既存設定を上書き
 - `ucli validate`：JSONリクエストの静的検証（スキーマ/必須項目/許可op等）
   - 保証範囲：形式・スキーマ・許可判定まで（実在確認や差分見積りは含まない）
@@ -541,6 +542,31 @@ CWDがUnityプロジェクトと判定可能な場合はそれを使う。そう
   - `status`：デーモン状態を取得
   - `logs`：デーモンログを取得
   - `--projectPath <path>`：対象Unityプロジェクト指定
+
+### `ucli init`
+`ucli init` は常に実行時CWDを対象として `.ucli` 雛形を生成する。
+
+#### `init` options
+| Option | Short | Description |
+| --- | --- | --- |
+| `--force` | - | 既存の `.ucli/config.json` と `.ucli/.gitignore` を上書きする |
+
+#### `init` の `payload` 契約
+- `configPath`：生成した `.ucli/config.json` の絶対パス
+- `gitignorePath`：生成した `.ucli/.gitignore` の絶対パス
+
+```json
+{
+  "configPath": "/path/to/current-working-directory/.ucli/config.json",
+  "gitignorePath": "/path/to/current-working-directory/.ucli/.gitignore"
+}
+```
+
+#### `init` のエラー契約
+- `INVALID_ARGUMENT`
+  - 既存テンプレートファイルがあり `--force` 未指定
+- `INTERNAL_ERROR`
+  - ディレクトリ/ファイル作成時のI/O障害
 
 ## readIndex（読取索引基盤）
 readIndex は、Unity未接続時でも観測系情報をローカル参照できるようにするための読取索引基盤である。  

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -497,7 +497,7 @@ public static class RebuildNavmesh
 ```
 
 ## コマンド
-`ucli init` を除く Unity 依存コマンドは、CWDがUnityプロジェクトと判定可能な場合はそれを使う。そうでない場合は `--projectPath` 指定が必要。
+Unityプロジェクトを対象に実行するコマンドは、CWDがUnityプロジェクトと判定可能な場合はそれを使う。そうでない場合は `--projectPath` を指定する。
 
 - `ucli init`：`.ucli` 雛形を作成する
   - 生成先：実行時CWD直下（`<cwd>/.ucli`）
@@ -546,6 +546,8 @@ public static class RebuildNavmesh
 ### `ucli init`
 `ucli init` は常に実行時CWDを対象として `.ucli` 雛形を生成する。
 
+生成対象は `.ucli/local/`, `.ucli/config.json`, `.ucli/.gitignore`。
+
 #### `init` options
 | Option | Short | Description |
 | --- | --- | --- |
@@ -566,7 +568,6 @@ public static class RebuildNavmesh
 - `INVALID_ARGUMENT`
   - 既存テンプレートファイルがあり `--force` 未指定
 - `INTERNAL_ERROR`
-  - ディレクトリ/ファイル作成時のI/O障害
 
 ## readIndex（読取索引基盤）
 readIndex は、Unity未接続時でも観測系情報をローカル参照できるようにするための読取索引基盤である。  

--- a/src/Ucli/Cli/InitCommand.cs
+++ b/src/Ucli/Cli/InitCommand.cs
@@ -22,20 +22,18 @@ internal sealed class InitCommand
 
     /// <summary> Executes the <c>init</c> command and emits the JSON result contract. </summary>
     /// <param name="force"> Whether existing template files can be overwritten. </param>
-    /// <param name="projectPath"> --projectPath, Optional UnityProject root path. When omitted, empty, or whitespace, the current working directory is used. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(CommandName)]
     public async Task<int> Init (
         bool force = false,
-        string? projectPath = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         CommandExecutionState.MarkStarted();
 
-        var executionResult = await initService.Execute(force, projectPath, cancellationToken).ConfigureAwait(false);
+        var executionResult = await initService.Execute(force, cancellationToken).ConfigureAwait(false);
         var result = CreateCommandResult(executionResult);
         CommandResultWriter.WriteToStandardOutput(result);
         return result.ExitCode;
@@ -57,8 +55,6 @@ internal sealed class InitCommand
                 message: "uCLI initialization completed.",
                 payload: new
                 {
-                    projectPath = output.ProjectPath,
-                    projectFingerprint = output.ProjectFingerprint,
                     configPath = output.ConfigPath,
                     gitignorePath = output.GitIgnorePath,
                 });

--- a/src/Ucli/Init/IInitService.cs
+++ b/src/Ucli/Init/IInitService.cs
@@ -1,15 +1,13 @@
 namespace MackySoft.Ucli.Init;
 
-/// <summary> Executes initialization flow for generating the <c>.ucli</c> template files. </summary>
+/// <summary> Executes initialization flow for generating <c>.ucli</c> template files under the current working directory. </summary>
 internal interface IInitService
 {
-    /// <summary> Executes initialization for a target UnityProject. </summary>
+    /// <summary> Executes initialization for the current working directory. </summary>
     /// <param name="force"> Whether existing files can be overwritten. </param>
-    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
     /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
     /// <returns> A task that resolves to the initialization execution result that contains either generated file paths or a structured error. </returns>
     ValueTask<InitExecutionResult> Execute (
         bool force,
-        string? projectPath,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli/Init/InitExecutionOutput.cs
+++ b/src/Ucli/Init/InitExecutionOutput.cs
@@ -1,12 +1,8 @@
 namespace MackySoft.Ucli.Init;
 
 /// <summary> Represents output values produced by a successful init execution. </summary>
-/// <param name="ProjectPath"> The resolved UnityProject root path. </param>
-/// <param name="ProjectFingerprint"> The resolved UnityProject fingerprint. </param>
-/// <param name="ConfigPath"> The path of the generated config file. </param>
-/// <param name="GitIgnorePath"> The path of the generated <c>.ucli/.gitignore</c> file. </param>
+/// <param name="ConfigPath"> The absolute path of the generated <c>.ucli/config.json</c> file. </param>
+/// <param name="GitIgnorePath"> The absolute path of the generated <c>.ucli/.gitignore</c> file. </param>
 internal sealed record InitExecutionOutput (
-    string ProjectPath,
-    string ProjectFingerprint,
     string ConfigPath,
     string GitIgnorePath);

--- a/src/Ucli/Init/InitService.cs
+++ b/src/Ucli/Init/InitService.cs
@@ -1,7 +1,5 @@
 using MackySoft.Ucli.Configuration;
-using MackySoft.Ucli.Context;
 using MackySoft.Ucli.Foundation;
-using MackySoft.Ucli.UnityProject;
 
 namespace MackySoft.Ucli.Init;
 
@@ -9,50 +7,45 @@ namespace MackySoft.Ucli.Init;
 internal sealed class InitService : IInitService
 {
     private const string UcliDirectoryName = ".ucli";
+    private const string LocalDirectoryName = "local";
+    private const string ConfigFileName = "config.json";
     private const string GitIgnoreFileName = ".gitignore";
     private const string GitIgnoreContents = "local/";
 
-    private readonly IUnityProjectResolver unityProjectResolver;
-    private readonly IInitStatusContextResolver contextResolver;
     private readonly IUcliConfigStore configStore;
 
     /// <summary> Initializes a new instance of the <see cref="InitService" /> class. </summary>
-    /// <param name="unityProjectResolver"> The UnityProject resolver dependency. </param>
-    /// <param name="contextResolver"> The init/status context resolver dependency. </param>
     /// <param name="configStore"> The config store dependency. </param>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProjectResolver" />, <paramref name="contextResolver" />, or <paramref name="configStore" /> is <see langword="null" />. </exception>
-    public InitService (
-        IUnityProjectResolver unityProjectResolver,
-        IInitStatusContextResolver contextResolver,
-        IUcliConfigStore configStore)
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="configStore" /> is <see langword="null" />. </exception>
+    public InitService (IUcliConfigStore configStore)
     {
-        this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
-        this.contextResolver = contextResolver ?? throw new ArgumentNullException(nameof(contextResolver));
         this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
     }
 
     /// <summary> Executes initialization to create or overwrite <c>.ucli/config.json</c> and <c>.ucli/.gitignore</c>. </summary>
     /// <param name="force"> Whether existing files can be overwritten. </param>
-    /// <param name="projectPath"> The optional <c>--projectPath</c> value. When <see langword="null" />, empty, or whitespace, the current working directory is used. </param>
     /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
     /// <returns> A task that resolves to the init execution result that contains generated file paths on success or a structured error on failure. </returns>
     public async ValueTask<InitExecutionResult> Execute (
         bool force,
-        string? projectPath,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var unityProjectResult = unityProjectResolver.Resolve(projectPath);
-        if (!unityProjectResult.IsSuccess)
+        string currentDirectoryPath;
+        try
         {
-            return InitExecutionResult.Failure(unityProjectResult.Error!);
+            currentDirectoryPath = Path.GetFullPath(Environment.CurrentDirectory);
+        }
+        catch (Exception ex) when (IsPathFormatException(ex))
+        {
+            return InitExecutionResult.Failure(CreateInvalidArgument(
+                $"Current working directory path is invalid: {Environment.CurrentDirectory}. {ex.Message}"));
         }
 
-        var unityProjectContext = unityProjectResult.Context!;
-        var unityProjectRoot = unityProjectContext.UnityProjectRoot;
-        var ucliDirectoryPath = Path.Combine(unityProjectRoot, UcliDirectoryName);
-        var configPath = unityProjectContext.ConfigPath;
+        var ucliDirectoryPath = Path.Combine(currentDirectoryPath, UcliDirectoryName);
+        var localDirectoryPath = Path.Combine(ucliDirectoryPath, LocalDirectoryName);
+        var configPath = Path.Combine(ucliDirectoryPath, ConfigFileName);
         var gitIgnorePath = Path.Combine(ucliDirectoryPath, GitIgnoreFileName);
         var existingPaths = CollectExistingTemplatePaths(configPath, gitIgnorePath);
 
@@ -63,26 +56,15 @@ internal sealed class InitService : IInitService
                 $"Initialization failed because template files already exist. Use --force to overwrite: {joinedPaths}"));
         }
 
-        if (!force)
-        {
-            // NOTE:
-            // Keep init and status using the same context pipeline.
-            // This ensures config parse/validation behavior stays consistent across command foundations.
-            var contextResult = await contextResolver.Resolve(projectPath, cancellationToken).ConfigureAwait(false);
-            if (!contextResult.IsSuccess)
-            {
-                return InitExecutionResult.Failure(contextResult.Error!);
-            }
-        }
-
         try
         {
             Directory.CreateDirectory(ucliDirectoryPath);
+            Directory.CreateDirectory(localDirectoryPath);
         }
         catch (Exception ex) when (IsPathFormatException(ex))
         {
             return InitExecutionResult.Failure(CreateInvalidArgument(
-                $"UnityProject path is invalid: {unityProjectRoot}. {ex.Message}"));
+                $"uCLI directory path is invalid: {ucliDirectoryPath}. {ex.Message}"));
         }
         catch (Exception ex) when (IsIoFailure(ex))
         {
@@ -93,7 +75,7 @@ internal sealed class InitService : IInitService
         cancellationToken.ThrowIfCancellationRequested();
 
         var defaultConfig = UcliConfig.CreateDefault();
-        var configSaveResult = await configStore.Save(unityProjectRoot, defaultConfig, cancellationToken).ConfigureAwait(false);
+        var configSaveResult = await configStore.Save(currentDirectoryPath, defaultConfig, cancellationToken).ConfigureAwait(false);
         if (!configSaveResult.IsSuccess)
         {
             return InitExecutionResult.Failure(configSaveResult.Error!);
@@ -115,8 +97,6 @@ internal sealed class InitService : IInitService
         }
 
         var output = new InitExecutionOutput(
-            ProjectPath: unityProjectRoot,
-            ProjectFingerprint: unityProjectContext.ProjectFingerprint,
             ConfigPath: configPath,
             GitIgnorePath: gitIgnorePath);
         return InitExecutionResult.Success(output);

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Cli;
@@ -17,9 +17,11 @@ public sealed class CliOutputContractTests
 
     private const string UcliDirectoryName = ".ucli";
 
-    private const string UnityProjectDirectoryName = "UnityProject";
+    private const string LocalDirectoryName = "local";
 
     private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+
+    private const string InitProjectPathOptionMessage = "Argument '--projectPath' is not recognized.";
 
     private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(15);
 
@@ -48,13 +50,13 @@ public sealed class CliOutputContractTests
     public async Task Init_ReturnsSuccessJsonContractAsSingleJson (bool force, string scopeName)
     {
         using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-        var (unityProjectPath, configPath, gitIgnorePath) = CreateUnityProjectPaths(scope);
+        var (workingDirectoryPath, _, localDirectoryPath, configPath, gitIgnorePath) = CreateInitTargetPaths(scope, "workspace");
         if (force)
         {
             PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
         }
 
-        var result = await RunInitAsync(unityProjectPath, force);
+        var result = await RunInitAsync(force, workingDirectoryPath);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.Success, result.ExitCode);
@@ -66,27 +68,54 @@ public sealed class CliOutputContractTests
         AssertNoErrors(outputJson.RootElement);
         JsonAssert.For(outputJson.RootElement)
             .HasProperty("payload", payload => payload
-                .HasString("projectPath", unityProjectPath)
-                .HasValueKind("projectFingerprint", JsonValueKind.String)
-                .HasString("configPath", configPath)
-                .HasString("gitignorePath", gitIgnorePath));
+                .HasValueKind("configPath", JsonValueKind.String)
+                .HasValueKind("gitignorePath", JsonValueKind.String));
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        var payloadPropertyCount = 0;
+        foreach (var _ in payload.EnumerateObject())
+        {
+            payloadPropertyCount++;
+        }
+
+        Assert.Equal(2, payloadPropertyCount);
+        FileSystemAssert.ForPath(payload
+            .GetProperty("configPath")
+            .GetString()!)
+            .IsRooted()
+            .HasFileName(ConfigFileName);
+        FileSystemAssert.ForFile(payload
+            .GetProperty("configPath")
+            .GetString()!)
+            .Exists();
+        FileSystemAssert.ForPath(payload
+            .GetProperty("gitignorePath")
+            .GetString()!)
+            .IsRooted()
+            .HasFileName(GitIgnoreFileName);
+        FileSystemAssert.ForFile(payload
+            .GetProperty("gitignorePath")
+            .GetString()!)
+            .Exists();
+
+        FileSystemAssert.ForDirectory(localDirectoryPath).Exists();
+        FileSystemAssert.ForFile(configPath).Exists();
+        FileSystemAssert.ForFile(gitIgnorePath).Exists();
     }
 
-    [Theory]
+    [Fact]
     [Trait("Size", "Medium")]
-    [InlineData(true, "init-config-file")]
-    [InlineData(false, "init-gitignore-file")]
-    public async Task Init_WithProjectPath_CreatesTemplateFiles (bool isConfigFile, string scopeName)
+    public async Task Init_AlwaysCreatesUnderCurrentWorkingDirectory ()
     {
-        using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-        var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
-        var templateFilePath = isConfigFile
-            ? GetConfigPath(unityProjectPath)
-            : GetGitIgnorePath(unityProjectPath);
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", "init-cwd");
+        var (workingDirectoryPath, ucliDirectoryPath, localDirectoryPath, configPath, gitIgnorePath) = CreateInitTargetPaths(scope, "workspace");
 
-        await RunInitAsync(unityProjectPath);
+        await RunInitAsync(force: false, workingDirectoryPath);
 
-        FileSystemAssert.ForFile(templateFilePath).Exists();
+        FileSystemAssert.ForDirectory(ucliDirectoryPath).Exists();
+        FileSystemAssert.ForDirectory(localDirectoryPath).Exists();
+        FileSystemAssert.ForFile(configPath).Exists();
+        FileSystemAssert.ForFile(gitIgnorePath).Exists();
     }
 
     [Theory]
@@ -96,13 +125,13 @@ public sealed class CliOutputContractTests
     public async Task Init_WritesDefaultConfigValues (bool force, string scopeName)
     {
         using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-        var (unityProjectPath, configPath, _) = CreateUnityProjectPaths(scope);
+        var (workingDirectoryPath, _, _, configPath, gitIgnorePath) = CreateInitTargetPaths(scope, "workspace");
         if (force)
         {
-            PrepareLegacyTemplateFiles(scope, configPath, GetGitIgnorePath(unityProjectPath));
+            PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
         }
 
-        await RunInitAsync(unityProjectPath, force);
+        await RunInitAsync(force, workingDirectoryPath);
 
         AssertDefaultConfigValues(configPath);
     }
@@ -114,13 +143,13 @@ public sealed class CliOutputContractTests
     public async Task Init_WritesLocalOnlyGitIgnoreContents (bool force, string scopeName)
     {
         using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-        var (unityProjectPath, _, gitIgnorePath) = CreateUnityProjectPaths(scope);
+        var (workingDirectoryPath, _, _, configPath, gitIgnorePath) = CreateInitTargetPaths(scope, "workspace");
         if (force)
         {
-            PrepareLegacyTemplateFiles(scope, GetConfigPath(unityProjectPath), gitIgnorePath);
+            PrepareLegacyTemplateFiles(scope, configPath, gitIgnorePath);
         }
 
-        await RunInitAsync(unityProjectPath, force);
+        await RunInitAsync(force, workingDirectoryPath);
 
         Assert.Equal(UcliContractConstants.LocalDirectoryIgnoreEntry + Environment.NewLine, File.ReadAllText(gitIgnorePath));
     }
@@ -135,13 +164,13 @@ public sealed class CliOutputContractTests
         string scopeName)
     {
         using var scope = TestDirectories.CreateTempScope("cli-output-contract", scopeName);
-        var (unityProjectPath, _, _) = CreateUnityProjectPaths(scope);
+        var (workingDirectoryPath, _, _, configPath, gitIgnorePath) = CreateInitTargetPaths(scope, "workspace");
         var existingTemplateFilePath = isConfigFile
-            ? GetConfigPath(unityProjectPath)
-            : GetGitIgnorePath(unityProjectPath);
+            ? configPath
+            : gitIgnorePath;
         WriteFileUnderScope(scope, existingTemplateFilePath, existingContent);
 
-        var result = await RunInitAsync(unityProjectPath);
+        var result = await RunInitAsync(force: false, workingDirectoryPath);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
@@ -153,6 +182,32 @@ public sealed class CliOutputContractTests
         AssertSingleError(
             outputJson.RootElement,
             expectedCode: ErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Init_WithProjectPathOption_ReturnsInvalidArgumentErrorAsSingleJson ()
+    {
+        using var scope = TestDirectories.CreateTempScope("cli-output-contract", "init-project-path-option");
+        var (workingDirectoryPath, _, _, _, _) = CreateInitTargetPaths(scope, "workspace");
+
+        var result = await RunToolWithWorkingDirectoryAsync(
+            workingDirectoryPath,
+            UcliCommandNames.Init,
+            UcliContractConstants.CliOption.ProjectPath,
+            workingDirectoryPath);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        AssertCommandResultCommon(
+            outputJson.RootElement,
+            command: UcliCommandNames.Init,
+            status: CliProtocol.StatusError,
+            exitCode: (int)CliExitCode.InvalidArgument);
+        AssertSingleError(
+            outputJson.RootElement,
+            expectedCode: ErrorCodes.InvalidArgument);
+        Assert.Contains(InitProjectPathOptionMessage, result.StdErr, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -224,7 +279,21 @@ public sealed class CliOutputContractTests
                 .IsNull("opId"));
     }
 
-    private static async Task<CommandExecutionResult> RunToolAsync (params string[] args)
+    private static Task<CommandExecutionResult> RunToolAsync (params string[] args)
+    {
+        return RunToolCoreAsync(args, null);
+    }
+
+    private static Task<CommandExecutionResult> RunToolWithWorkingDirectoryAsync (
+        string workingDirectory,
+        params string[] args)
+    {
+        return RunToolCoreAsync(args, workingDirectory);
+    }
+
+    private static async Task<CommandExecutionResult> RunToolCoreAsync (
+        string[] args,
+        string? workingDirectory)
     {
         // NOTE:
         // This test validates the process-level CLI contract (stdout JSON, stderr, exit code).
@@ -239,6 +308,11 @@ public sealed class CliOutputContractTests
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
         startInfo.CreateNoWindow = true;
+        if (!string.IsNullOrWhiteSpace(workingDirectory))
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
         startInfo.ArgumentList.Add(toolPath);
         foreach (var arg in args)
         {
@@ -272,36 +346,52 @@ public sealed class CliOutputContractTests
             StdErr: await stdErrTask);
     }
 
-    private static async Task<CommandExecutionResult> RunInitAsync (string unityProjectPath, bool force = false)
+    private static async Task<CommandExecutionResult> RunInitAsync (
+        bool force = false,
+        string? workingDirectory = null)
     {
-        if (force)
+        if (string.IsNullOrWhiteSpace(workingDirectory))
         {
-            return await RunToolAsync(
-                UcliCommandNames.Init,
-                UcliContractConstants.CliOption.ProjectPath,
-                unityProjectPath,
-                UcliContractConstants.CliOption.Force);
+            return force
+                ? await RunToolAsync(UcliCommandNames.Init, UcliContractConstants.CliOption.Force)
+                : await RunToolAsync(UcliCommandNames.Init);
         }
 
-        return await RunToolAsync(UcliCommandNames.Init, UcliContractConstants.CliOption.ProjectPath, unityProjectPath);
+        return force
+            ? await RunToolWithWorkingDirectoryAsync(workingDirectory, UcliCommandNames.Init, UcliContractConstants.CliOption.Force)
+            : await RunToolWithWorkingDirectoryAsync(workingDirectory, UcliCommandNames.Init);
     }
 
-    private static (string UnityProjectPath, string ConfigPath, string GitIgnorePath) CreateUnityProjectPaths (TestDirectoryScope scope)
+    private static (string WorkingDirectoryPath, string UcliDirectoryPath, string LocalDirectoryPath, string ConfigPath, string GitIgnorePath) CreateInitTargetPaths (
+        TestDirectoryScope scope,
+        string targetDirectoryName)
     {
-        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, UnityProjectDirectoryName);
-        var configPath = GetConfigPath(unityProjectPath);
-        var gitIgnorePath = GetGitIgnorePath(unityProjectPath);
-        return (unityProjectPath, configPath, gitIgnorePath);
+        var workingDirectoryPath = scope.CreateDirectory(targetDirectoryName);
+        var ucliDirectoryPath = GetUcliDirectoryPath(workingDirectoryPath);
+        var localDirectoryPath = GetLocalDirectoryPath(workingDirectoryPath);
+        var configPath = GetConfigPath(workingDirectoryPath);
+        var gitIgnorePath = GetGitIgnorePath(workingDirectoryPath);
+        return (workingDirectoryPath, ucliDirectoryPath, localDirectoryPath, configPath, gitIgnorePath);
     }
 
-    private static string GetConfigPath (string unityProjectPath)
+    private static string GetUcliDirectoryPath (string workingDirectoryPath)
     {
-        return Path.Combine(unityProjectPath, UcliDirectoryName, ConfigFileName);
+        return Path.Combine(workingDirectoryPath, UcliDirectoryName);
     }
 
-    private static string GetGitIgnorePath (string unityProjectPath)
+    private static string GetLocalDirectoryPath (string workingDirectoryPath)
     {
-        return Path.Combine(unityProjectPath, UcliDirectoryName, GitIgnoreFileName);
+        return Path.Combine(GetUcliDirectoryPath(workingDirectoryPath), LocalDirectoryName);
+    }
+
+    private static string GetConfigPath (string workingDirectoryPath)
+    {
+        return Path.Combine(GetUcliDirectoryPath(workingDirectoryPath), ConfigFileName);
+    }
+
+    private static string GetGitIgnorePath (string workingDirectoryPath)
+    {
+        return Path.Combine(GetUcliDirectoryPath(workingDirectoryPath), GitIgnoreFileName);
     }
 
     private static void AssertDefaultConfigValues (string configPath)


### PR DESCRIPTION
## Summary
- `ucli init` を CWD 基準で `.ucli` 雛形を生成する挙動に整理し、初期化時に `.ucli/local` も作成するようにしました。
- `init` 成功時 `payload` を `configPath` / `gitignorePath` のファイルパス契約へ更新しました。
- 実装変更に合わせて CLI 契約テストと `docs/uCLI.md` を更新し、レビュー指摘の不要記述も除去しました。

## Scope
- Core (`init`):
  - `src/Ucli/Init/InitService.cs`
  - `src/Ucli/Init/IInitService.cs`
  - `src/Ucli/Init/InitExecutionOutput.cs`
  - `src/Ucli/Cli/InitCommand.cs`
- Tests:
  - `tests/Ucli.Tests/CliOutputContractTests.cs`
- Docs:
  - `docs/uCLI.md`

## Verification
- Gate level: Standard
- Diff budget: PASS (`6 files changed, 188 insertions(+), 102 deletions(-)`)
- Spec drift: Skipped (`docs/agents/feature_issue-33-cmd-init/spec.md` が存在しないため)
- Format: Skipped（リポジトリ側の対象外ファイルに既存 `FINALNEWLINE` 差異があり、対象外変更を混ぜない方針のため）
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj`)
- Coverage: N/A

## Risks / Rollback
- Risk:
  - `payload.ucliDirectoryPath` を参照している呼び出し側は `configPath` / `gitignorePath` へ追従が必要です。
- Rollback:
  - `feature/issue-33-cmd-init` の3コミットをrevertすれば、`master` 時点の契約へ戻せます。

## Checklist
- [x] `ucli init` が `.ucli/local` を生成する
- [x] `ucli init` 成功 `payload` が `configPath` / `gitignorePath` を返す
- [x] `CliOutputContractTests` で新契約を検証している
- [x] `docs/uCLI.md` が実装契約と一致している

Closes #33
