### PR TITLE
docs: sync contracts package operation examples to 0.2.2

### DIFF
--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -38,9 +38,9 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
-- タグは `v` プレフィックスを付けない（例: `contracts/0.2.1`）。
+- タグは `v` プレフィックスを付けない（例: `contracts/0.2.2`）。
 
 ```bash
-git tag contracts/0.2.1
-git push origin contracts/0.2.1
+git tag contracts/0.2.2
+git push origin contracts/0.2.2
 ```


### PR DESCRIPTION
## Summary
- Contracts パッケージ更新後のリリース手順ドキュメントを 0.2.2 に同期しました。
- `docs/package-operations.md` のタグ例とコマンド例を最新バージョンへ統一しました。

## Scope
- docs/package-operations.md
  - `contracts/0.2.1` の例示を `contracts/0.2.2` に更新
  - `git tag` / `git push` のサンプルを 0.2.2 に更新

## Verification
- Gate level: Standard
- Diff budget: PASS (1 file, 3 insertions, 3 deletions)
- Spec drift: Skipped (`docs/agents/chore_ucli-contracts-tests-helper/spec.md` not found)
- Format: PASS (`dotnet format Ucli.slnx --verify-no-changes --no-restore`)
- Tests: Skipped (docsのみの変更で受け入れ判定に不要)
- Coverage: Skipped

## Risks / Rollback
- Risk: 実装コード変更は含まないため機能リスクは低い。
- Rollback: commit `fb7816f` を revert すれば元に戻せる。

## Checklist
- [x] docs の版数整合性を確認
- [x] PR差分がドキュメント変更のみであることを確認

Issue: none (ad-hoc task)
