### PR TITLE
chore: release MackySoft.Ucli.Contracts 0.2.1

### DIFF
--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -38,9 +38,9 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
-- タグは `v` プレフィックスを付けない（例: `contracts/0.2.0`）。
+- タグは `v` プレフィックスを付けない（例: `contracts/0.2.1`）。
 
 ```bash
-git tag contracts/0.2.0
-git push origin contracts/0.2.0
+git tag contracts/0.2.1
+git push origin contracts/0.2.1
 ```

--- a/src/Ucli.Contracts/Ucli.Contracts.csproj
+++ b/src/Ucli.Contracts/Ucli.Contracts.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Contracts</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Description>Shared contract types for uCLI IPC protocol.</Description>
     <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;ipc</PackageTags>

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.2.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.2.1" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="netstandard2.0" />
   <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="netstandard2.0" />


### PR DESCRIPTION
## Summary
- `MackySoft.Ucli.Contracts` のパッチバージョンを `0.2.0` から `0.2.1` に更新
- Unity 側 `packages.config` の Contracts 依存バージョンを `0.2.1` に同期
- package release 手順ドキュメントのタグ例を `contracts/0.2.1` に更新

## Verification
- `dotnet restore src/Ucli.Contracts/Ucli.Contracts.csproj`
- `dotnet build src/Ucli.Contracts/Ucli.Contracts.csproj --configuration Release --no-restore`
- `dotnet pack src/Ucli.Contracts/Ucli.Contracts.csproj --configuration Release --no-build --output artifacts/packages`
