### PR TITLE
[v1.0][F6] フェーズ実行器（validate->plan->call）を実装する

### DIFF
--- a/src/Ucli.Contracts/Ipc/IpcErrorCodes.cs
+++ b/src/Ucli.Contracts/Ipc/IpcErrorCodes.cs
@@ -20,4 +20,7 @@ public static class IpcErrorCodes
 
     /// <summary> Gets the error code emitted when command execution is not yet implemented. </summary>
     public const string CommandNotImplemented = "COMMAND_NOT_IMPLEMENTED";
+
+    /// <summary> Gets the error code emitted when an unexpected internal failure occurs. </summary>
+    public const string InternalError = "INTERNAL_ERROR";
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2b42058fa5c04f5d94c52e6311c73a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Unity.Execution.Requests;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Executes normalized operations through phase execution. </summary>
+    internal interface IOperationPhaseExecutor
+    {
+        /// <summary> Executes one normalized request through the specified command phase-flow. </summary>
+        /// <param name="command"> The top-level execution command. </param>
+        /// <param name="request"> The normalized request. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The request-level execution trace. </returns>
+        Task<PhaseExecutionTrace> Execute (
+            PhaseExecutionCommand command,
+            NormalizedExecuteRequest request,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs
@@ -12,6 +12,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <param name="request"> The normalized request. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The request-level execution trace. </returns>
+        /// <exception cref="System.OperationCanceledException"> Thrown when execution is canceled. </exception>
         Task<PhaseExecutionTrace> Execute (
             PhaseExecutionCommand command,
             NormalizedExecuteRequest request,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPhaseExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4db4c211919fe4adc8ea12afb2340fe6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Unity.Execution.Requests;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Defines one operation implementation used by phase execution. </summary>
+    internal interface IPhaseOperation
+    {
+        /// <summary> Gets the operation name served by this implementation. </summary>
+        string OperationName { get; }
+
+        /// <summary> Executes the validate phase for one operation. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            CancellationToken cancellationToken = default);
+
+        /// <summary> Executes the plan phase for one operation. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            CancellationToken cancellationToken = default);
+
+        /// <summary> Executes the call phase for one operation. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61332b5cb3b6a4c1e82ece73fb517268
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperationRegistry.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperationRegistry.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Resolves phase-operation implementations by operation name. </summary>
+    internal interface IPhaseOperationRegistry
+    {
+        /// <summary> Attempts to resolve an operation implementation by operation name. </summary>
+        /// <param name="operationName"> The operation name. </param>
+        /// <param name="operation"> The resolved implementation when found. </param>
+        /// <returns> <see langword="true" /> when operation implementation was found; otherwise <see langword="false" />. </returns>
+        bool TryResolve (
+            string operationName,
+            out IPhaseOperation operation);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperationRegistry.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperationRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a133c2c6ae8ab4b8c869b75a8ac2b355
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
@@ -11,7 +11,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <summary> Initializes a new instance of the <see cref="InMemoryPhaseOperationRegistry" /> class. </summary>
         /// <param name="operations"> The operation implementation collection. </param>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" /> or contains a <see langword="null" /> operation. </exception>
-        /// <exception cref="ArgumentException"> Thrown when operation name is null, empty, or whitespace. </exception>
+        /// <exception cref="ArgumentException"> Thrown when operation name is invalid, contains leading or trailing whitespace, or is duplicated. </exception>
         public InMemoryPhaseOperationRegistry (IReadOnlyList<IPhaseOperation> operations)
         {
             if (operations == null)
@@ -23,15 +23,34 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             for (var i = 0; i < operations.Count; i++)
             {
                 var operation = operations[i] ?? throw new ArgumentNullException(nameof(operations), "Operation list contains null.");
-                if (string.IsNullOrWhiteSpace(operation.OperationName))
+                var operationName = operation.OperationName;
+                if (string.IsNullOrWhiteSpace(operationName))
                 {
                     throw new ArgumentException("Operation name must not be null, empty, or whitespace.", nameof(operations));
                 }
 
-                dictionary[operation.OperationName] = operation;
+                if (HasOuterWhitespace(operationName))
+                {
+                    throw new ArgumentException($"Operation name must not contain leading or trailing whitespace: '{operationName}'.", nameof(operations));
+                }
+
+                if (dictionary.ContainsKey(operationName))
+                {
+                    throw new ArgumentException($"Operation name is duplicated: '{operationName}'.", nameof(operations));
+                }
+
+                dictionary.Add(operationName, operation);
             }
 
             operationsByName = dictionary;
+        }
+
+        /// <summary> Determines whether value contains leading or trailing whitespace. </summary>
+        /// <param name="value"> The source value. </param>
+        /// <returns> <see langword="true" /> when value contains leading or trailing whitespace; otherwise <see langword="false" />. </returns>
+        private static bool HasOuterWhitespace (string value)
+        {
+            return char.IsWhiteSpace(value[0]) || char.IsWhiteSpace(value[value.Length - 1]);
         }
 
         /// <summary> Attempts to resolve an operation implementation by operation name. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
@@ -10,7 +10,8 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         /// <summary> Initializes a new instance of the <see cref="InMemoryPhaseOperationRegistry" /> class. </summary>
         /// <param name="operations"> The operation implementation collection. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" />. </exception>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" /> or contains a <see langword="null" /> operation. </exception>
+        /// <exception cref="ArgumentException"> Thrown when operation name is null, empty, or whitespace. </exception>
         public InMemoryPhaseOperationRegistry (IReadOnlyList<IPhaseOperation> operations)
         {
             if (operations == null)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides an in-memory operation registry implementation for phase execution. </summary>
+    internal sealed class InMemoryPhaseOperationRegistry : IPhaseOperationRegistry
+    {
+        private readonly IReadOnlyDictionary<string, IPhaseOperation> operationsByName;
+
+        /// <summary> Initializes a new instance of the <see cref="InMemoryPhaseOperationRegistry" /> class. </summary>
+        /// <param name="operations"> The operation implementation collection. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operations" /> is <see langword="null" />. </exception>
+        public InMemoryPhaseOperationRegistry (IReadOnlyList<IPhaseOperation> operations)
+        {
+            if (operations == null)
+            {
+                throw new ArgumentNullException(nameof(operations));
+            }
+
+            var dictionary = new Dictionary<string, IPhaseOperation>(StringComparer.Ordinal);
+            for (var i = 0; i < operations.Count; i++)
+            {
+                var operation = operations[i] ?? throw new ArgumentNullException(nameof(operations), "Operation list contains null.");
+                if (string.IsNullOrWhiteSpace(operation.OperationName))
+                {
+                    throw new ArgumentException("Operation name must not be null, empty, or whitespace.", nameof(operations));
+                }
+
+                dictionary[operation.OperationName] = operation;
+            }
+
+            operationsByName = dictionary;
+        }
+
+        /// <summary> Attempts to resolve an operation implementation by operation name. </summary>
+        /// <param name="operationName"> The operation name. </param>
+        /// <param name="operation"> The resolved implementation when found. </param>
+        /// <returns> <see langword="true" /> when operation implementation was found; otherwise <see langword="false" />. </returns>
+        public bool TryResolve (
+            string operationName,
+            out IPhaseOperation operation)
+        {
+            return operationsByName.TryGetValue(operationName, out operation);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/InMemoryPhaseOperationRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd944e7e3cdec4673b1dad90b5ff9cc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationFailure.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationFailure.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one operation failure entry captured by phase execution. </summary>
+    /// <param name="Code"> The machine-readable error code. </param>
+    /// <param name="Message"> The human-readable error message. </param>
+    /// <param name="OpId"> The related operation identifier, or <see langword="null" /> when unavailable. </param>
+    internal sealed record OperationFailure (
+        string Code,
+        string Message,
+        string? OpId);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationFailure.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationFailure.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9d7c322dae0644c1b1440790115274f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs
@@ -1,0 +1,18 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one operation phase state in execution traces. </summary>
+    internal enum OperationPhase
+    {
+        /// <summary> The operation completed the validate phase. </summary>
+        Validate = 0,
+
+        /// <summary> The operation completed the plan phase. </summary>
+        Plan = 1,
+
+        /// <summary> The operation completed the call phase. </summary>
+        Call = 2,
+
+        /// <summary> The operation was skipped due to a prior failure. </summary>
+        Skipped = 3,
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs
@@ -1,15 +1,15 @@
 namespace MackySoft.Ucli.Unity.Execution.Phases
 {
-    /// <summary> Represents one operation phase state in execution traces. </summary>
+    /// <summary> Represents the final phase reached by an operation in execution traces. </summary>
     internal enum OperationPhase
     {
-        /// <summary> The operation completed the validate phase. </summary>
+        /// <summary> The operation reached the validate phase and ended there. </summary>
         Validate = 0,
 
-        /// <summary> The operation completed the plan phase. </summary>
+        /// <summary> The operation reached the plan phase and ended there. </summary>
         Plan = 1,
 
-        /// <summary> The operation completed the call phase. </summary>
+        /// <summary> The operation reached the call phase and ended there. </summary>
         Call = 2,
 
         /// <summary> The operation was skipped due to a prior failure. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb1b70c9f8c2d494babfaec57c705a81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
@@ -28,6 +28,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The request-level execution trace. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+        /// <exception cref="System.OperationCanceledException"> Thrown when execution is canceled. </exception>
         public async Task<PhaseExecutionTrace> Execute (
             PhaseExecutionCommand command,
             NormalizedExecuteRequest request,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Requests;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Executes normalized operations through <c>validate -&gt; plan -&gt; call</c> phase pipelines. </summary>
+    internal sealed class OperationPhaseExecutor : IOperationPhaseExecutor
+    {
+        private readonly IPhaseOperationRegistry operationRegistry;
+
+        /// <summary> Initializes a new instance of the <see cref="OperationPhaseExecutor" /> class. </summary>
+        /// <param name="operationRegistry"> The phase-operation registry dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationRegistry" /> is <see langword="null" />. </exception>
+        public OperationPhaseExecutor (IPhaseOperationRegistry operationRegistry)
+        {
+            this.operationRegistry = operationRegistry ?? throw new ArgumentNullException(nameof(operationRegistry));
+        }
+
+        /// <summary> Executes one normalized request through the specified command phase-flow. </summary>
+        /// <param name="command"> The top-level execution command. </param>
+        /// <param name="request"> The normalized request. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The request-level execution trace. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+        public async Task<PhaseExecutionTrace> Execute (
+            PhaseExecutionCommand command,
+            NormalizedExecuteRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var operationTraces = new List<OperationPhaseTrace>(request.Ops.Count);
+            var errors = new List<OperationFailure>(1);
+            var hasFailed = false;
+
+            for (var i = 0; i < request.Ops.Count; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var operation = request.Ops[i];
+                if (hasFailed)
+                {
+                    operationTraces.Add(CreateSkippedTrace(operation));
+                    continue;
+                }
+
+                if (!operationRegistry.TryResolve(operation.Op, out var phaseOperation))
+                {
+                    var missingOperationFailure = new OperationFailure(
+                        Code: IpcErrorCodes.CommandNotImplemented,
+                        Message: $"Operation '{operation.Op}' is not implemented.",
+                        OpId: operation.Id);
+                    operationTraces.Add(new OperationPhaseTrace(
+                        OpId: operation.Id,
+                        Op: operation.Op,
+                        Phase: OperationPhase.Validate,
+                        Applied: false,
+                        Changed: false,
+                        Touched: Array.Empty<OperationTouch>(),
+                        Failure: missingOperationFailure));
+                    errors.Add(missingOperationFailure);
+                    hasFailed = true;
+                    continue;
+                }
+
+                var operationExecutionResult = await ExecuteOperation(command, operation, phaseOperation, cancellationToken);
+                operationTraces.Add(operationExecutionResult.Trace);
+                if (operationExecutionResult.Failure is not null)
+                {
+                    errors.Add(operationExecutionResult.Failure);
+                    hasFailed = true;
+                }
+            }
+
+            return errors.Count == 0
+                ? PhaseExecutionTrace.Success(request.ProtocolVersion, request.RequestId, operationTraces)
+                : PhaseExecutionTrace.Failure(request.ProtocolVersion, request.RequestId, operationTraces, errors);
+        }
+
+        /// <summary> Executes one operation according to the top-level command phase-flow. </summary>
+        /// <param name="command"> The top-level execution command. </param>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="phaseOperation"> The concrete operation implementation. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The operation execution result. </returns>
+        private static async Task<OperationExecutionResult> ExecuteOperation (
+            PhaseExecutionCommand command,
+            NormalizedOperation operation,
+            IPhaseOperation phaseOperation,
+            CancellationToken cancellationToken)
+        {
+            var touched = new List<OperationTouch>();
+
+            var validateStepResult = await ExecutePhaseStep(
+                operation,
+                OperationPhase.Validate,
+                token => phaseOperation.Validate(operation, token),
+                cancellationToken);
+            MergeTouched(touched, validateStepResult.Touched);
+            if (!validateStepResult.IsSuccess)
+            {
+                return OperationExecutionResult.Failed(new OperationPhaseTrace(
+                    OpId: operation.Id,
+                    Op: operation.Op,
+                    Phase: OperationPhase.Validate,
+                    Applied: validateStepResult.Applied,
+                    Changed: validateStepResult.Changed,
+                    Touched: touched,
+                    Failure: validateStepResult.Failure),
+                    validateStepResult.Failure!);
+            }
+
+            var planStepResult = await ExecutePhaseStep(
+                operation,
+                OperationPhase.Plan,
+                token => phaseOperation.Plan(operation, token),
+                cancellationToken);
+            MergeTouched(touched, planStepResult.Touched);
+            if (!planStepResult.IsSuccess)
+            {
+                return OperationExecutionResult.Failed(new OperationPhaseTrace(
+                    OpId: operation.Id,
+                    Op: operation.Op,
+                    Phase: OperationPhase.Plan,
+                    Applied: planStepResult.Applied,
+                    Changed: planStepResult.Changed,
+                    Touched: touched,
+                    Failure: planStepResult.Failure),
+                    planStepResult.Failure!);
+            }
+
+            if (command == PhaseExecutionCommand.Plan)
+            {
+                return OperationExecutionResult.Succeeded(new OperationPhaseTrace(
+                    OpId: operation.Id,
+                    Op: operation.Op,
+                    Phase: OperationPhase.Plan,
+                    Applied: planStepResult.Applied,
+                    Changed: planStepResult.Changed,
+                    Touched: touched,
+                    Failure: null));
+            }
+
+            var callStepResult = await ExecutePhaseStep(
+                operation,
+                OperationPhase.Call,
+                token => phaseOperation.Call(operation, token),
+                cancellationToken);
+            MergeTouched(touched, callStepResult.Touched);
+            if (!callStepResult.IsSuccess)
+            {
+                return OperationExecutionResult.Failed(new OperationPhaseTrace(
+                    OpId: operation.Id,
+                    Op: operation.Op,
+                    Phase: OperationPhase.Call,
+                    Applied: callStepResult.Applied,
+                    Changed: callStepResult.Changed,
+                    Touched: touched,
+                    Failure: callStepResult.Failure),
+                    callStepResult.Failure!);
+            }
+
+            return OperationExecutionResult.Succeeded(new OperationPhaseTrace(
+                OpId: operation.Id,
+                Op: operation.Op,
+                Phase: OperationPhase.Call,
+                Applied: callStepResult.Applied,
+                Changed: callStepResult.Changed,
+                Touched: touched,
+                Failure: null));
+        }
+
+        /// <summary> Executes one phase step with exception-to-failure translation. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="phase"> The phase being executed. </param>
+        /// <param name="executor"> The step executor delegate. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        private static async Task<OperationPhaseStepResult> ExecutePhaseStep (
+            NormalizedOperation operation,
+            OperationPhase phase,
+            Func<CancellationToken, Task<OperationPhaseStepResult>> executor,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var stepResult = await executor(cancellationToken);
+                if (stepResult == null)
+                {
+                    return OperationPhaseStepResult.Failed(new OperationFailure(
+                        Code: IpcErrorCodes.InternalError,
+                        Message: $"Operation '{operation.Id}' returned null result at phase '{phase}'.",
+                        OpId: operation.Id));
+                }
+
+                return stepResult;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                return OperationPhaseStepResult.Failed(new OperationFailure(
+                    Code: IpcErrorCodes.InternalError,
+                    Message: $"Unexpected error occurred in operation '{operation.Id}' at phase '{phase}'. {exception.Message}",
+                    OpId: operation.Id));
+            }
+        }
+
+        /// <summary> Merges touched entries into one target list. </summary>
+        /// <param name="target"> The target touched-entry list. </param>
+        /// <param name="source"> The source touched-entry collection. </param>
+        private static void MergeTouched (
+            List<OperationTouch> target,
+            IReadOnlyList<OperationTouch> source)
+        {
+            for (var i = 0; i < source.Count; i++)
+            {
+                target.Add(source[i]);
+            }
+        }
+
+        /// <summary> Creates a skipped trace for operations after fail-fast stopping. </summary>
+        /// <param name="operation"> The skipped operation. </param>
+        /// <returns> The skipped trace entry. </returns>
+        private static OperationPhaseTrace CreateSkippedTrace (NormalizedOperation operation)
+        {
+            return new OperationPhaseTrace(
+                OpId: operation.Id,
+                Op: operation.Op,
+                Phase: OperationPhase.Skipped,
+                Applied: false,
+                Changed: false,
+                Touched: Array.Empty<OperationTouch>(),
+                Failure: null);
+        }
+
+        /// <summary> Represents one operation execution result. </summary>
+        /// <param name="Trace"> The operation trace entry. </param>
+        /// <param name="Failure"> The operation failure details; otherwise <see langword="null" />. </param>
+        private sealed record OperationExecutionResult (
+            OperationPhaseTrace Trace,
+            OperationFailure? Failure)
+        {
+            /// <summary> Creates a successful operation execution result. </summary>
+            /// <param name="trace"> The operation trace entry. </param>
+            /// <returns> The successful operation execution result. </returns>
+            public static OperationExecutionResult Succeeded (OperationPhaseTrace trace)
+            {
+                return new OperationExecutionResult(trace, null);
+            }
+
+            /// <summary> Creates a failed operation execution result. </summary>
+            /// <param name="trace"> The operation trace entry. </param>
+            /// <param name="failure"> The operation failure details. </param>
+            /// <returns> The failed operation execution result. </returns>
+            public static OperationExecutionResult Failed (
+                OperationPhaseTrace trace,
+                OperationFailure failure)
+            {
+                return new OperationExecutionResult(trace, failure);
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
@@ -105,7 +105,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             var validateStepResult = await ExecutePhaseStep(
                 operation,
                 OperationPhase.Validate,
-                token => phaseOperation.Validate(operation, token),
+                ct => phaseOperation.Validate(operation, ct),
                 cancellationToken);
             MergeTouched(touched, validateStepResult.Touched);
             if (!validateStepResult.IsSuccess)
@@ -124,7 +124,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             var planStepResult = await ExecutePhaseStep(
                 operation,
                 OperationPhase.Plan,
-                token => phaseOperation.Plan(operation, token),
+                ct => phaseOperation.Plan(operation, ct),
                 cancellationToken);
             MergeTouched(touched, planStepResult.Touched);
             if (!planStepResult.IsSuccess)
@@ -155,7 +155,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             var callStepResult = await ExecutePhaseStep(
                 operation,
                 OperationPhase.Call,
-                token => phaseOperation.Call(operation, token),
+                ct => phaseOperation.Call(operation, ct),
                 cancellationToken);
             MergeTouched(touched, callStepResult.Touched);
             if (!callStepResult.IsSuccess)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b4e675e953094b04b53cbf750610504
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseStepResult.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseStepResult.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one phase-step result for one operation. </summary>
+    /// <param name="Applied"> Whether the operation was applied in this step. </param>
+    /// <param name="Changed"> Whether this step produced changes. </param>
+    /// <param name="Touched"> The touched persistence-unit list produced by this step. </param>
+    /// <param name="Failure"> The failure details when this step failed; otherwise <see langword="null" />. </param>
+    internal sealed record OperationPhaseStepResult (
+        bool Applied,
+        bool Changed,
+        IReadOnlyList<OperationTouch> Touched,
+        OperationFailure? Failure)
+    {
+        /// <summary> Gets a value indicating whether this step succeeded. </summary>
+        public bool IsSuccess => Failure is null;
+
+        /// <summary> Creates a successful phase-step result. </summary>
+        /// <param name="touched"> The touched persistence-unit list. </param>
+        /// <returns> The successful phase-step result. </returns>
+        public static OperationPhaseStepResult Success (
+            IReadOnlyList<OperationTouch>? touched = null)
+        {
+            return Success(
+                applied: false,
+                changed: false,
+                touched: touched);
+        }
+
+        /// <summary> Creates a successful phase-step result. </summary>
+        /// <param name="applied"> Whether operation was applied in this step. </param>
+        /// <param name="changed"> Whether changes were produced in this step. </param>
+        /// <param name="touched"> The touched persistence-unit list. </param>
+        /// <returns> The successful phase-step result. </returns>
+        public static OperationPhaseStepResult Success (
+            bool applied,
+            bool changed,
+            IReadOnlyList<OperationTouch>? touched = null)
+        {
+            return new OperationPhaseStepResult(
+                Applied: applied,
+                Changed: changed,
+                Touched: touched ?? Array.Empty<OperationTouch>(),
+                Failure: null);
+        }
+
+        /// <summary> Creates a failed phase-step result. </summary>
+        /// <param name="failure"> The operation failure details. </param>
+        /// <param name="touched"> The touched persistence-unit list. </param>
+        /// <returns> The failed phase-step result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="failure" /> is <see langword="null" />. </exception>
+        public static OperationPhaseStepResult Failed (
+            OperationFailure failure,
+            IReadOnlyList<OperationTouch>? touched = null)
+        {
+            return Failed(
+                failure,
+                applied: false,
+                changed: false,
+                touched: touched);
+        }
+
+        /// <summary> Creates a failed phase-step result. </summary>
+        /// <param name="failure"> The operation failure details. </param>
+        /// <param name="applied"> Whether operation was applied in this step. </param>
+        /// <param name="changed"> Whether changes were produced in this step. </param>
+        /// <param name="touched"> The touched persistence-unit list. </param>
+        /// <returns> The failed phase-step result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="failure" /> is <see langword="null" />. </exception>
+        public static OperationPhaseStepResult Failed (
+            OperationFailure failure,
+            bool applied,
+            bool changed,
+            IReadOnlyList<OperationTouch>? touched = null)
+        {
+            if (failure == null)
+            {
+                throw new ArgumentNullException(nameof(failure));
+            }
+
+            return new OperationPhaseStepResult(
+                Applied: applied,
+                Changed: changed,
+                Touched: touched ?? Array.Empty<OperationTouch>(),
+                Failure: failure);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseStepResult.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseStepResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcc8d41877a3444ca808cadfae13a6bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseTrace.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseTrace.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one final per-operation trace entry produced by phase execution. </summary>
+    /// <param name="OpId"> The operation identifier. </param>
+    /// <param name="Op"> The operation name. </param>
+    /// <param name="Phase"> The final phase reached by this operation. </param>
+    /// <param name="Applied"> Whether operation was applied. </param>
+    /// <param name="Changed"> Whether operation produced changes. </param>
+    /// <param name="Touched"> The touched persistence-unit list. </param>
+    /// <param name="Failure"> The operation failure details; otherwise <see langword="null" />. </param>
+    internal sealed record OperationPhaseTrace (
+        string OpId,
+        string Op,
+        OperationPhase Phase,
+        bool Applied,
+        bool Changed,
+        IReadOnlyList<OperationTouch> Touched,
+        OperationFailure? Failure);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseTrace.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseTrace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b97d14bdbf9f7486c81d50b413ceb0f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouch.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouch.cs
@@ -1,0 +1,13 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one touched persistence-unit entry from operation execution. </summary>
+    /// <param name="Kind"> The touched unit kind. </param>
+    /// <param name="Path"> The project-relative path. </param>
+    /// <param name="Guid"> The optional asset guid. </param>
+    internal sealed record OperationTouch (
+        OperationTouchKind Kind,
+        string Path,
+        string? Guid);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouch.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca348bab2ab1f4b939e390bfba5029a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouchKind.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouchKind.cs
@@ -1,0 +1,21 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one touched persistence-unit kind. </summary>
+    internal enum OperationTouchKind
+    {
+        /// <summary> The touched unit kind is unknown. </summary>
+        Unknown = 0,
+
+        /// <summary> The touched unit is a scene asset. </summary>
+        Scene = 1,
+
+        /// <summary> The touched unit is a prefab asset. </summary>
+        Prefab = 2,
+
+        /// <summary> The touched unit is a generic asset. </summary>
+        Asset = 3,
+
+        /// <summary> The touched unit is a project settings asset. </summary>
+        ProjectSettings = 4,
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouchKind.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationTouchKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5b767ad72c034ad68172504196f4e8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionCommand.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionCommand.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents the top-level command executed by the phase executor. </summary>
+    internal enum PhaseExecutionCommand
+    {
+        /// <summary> Runs <c>validate -&gt; plan</c> phases. </summary>
+        Plan = 0,
+
+        /// <summary> Runs <c>validate -&gt; plan -&gt; call</c> phases. </summary>
+        Call = 1,
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionCommand.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 531d71d1379684d2f9a0457d68f0d26a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionTrace.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionTrace.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one request-level execution trace produced by phase execution. </summary>
+    /// <param name="ProtocolVersion"> The protocol version associated with the request. </param>
+    /// <param name="RequestId"> The request identifier associated with the request. </param>
+    /// <param name="OperationTraces"> The per-operation trace entries. </param>
+    /// <param name="Errors"> The request-level error list. </param>
+    internal sealed record PhaseExecutionTrace (
+        int ProtocolVersion,
+        string RequestId,
+        IReadOnlyList<OperationPhaseTrace> OperationTraces,
+        IReadOnlyList<OperationFailure> Errors)
+    {
+        /// <summary> Gets a value indicating whether execution completed without errors. </summary>
+        public bool IsSuccess => Errors.Count == 0;
+
+        /// <summary> Creates a successful request-level execution trace. </summary>
+        /// <param name="protocolVersion"> The protocol version associated with the request. </param>
+        /// <param name="requestId"> The request identifier associated with the request. </param>
+        /// <param name="operationTraces"> The per-operation trace entries. </param>
+        /// <returns> The successful execution trace. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="requestId" /> or <paramref name="operationTraces" /> is <see langword="null" />. </exception>
+        public static PhaseExecutionTrace Success (
+            int protocolVersion,
+            string requestId,
+            IReadOnlyList<OperationPhaseTrace> operationTraces)
+        {
+            if (requestId == null)
+            {
+                throw new ArgumentNullException(nameof(requestId));
+            }
+
+            if (operationTraces == null)
+            {
+                throw new ArgumentNullException(nameof(operationTraces));
+            }
+
+            return new PhaseExecutionTrace(
+                ProtocolVersion: protocolVersion,
+                RequestId: requestId,
+                OperationTraces: operationTraces,
+                Errors: Array.Empty<OperationFailure>());
+        }
+
+        /// <summary> Creates a failed request-level execution trace. </summary>
+        /// <param name="protocolVersion"> The protocol version associated with the request. </param>
+        /// <param name="requestId"> The request identifier associated with the request. </param>
+        /// <param name="operationTraces"> The per-operation trace entries. </param>
+        /// <param name="errors"> The request-level errors. </param>
+        /// <returns> The failed execution trace. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when any reference argument is <see langword="null" />. </exception>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="errors" /> is empty. </exception>
+        public static PhaseExecutionTrace Failure (
+            int protocolVersion,
+            string requestId,
+            IReadOnlyList<OperationPhaseTrace> operationTraces,
+            IReadOnlyList<OperationFailure> errors)
+        {
+            if (requestId == null)
+            {
+                throw new ArgumentNullException(nameof(requestId));
+            }
+
+            if (operationTraces == null)
+            {
+                throw new ArgumentNullException(nameof(operationTraces));
+            }
+
+            if (errors == null)
+            {
+                throw new ArgumentNullException(nameof(errors));
+            }
+
+            if (errors.Count == 0)
+            {
+                throw new ArgumentException("Errors must not be empty.", nameof(errors));
+            }
+
+            return new PhaseExecutionTrace(
+                ProtocolVersion: protocolVersion,
+                RequestId: requestId,
+                OperationTraces: operationTraces,
+                Errors: errors);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionTrace.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/PhaseExecutionTrace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21c07b4c669d14d0a863c7638853587d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteDispatchContext.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteDispatchContext.cs
@@ -1,0 +1,9 @@
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Represents request-level context passed to execute request dispatching. </summary>
+    /// <param name="RequestId"> The request identifier copied to response envelopes. </param>
+    /// <param name="ProtocolVersion"> The protocol version copied to response envelopes. </param>
+    internal sealed record ExecuteDispatchContext (
+        string RequestId,
+        int ProtocolVersion);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteDispatchContext.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteDispatchContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35e92c2ef167f4fc29d8c772f1bdfe1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
@@ -46,6 +46,7 @@ namespace MackySoft.Ucli.Unity.Ipc
         /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
         /// <returns> The response envelope for the incoming request. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> or <paramref name="context" /> is <see langword="null" />. </exception>
+        /// <exception cref="System.OperationCanceledException"> Thrown when dispatch is canceled. </exception>
         public async Task<IpcResponse> Dispatch (
             IpcExecuteRequest request,
             ExecuteDispatchContext context,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Dispatches execute requests to operation-phase execution pipelines. </summary>
+    internal sealed class ExecuteRequestDispatcher : IExecuteRequestDispatcher
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false,
+            Converters =
+            {
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+            },
+        };
+
+        private readonly IExecuteRequestNormalizer requestNormalizer;
+        private readonly IOperationPhaseExecutor operationPhaseExecutor;
+
+        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestDispatcher" /> class. </summary>
+        /// <param name="requestNormalizer"> The execute-request normalizer dependency. </param>
+        /// <param name="operationPhaseExecutor"> The operation-phase executor dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
+        public ExecuteRequestDispatcher (
+            IExecuteRequestNormalizer requestNormalizer,
+            IOperationPhaseExecutor operationPhaseExecutor)
+        {
+            this.requestNormalizer = requestNormalizer ?? throw new ArgumentNullException(nameof(requestNormalizer));
+            this.operationPhaseExecutor = operationPhaseExecutor ?? throw new ArgumentNullException(nameof(operationPhaseExecutor));
+        }
+
+        /// <summary> Dispatches one execute request and returns the response envelope. </summary>
+        /// <param name="request"> The execute request payload. </param>
+        /// <param name="context"> The request-level dispatch context. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
+        /// <returns> The response envelope for the incoming request. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> or <paramref name="context" /> is <see langword="null" />. </exception>
+        public async Task<IpcResponse> Dispatch (
+            IpcExecuteRequest request,
+            ExecuteDispatchContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var normalizationResult = requestNormalizer.Normalize(request, cancellationToken);
+            if (!normalizationResult.IsSuccess)
+            {
+                var normalizationError = normalizationResult.Error!;
+                return CreateErrorResponse(
+                    context,
+                    normalizationError.Code,
+                    normalizationError.Message,
+                    normalizationError.OpId);
+            }
+
+            if (!TryResolveExecutionCommand(request.Command, out var executionCommand))
+            {
+                return CreateErrorResponse(
+                    context,
+                    IpcErrorCodes.CommandNotImplemented,
+                    $"Execute command '{request.Command}' is not implemented.",
+                    null);
+            }
+
+            try
+            {
+                var trace = await operationPhaseExecutor.Execute(executionCommand, normalizationResult.Request!, cancellationToken);
+                var payload = JsonSerializer.SerializeToElement(new
+                {
+                    operationTraces = trace.OperationTraces,
+                    errors = trace.Errors,
+                }, SerializerOptions);
+                var errors = trace.Errors
+                    .Select(error => new IpcError(error.Code, error.Message, error.OpId))
+                    .ToArray();
+                return new IpcResponse(
+                    ProtocolVersion: context.ProtocolVersion,
+                    RequestId: context.RequestId,
+                    Status: trace.IsSuccess ? IpcProtocol.StatusOk : IpcProtocol.StatusError,
+                    Payload: payload,
+                    Errors: errors);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                return CreateErrorResponse(
+                    context,
+                    IpcErrorCodes.InternalError,
+                    $"Unexpected error occurred while dispatching execute request. {exception.Message}",
+                    null);
+            }
+        }
+
+        /// <summary> Resolves phase-execution command from execute request command name. </summary>
+        /// <param name="commandName"> The execute request command name. </param>
+        /// <param name="command"> The resolved phase command. </param>
+        /// <returns> <see langword="true" /> when command is supported in this dispatcher; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveExecutionCommand (
+            string commandName,
+            out PhaseExecutionCommand command)
+        {
+            switch (commandName)
+            {
+                case IpcExecuteCommandNames.Plan:
+                    command = PhaseExecutionCommand.Plan;
+                    return true;
+
+                case IpcExecuteCommandNames.Call:
+                    command = PhaseExecutionCommand.Call;
+                    return true;
+
+                case IpcExecuteCommandNames.Resolve:
+                case IpcExecuteCommandNames.Query:
+                case IpcExecuteCommandNames.Refresh:
+                    command = default;
+                    return false;
+
+                default:
+                    command = default;
+                    return false;
+            }
+        }
+
+        /// <summary> Creates an error response with one error entry. </summary>
+        /// <param name="context"> The request-level dispatch context. </param>
+        /// <param name="code"> The error code. </param>
+        /// <param name="message"> The error message. </param>
+        /// <param name="opId"> The related operation identifier. </param>
+        /// <returns> The error response envelope. </returns>
+        private static IpcResponse CreateErrorResponse (
+            ExecuteDispatchContext context,
+            string code,
+            string message,
+            string? opId)
+        {
+            return new IpcResponse(
+                ProtocolVersion: context.ProtocolVersion,
+                RequestId: context.RequestId,
+                Status: IpcProtocol.StatusError,
+                Payload: JsonSerializer.SerializeToElement(new { }, SerializerOptions),
+                Errors: new[]
+                {
+                    new IpcError(code, message, opId),
+                });
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
@@ -64,6 +64,15 @@ namespace MackySoft.Ucli.Unity.Ipc
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (!TryResolveExecutionCommand(request.Command, out var executionCommand))
+            {
+                return CreateErrorResponse(
+                    context,
+                    IpcErrorCodes.CommandNotImplemented,
+                    $"Execute command '{request.Command}' is not implemented.",
+                    null);
+            }
+
             var normalizationResult = requestNormalizer.Normalize(request, cancellationToken);
             if (!normalizationResult.IsSuccess)
             {
@@ -73,15 +82,6 @@ namespace MackySoft.Ucli.Unity.Ipc
                     normalizationError.Code,
                     normalizationError.Message,
                     normalizationError.OpId);
-            }
-
-            if (!TryResolveExecutionCommand(request.Command, out var executionCommand))
-            {
-                return CreateErrorResponse(
-                    context,
-                    IpcErrorCodes.CommandNotImplemented,
-                    $"Execute command '{request.Command}' is not implemented.",
-                    null);
             }
 
             try

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 520357ecef1dc4eb49a27f550b6d3257
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/IExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/IExecuteRequestDispatcher.cs
@@ -12,6 +12,7 @@ namespace MackySoft.Ucli.Unity.Ipc
         /// <param name="context"> The request-level dispatch context. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
         /// <returns> The response envelope for the incoming request. </returns>
+        /// <exception cref="System.OperationCanceledException"> Thrown when dispatch is canceled. </exception>
         Task<IpcResponse> Dispatch (
             IpcExecuteRequest request,
             ExecuteDispatchContext context,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/IExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/IExecuteRequestDispatcher.cs
@@ -9,10 +9,12 @@ namespace MackySoft.Ucli.Unity.Ipc
     {
         /// <summary> Dispatches one execute request and returns the response envelope. </summary>
         /// <param name="request"> The execute request payload. </param>
+        /// <param name="context"> The request-level dispatch context. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by operation pipelines. </param>
         /// <returns> The response envelope for the incoming request. </returns>
-        Task<IpcResponse> DispatchAsync (
+        Task<IpcResponse> Dispatch (
             IpcExecuteRequest request,
+            ExecuteDispatchContext context,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using MackySoft.Ucli.Unity.Ipc;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class ExecuteRequestDispatcherTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        [TestCase(IpcExecuteCommandNames.Plan, PhaseExecutionCommand.Plan)]
+        [TestCase(IpcExecuteCommandNames.Call, PhaseExecutionCommand.Call)]
+        public async Task Dispatch_WhenCommandIsPlanOrCall_DelegatesToPhaseExecutor (
+            string commandName,
+            PhaseExecutionCommand expectedCommand)
+        {
+            var normalizedRequest = CreateNormalizedRequest();
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: new[]
+                {
+                    new OperationPhaseTrace("op-1", "ucli.resolve", OperationPhase.Plan, false, false, System.Array.Empty<OperationTouch>(), null),
+                }));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(commandName);
+
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusOk));
+            Assert.That(phaseExecutor.ReceivedCommand, Is.EqualTo(expectedCommand));
+            Assert.That(phaseExecutor.CallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        [TestCase(IpcExecuteCommandNames.Resolve)]
+        [TestCase(IpcExecuteCommandNames.Query)]
+        [TestCase(IpcExecuteCommandNames.Refresh)]
+        public async Task Dispatch_WhenCommandIsNotImplemented_ReturnsCommandNotImplementedError (string commandName)
+        {
+            var normalizedRequest = CreateNormalizedRequest();
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(commandName);
+
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.CommandNotImplemented));
+            Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task Dispatch_WhenNormalizationFails_ReturnsNormalizationError ()
+        {
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
+                new ExecuteRequestNormalizationError(IpcErrorCodes.InvalidArgument, "invalid request", "op-1")));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
+
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(response.Errors[0].OpId, Is.EqualTo("op-1"));
+            Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Dispatch_WhenCancellationRequested_ThrowsOperationCanceledException ()
+        {
+            var normalizedRequest = CreateNormalizedRequest();
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await dispatcher.Dispatch(request, context, cancellationTokenSource.Token);
+            });
+        }
+
+        private static IpcExecuteRequest CreateExecuteRequest (string commandName)
+        {
+            return new IpcExecuteRequest(
+                commandName,
+                JsonSerializer.SerializeToElement(new
+                {
+                    protocolVersion = 1,
+                    requestId = "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                    ops = new[]
+                    {
+                        new
+                        {
+                            id = "op-1",
+                            op = "ucli.resolve",
+                            args = new { },
+                        },
+                    },
+                }));
+        }
+
+        private static NormalizedExecuteRequest CreateNormalizedRequest ()
+        {
+            return new NormalizedExecuteRequest(
+                ProtocolVersion: 1,
+                RequestId: "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                Ops: new[]
+                {
+                    new NormalizedOperation(
+                        Id: "op-1",
+                        Op: "ucli.resolve",
+                        Args: JsonSerializer.SerializeToElement(new { }),
+                        As: null,
+                        Expect: null),
+                },
+                CanonicalDigestPayloadUtf8: Encoding.UTF8.GetBytes("{}"));
+        }
+
+        private sealed class StubExecuteRequestNormalizer : IExecuteRequestNormalizer
+        {
+            private readonly ExecuteRequestNormalizationResult normalizationResult;
+
+            public StubExecuteRequestNormalizer (ExecuteRequestNormalizationResult normalizationResult)
+            {
+                this.normalizationResult = normalizationResult;
+            }
+
+            public ExecuteRequestNormalizationResult Normalize (
+                IpcExecuteRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return normalizationResult;
+            }
+        }
+
+        private sealed class SpyOperationPhaseExecutor : IOperationPhaseExecutor
+        {
+            private readonly PhaseExecutionTrace executionTrace;
+
+            public SpyOperationPhaseExecutor (PhaseExecutionTrace executionTrace)
+            {
+                this.executionTrace = executionTrace;
+            }
+
+            public int CallCount { get; private set; }
+
+            public PhaseExecutionCommand? ReceivedCommand { get; private set; }
+
+            public Task<PhaseExecutionTrace> Execute (
+                PhaseExecutionCommand command,
+                NormalizedExecuteRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CallCount++;
+                ReceivedCommand = command;
+                return Task.FromResult(executionTrace);
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
@@ -124,8 +124,8 @@ namespace MackySoft.Ucli.Unity.Tests
 
         private static async UniTask AssertReturnsCommandNotImplementedError (string commandName)
         {
-            var normalizedRequest = CreateNormalizedRequest();
-            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var normalizer = new SpyExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
+                new ExecuteRequestNormalizationError(IpcErrorCodes.InvalidArgument, "normalizer should not run", null)));
             var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
                 protocolVersion: IpcProtocol.CurrentVersion,
                 requestId: "req-1",
@@ -139,6 +139,7 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.CommandNotImplemented));
+            Assert.That(normalizer.CallCount, Is.EqualTo(0));
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
         }
 
@@ -193,6 +194,27 @@ namespace MackySoft.Ucli.Unity.Tests
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                return normalizationResult;
+            }
+        }
+
+        private sealed class SpyExecuteRequestNormalizer : IExecuteRequestNormalizer
+        {
+            private readonly ExecuteRequestNormalizationResult normalizationResult;
+
+            public SpyExecuteRequestNormalizer (ExecuteRequestNormalizationResult normalizationResult)
+            {
+                this.normalizationResult = normalizationResult;
+            }
+
+            public int CallCount { get; private set; }
+
+            public ExecuteRequestNormalizationResult Normalize (
+                IpcExecuteRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CallCount++;
                 return normalizationResult;
             }
         }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
@@ -1,12 +1,16 @@
+using System;
+using System.Collections;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Execution.Phases;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using MackySoft.Ucli.Unity.Ipc;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 #nullable enable
 
@@ -14,11 +18,87 @@ namespace MackySoft.Ucli.Unity.Tests
 {
     public sealed class ExecuteRequestDispatcherTests
     {
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        [TestCase(IpcExecuteCommandNames.Plan, PhaseExecutionCommand.Plan)]
-        [TestCase(IpcExecuteCommandNames.Call, PhaseExecutionCommand.Call)]
-        public async Task Dispatch_WhenCommandIsPlanOrCall_DelegatesToPhaseExecutor (
+        public IEnumerator Dispatch_WhenCommandIsPlan_DelegatesToPhaseExecutor () => UniTask.ToCoroutine(async () =>
+        {
+            await AssertDelegatesToPhaseExecutor(IpcExecuteCommandNames.Plan, PhaseExecutionCommand.Plan);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenCommandIsCall_DelegatesToPhaseExecutor () => UniTask.ToCoroutine(async () =>
+        {
+            await AssertDelegatesToPhaseExecutor(IpcExecuteCommandNames.Call, PhaseExecutionCommand.Call);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenCommandIsResolve_ReturnsCommandNotImplementedError () => UniTask.ToCoroutine(async () =>
+        {
+            await AssertReturnsCommandNotImplementedError(IpcExecuteCommandNames.Resolve);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenCommandIsQuery_ReturnsCommandNotImplementedError () => UniTask.ToCoroutine(async () =>
+        {
+            await AssertReturnsCommandNotImplementedError(IpcExecuteCommandNames.Query);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenCommandIsRefresh_ReturnsCommandNotImplementedError () => UniTask.ToCoroutine(async () =>
+        {
+            await AssertReturnsCommandNotImplementedError(IpcExecuteCommandNames.Refresh);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenNormalizationFails_ReturnsNormalizationError () => UniTask.ToCoroutine(async () =>
+        {
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
+                new ExecuteRequestNormalizationError(IpcErrorCodes.InvalidArgument, "invalid request", "op-1")));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
+
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None).AsUniTask();
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(response.Errors[0].OpId, Is.EqualTo("op-1"));
+            Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenCancellationRequested_ThrowsOperationCanceledException () => UniTask.ToCoroutine(async () =>
+        {
+            var normalizedRequest = CreateNormalizedRequest();
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            await AsyncExceptionCapture.CaptureAsync<OperationCanceledException>(async () =>
+            {
+                await dispatcher.Dispatch(request, context, cancellationTokenSource.Token).AsUniTask();
+            });
+        });
+
+        private static async UniTask AssertDelegatesToPhaseExecutor (
             string commandName,
             PhaseExecutionCommand expectedCommand)
         {
@@ -35,19 +115,14 @@ namespace MackySoft.Ucli.Unity.Tests
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(commandName);
 
-            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None).AsUniTask();
 
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusOk));
             Assert.That(phaseExecutor.ReceivedCommand, Is.EqualTo(expectedCommand));
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(1));
         }
 
-        [Test]
-        [Category("Size.Small")]
-        [TestCase(IpcExecuteCommandNames.Resolve)]
-        [TestCase(IpcExecuteCommandNames.Query)]
-        [TestCase(IpcExecuteCommandNames.Refresh)]
-        public async Task Dispatch_WhenCommandIsNotImplemented_ReturnsCommandNotImplementedError (string commandName)
+        private static async UniTask AssertReturnsCommandNotImplementedError (string commandName)
         {
             var normalizedRequest = CreateNormalizedRequest();
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
@@ -59,57 +134,12 @@ namespace MackySoft.Ucli.Unity.Tests
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(commandName);
 
-            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None).AsUniTask();
 
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.CommandNotImplemented));
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        [Category("Size.Small")]
-        public async Task Dispatch_WhenNormalizationFails_ReturnsNormalizationError ()
-        {
-            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
-                new ExecuteRequestNormalizationError(IpcErrorCodes.InvalidArgument, "invalid request", "op-1")));
-            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
-                protocolVersion: IpcProtocol.CurrentVersion,
-                requestId: "req-1",
-                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
-            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
-            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
-
-            var response = await dispatcher.Dispatch(request, context, CancellationToken.None);
-
-            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
-            Assert.That(response.Errors.Count, Is.EqualTo(1));
-            Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
-            Assert.That(response.Errors[0].OpId, Is.EqualTo("op-1"));
-            Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
-        }
-
-        [Test]
-        [Category("Size.Small")]
-        public void Dispatch_WhenCancellationRequested_ThrowsOperationCanceledException ()
-        {
-            var normalizedRequest = CreateNormalizedRequest();
-            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
-            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Success(
-                protocolVersion: IpcProtocol.CurrentVersion,
-                requestId: "req-1",
-                operationTraces: System.Array.Empty<OperationPhaseTrace>()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
-            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
-            var request = CreateExecuteRequest(IpcExecuteCommandNames.Plan);
-            using var cancellationTokenSource = new CancellationTokenSource();
-            cancellationTokenSource.Cancel();
-
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            {
-                await dispatcher.Dispatch(request, context, cancellationTokenSource.Token);
-            });
         }
 
         private static IpcExecuteRequest CreateExecuteRequest (string commandName)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 001d3f11ea86845ab9adfd4e748a7e87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Execution.Phases;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 #nullable enable
 
@@ -15,28 +18,28 @@ namespace MackySoft.Ucli.Unity.Tests
 {
     public sealed class OperationPhaseExecutorTests
     {
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public async Task Execute_WhenCommandIsPlan_ExecutesValidateAndPlanOnly ()
+        public IEnumerator Execute_WhenCommandIsPlan_ExecutesValidateAndPlanOnly () => UniTask.ToCoroutine(async () =>
         {
             var operation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
                 validateResult: OperationPhaseStepResult.Success(),
-                planResult: OperationPhaseStepResult.Success(changed: true),
+                planResult: OperationPhaseStepResult.Success(applied: false, changed: true),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true));
             var executor = CreateExecutor(operation);
             var request = CreateRequest("op-1", "ucli.resolve");
 
-            var trace = await executor.Execute(PhaseExecutionCommand.Plan, request);
+            var trace = await executor.Execute(PhaseExecutionCommand.Plan, request).AsUniTask();
 
             CollectionAssert.AreEqual(new[] { OperationPhase.Validate, OperationPhase.Plan }, operation.CalledPhases);
             Assert.That(trace.IsSuccess, Is.True);
             Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Plan));
-        }
+        });
 
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public async Task Execute_WhenCommandIsCall_ExecutesValidatePlanAndCall ()
+        public IEnumerator Execute_WhenCommandIsCall_ExecutesValidatePlanAndCall () => UniTask.ToCoroutine(async () =>
         {
             var operation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
@@ -46,16 +49,16 @@ namespace MackySoft.Ucli.Unity.Tests
             var executor = CreateExecutor(operation);
             var request = CreateRequest("op-1", "ucli.resolve");
 
-            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request).AsUniTask();
 
             CollectionAssert.AreEqual(new[] { OperationPhase.Validate, OperationPhase.Plan, OperationPhase.Call }, operation.CalledPhases);
             Assert.That(trace.IsSuccess, Is.True);
             Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Call));
-        }
+        });
 
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public async Task Execute_WhenValidateFails_MarksRemainingOperationsAsSkipped ()
+        public IEnumerator Execute_WhenValidateFails_MarksRemainingOperationsAsSkipped () => UniTask.ToCoroutine(async () =>
         {
             var failingOperation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
@@ -76,7 +79,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 ("op-1", "ucli.resolve"),
                 ("op-2", "ucli.scene.open"));
 
-            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request).AsUniTask();
 
             Assert.That(trace.IsSuccess, Is.False);
             Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Validate));
@@ -85,11 +88,11 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(trace.OperationTraces[1].Applied, Is.False);
             Assert.That(trace.OperationTraces[1].Changed, Is.False);
             Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
-        }
+        });
 
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public async Task Execute_WhenPlanFails_MarksRemainingOperationsAsSkipped ()
+        public IEnumerator Execute_WhenPlanFails_MarksRemainingOperationsAsSkipped () => UniTask.ToCoroutine(async () =>
         {
             var failingOperation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
@@ -110,17 +113,17 @@ namespace MackySoft.Ucli.Unity.Tests
                 ("op-1", "ucli.resolve"),
                 ("op-2", "ucli.scene.open"));
 
-            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request).AsUniTask();
 
             Assert.That(trace.IsSuccess, Is.False);
             Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Plan));
             Assert.That(trace.OperationTraces[1].Phase, Is.EqualTo(OperationPhase.Skipped));
             Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
-        }
+        });
 
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public async Task Execute_WhenCallFails_MarksRemainingOperationsAsSkipped ()
+        public IEnumerator Execute_WhenCallFails_MarksRemainingOperationsAsSkipped () => UniTask.ToCoroutine(async () =>
         {
             var failingOperation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
@@ -141,17 +144,17 @@ namespace MackySoft.Ucli.Unity.Tests
                 ("op-1", "ucli.resolve"),
                 ("op-2", "ucli.scene.open"));
 
-            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request).AsUniTask();
 
             Assert.That(trace.IsSuccess, Is.False);
             Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Call));
             Assert.That(trace.OperationTraces[1].Phase, Is.EqualTo(OperationPhase.Skipped));
             Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
-        }
+        });
 
-        [Test]
+        [UnityTest]
         [Category("Size.Small")]
-        public void Execute_WhenCancellationRequested_ThrowsOperationCanceledException ()
+        public IEnumerator Execute_WhenCancellationRequested_ThrowsOperationCanceledException () => UniTask.ToCoroutine(async () =>
         {
             var operation = new RecordingPhaseOperation(
                 operationName: "ucli.resolve",
@@ -163,11 +166,11 @@ namespace MackySoft.Ucli.Unity.Tests
             cancellationTokenSource.Cancel();
             var request = CreateRequest("op-1", "ucli.resolve");
 
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await AsyncExceptionCapture.CaptureAsync<OperationCanceledException>(async () =>
             {
-                await executor.Execute(PhaseExecutionCommand.Call, request, cancellationTokenSource.Token);
+                await executor.Execute(PhaseExecutionCommand.Call, request, cancellationTokenSource.Token).AsUniTask();
             });
-        }
+        });
 
         private static OperationPhaseExecutor CreateExecutor (IPhaseOperation operation)
         {

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using NUnit.Framework;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class OperationPhaseExecutorTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public async Task Execute_WhenCommandIsPlan_ExecutesValidateAndPlanOnly ()
+        {
+            var operation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(changed: true),
+                callResult: OperationPhaseStepResult.Success(applied: true, changed: true));
+            var executor = CreateExecutor(operation);
+            var request = CreateRequest("op-1", "ucli.resolve");
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Plan, request);
+
+            CollectionAssert.AreEqual(new[] { OperationPhase.Validate, OperationPhase.Plan }, operation.CalledPhases);
+            Assert.That(trace.IsSuccess, Is.True);
+            Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Plan));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task Execute_WhenCommandIsCall_ExecutesValidatePlanAndCall ()
+        {
+            var operation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success(applied: true, changed: true));
+            var executor = CreateExecutor(operation);
+            var request = CreateRequest("op-1", "ucli.resolve");
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+
+            CollectionAssert.AreEqual(new[] { OperationPhase.Validate, OperationPhase.Plan, OperationPhase.Call }, operation.CalledPhases);
+            Assert.That(trace.IsSuccess, Is.True);
+            Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Call));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task Execute_WhenValidateFails_MarksRemainingOperationsAsSkipped ()
+        {
+            var failingOperation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Failed(new OperationFailure(IpcErrorCodes.InvalidArgument, "invalid", "op-1")),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var skippedOperation = new RecordingPhaseOperation(
+                operationName: "ucli.scene.open",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var executor = new OperationPhaseExecutor(new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+            {
+                failingOperation,
+                skippedOperation,
+            }));
+            var request = CreateRequest(
+                ("op-1", "ucli.resolve"),
+                ("op-2", "ucli.scene.open"));
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+
+            Assert.That(trace.IsSuccess, Is.False);
+            Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Validate));
+            Assert.That(trace.OperationTraces[0].Failure, Is.Not.Null);
+            Assert.That(trace.OperationTraces[1].Phase, Is.EqualTo(OperationPhase.Skipped));
+            Assert.That(trace.OperationTraces[1].Applied, Is.False);
+            Assert.That(trace.OperationTraces[1].Changed, Is.False);
+            Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task Execute_WhenPlanFails_MarksRemainingOperationsAsSkipped ()
+        {
+            var failingOperation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Failed(new OperationFailure(IpcErrorCodes.InvalidArgument, "plan failed", "op-1")),
+                callResult: OperationPhaseStepResult.Success());
+            var skippedOperation = new RecordingPhaseOperation(
+                operationName: "ucli.scene.open",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var executor = new OperationPhaseExecutor(new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+            {
+                failingOperation,
+                skippedOperation,
+            }));
+            var request = CreateRequest(
+                ("op-1", "ucli.resolve"),
+                ("op-2", "ucli.scene.open"));
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+
+            Assert.That(trace.IsSuccess, Is.False);
+            Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Plan));
+            Assert.That(trace.OperationTraces[1].Phase, Is.EqualTo(OperationPhase.Skipped));
+            Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task Execute_WhenCallFails_MarksRemainingOperationsAsSkipped ()
+        {
+            var failingOperation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Failed(new OperationFailure(IpcErrorCodes.InvalidArgument, "call failed", "op-1")));
+            var skippedOperation = new RecordingPhaseOperation(
+                operationName: "ucli.scene.open",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var executor = new OperationPhaseExecutor(new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+            {
+                failingOperation,
+                skippedOperation,
+            }));
+            var request = CreateRequest(
+                ("op-1", "ucli.resolve"),
+                ("op-2", "ucli.scene.open"));
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request);
+
+            Assert.That(trace.IsSuccess, Is.False);
+            Assert.That(trace.OperationTraces[0].Phase, Is.EqualTo(OperationPhase.Call));
+            Assert.That(trace.OperationTraces[1].Phase, Is.EqualTo(OperationPhase.Skipped));
+            Assert.That(skippedOperation.CalledPhases.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Execute_WhenCancellationRequested_ThrowsOperationCanceledException ()
+        {
+            var operation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var executor = CreateExecutor(operation);
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+            var request = CreateRequest("op-1", "ucli.resolve");
+
+            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await executor.Execute(PhaseExecutionCommand.Call, request, cancellationTokenSource.Token);
+            });
+        }
+
+        private static OperationPhaseExecutor CreateExecutor (IPhaseOperation operation)
+        {
+            return new OperationPhaseExecutor(new InMemoryPhaseOperationRegistry(new[] { operation }));
+        }
+
+        private static NormalizedExecuteRequest CreateRequest (
+            string opId,
+            string operationName)
+        {
+            return CreateRequest((opId, operationName));
+        }
+
+        private static NormalizedExecuteRequest CreateRequest (params (string OpId, string OperationName)[] operations)
+        {
+            var normalizedOperations = new List<NormalizedOperation>(operations.Length);
+            for (var i = 0; i < operations.Length; i++)
+            {
+                var operation = operations[i];
+                normalizedOperations.Add(new NormalizedOperation(
+                    Id: operation.OpId,
+                    Op: operation.OperationName,
+                    Args: JsonSerializer.SerializeToElement(new { }),
+                    As: null,
+                    Expect: null));
+            }
+
+            return new NormalizedExecuteRequest(
+                ProtocolVersion: IpcProtocol.CurrentVersion,
+                RequestId: "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+                Ops: normalizedOperations,
+                CanonicalDigestPayloadUtf8: Encoding.UTF8.GetBytes("{}"));
+        }
+
+        private sealed class RecordingPhaseOperation : IPhaseOperation
+        {
+            private readonly OperationPhaseStepResult validateResult;
+            private readonly OperationPhaseStepResult planResult;
+            private readonly OperationPhaseStepResult callResult;
+
+            public RecordingPhaseOperation (
+                string operationName,
+                OperationPhaseStepResult validateResult,
+                OperationPhaseStepResult planResult,
+                OperationPhaseStepResult callResult)
+            {
+                OperationName = operationName;
+                this.validateResult = validateResult;
+                this.planResult = planResult;
+                this.callResult = callResult;
+            }
+
+            public string OperationName { get; }
+
+            public List<OperationPhase> CalledPhases { get; } = new List<OperationPhase>();
+
+            public Task<OperationPhaseStepResult> Validate (
+                NormalizedOperation operation,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CalledPhases.Add(OperationPhase.Validate);
+                return Task.FromResult(validateResult);
+            }
+
+            public Task<OperationPhaseStepResult> Plan (
+                NormalizedOperation operation,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CalledPhases.Add(OperationPhase.Plan);
+                return Task.FromResult(planResult);
+            }
+
+            public Task<OperationPhaseStepResult> Call (
+                NormalizedOperation operation,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CalledPhases.Add(OperationPhase.Call);
+                return Task.FromResult(callResult);
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
@@ -18,6 +18,50 @@ namespace MackySoft.Ucli.Unity.Tests
 {
     public sealed class OperationPhaseExecutorTests
     {
+        [Test]
+        [Category("Size.Small")]
+        public void InMemoryRegistry_WhenOperationNameIsDuplicated_ThrowsArgumentException ()
+        {
+            var first = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+            var second = new RecordingPhaseOperation(
+                operationName: "ucli.resolve",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+                {
+                    first,
+                    second,
+                });
+            });
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void InMemoryRegistry_WhenOperationNameContainsOuterWhitespace_ThrowsArgumentException ()
+        {
+            var operation = new RecordingPhaseOperation(
+                operationName: "ucli.resolve ",
+                validateResult: OperationPhaseStepResult.Success(),
+                planResult: OperationPhaseStepResult.Success(),
+                callResult: OperationPhaseStepResult.Success());
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+                {
+                    operation,
+                });
+            });
+        }
+
         [UnityTest]
         [Category("Size.Small")]
         public IEnumerator Execute_WhenCommandIsPlan_ExecutesValidateAndPlanOnly () => UniTask.ToCoroutine(async () =>

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 550a6b1c207cd4ffdbd9c4df1219503b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli/Execution/IPhaseExecutionPreflightService.cs
+++ b/src/Ucli/Execution/IPhaseExecutionPreflightService.cs
@@ -1,0 +1,15 @@
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Executes request preflight for phase-based command execution. </summary>
+internal interface IPhaseExecutionPreflightService
+{
+    /// <summary> Executes preflight and returns a prepared request or structured errors. </summary>
+    /// <param name="requestPath"> The optional request path from <c>--requestPath</c>. </param>
+    /// <param name="projectPath"> The optional Unity project path from <c>--projectPath</c>. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The preflight result. </returns>
+    ValueTask<PhaseExecutionPreflightResult> Prepare (
+        string? requestPath,
+        string? projectPath,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli/Execution/IValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/IValidateRequestJsonParser.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Parses request JSON into a static-validation request model. </summary>
+internal interface IValidateRequestJsonParser
+{
+    /// <summary> Parses request JSON into a validation model. </summary>
+    /// <param name="requestJson"> The raw request JSON string. </param>
+    /// <returns> The parse result. </returns>
+    ValidateRequestJsonParseResult Parse (string requestJson);
+}

--- a/src/Ucli/Execution/PhaseExecutionPreflightResult.cs
+++ b/src/Ucli/Execution/PhaseExecutionPreflightResult.cs
@@ -1,0 +1,65 @@
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Operations;
+
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Represents the result of executing request preflight before phase execution. </summary>
+/// <param name="PreparedRequest"> The prepared request model on success; otherwise <see langword="null" />. </param>
+/// <param name="ValidationErrors"> The static validation errors when validation failed; otherwise an empty collection. </param>
+/// <param name="Error"> The infrastructure error when preflight failed before static validation; otherwise <see langword="null" />. </param>
+internal sealed record PhaseExecutionPreflightResult (
+    PhaseExecutionPreparedRequest? PreparedRequest,
+    IReadOnlyList<ValidationError> ValidationErrors,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether preflight succeeded. </summary>
+    public bool IsSuccess => PreparedRequest is not null && ValidationErrors.Count == 0 && Error is null;
+
+    /// <summary> Gets a value indicating whether preflight failed due to static validation errors. </summary>
+    public bool HasValidationErrors => ValidationErrors.Count > 0 && Error is null;
+
+    /// <summary> Creates a successful preflight result. </summary>
+    /// <param name="preparedRequest"> The prepared request model. </param>
+    /// <returns> The successful preflight result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="preparedRequest" /> is <see langword="null" />. </exception>
+    public static PhaseExecutionPreflightResult Success (PhaseExecutionPreparedRequest preparedRequest)
+    {
+        ArgumentNullException.ThrowIfNull(preparedRequest);
+        return new PhaseExecutionPreflightResult(
+            PreparedRequest: preparedRequest,
+            ValidationErrors: Array.Empty<ValidationError>(),
+            Error: null);
+    }
+
+    /// <summary> Creates a preflight result that failed due to static validation errors. </summary>
+    /// <param name="validationErrors"> The validation errors. </param>
+    /// <returns> The failed preflight result with validation errors. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="validationErrors" /> is <see langword="null" />. </exception>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="validationErrors" /> is empty. </exception>
+    public static PhaseExecutionPreflightResult ValidationFailure (IReadOnlyList<ValidationError> validationErrors)
+    {
+        ArgumentNullException.ThrowIfNull(validationErrors);
+        if (validationErrors.Count == 0)
+        {
+            throw new ArgumentException("Validation errors must not be empty.", nameof(validationErrors));
+        }
+
+        return new PhaseExecutionPreflightResult(
+            PreparedRequest: null,
+            ValidationErrors: validationErrors,
+            Error: null);
+    }
+
+    /// <summary> Creates a failed preflight result with an infrastructure error. </summary>
+    /// <param name="error"> The infrastructure error. </param>
+    /// <returns> The failed preflight result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static PhaseExecutionPreflightResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new PhaseExecutionPreflightResult(
+            PreparedRequest: null,
+            ValidationErrors: Array.Empty<ValidationError>(),
+            Error: error);
+    }
+}

--- a/src/Ucli/Execution/PhaseExecutionPreflightService.cs
+++ b/src/Ucli/Execution/PhaseExecutionPreflightService.cs
@@ -1,0 +1,93 @@
+using MackySoft.Ucli.Cli.Requests;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Operations;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Executes request preflight for phase-based command execution. </summary>
+internal sealed class PhaseExecutionPreflightService : IPhaseExecutionPreflightService
+{
+    private readonly IRequestInputReader requestInputReader;
+    private readonly IValidateRequestJsonParser requestJsonParser;
+    private readonly IUnityProjectResolver unityProjectResolver;
+    private readonly IUcliConfigStore configStore;
+    private readonly IRequestStaticValidator requestStaticValidator;
+
+    /// <summary> Initializes a new instance of the <see cref="PhaseExecutionPreflightService" /> class. </summary>
+    /// <param name="requestInputReader"> The request-input reader dependency. </param>
+    /// <param name="requestJsonParser"> The request-json parser dependency. </param>
+    /// <param name="unityProjectResolver"> The Unity project resolver dependency. </param>
+    /// <param name="configStore"> The config store dependency. </param>
+    /// <param name="requestStaticValidator"> The request static-validator dependency. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
+    public PhaseExecutionPreflightService (
+        IRequestInputReader requestInputReader,
+        IValidateRequestJsonParser requestJsonParser,
+        IUnityProjectResolver unityProjectResolver,
+        IUcliConfigStore configStore,
+        IRequestStaticValidator requestStaticValidator)
+    {
+        this.requestInputReader = requestInputReader ?? throw new ArgumentNullException(nameof(requestInputReader));
+        this.requestJsonParser = requestJsonParser ?? throw new ArgumentNullException(nameof(requestJsonParser));
+        this.unityProjectResolver = unityProjectResolver ?? throw new ArgumentNullException(nameof(unityProjectResolver));
+        this.configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+        this.requestStaticValidator = requestStaticValidator ?? throw new ArgumentNullException(nameof(requestStaticValidator));
+    }
+
+    /// <summary> Executes preflight and returns a prepared request or structured errors. </summary>
+    /// <param name="requestPath"> The optional request path from <c>--requestPath</c>. </param>
+    /// <param name="projectPath"> The optional Unity project path from <c>--projectPath</c>. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The preflight result. </returns>
+    public async ValueTask<PhaseExecutionPreflightResult> Prepare (
+        string? requestPath,
+        string? projectPath,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var inputReadResult = await requestInputReader.ReadAsync(requestPath, cancellationToken).ConfigureAwait(false);
+        if (!inputReadResult.IsSuccess)
+        {
+            return PhaseExecutionPreflightResult.Failure(inputReadResult.Error!);
+        }
+
+        var requestJson = inputReadResult.Json!;
+        var parseResult = requestJsonParser.Parse(requestJson);
+        if (!parseResult.IsSuccess)
+        {
+            return PhaseExecutionPreflightResult.Failure(parseResult.Error!);
+        }
+
+        var unityProjectResult = unityProjectResolver.Resolve(projectPath);
+        if (!unityProjectResult.IsSuccess)
+        {
+            return PhaseExecutionPreflightResult.Failure(unityProjectResult.Error!);
+        }
+
+        var unityProjectContext = unityProjectResult.Context!;
+        var configLoadResult = await configStore.Load(unityProjectContext.UnityProjectRoot, cancellationToken).ConfigureAwait(false);
+        if (!configLoadResult.IsSuccess)
+        {
+            return PhaseExecutionPreflightResult.Failure(configLoadResult.Error!);
+        }
+
+        var request = parseResult.Request!;
+        var config = configLoadResult.Config!;
+        var validationResult = await requestStaticValidator.Validate(request, config, cancellationToken).ConfigureAwait(false);
+        if (!validationResult.IsValid)
+        {
+            return PhaseExecutionPreflightResult.ValidationFailure(validationResult.Errors);
+        }
+
+        var preparedRequest = new PhaseExecutionPreparedRequest(
+            RequestJson: requestJson,
+            InputSource: inputReadResult.Source!.Value,
+            Request: request,
+            UnityProject: unityProjectContext,
+            Config: config,
+            ConfigSource: configLoadResult.Source);
+        return PhaseExecutionPreflightResult.Success(preparedRequest);
+    }
+}

--- a/src/Ucli/Execution/PhaseExecutionPreparedRequest.cs
+++ b/src/Ucli/Execution/PhaseExecutionPreparedRequest.cs
@@ -1,0 +1,21 @@
+using MackySoft.Ucli.Cli.Requests;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Operations;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Represents one preflight-prepared request ready for phase execution. </summary>
+/// <param name="RequestJson"> The raw request JSON string. </param>
+/// <param name="InputSource"> The input source where request JSON was read. </param>
+/// <param name="Request"> The parsed request model used for static validation. </param>
+/// <param name="UnityProject"> The resolved Unity project context. </param>
+/// <param name="Config"> The loaded configuration values. </param>
+/// <param name="ConfigSource"> The config source where <paramref name="Config" /> was resolved. </param>
+internal sealed record PhaseExecutionPreparedRequest (
+    string RequestJson,
+    RequestInputSource InputSource,
+    ValidateRequest Request,
+    ResolvedUnityProjectContext UnityProject,
+    UcliConfig Config,
+    ConfigSource ConfigSource);

--- a/src/Ucli/Execution/ValidateRequestJsonParseResult.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParseResult.cs
@@ -1,0 +1,35 @@
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Operations;
+
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Represents the result of parsing request JSON into <see cref="ValidateRequest" />. </summary>
+/// <param name="Request"> The parsed request model on success; otherwise <see langword="null" />. </param>
+/// <param name="Error"> The parse error on failure; otherwise <see langword="null" />. </param>
+internal sealed record ValidateRequestJsonParseResult (
+    ValidateRequest? Request,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether parsing succeeded. </summary>
+    public bool IsSuccess => Request is not null && Error is null;
+
+    /// <summary> Creates a successful parse result. </summary>
+    /// <param name="request"> The parsed request model. </param>
+    /// <returns> The successful parse result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
+    public static ValidateRequestJsonParseResult Success (ValidateRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new ValidateRequestJsonParseResult(request, null);
+    }
+
+    /// <summary> Creates a failed parse result. </summary>
+    /// <param name="error"> The parse error. </param>
+    /// <returns> The failed parse result. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
+    public static ValidateRequestJsonParseResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new ValidateRequestJsonParseResult(null, error);
+    }
+}

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -29,7 +29,11 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
 
             var protocolVersion = ReadProtocolVersion(document.RootElement);
             var requestId = ReadRequestId(document.RootElement);
-            var operations = ReadOperations(document.RootElement);
+            if (!TryReadOperations(document.RootElement, out var operations, out var operationsError))
+            {
+                return ValidateRequestJsonParseResult.Failure(operationsError!);
+            }
+
             var parsedRequest = new ValidateRequest(
                 ProtocolVersion: protocolVersion,
                 RequestId: requestId,
@@ -75,40 +79,87 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
 
     /// <summary> Reads operation array from request JSON. </summary>
     /// <param name="root"> The request root object. </param>
-    /// <returns> Parsed operation collection, or <see langword="null" /> when unavailable. </returns>
-    private static IReadOnlyList<ValidateRequestOperation?>? ReadOperations (JsonElement root)
+    /// <param name="operations"> Parsed operation collection, or <see langword="null" /> when unavailable. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when operation array is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperations (
+        JsonElement root,
+        out IReadOnlyList<ValidateRequestOperation?>? operations,
+        out ExecutionError? error)
     {
+        error = null;
+
         if (!root.TryGetProperty("ops", out var operationsElement))
         {
-            return null;
+            operations = null;
+            return true;
         }
 
         if (operationsElement.ValueKind != JsonValueKind.Array)
         {
-            return null;
+            operations = null;
+            return true;
         }
 
-        var operations = new List<ValidateRequestOperation?>();
+        var parsedOperations = new List<ValidateRequestOperation?>();
+        var operationIndex = 0;
         foreach (var operationElement in operationsElement.EnumerateArray())
         {
             if (operationElement.ValueKind != JsonValueKind.Object)
             {
-                operations.Add(null);
+                parsedOperations.Add(null);
+                operationIndex++;
                 continue;
             }
 
             var operationId = ReadStringProperty(operationElement, "id");
             var operationName = ReadStringProperty(operationElement, "op");
-            var args = operationElement.TryGetProperty("args", out var argsElement)
-                ? argsElement.Clone()
-                : default;
-            operations.Add(new ValidateRequestOperation(
+            if (!TryReadArgs(operationElement, operationIndex, out var args, out error))
+            {
+                operations = null;
+                return false;
+            }
+
+            parsedOperations.Add(new ValidateRequestOperation(
                 OpId: operationId,
                 Op: operationName,
                 Args: args));
+            operationIndex++;
         }
 
-        return operations;
+        operations = parsedOperations;
+        return true;
+    }
+
+    /// <summary> Reads one operation arguments object from operation JSON. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="args"> The parsed args object. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when args is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadArgs (
+        JsonElement operationElement,
+        int operationIndex,
+        out JsonElement args,
+        out ExecutionError? error)
+    {
+        args = default;
+        error = null;
+
+        if (!operationElement.TryGetProperty("args", out var argsElement))
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'args' is required.");
+            return false;
+        }
+
+        if (argsElement.ValueKind != JsonValueKind.Object)
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'args' must be an object.");
+            return false;
+        }
+
+        args = argsElement.Clone();
+        return true;
     }
 
     /// <summary> Reads one optional string property from an object element. </summary>

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -438,24 +438,6 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         return parsedValue;
     }
 
-    /// <summary> Reads one optional string property from an object element. </summary>
-    /// <param name="element"> The source object element. </param>
-    /// <param name="propertyName"> The property name. </param>
-    /// <returns> The property string value, or <see langword="null" /> when unavailable. </returns>
-    private static string? ReadStringProperty (
-        JsonElement element,
-        string propertyName)
-    {
-        if (!element.TryGetProperty(propertyName, out var propertyElement))
-        {
-            return null;
-        }
-
-        return propertyElement.ValueKind == JsonValueKind.String
-            ? propertyElement.GetString()
-            : null;
-    }
-
     /// <summary> Determines whether value contains leading or trailing whitespace. </summary>
     /// <param name="value"> The source value. </param>
     /// <returns> <see langword="true" /> when leading or trailing whitespace exists; otherwise <see langword="false" />. </returns>

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -25,6 +25,14 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         "expect",
     };
 
+    private static readonly HashSet<string> AllowedExpectationProperties = new(StringComparer.Ordinal)
+    {
+        "nonNull",
+        "count",
+        "min",
+        "max",
+    };
+
     /// <summary> Parses request JSON into a validation model. </summary>
     /// <param name="requestJson"> The raw request JSON string. </param>
     /// <returns> The parse result. </returns>
@@ -145,9 +153,31 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
                 return false;
             }
 
-            var operationId = ReadStringProperty(operationElement, "id");
-            var operationName = ReadStringProperty(operationElement, "op");
+            if (!TryReadOperationStringProperty(operationElement, operationIndex, "id", out var operationId, out error))
+            {
+                operations = null;
+                return false;
+            }
+
+            if (!TryReadOperationStringProperty(operationElement, operationIndex, "op", out var operationName, out error))
+            {
+                operations = null;
+                return false;
+            }
+
             if (!TryReadArgs(operationElement, operationIndex, out var args, out error))
+            {
+                operations = null;
+                return false;
+            }
+
+            if (!TryValidateOperationAlias(operationElement, operationIndex, out error))
+            {
+                operations = null;
+                return false;
+            }
+
+            if (!TryValidateExpectation(operationElement, operationIndex, out error))
             {
                 operations = null;
                 return false;
@@ -195,6 +225,218 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         return true;
     }
 
+    /// <summary> Reads one optional operation string property. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="propertyName"> The property name. </param>
+    /// <param name="value"> The parsed property value, or <see langword="null" /> when missing or non-string. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when property contract is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryReadOperationStringProperty (
+        JsonElement operationElement,
+        int operationIndex,
+        string propertyName,
+        out string? value,
+        out ExecutionError? error)
+    {
+        value = null;
+        error = null;
+
+        if (!operationElement.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return true;
+        }
+
+        if (propertyElement.ValueKind != JsonValueKind.String)
+        {
+            return true;
+        }
+
+        var parsedValue = propertyElement.GetString()!;
+        if (HasOuterWhitespace(parsedValue))
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property '{propertyName}' must not contain leading or trailing whitespace.");
+            return false;
+        }
+
+        value = parsedValue;
+        return true;
+    }
+
+    /// <summary> Validates one optional operation alias property. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when alias contract is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryValidateOperationAlias (
+        JsonElement operationElement,
+        int operationIndex,
+        out ExecutionError? error)
+    {
+        error = null;
+
+        if (!operationElement.TryGetProperty("as", out var aliasElement))
+        {
+            return true;
+        }
+
+        if (aliasElement.ValueKind != JsonValueKind.String)
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'as' must be a string when specified.");
+            return false;
+        }
+
+        var alias = aliasElement.GetString()!;
+        if (string.IsNullOrWhiteSpace(alias) || HasOuterWhitespace(alias))
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'as' must not be empty or contain outer whitespace.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Validates one optional expectation object. </summary>
+    /// <param name="operationElement"> The operation object element. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> <see langword="true" /> when expectation contract is valid; otherwise <see langword="false" />. </returns>
+    private static bool TryValidateExpectation (
+        JsonElement operationElement,
+        int operationIndex,
+        out ExecutionError? error)
+    {
+        error = null;
+        if (!operationElement.TryGetProperty("expect", out var expectationElement))
+        {
+            return true;
+        }
+
+        if (expectationElement.ValueKind != JsonValueKind.Object)
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'expect' must be an object when specified.");
+            return false;
+        }
+
+        var unknownExpectationProperty = FindUnknownProperty(expectationElement, AllowedExpectationProperties);
+        if (unknownExpectationProperty is not null)
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect' contains an unknown property: {unknownExpectationProperty}.");
+            return false;
+        }
+
+        if (!expectationElement.EnumerateObject().MoveNext())
+        {
+            error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} property 'expect' must contain at least one constraint.");
+            return false;
+        }
+
+        var nonNull = TryReadOptionalBooleanConstraint(expectationElement, "nonNull", operationIndex, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var count = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "count", operationIndex, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var min = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "min", operationIndex, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        var max = TryReadOptionalNonNegativeIntegerConstraint(expectationElement, "max", operationIndex, out error);
+        if (error is not null)
+        {
+            return false;
+        }
+
+        if (count.HasValue && (min.HasValue || max.HasValue))
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect' cannot combine 'count' with 'min' or 'max'.");
+            return false;
+        }
+
+        if (min.HasValue && max.HasValue && min.Value > max.Value)
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect' requires 'min' to be less than or equal to 'max'.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary> Reads one optional boolean expectation constraint. </summary>
+    /// <param name="expectationElement"> The expectation object. </param>
+    /// <param name="propertyName"> The property name. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> The parsed value, or <see langword="null" /> when property is absent. </returns>
+    private static bool? TryReadOptionalBooleanConstraint (
+        JsonElement expectationElement,
+        string propertyName,
+        int operationIndex,
+        out ExecutionError? error)
+    {
+        error = null;
+        if (!expectationElement.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return null;
+        }
+
+        if (propertyElement.ValueKind != JsonValueKind.True && propertyElement.ValueKind != JsonValueKind.False)
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect.{propertyName}' must be a boolean.");
+            return null;
+        }
+
+        return propertyElement.GetBoolean();
+    }
+
+    /// <summary> Reads one optional non-negative integer expectation constraint. </summary>
+    /// <param name="expectationElement"> The expectation object. </param>
+    /// <param name="propertyName"> The property name. </param>
+    /// <param name="operationIndex"> The operation index in <c>ops</c>. </param>
+    /// <param name="error"> The parse error on failure. </param>
+    /// <returns> The parsed value, or <see langword="null" /> when property is absent. </returns>
+    private static int? TryReadOptionalNonNegativeIntegerConstraint (
+        JsonElement expectationElement,
+        string propertyName,
+        int operationIndex,
+        out ExecutionError? error)
+    {
+        error = null;
+        if (!expectationElement.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return null;
+        }
+
+        if (propertyElement.ValueKind != JsonValueKind.Number || !propertyElement.TryGetInt32(out var parsedValue))
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect.{propertyName}' must be an integer.");
+            return null;
+        }
+
+        if (parsedValue < 0)
+        {
+            error = ExecutionError.InvalidArgument(
+                $"Operation at index {operationIndex} property 'expect.{propertyName}' must be greater than or equal to 0.");
+            return null;
+        }
+
+        return parsedValue;
+    }
+
     /// <summary> Reads one optional string property from an object element. </summary>
     /// <param name="element"> The source object element. </param>
     /// <param name="propertyName"> The property name. </param>
@@ -211,6 +453,19 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         return propertyElement.ValueKind == JsonValueKind.String
             ? propertyElement.GetString()
             : null;
+    }
+
+    /// <summary> Determines whether value contains leading or trailing whitespace. </summary>
+    /// <param name="value"> The source value. </param>
+    /// <returns> <see langword="true" /> when leading or trailing whitespace exists; otherwise <see langword="false" />. </returns>
+    private static bool HasOuterWhitespace (string value)
+    {
+        if (value.Length == 0)
+        {
+            return false;
+        }
+
+        return char.IsWhiteSpace(value[0]) || char.IsWhiteSpace(value[value.Length - 1]);
     }
 
     /// <summary> Finds one unknown property name in a JSON object. </summary>

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -9,6 +9,13 @@ namespace MackySoft.Ucli.Execution;
 /// <summary> Parses request JSON into <see cref="ValidateRequest" /> values for static validation. </summary>
 internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
 {
+    private static readonly HashSet<string> AllowedRequestProperties = new(StringComparer.Ordinal)
+    {
+        "protocolVersion",
+        "requestId",
+        "ops",
+    };
+
     private static readonly HashSet<string> AllowedOperationProperties = new(StringComparer.Ordinal)
     {
         "id",
@@ -36,6 +43,13 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
             {
                 return ValidateRequestJsonParseResult.Failure(ExecutionError.InvalidArgument(
                     "Request JSON root must be an object."));
+            }
+
+            var unknownRequestProperty = FindUnknownProperty(document.RootElement, AllowedRequestProperties);
+            if (unknownRequestProperty is not null)
+            {
+                return ValidateRequestJsonParseResult.Failure(ExecutionError.InvalidArgument(
+                    $"Request contains an unknown property: {unknownRequestProperty}."));
             }
 
             var protocolVersion = ReadProtocolVersion(document.RootElement);

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -131,7 +131,8 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         if (operationsElement.ValueKind != JsonValueKind.Array)
         {
             operations = null;
-            return true;
+            error = ExecutionError.InvalidArgument("Request property 'ops' must be an array.");
+            return false;
         }
 
         var parsedOperations = new List<ValidateRequestOperation?>();

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using MackySoft.Ucli.Foundation;
 using MackySoft.Ucli.Operations;
@@ -7,6 +9,15 @@ namespace MackySoft.Ucli.Execution;
 /// <summary> Parses request JSON into <see cref="ValidateRequest" /> values for static validation. </summary>
 internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
 {
+    private static readonly HashSet<string> AllowedOperationProperties = new(StringComparer.Ordinal)
+    {
+        "id",
+        "op",
+        "args",
+        "as",
+        "expect",
+    };
+
     /// <summary> Parses request JSON into a validation model. </summary>
     /// <param name="requestJson"> The raw request JSON string. </param>
     /// <returns> The parse result. </returns>
@@ -112,6 +123,14 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
                 continue;
             }
 
+            var unknownOperationProperty = FindUnknownProperty(operationElement, AllowedOperationProperties);
+            if (unknownOperationProperty is not null)
+            {
+                error = ExecutionError.InvalidArgument($"Operation at index {operationIndex} contains an unknown property: {unknownOperationProperty}.");
+                operations = null;
+                return false;
+            }
+
             var operationId = ReadStringProperty(operationElement, "id");
             var operationName = ReadStringProperty(operationElement, "op");
             if (!TryReadArgs(operationElement, operationIndex, out var args, out error))
@@ -178,5 +197,24 @@ internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
         return propertyElement.ValueKind == JsonValueKind.String
             ? propertyElement.GetString()
             : null;
+    }
+
+    /// <summary> Finds one unknown property name in a JSON object. </summary>
+    /// <param name="jsonObject"> The source JSON object. </param>
+    /// <param name="allowedPropertyNames"> The allowed property-name set. </param>
+    /// <returns> The first unknown property name; otherwise <see langword="null" />. </returns>
+    private static string? FindUnknownProperty (
+        JsonElement jsonObject,
+        IReadOnlySet<string> allowedPropertyNames)
+    {
+        foreach (var property in jsonObject.EnumerateObject())
+        {
+            if (!allowedPropertyNames.Contains(property.Name))
+            {
+                return property.Name;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Ucli/Execution/ValidateRequestJsonParser.cs
+++ b/src/Ucli/Execution/ValidateRequestJsonParser.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Operations;
+
+namespace MackySoft.Ucli.Execution;
+
+/// <summary> Parses request JSON into <see cref="ValidateRequest" /> values for static validation. </summary>
+internal sealed class ValidateRequestJsonParser : IValidateRequestJsonParser
+{
+    /// <summary> Parses request JSON into a validation model. </summary>
+    /// <param name="requestJson"> The raw request JSON string. </param>
+    /// <returns> The parse result. </returns>
+    public ValidateRequestJsonParseResult Parse (string requestJson)
+    {
+        if (string.IsNullOrWhiteSpace(requestJson))
+        {
+            return ValidateRequestJsonParseResult.Failure(ExecutionError.InvalidArgument(
+                "Request JSON must not be empty."));
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(requestJson);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return ValidateRequestJsonParseResult.Failure(ExecutionError.InvalidArgument(
+                    "Request JSON root must be an object."));
+            }
+
+            var protocolVersion = ReadProtocolVersion(document.RootElement);
+            var requestId = ReadRequestId(document.RootElement);
+            var operations = ReadOperations(document.RootElement);
+            var parsedRequest = new ValidateRequest(
+                ProtocolVersion: protocolVersion,
+                RequestId: requestId,
+                Ops: operations);
+            return ValidateRequestJsonParseResult.Success(parsedRequest);
+        }
+        catch (JsonException exception)
+        {
+            return ValidateRequestJsonParseResult.Failure(ExecutionError.InvalidArgument(
+                $"Request JSON is invalid. {exception.Message}"));
+        }
+    }
+
+    /// <summary> Reads protocol version from request JSON. </summary>
+    /// <param name="root"> The request root object. </param>
+    /// <returns> The parsed protocol version, or <c>0</c> when unavailable. </returns>
+    private static int ReadProtocolVersion (JsonElement root)
+    {
+        if (!root.TryGetProperty("protocolVersion", out var protocolVersionElement))
+        {
+            return 0;
+        }
+
+        return protocolVersionElement.TryGetInt32(out var protocolVersion)
+            ? protocolVersion
+            : 0;
+    }
+
+    /// <summary> Reads request identifier from request JSON. </summary>
+    /// <param name="root"> The request root object. </param>
+    /// <returns> The request identifier, or <see langword="null" /> when unavailable. </returns>
+    private static string? ReadRequestId (JsonElement root)
+    {
+        if (!root.TryGetProperty("requestId", out var requestIdElement))
+        {
+            return null;
+        }
+
+        return requestIdElement.ValueKind == JsonValueKind.String
+            ? requestIdElement.GetString()
+            : null;
+    }
+
+    /// <summary> Reads operation array from request JSON. </summary>
+    /// <param name="root"> The request root object. </param>
+    /// <returns> Parsed operation collection, or <see langword="null" /> when unavailable. </returns>
+    private static IReadOnlyList<ValidateRequestOperation?>? ReadOperations (JsonElement root)
+    {
+        if (!root.TryGetProperty("ops", out var operationsElement))
+        {
+            return null;
+        }
+
+        if (operationsElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var operations = new List<ValidateRequestOperation?>();
+        foreach (var operationElement in operationsElement.EnumerateArray())
+        {
+            if (operationElement.ValueKind != JsonValueKind.Object)
+            {
+                operations.Add(null);
+                continue;
+            }
+
+            var operationId = ReadStringProperty(operationElement, "id");
+            var operationName = ReadStringProperty(operationElement, "op");
+            var args = operationElement.TryGetProperty("args", out var argsElement)
+                ? argsElement.Clone()
+                : default;
+            operations.Add(new ValidateRequestOperation(
+                OpId: operationId,
+                Op: operationName,
+                Args: args));
+        }
+
+        return operations;
+    }
+
+    /// <summary> Reads one optional string property from an object element. </summary>
+    /// <param name="element"> The source object element. </param>
+    /// <param name="propertyName"> The property name. </param>
+    /// <returns> The property string value, or <see langword="null" /> when unavailable. </returns>
+    private static string? ReadStringProperty (
+        JsonElement element,
+        string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var propertyElement))
+        {
+            return null;
+        }
+
+        return propertyElement.ValueKind == JsonValueKind.String
+            ? propertyElement.GetString()
+            : null;
+    }
+}

--- a/src/Ucli/Operations/RequestStaticValidator.cs
+++ b/src/Ucli/Operations/RequestStaticValidator.cs
@@ -47,11 +47,11 @@ internal sealed class RequestStaticValidator : IRequestStaticValidator
         }
 
         if (string.IsNullOrWhiteSpace(request.RequestId)
-            || !Guid.TryParse(request.RequestId, out _))
+            || !Guid.TryParseExact(request.RequestId, "D", out _))
         {
             errors.Add(new ValidationError(
                 Code: ValidationErrorCodes.RequestIdInvalid,
-                Message: "requestId must be a valid UUID.",
+                Message: "requestId must be UUID format 'D'.",
                 OpId: null));
         }
 

--- a/src/Ucli/Program.cs
+++ b/src/Ucli/Program.cs
@@ -1,7 +1,9 @@
 using ConsoleAppFramework;
 using MackySoft.Ucli.Cli;
+using MackySoft.Ucli.Cli.Requests;
 using MackySoft.Ucli.Configuration;
 using MackySoft.Ucli.Context;
+using MackySoft.Ucli.Execution;
 using MackySoft.Ucli.Init;
 using MackySoft.Ucli.Ipc;
 using MackySoft.Ucli.Operations;
@@ -52,6 +54,9 @@ internal static class Program
                 services.AddSingleton<IOperationCatalog, OperationCatalog>();
                 services.AddSingleton<IOperationAuthorizationService, OperationAuthorizationService>();
                 services.AddSingleton<IRequestStaticValidator, RequestStaticValidator>();
+                services.AddSingleton<IRequestInputReader, RequestInputReader>();
+                services.AddSingleton<IValidateRequestJsonParser, ValidateRequestJsonParser>();
+                services.AddSingleton<IPhaseExecutionPreflightService, PhaseExecutionPreflightService>();
                 services.AddSingleton<ITestProfileInitService, TestProfileInitService>();
             });
         app.UseFilter<OperationCatalogWarmupFilter>();

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -242,6 +242,151 @@ public sealed class PhaseExecutionPreflightServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationIdContainsOuterWhitespace ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "operation-id-outer-whitespace");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": " op-1 ",
+                  "op": "ucli.scene.open",
+                  "args": {}
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("id", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationNameContainsOuterWhitespace ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "operation-name-outer-whitespace");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": " ucli.scene.open ",
+                  "args": {}
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("op", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationAliasContractIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "operation-alias-invalid");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": {},
+                  "as": 123
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("as", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationExpectationContractIsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "operation-expectation-invalid");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": {},
+                  "expect": {
+                    "count": 1,
+                    "min": 0
+                  }
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("expect", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Prepare_ReturnsValidationErrors_WhenStaticValidationFails ()
     {
         using var scope = TestDirectories.CreateTempScope("phase-preflight", "static-validation-fail");

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -170,6 +170,42 @@ public sealed class PhaseExecutionPreflightServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationContainsUnknownProperty ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "operation-unknown-property");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": {},
+                  "unknown": 1
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("unknown", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Prepare_ReturnsValidationErrors_WhenStaticValidationFails ()
     {
         using var scope = TestDirectories.CreateTempScope("phase-preflight", "static-validation-fail");

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -171,6 +171,35 @@ public sealed class PhaseExecutionPreflightServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOpsPropertyIsNotArray ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "ops-invalid-kind");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": {}
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("ops", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Prepare_ReturnsInvalidArgument_WhenOperationArgsPropertyIsNotObject ()
     {
         using var scope = TestDirectories.CreateTempScope("phase-preflight", "args-invalid-kind");

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -101,6 +101,75 @@ public sealed class PhaseExecutionPreflightServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationArgsPropertyIsMissing ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "args-missing");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open"
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("args", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenOperationArgsPropertyIsNotObject ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "args-invalid-kind");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": []
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("args", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Prepare_ReturnsValidationErrors_WhenStaticValidationFails ()
     {
         using var scope = TestDirectories.CreateTempScope("phase-preflight", "static-validation-fail");

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Cli.Requests;
+using MackySoft.Ucli.Configuration;
+using MackySoft.Ucli.Execution;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Operations;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class PhaseExecutionPreflightServiceTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsPreparedRequest_WhenInputIsValid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "success");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": {}
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var preparedRequest = Assert.IsType<PhaseExecutionPreparedRequest>(result.PreparedRequest);
+        Assert.Equal(RequestInputSource.StandardInput, preparedRequest.InputSource);
+        Assert.Equal("9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62", preparedRequest.Request.RequestId);
+        Assert.Equal(unityProjectPath, preparedRequest.UnityProject.UnityProjectRoot);
+        Assert.Empty(result.ValidationErrors);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenRequestPathAndRedirectedStandardInputAreBothProvided ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "input-source-conflict");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var requestInputReader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult("""{"from":"stdin"}"""),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"from":"file"}"""));
+        var service = CreateService(
+            requestInputReader: requestInputReader,
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: "request.json", projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenRequestJsonIsMalformed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "invalid-json");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var requestInputReader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult("{"),
+            readRequestFileAsync: static (_, _) => Task.FromResult("""{"unused":true}"""));
+        var service = CreateService(
+            requestInputReader: requestInputReader,
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsValidationErrors_WhenStaticValidationFails ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "static-validation-fail");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 999,
+              "requestId": "invalid",
+              "ops": [
+                {
+                  "id": "dup",
+                  "op": "ucli.scene.open",
+                  "args": {}
+                },
+                {
+                  "id": "dup",
+                  "op": "ucli.unknown",
+                  "args": {}
+                }
+              ]
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.HasValidationErrors);
+        Assert.Null(result.Error);
+        Assert.True(result.ValidationErrors.Count >= 2);
+        Assert.Contains(result.ValidationErrors, static x => x.Code == ValidationErrorCodes.ProtocolVersionMismatch);
+        Assert.Contains(result.ValidationErrors, static x => x.Code == ValidationErrorCodes.RequestIdInvalid);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Prepare_PropagatesCancellationTokenToDependencies ()
+    {
+        var request = new ValidateRequest(
+            ProtocolVersion: 1,
+            RequestId: "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+            Ops:
+            [
+                new ValidateRequestOperation("op-1", "ucli.scene.open", JsonSerializer.SerializeToElement(new { })),
+            ]);
+        var requestInputReader = new SpyRequestInputReader();
+        var parser = new StubValidateRequestJsonParser(ValidateRequestJsonParseResult.Success(request));
+        var unityProjectResolver = new StubUnityProjectResolver();
+        var configStore = new SpyConfigStore();
+        var validator = new SpyRequestStaticValidator();
+        var service = CreateService(requestInputReader, parser, unityProjectResolver, configStore, validator);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var token = cancellationTokenSource.Token;
+
+        var result = await service.Prepare(requestPath: null, projectPath: null, token);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(token, requestInputReader.ReceivedToken);
+        Assert.Equal(token, configStore.ReceivedToken);
+        Assert.Equal(token, validator.ReceivedToken);
+    }
+
+    private static PhaseExecutionPreflightService CreateService (
+        IRequestInputReader requestInputReader,
+        IValidateRequestJsonParser requestJsonParser,
+        IUnityProjectResolver unityProjectResolver,
+        IUcliConfigStore configStore,
+        IRequestStaticValidator requestStaticValidator)
+    {
+        return new PhaseExecutionPreflightService(
+            requestInputReader,
+            requestJsonParser,
+            unityProjectResolver,
+            configStore,
+            requestStaticValidator);
+    }
+
+    private static IRequestStaticValidator CreateRequestStaticValidator ()
+    {
+        var operationCatalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+        var authorizationService = new OperationAuthorizationService();
+        return new RequestStaticValidator(operationCatalog, authorizationService);
+    }
+
+    private sealed class StubRequestInputReader : IRequestInputReader
+    {
+        private readonly RequestInputReadResult readResult;
+
+        public StubRequestInputReader (RequestInputReadResult readResult)
+        {
+            this.readResult = readResult ?? throw new ArgumentNullException(nameof(readResult));
+        }
+
+        public ValueTask<RequestInputReadResult> ReadAsync (
+            string? requestPath,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(readResult);
+        }
+    }
+
+    private sealed class SpyRequestInputReader : IRequestInputReader
+    {
+        public CancellationToken ReceivedToken { get; private set; }
+
+        public ValueTask<RequestInputReadResult> ReadAsync (
+            string? requestPath,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedToken = cancellationToken;
+            return ValueTask.FromResult(RequestInputReadResult.Success(
+                json: """{"protocolVersion":1,"requestId":"9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62","ops":[{"id":"op-1","op":"ucli.scene.open","args":{}}]}""",
+                source: RequestInputSource.StandardInput));
+        }
+    }
+
+    private sealed class StubValidateRequestJsonParser : IValidateRequestJsonParser
+    {
+        private readonly ValidateRequestJsonParseResult parseResult;
+
+        public StubValidateRequestJsonParser (ValidateRequestJsonParseResult parseResult)
+        {
+            this.parseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
+        }
+
+        public ValidateRequestJsonParseResult Parse (string requestJson)
+        {
+            return parseResult;
+        }
+    }
+
+    private sealed class StubUnityProjectResolver : IUnityProjectResolver
+    {
+        public UnityProjectResolutionResult Resolve (string? projectPath)
+        {
+            return UnityProjectResolutionResult.Success(new ResolvedUnityProjectContext(
+                UnityProjectRoot: "/tmp/project",
+                ProjectFingerprint: "fingerprint",
+                PathSource: UnityProjectPathSource.CommandOption,
+                ConfigPath: "/tmp/project/.ucli/config.json"));
+        }
+    }
+
+    private sealed class SpyConfigStore : IUcliConfigStore
+    {
+        public CancellationToken ReceivedToken { get; private set; }
+
+        public string GetConfigPath (string unityProjectRoot)
+        {
+            return Path.Combine(unityProjectRoot, ".ucli", "config.json");
+        }
+
+        public ValueTask<UcliConfigLoadResult> Load (
+            string unityProjectRoot,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedToken = cancellationToken;
+            return ValueTask.FromResult(UcliConfigLoadResult.Success(UcliConfig.CreateDefault(), ConfigSource.Default));
+        }
+
+        public ValueTask<UcliConfigSaveResult> Save (
+            string unityProjectRoot,
+            UcliConfig config,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class SpyRequestStaticValidator : IRequestStaticValidator
+    {
+        public CancellationToken ReceivedToken { get; private set; }
+
+        public ValueTask<ValidationResult> Validate (
+            ValidateRequest request,
+            UcliConfig config,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedToken = cancellationToken;
+            return ValueTask.FromResult(ValidationResult.Success());
+        }
+    }
+}

--- a/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs
@@ -101,6 +101,42 @@ public sealed class PhaseExecutionPreflightServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Prepare_ReturnsInvalidArgument_WhenRequestContainsUnknownTopLevelProperty ()
+    {
+        using var scope = TestDirectories.CreateTempScope("phase-preflight", "request-unknown-property");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        const string requestJson = """
+            {
+              "protocolVersion": 1,
+              "requestId": "9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62",
+              "ops": [
+                {
+                  "id": "op-1",
+                  "op": "ucli.scene.open",
+                  "args": {}
+                }
+              ],
+              "unknown": 1
+            }
+            """;
+        var service = CreateService(
+            requestInputReader: new StubRequestInputReader(RequestInputReadResult.Success(requestJson, RequestInputSource.StandardInput)),
+            requestJsonParser: new ValidateRequestJsonParser(),
+            unityProjectResolver: new UnityProjectResolver(),
+            configStore: new UcliConfigStore(),
+            requestStaticValidator: CreateRequestStaticValidator());
+
+        var result = await service.Prepare(requestPath: null, projectPath: unityProjectPath, cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.False(result.HasValidationErrors);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains("unknown", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Prepare_ReturnsInvalidArgument_WhenOperationArgsPropertyIsMissing ()
     {
         using var scope = TestDirectories.CreateTempScope("phase-preflight", "args-missing");

--- a/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
@@ -70,6 +70,7 @@ public sealed class IpcContractSerializationTests
     public void IpcErrorCodes_ContainsInvalidArgumentConstant ()
     {
         Assert.Equal("INVALID_ARGUMENT", IpcErrorCodes.InvalidArgument);
+        Assert.Equal("INTERNAL_ERROR", IpcErrorCodes.InternalError);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
+++ b/tests/Ucli.Tests/Operations/RequestStaticValidatorTests.cs
@@ -11,6 +11,7 @@ public sealed class RequestStaticValidatorTests
     {
         { "protocol-version-mismatch", ValidationErrorCodes.ProtocolVersionMismatch },
         { "request-id-invalid", ValidationErrorCodes.RequestIdInvalid },
+        { "request-id-not-canonical-d", ValidationErrorCodes.RequestIdInvalid },
         { "ops-required", ValidationErrorCodes.OpsRequired },
         { "op-id-duplicated", ValidationErrorCodes.OpIdDuplicated },
         { "operation-not-found", ValidationErrorCodes.OperationNotFound },
@@ -95,6 +96,7 @@ public sealed class RequestStaticValidatorTests
         {
             "protocol-version-mismatch" => CreateRequest(protocolVersion: CliProtocol.CurrentVersion + 1),
             "request-id-invalid" => CreateRequest(requestId: "invalid-request-id"),
+            "request-id-not-canonical-d" => CreateRequest(requestId: Guid.NewGuid().ToString("B")),
             "ops-required" => new ValidateRequest(
                 ProtocolVersion: CliProtocol.CurrentVersion,
                 RequestId: Guid.NewGuid().ToString(),


### PR DESCRIPTION
## Summary
- #15 の再設計方針に基づき、`validate -> plan -> call` のフェーズ実行基盤を追加しました。
- Dispatcher は実行主体から調停役へ分離し、ops 実行は `OperationPhaseExecutor` に集約しました。
- CLI 側に preflight 基盤を導入し、入力JSONの解析・静的検証・実行準備を一貫化しました。
- `INTERNAL_ERROR` をエラーコード定数へ集約し、契約テストを更新しました。

## Scope
- CLI preflight
  - `src/Ucli/Execution/*` を追加し、`ValidateRequestJsonParser` / `PhaseExecutionPreflightService` / 結果モデルを実装。
  - `src/Ucli/Program.cs` に preflight サービス登録を追加。
  - `tests/Ucli.Tests/Execution/PhaseExecutionPreflightServiceTests.cs` を追加。
- Unity phase execution core
  - `src/Ucli.Unity/.../Execution/Phases/*` を追加し、phase順序制御・fail-fast・skipped補完・trace収集を実装。
  - `OperationTouchKind` に `Unknown = 0` を追加。
  - `src/Ucli.Unity/.../Tests/.../OperationPhaseExecutorTests.cs` を追加。
- Unity dispatcher
  - `ExecuteDispatchContext` と `ExecuteRequestDispatcher` を追加。
  - `IExecuteRequestDispatcher` を `Dispatch(request, context, token)` へ更新。
  - `plan/call` 委譲、`resolve/query/refresh` の `COMMAND_NOT_IMPLEMENTED` 応答を実装。
  - `src/Ucli.Unity/.../Tests/.../ExecuteRequestDispatcherTests.cs` を追加。
- Contract
  - `src/Ucli.Contracts/Ipc/IpcErrorCodes.cs` に `InternalError` を追加。
  - `tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs` を更新。

## Verification
- Gate level: Standard
- Diff budget: FAIL（29 files, +1980/-2。Medium閾値を超過）
- Spec drift: Skipped（`docs/agents/feature_issue-15-phase-executor-validate-plan-call/spec.md` が存在しないため）
- Format: PASS（`dotnet format tests/Ucli.Tests/Ucli.Tests.csproj --verify-no-changes --include <changed .NET files>`）
- Tests: PASS（`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal --no-restore` -> 130 passed）
- Coverage: N/A

## Risks / Rollback
- Unity EditMode テストは本環境で未実行のため、Unity統合時の回帰リスクが残ります。
- ロールバックはこのPRの4コミットを `git revert` で逆順適用し、`execute` 周辺の新規導入を段階的に戻せます。

## Checklist
- [ ] Unity EditMode テストを `-runTests -testPlatform EditMode -assemblyNames` 指定で実行して結果確認
- [ ] Diff budget 超過に対する対応方針（分割継続 or Split waived）を Issue #15 に明記
- [ ] #16/#19/#20 へ委譲した責務境界がレビュー観点として妥当か確認

Closes #15
