### PR TITLE
refactor: improve JsonAssert cohesion and split assertion tests

### DIFF
--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonAssert.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonAssert.cs
@@ -1,6 +1,5 @@
 namespace MackySoft.Tests;
 
-using System.Text;
 using System.Text.Json;
 using Xunit.Sdk;
 
@@ -14,50 +13,49 @@ internal static class JsonAssert
 
 internal sealed class JsonAssertion
 {
-    private readonly JsonElement root;
-    private readonly string currentPath;
+    private readonly JsonAssertionContext context;
 
     public JsonAssertion (JsonElement root)
-        : this(root, "$")
+        : this(new JsonAssertionContext(root, "$"))
     {
     }
 
-    private JsonAssertion (JsonElement root, string currentPath)
+    private JsonAssertion (JsonAssertionContext context)
     {
-        this.root = root;
-        this.currentPath = currentPath;
+        this.context = context;
     }
 
     public JsonAssertion HasProperty (string propertyName)
     {
-        ResolveOrThrow(propertyName);
+        JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
         return this;
     }
 
     public JsonAssertion HasProperty (string propertyName, Action<JsonAssertion> assertion)
     {
-        var (value, path) = ResolvePropertyNodeOrThrow(propertyName);
-        ApplyNestedAssertion(assertion, value, path);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        ApplyNestedAssertion(assertion, propertyContext);
         return this;
     }
 
     public JsonAssertion HasProperty (string propertyName, int index, Action<JsonAssertion> assertion)
     {
-        var (value, path) = ResolvePropertyNodeOrThrow(propertyName);
-        new JsonAssertion(value, path).HasIndex(index, assertion);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        var indexContext = JsonPathResolver.ResolveIndexOrThrow(propertyContext, index);
+        ApplyNestedAssertion(assertion, indexContext);
         return this;
     }
 
     public JsonAssertion HasIndex (int index)
     {
-        ResolveIndexOrThrow(index);
+        JsonPathResolver.ResolveIndexOrThrow(context, index);
         return this;
     }
 
     public JsonAssertion HasIndex (int index, Action<JsonAssertion> assertion)
     {
-        var (value, path) = ResolveIndexNodeOrThrow(index);
-        ApplyNestedAssertion(assertion, value, path);
+        var indexContext = JsonPathResolver.ResolveIndexOrThrow(context, index);
+        ApplyNestedAssertion(assertion, indexContext);
         return this;
     }
 
@@ -70,7 +68,7 @@ internal sealed class JsonAssertion
 
         foreach (var propertyName in propertyNames)
         {
-            ResolveOrThrow(propertyName);
+            JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
         }
 
         return this;
@@ -78,154 +76,79 @@ internal sealed class JsonAssertion
 
     public JsonAssertion HasValueKind (string propertyName, JsonValueKind expect)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasValueKindValue(BuildDisplayPath(propertyName), value, expect);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertValueKind(propertyContext, expect);
+        return this;
     }
 
     public JsonAssertion HasValueKind (JsonValueKind expect)
     {
-        return HasValueKindValue(currentPath, root, expect);
+        JsonValueAssertion.AssertValueKind(context, expect);
+        return this;
     }
 
     public JsonAssertion HasString (string propertyName, string? expect)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasStringValue(BuildDisplayPath(propertyName), value, expect);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertString(propertyContext, expect);
+        return this;
     }
 
     public JsonAssertion HasString (string? expect)
     {
-        return HasStringValue(currentPath, root, expect);
+        JsonValueAssertion.AssertString(context, expect);
+        return this;
     }
 
     public JsonAssertion HasInt32 (string propertyName, int expect)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasInt32Value(BuildDisplayPath(propertyName), value, expect);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertInt32(propertyContext, expect);
+        return this;
     }
 
     public JsonAssertion HasInt32 (int expect)
     {
-        return HasInt32Value(currentPath, root, expect);
+        JsonValueAssertion.AssertInt32(context, expect);
+        return this;
     }
 
     public JsonAssertion HasBoolean (string propertyName, bool expect)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasBooleanValue(BuildDisplayPath(propertyName), value, expect);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertBoolean(propertyContext, expect);
+        return this;
     }
 
     public JsonAssertion HasBoolean (bool expect)
     {
-        return HasBooleanValue(currentPath, root, expect);
+        JsonValueAssertion.AssertBoolean(context, expect);
+        return this;
     }
 
     public JsonAssertion IsNull (string propertyName)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasNullValue(BuildDisplayPath(propertyName), value);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertNull(propertyContext);
+        return this;
     }
 
     public JsonAssertion IsNull ()
     {
-        return HasNullValue(currentPath, root);
+        JsonValueAssertion.AssertNull(context);
+        return this;
     }
 
     public JsonAssertion HasArrayLength (string propertyName, int expect)
     {
-        var value = ResolveOrThrow(propertyName);
-        return HasArrayLengthValue(BuildDisplayPath(propertyName), value, expect);
+        var propertyContext = JsonPathResolver.ResolvePropertyOrThrow(context, propertyName);
+        JsonValueAssertion.AssertArrayLength(propertyContext, expect);
+        return this;
     }
 
     public JsonAssertion HasArrayLength (int expect)
     {
-        return HasArrayLengthValue(currentPath, root, expect);
-    }
-
-    private JsonAssertion HasValueKindValue (string sourcePath, JsonElement value, JsonValueKind expect)
-    {
-        if (value.ValueKind != expect)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected kind '{expect}' but was '{value.ValueKind}'.");
-        }
-
-        return this;
-    }
-
-    private JsonAssertion HasStringValue (string sourcePath, JsonElement value, string? expect)
-    {
-        if (expect is null)
-        {
-            if (value.ValueKind != JsonValueKind.Null)
-            {
-                throw new XunitException(
-                    $"JSON path '{sourcePath}' expected null but was '{value.ValueKind}'.");
-            }
-
-            return this;
-        }
-
-        if (value.ValueKind != JsonValueKind.String)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected string but was '{value.ValueKind}'.");
-        }
-
-        Assert.Equal(expect, value.GetString());
-        return this;
-    }
-
-    private JsonAssertion HasInt32Value (string sourcePath, JsonElement value, int expect)
-    {
-        if (value.ValueKind != JsonValueKind.Number)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected number but was '{value.ValueKind}'.");
-        }
-
-        if (!value.TryGetInt32(out var actual))
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected Int32-compatible number but was '{value.GetRawText()}'.");
-        }
-
-        Assert.Equal(expect, actual);
-        return this;
-    }
-
-    private JsonAssertion HasBooleanValue (string sourcePath, JsonElement value, bool expect)
-    {
-        if (value.ValueKind != JsonValueKind.True && value.ValueKind != JsonValueKind.False)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected boolean but was '{value.ValueKind}'.");
-        }
-
-        Assert.Equal(expect, value.GetBoolean());
-        return this;
-    }
-
-    private JsonAssertion HasNullValue (string sourcePath, JsonElement value)
-    {
-        if (value.ValueKind != JsonValueKind.Null)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected null but was '{value.ValueKind}'.");
-        }
-
-        return this;
-    }
-
-    private JsonAssertion HasArrayLengthValue (string sourcePath, JsonElement value, int expect)
-    {
-        if (value.ValueKind != JsonValueKind.Array)
-        {
-            throw new XunitException(
-                $"JSON path '{sourcePath}' expected array but was '{value.ValueKind}'.");
-        }
-
-        Assert.Equal(expect, value.GetArrayLength());
+        JsonValueAssertion.AssertArrayLength(context, expect);
         return this;
     }
 
@@ -233,411 +156,21 @@ internal sealed class JsonAssertion
     {
         ArgumentNullException.ThrowIfNull(schema);
 
-        var errors = new List<string>();
-        ValidateAgainstSchema(
-            element: root,
+        var errors = JsonSchemaValidator.Validate(
+            element: context.Value,
             schema: schema,
-            path: currentPath,
-            errors: errors);
-
+            path: context.Path);
         if (errors.Count > 0)
         {
-            var builder = new StringBuilder();
-            if (string.IsNullOrWhiteSpace(schemaName))
-            {
-                builder.Append("JSON schema validation failed.");
-            }
-            else
-            {
-                builder.Append($"JSON schema validation failed. schema={schemaName}");
-            }
-
-            foreach (var error in errors)
-            {
-                builder.AppendLine();
-                builder.Append("- ");
-                builder.Append(error);
-            }
-
-            throw new XunitException(builder.ToString());
+            throw new XunitException(JsonSchemaValidationMessageBuilder.Build(errors, schemaName));
         }
 
         return this;
     }
 
-    private void ApplyNestedAssertion (
-        Action<JsonAssertion> assertion,
-        JsonElement value,
-        string path)
+    private static void ApplyNestedAssertion (Action<JsonAssertion> assertion, JsonAssertionContext nestedContext)
     {
         ArgumentNullException.ThrowIfNull(assertion);
-        assertion(new JsonAssertion(value, path));
-    }
-
-    private (JsonElement Value, string Path) ResolvePropertyNodeOrThrow (string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(propertyName))
-        {
-            throw new XunitException("JSON path must not be null or whitespace.");
-        }
-
-        if (!TryResolvePath(root, propertyName, out var value, out var error))
-        {
-            throw new XunitException($"Failed to resolve JSON path '{BuildDisplayPath(propertyName)}': {error}");
-        }
-
-        return (value, BuildDisplayPath(propertyName));
-    }
-
-    private JsonElement ResolveOrThrow (string propertyName)
-    {
-        return ResolvePropertyNodeOrThrow(propertyName).Value;
-    }
-
-    private JsonElement ResolveIndexOrThrow (int index)
-    {
-        return ResolveIndexNodeOrThrow(index).Value;
-    }
-
-    private (JsonElement Value, string Path) ResolveIndexNodeOrThrow (int index)
-    {
-        if (index < 0)
-        {
-            throw new XunitException("Array index must be non-negative.");
-        }
-
-        if (root.ValueKind != JsonValueKind.Array)
-        {
-            throw new XunitException(
-                $"JSON path '{currentPath}' expected array before index access but was '{root.ValueKind}'.");
-        }
-
-        var length = root.GetArrayLength();
-        if (index >= length)
-        {
-            throw new XunitException(
-                $"JSON path '{currentPath}' array index {index} is out of range. Length is {length}.");
-        }
-
-        return (root[index], $"{currentPath}[{index}]");
-    }
-
-    private string BuildDisplayPath (string propertyPath)
-    {
-        if (string.IsNullOrWhiteSpace(propertyPath))
-        {
-            return currentPath;
-        }
-
-        if (currentPath == "$")
-        {
-            return propertyPath[0] == '[' ? $"${propertyPath}" : $"$.{propertyPath}";
-        }
-
-        return propertyPath[0] == '[' ? $"{currentPath}{propertyPath}" : $"{currentPath}.{propertyPath}";
-    }
-
-    private static bool TryResolvePath (
-        JsonElement root,
-        string path,
-        out JsonElement value,
-        out string error)
-    {
-        value = root;
-        error = string.Empty;
-        var index = 0;
-
-        while (index < path.Length)
-        {
-            if (path[index] == '.')
-            {
-                error = $"Unexpected '.' at index {index}.";
-                return false;
-            }
-
-            if (path[index] == '[')
-            {
-                if (!TryApplyArrayIndex(ref value, path, ref index, out error))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (!TryReadPropertyName(path, ref index, out var propertyName, out error))
-                {
-                    return false;
-                }
-
-                if (value.ValueKind != JsonValueKind.Object)
-                {
-                    error = $"Expected object before property '{propertyName}' but was '{value.ValueKind}'.";
-                    return false;
-                }
-
-                if (!value.TryGetProperty(propertyName, out var child))
-                {
-                    error = $"Property '{propertyName}' was not found.";
-                    return false;
-                }
-
-                value = child;
-
-                while (index < path.Length && path[index] == '[')
-                {
-                    if (!TryApplyArrayIndex(ref value, path, ref index, out error))
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            if (index < path.Length)
-            {
-                if (path[index] != '.')
-                {
-                    error = $"Expected '.' at index {index} but found '{path[index]}'.";
-                    return false;
-                }
-
-                index++;
-                if (index == path.Length)
-                {
-                    error = "Path must not end with '.'.";
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static bool TryReadPropertyName (
-        string path,
-        ref int index,
-        out string propertyName,
-        out string error)
-    {
-        var start = index;
-        while (index < path.Length && path[index] != '.' && path[index] != '[')
-        {
-            index++;
-        }
-
-        if (start == index)
-        {
-            propertyName = string.Empty;
-            error = $"Expected property name at index {index}.";
-            return false;
-        }
-
-        propertyName = path[start..index];
-        error = string.Empty;
-        return true;
-    }
-
-    private static bool TryApplyArrayIndex (
-        ref JsonElement value,
-        string path,
-        ref int index,
-        out string error)
-    {
-        if (value.ValueKind != JsonValueKind.Array)
-        {
-            error = $"Expected array before index access but was '{value.ValueKind}'.";
-            return false;
-        }
-
-        index++;
-        var start = index;
-
-        while (index < path.Length && char.IsDigit(path[index]))
-        {
-            index++;
-        }
-
-        if (start == index)
-        {
-            error = $"Array index was not specified at index {start}.";
-            return false;
-        }
-
-        if (index >= path.Length || path[index] != ']')
-        {
-            error = $"Expected ']' after array index at index {index}.";
-            return false;
-        }
-
-        if (!int.TryParse(path[start..index], out var arrayIndex))
-        {
-            error = $"Array index '{path[start..index]}' is not a valid Int32.";
-            return false;
-        }
-
-        var length = value.GetArrayLength();
-        if (arrayIndex < 0 || arrayIndex >= length)
-        {
-            error = $"Array index {arrayIndex} is out of range. Length is {length}.";
-            return false;
-        }
-
-        value = value[arrayIndex];
-        index++;
-        error = string.Empty;
-        return true;
-    }
-
-    private static void ValidateAgainstSchema (
-        JsonElement element,
-        JsonSchemaNode schema,
-        string path,
-        List<string> errors)
-    {
-        if (schema.Types is null || schema.Types.Count == 0)
-        {
-            errors.Add($"path '{path}' has an invalid schema definition: no allowed types.");
-            return;
-        }
-
-        if (!MatchesAnyType(element, schema.Types))
-        {
-            errors.Add(
-                $"path '{path}' expected {FormatExpectedTypes(schema.Types)} but was {DescribeActualType(element)}.");
-            return;
-        }
-
-        if (HasType(schema.Types, JsonSchemaType.Object) && element.ValueKind == JsonValueKind.Object)
-        {
-            ValidateObject(element, schema, path, errors);
-        }
-
-        if (HasType(schema.Types, JsonSchemaType.Array) && element.ValueKind == JsonValueKind.Array)
-        {
-            ValidateArray(element, schema, path, errors);
-        }
-    }
-
-    private static void ValidateObject (
-        JsonElement element,
-        JsonSchemaNode schema,
-        string path,
-        List<string> errors)
-    {
-        var schemaProperties = schema.Properties ?? new Dictionary<string, JsonSchemaProperty>();
-
-        foreach (var (propertyName, propertySchema) in schemaProperties)
-        {
-            if (!element.TryGetProperty(propertyName, out var propertyValue))
-            {
-                if (propertySchema.Required)
-                {
-                    errors.Add($"path '{BuildPropertyPath(path, propertyName)}' is missing.");
-                }
-
-                continue;
-            }
-
-            ValidateAgainstSchema(
-                element: propertyValue,
-                schema: propertySchema.Schema,
-                path: BuildPropertyPath(path, propertyName),
-                errors: errors);
-        }
-
-        if (!schema.AllowAdditionalProperties)
-        {
-            foreach (var property in element.EnumerateObject())
-            {
-                if (!schemaProperties.ContainsKey(property.Name))
-                {
-                    errors.Add(
-                        $"path '{BuildPropertyPath(path, property.Name)}' is not allowed by schema.");
-                }
-            }
-        }
-    }
-
-    private static void ValidateArray (
-        JsonElement element,
-        JsonSchemaNode schema,
-        string path,
-        List<string> errors)
-    {
-        if (schema.ItemSchema is null)
-        {
-            errors.Add($"path '{path}' has an invalid schema definition: item schema is missing.");
-            return;
-        }
-
-        var index = 0;
-        foreach (var item in element.EnumerateArray())
-        {
-            ValidateAgainstSchema(
-                element: item,
-                schema: schema.ItemSchema,
-                path: $"{path}[{index}]",
-                errors: errors);
-            index++;
-        }
-    }
-
-    private static bool MatchesAnyType (JsonElement element, IReadOnlyList<JsonSchemaType> allowedTypes)
-    {
-        foreach (var allowedType in allowedTypes)
-        {
-            if (MatchesType(element, allowedType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool MatchesType (JsonElement element, JsonSchemaType allowedType)
-    {
-        return allowedType switch
-        {
-            JsonSchemaType.Object => element.ValueKind == JsonValueKind.Object,
-            JsonSchemaType.Array => element.ValueKind == JsonValueKind.Array,
-            JsonSchemaType.String => element.ValueKind == JsonValueKind.String,
-            JsonSchemaType.Int32 => element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out _),
-            JsonSchemaType.Boolean => element.ValueKind == JsonValueKind.True || element.ValueKind == JsonValueKind.False,
-            JsonSchemaType.Null => element.ValueKind == JsonValueKind.Null,
-            _ => false,
-        };
-    }
-
-    private static bool HasType (IReadOnlyList<JsonSchemaType> allowedTypes, JsonSchemaType type)
-    {
-        foreach (var allowedType in allowedTypes)
-        {
-            if (allowedType == type)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static string FormatExpectedTypes (IReadOnlyList<JsonSchemaType> allowedTypes)
-    {
-        return "one of [" + string.Join(", ", allowedTypes.Select(static x => x.ToString())) + "]";
-    }
-
-    private static string DescribeActualType (JsonElement element)
-    {
-        if (element.ValueKind == JsonValueKind.Number && !element.TryGetInt32(out _))
-        {
-            return "Number(non-Int32)";
-        }
-
-        return element.ValueKind.ToString();
-    }
-
-    private static string BuildPropertyPath (string parentPath, string propertyName)
-    {
-        return $"{parentPath}.{propertyName}";
+        assertion(new JsonAssertion(nestedContext));
     }
 }

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonAssertionContext.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonAssertionContext.cs
@@ -1,0 +1,21 @@
+namespace MackySoft.Tests;
+
+using System.Text.Json;
+
+internal readonly struct JsonAssertionContext
+{
+    public JsonAssertionContext (JsonElement value, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("JSON path must not be null or whitespace.", nameof(path));
+        }
+
+        Value = value;
+        Path = path;
+    }
+
+    public JsonElement Value { get; }
+
+    public string Path { get; }
+}

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonPathResolver.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonPathResolver.cs
@@ -1,0 +1,211 @@
+namespace MackySoft.Tests;
+
+using System.Text.Json;
+using Xunit.Sdk;
+
+internal static class JsonPathResolver
+{
+    public static JsonAssertionContext ResolvePropertyOrThrow (JsonAssertionContext context, string propertyPath)
+    {
+        if (string.IsNullOrWhiteSpace(propertyPath))
+        {
+            throw new XunitException("JSON path must not be null or whitespace.");
+        }
+
+        var displayPath = BuildDisplayPath(context.Path, propertyPath);
+        if (!TryResolvePath(context.Value, propertyPath, out var value, out var error))
+        {
+            throw new XunitException($"Failed to resolve JSON path '{displayPath}': {error}");
+        }
+
+        return new JsonAssertionContext(value, displayPath);
+    }
+
+    public static JsonAssertionContext ResolveIndexOrThrow (JsonAssertionContext context, int index)
+    {
+        if (index < 0)
+        {
+            throw new XunitException("Array index must be non-negative.");
+        }
+
+        if (context.Value.ValueKind != JsonValueKind.Array)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected array before index access but was '{context.Value.ValueKind}'.");
+        }
+
+        var length = context.Value.GetArrayLength();
+        if (index >= length)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' array index {index} is out of range. Length is {length}.");
+        }
+
+        return new JsonAssertionContext(context.Value[index], $"{context.Path}[{index}]");
+    }
+
+    private static string BuildDisplayPath (string currentPath, string propertyPath)
+    {
+        if (string.IsNullOrWhiteSpace(propertyPath))
+        {
+            return currentPath;
+        }
+
+        if (currentPath == "$")
+        {
+            return propertyPath[0] == '[' ? $"${propertyPath}" : $"$.{propertyPath}";
+        }
+
+        return propertyPath[0] == '[' ? $"{currentPath}{propertyPath}" : $"{currentPath}.{propertyPath}";
+    }
+
+    private static bool TryResolvePath (
+        JsonElement root,
+        string path,
+        out JsonElement value,
+        out string error)
+    {
+        value = root;
+        error = string.Empty;
+        var index = 0;
+
+        while (index < path.Length)
+        {
+            if (path[index] == '.')
+            {
+                error = $"Unexpected '.' at index {index}.";
+                return false;
+            }
+
+            if (path[index] == '[')
+            {
+                if (!TryApplyArrayIndex(ref value, path, ref index, out error))
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!TryReadPropertyName(path, ref index, out var propertyName, out error))
+                {
+                    return false;
+                }
+
+                if (value.ValueKind != JsonValueKind.Object)
+                {
+                    error = $"Expected object before property '{propertyName}' but was '{value.ValueKind}'.";
+                    return false;
+                }
+
+                if (!value.TryGetProperty(propertyName, out var child))
+                {
+                    error = $"Property '{propertyName}' was not found.";
+                    return false;
+                }
+
+                value = child;
+
+                while (index < path.Length && path[index] == '[')
+                {
+                    if (!TryApplyArrayIndex(ref value, path, ref index, out error))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (index < path.Length)
+            {
+                if (path[index] != '.')
+                {
+                    error = $"Expected '.' at index {index} but found '{path[index]}'.";
+                    return false;
+                }
+
+                index++;
+                if (index == path.Length)
+                {
+                    error = "Path must not end with '.'.";
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadPropertyName (
+        string path,
+        ref int index,
+        out string propertyName,
+        out string error)
+    {
+        var start = index;
+        while (index < path.Length && path[index] != '.' && path[index] != '[')
+        {
+            index++;
+        }
+
+        if (start == index)
+        {
+            propertyName = string.Empty;
+            error = $"Expected property name at index {index}.";
+            return false;
+        }
+
+        propertyName = path[start..index];
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryApplyArrayIndex (
+        ref JsonElement value,
+        string path,
+        ref int index,
+        out string error)
+    {
+        if (value.ValueKind != JsonValueKind.Array)
+        {
+            error = $"Expected array before index access but was '{value.ValueKind}'.";
+            return false;
+        }
+
+        index++;
+        var start = index;
+
+        while (index < path.Length && char.IsDigit(path[index]))
+        {
+            index++;
+        }
+
+        if (start == index)
+        {
+            error = $"Array index was not specified at index {start}.";
+            return false;
+        }
+
+        if (index >= path.Length || path[index] != ']')
+        {
+            error = $"Expected ']' after array index at index {index}.";
+            return false;
+        }
+
+        if (!int.TryParse(path[start..index], out var arrayIndex))
+        {
+            error = $"Array index '{path[start..index]}' is not a valid Int32.";
+            return false;
+        }
+
+        var length = value.GetArrayLength();
+        if (arrayIndex < 0 || arrayIndex >= length)
+        {
+            error = $"Array index {arrayIndex} is out of range. Length is {length}.";
+            return false;
+        }
+
+        value = value[arrayIndex];
+        index++;
+        error = string.Empty;
+        return true;
+    }
+}

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaValidationMessageBuilder.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaValidationMessageBuilder.cs
@@ -1,0 +1,30 @@
+namespace MackySoft.Tests;
+
+using System.Text;
+
+internal static class JsonSchemaValidationMessageBuilder
+{
+    public static string Build (IReadOnlyList<string> errors, string? schemaName)
+    {
+        ArgumentNullException.ThrowIfNull(errors);
+
+        var builder = new StringBuilder();
+        if (string.IsNullOrWhiteSpace(schemaName))
+        {
+            builder.Append("JSON schema validation failed.");
+        }
+        else
+        {
+            builder.Append($"JSON schema validation failed. schema={schemaName}");
+        }
+
+        foreach (var error in errors)
+        {
+            builder.AppendLine();
+            builder.Append("- ");
+            builder.Append(error);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaValidator.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaValidator.cs
@@ -1,0 +1,176 @@
+namespace MackySoft.Tests;
+
+using System.Text.Json;
+
+internal static class JsonSchemaValidator
+{
+    private static readonly IReadOnlyDictionary<string, JsonSchemaProperty> EmptyProperties =
+        new Dictionary<string, JsonSchemaProperty>();
+
+    public static IReadOnlyList<string> Validate (JsonElement element, JsonSchemaNode schema, string path)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+
+        var errors = new List<string>();
+        ValidateAgainstSchema(
+            element: element,
+            schema: schema,
+            path: path,
+            errors: errors);
+        return errors;
+    }
+
+    private static void ValidateAgainstSchema (
+        JsonElement element,
+        JsonSchemaNode schema,
+        string path,
+        List<string> errors)
+    {
+        if (schema.Types is null || schema.Types.Count == 0)
+        {
+            errors.Add($"path '{path}' has an invalid schema definition: no allowed types.");
+            return;
+        }
+
+        if (!MatchesAnyType(element, schema.Types))
+        {
+            errors.Add(
+                $"path '{path}' expected {FormatExpectedTypes(schema.Types)} but was {DescribeActualType(element)}.");
+            return;
+        }
+
+        if (HasType(schema.Types, JsonSchemaType.Object) && element.ValueKind == JsonValueKind.Object)
+        {
+            ValidateObject(element, schema, path, errors);
+        }
+
+        if (HasType(schema.Types, JsonSchemaType.Array) && element.ValueKind == JsonValueKind.Array)
+        {
+            ValidateArray(element, schema, path, errors);
+        }
+    }
+
+    private static void ValidateObject (
+        JsonElement element,
+        JsonSchemaNode schema,
+        string path,
+        List<string> errors)
+    {
+        var schemaProperties = schema.Properties ?? EmptyProperties;
+
+        foreach (var (propertyName, propertySchema) in schemaProperties)
+        {
+            if (!element.TryGetProperty(propertyName, out var propertyValue))
+            {
+                if (propertySchema.Required)
+                {
+                    errors.Add($"path '{BuildPropertyPath(path, propertyName)}' is missing.");
+                }
+
+                continue;
+            }
+
+            ValidateAgainstSchema(
+                element: propertyValue,
+                schema: propertySchema.Schema,
+                path: BuildPropertyPath(path, propertyName),
+                errors: errors);
+        }
+
+        if (!schema.AllowAdditionalProperties)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!schemaProperties.ContainsKey(property.Name))
+                {
+                    errors.Add(
+                        $"path '{BuildPropertyPath(path, property.Name)}' is not allowed by schema.");
+                }
+            }
+        }
+    }
+
+    private static void ValidateArray (
+        JsonElement element,
+        JsonSchemaNode schema,
+        string path,
+        List<string> errors)
+    {
+        if (schema.ItemSchema is null)
+        {
+            errors.Add($"path '{path}' has an invalid schema definition: item schema is missing.");
+            return;
+        }
+
+        var index = 0;
+        foreach (var item in element.EnumerateArray())
+        {
+            ValidateAgainstSchema(
+                element: item,
+                schema: schema.ItemSchema,
+                path: $"{path}[{index}]",
+                errors: errors);
+            index++;
+        }
+    }
+
+    private static bool MatchesAnyType (JsonElement element, IReadOnlyList<JsonSchemaType> allowedTypes)
+    {
+        foreach (var allowedType in allowedTypes)
+        {
+            if (MatchesType(element, allowedType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesType (JsonElement element, JsonSchemaType allowedType)
+    {
+        return allowedType switch
+        {
+            JsonSchemaType.Object => element.ValueKind == JsonValueKind.Object,
+            JsonSchemaType.Array => element.ValueKind == JsonValueKind.Array,
+            JsonSchemaType.String => element.ValueKind == JsonValueKind.String,
+            JsonSchemaType.Int32 => element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out _),
+            JsonSchemaType.Boolean => element.ValueKind == JsonValueKind.True || element.ValueKind == JsonValueKind.False,
+            JsonSchemaType.Null => element.ValueKind == JsonValueKind.Null,
+            _ => false,
+        };
+    }
+
+    private static bool HasType (IReadOnlyList<JsonSchemaType> allowedTypes, JsonSchemaType type)
+    {
+        foreach (var allowedType in allowedTypes)
+        {
+            if (allowedType == type)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string FormatExpectedTypes (IReadOnlyList<JsonSchemaType> allowedTypes)
+    {
+        return "one of [" + string.Join(", ", allowedTypes.Select(static x => x.ToString())) + "]";
+    }
+
+    private static string DescribeActualType (JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Number && !element.TryGetInt32(out _))
+        {
+            return "Number(non-Int32)";
+        }
+
+        return element.ValueKind.ToString();
+    }
+
+    private static string BuildPropertyPath (string parentPath, string propertyName)
+    {
+        return $"{parentPath}.{propertyName}";
+    }
+}

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonValueAssertion.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonValueAssertion.cs
@@ -1,0 +1,86 @@
+namespace MackySoft.Tests;
+
+using System.Text.Json;
+using Xunit.Sdk;
+
+internal static class JsonValueAssertion
+{
+    public static void AssertValueKind (JsonAssertionContext context, JsonValueKind expect)
+    {
+        if (context.Value.ValueKind != expect)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected kind '{expect}' but was '{context.Value.ValueKind}'.");
+        }
+    }
+
+    public static void AssertString (JsonAssertionContext context, string? expect)
+    {
+        if (expect is null)
+        {
+            if (context.Value.ValueKind != JsonValueKind.Null)
+            {
+                throw new XunitException(
+                    $"JSON path '{context.Path}' expected null but was '{context.Value.ValueKind}'.");
+            }
+
+            return;
+        }
+
+        if (context.Value.ValueKind != JsonValueKind.String)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected string but was '{context.Value.ValueKind}'.");
+        }
+
+        Assert.Equal(expect, context.Value.GetString());
+    }
+
+    public static void AssertInt32 (JsonAssertionContext context, int expect)
+    {
+        if (context.Value.ValueKind != JsonValueKind.Number)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected number but was '{context.Value.ValueKind}'.");
+        }
+
+        if (!context.Value.TryGetInt32(out var actual))
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected Int32-compatible number but was '{context.Value.GetRawText()}'.");
+        }
+
+        Assert.Equal(expect, actual);
+    }
+
+    public static void AssertBoolean (JsonAssertionContext context, bool expect)
+    {
+        if (context.Value.ValueKind != JsonValueKind.True && context.Value.ValueKind != JsonValueKind.False)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected boolean but was '{context.Value.ValueKind}'.");
+        }
+
+        Assert.Equal(expect, context.Value.GetBoolean());
+    }
+
+    public static void AssertNull (JsonAssertionContext context)
+    {
+        if (context.Value.ValueKind != JsonValueKind.Null)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected null but was '{context.Value.ValueKind}'.");
+        }
+    }
+
+    public static void AssertArrayLength (JsonAssertionContext context, int expect)
+    {
+        if (context.Value.ValueKind != JsonValueKind.Array)
+        {
+            throw new XunitException(
+                $"JSON path '{context.Path}' expected array but was '{context.Value.ValueKind}'.");
+        }
+
+        Assert.Equal(expect, context.Value.GetArrayLength());
+    }
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssertTests.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssertTests.cs
@@ -10,10 +10,9 @@ public sealed class JsonAssertTests
     [Trait("Size", "Small")]
     public void For_CanAssertNestedPropertiesAndArrayIndices ()
     {
-        using var document = CreateSampleDocument();
-        var assertion = JsonAssert.For(document.RootElement);
+        using var document = JsonAssertionTestData.CreateSampleDocument();
 
-        assertion
+        JsonAssert.For(document.RootElement)
             .HasString("status", "pass")
             .IsNull("errorKind")
             .HasInt32("exitCode", 0)
@@ -29,7 +28,7 @@ public sealed class JsonAssertTests
     [Trait("Size", "Small")]
     public void HasProperty_Throws_WhenPathCannotBeResolved ()
     {
-        using var document = CreateSampleDocument();
+        using var document = JsonAssertionTestData.CreateSampleDocument();
 
         var exception = Assert.Throws<XunitException>(
             () => JsonAssert.For(document.RootElement).HasProperty("counts.missing"));
@@ -39,206 +38,52 @@ public sealed class JsonAssertTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void HasString_Throws_WhenPathSyntaxIsInvalid ()
+    public void HasProperties_Throws_WhenNoPropertyPathIsProvided ()
     {
-        using var document = CreateSampleDocument();
+        using var document = JsonAssertionTestData.CreateSampleDocument();
 
         var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement).HasString("tests[].fullName", "Cafe.Tests.Pass"));
+            () => JsonAssert.For(document.RootElement).HasProperties());
 
-        Assert.Contains("Array index was not specified", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("At least one property path is required.", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     [Trait("Size", "Small")]
-    public void HasString_Throws_WhenPathIndexIsOutOfRange ()
+    public void HasInt32_Throws_WhenValueIsNotInt32CompatibleNumber ()
     {
-        using var document = CreateSampleDocument();
+        using var document = JsonDocument.Parse("""{"exitCode": 1.5}""");
 
         var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement).HasString("tests[2].fullName", "Cafe.Tests.Unknown"));
+            () => JsonAssert.For(document.RootElement).HasInt32("exitCode", 1));
 
-        Assert.Contains("tests[2]", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("out of range", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public void HasProperty_WithIndex_Throws_WhenArrayIndexIsOutOfRange ()
-    {
-        using var document = CreateSampleDocument();
-
-        var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement)
-                .HasProperty("tests", 2, static test => test.HasString("fullName", "Cafe.Tests.Unknown")));
-
-        Assert.Contains("$.tests", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("out of range", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Int32-compatible number", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     [Trait("Size", "Small")]
     public void MatchesSchema_Succeeds_WhenAllRequiredNamesAndTypesMatch ()
     {
-        using var document = CreateSampleDocument();
+        using var document = JsonAssertionTestData.CreateSampleDocument();
 
-        JsonAssert.For(document.RootElement).MatchesSchema(CreateSampleSchema(), "sampleSchema");
+        JsonAssert.For(document.RootElement).MatchesSchema(JsonAssertionTestData.CreateSampleSchema(), "sampleSchema");
     }
 
     [Fact]
     [Trait("Size", "Small")]
-    public void MatchesSchema_Throws_WhenRequiredPropertyIsMissing ()
+    public void MatchesSchema_Throws_WithSchemaNameAndBulletList ()
     {
         using var document = JsonDocument.Parse(
             """
             {
-              "status": "pass",
-              "exitCode": 0,
-              "counts": {
-                "passed": 10,
-                "failed": 1
-              },
-              "flags": {
-                "hasRetries": true
-              },
-              "tests": [
-                {
-                  "fullName": "Cafe.Tests.Pass"
-                }
-              ]
+              "status": "pass"
             }
             """);
 
         var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement).MatchesSchema(CreateSampleSchema(), "sampleSchema"));
+            () => JsonAssert.For(document.RootElement).MatchesSchema(JsonAssertionTestData.CreateSampleSchema(), "sampleSchema"));
 
-        Assert.Contains("$.errorKind", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("is missing", exception.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public void MatchesSchema_Throws_WhenPropertyTypeDoesNotMatch ()
-    {
-        using var document = JsonDocument.Parse(
-            """
-            {
-              "status": "pass",
-              "errorKind": null,
-              "exitCode": 1.5,
-              "counts": {
-                "passed": 10,
-                "failed": 1
-              },
-              "flags": {
-                "hasRetries": true
-              },
-              "tests": [
-                {
-                  "fullName": "Cafe.Tests.Pass"
-                }
-              ]
-            }
-            """);
-
-        var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement).MatchesSchema(CreateSampleSchema(), "sampleSchema"));
-
-        Assert.Contains("$.exitCode", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Int32", exception.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public void MatchesSchema_Throws_WhenArrayItemTypeDoesNotMatch ()
-    {
-        using var document = JsonDocument.Parse(
-            """
-            {
-              "status": "pass",
-              "errorKind": null,
-              "exitCode": 0,
-              "counts": {
-                "passed": 10,
-                "failed": 1
-              },
-              "flags": {
-                "hasRetries": true
-              },
-              "tests": [
-                {
-                  "fullName": "Cafe.Tests.Pass"
-                },
-                {
-                  "fullName": 42
-                }
-              ]
-            }
-            """);
-
-        var exception = Assert.Throws<XunitException>(
-            () => JsonAssert.For(document.RootElement).MatchesSchema(CreateSampleSchema(), "sampleSchema"));
-
-        Assert.Contains("$.tests[1].fullName", exception.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public void MatchesSchema_AllowsAdditionalProperties_ByDefault ()
-    {
-        using var document = CreateSampleDocument();
-        var schema = JsonSchemaNode.Object(
-            static root => root.Required("status", JsonSchemaNode.Value(JsonSchemaType.String)));
-
-        JsonAssert.For(document.RootElement).MatchesSchema(schema, "statusOnly");
-    }
-
-    private static JsonDocument CreateSampleDocument ()
-    {
-        return JsonDocument.Parse(
-            """
-            {
-              "status": "pass",
-              "errorKind": null,
-              "exitCode": 0,
-              "counts": {
-                "passed": 10,
-                "failed": 1
-              },
-              "flags": {
-                "hasRetries": true
-              },
-              "tests": [
-                {
-                  "fullName": "Cafe.Tests.Pass"
-                },
-                {
-                  "fullName": "Cafe.Tests.Fail"
-                }
-              ]
-            }
-            """);
-    }
-
-    private static JsonSchemaNode CreateSampleSchema ()
-    {
-        return JsonSchemaNode.Object(
-            static root => root
-                .Required("status", JsonSchemaNode.Value(JsonSchemaType.String))
-                .Required("errorKind", JsonSchemaNode.Union(JsonSchemaType.String, JsonSchemaType.Null))
-                .Required("exitCode", JsonSchemaNode.Value(JsonSchemaType.Int32))
-                .RequiredObject(
-                    "counts",
-                    static counts => counts
-                        .Required("passed", JsonSchemaNode.Value(JsonSchemaType.Int32))
-                        .Required("failed", JsonSchemaNode.Value(JsonSchemaType.Int32)))
-                .RequiredObject(
-                    "flags",
-                    static flags => flags
-                        .Required("hasRetries", JsonSchemaNode.Value(JsonSchemaType.Boolean)))
-                .RequiredArrayOfObject(
-                    "tests",
-                    static tests => tests
-                        .Required("fullName", JsonSchemaNode.Value(JsonSchemaType.String))));
+        Assert.StartsWith("JSON schema validation failed. schema=sampleSchema", exception.Message, StringComparison.Ordinal);
+        Assert.Contains($"{Environment.NewLine}- path '$.errorKind' is missing.", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssertionTestData.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonAssertionTestData.cs
@@ -1,0 +1,56 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Tests;
+
+internal static class JsonAssertionTestData
+{
+    public static JsonDocument CreateSampleDocument ()
+    {
+        return JsonDocument.Parse(
+            """
+            {
+              "status": "pass",
+              "errorKind": null,
+              "exitCode": 0,
+              "counts": {
+                "passed": 10,
+                "failed": 1
+              },
+              "flags": {
+                "hasRetries": true
+              },
+              "tests": [
+                {
+                  "fullName": "Cafe.Tests.Pass"
+                },
+                {
+                  "fullName": "Cafe.Tests.Fail"
+                }
+              ]
+            }
+            """);
+    }
+
+    public static JsonSchemaNode CreateSampleSchema ()
+    {
+        return JsonSchemaNode.Object(
+            static root => root
+                .Required("status", JsonSchemaNode.Value(JsonSchemaType.String))
+                .Required("errorKind", JsonSchemaNode.Union(JsonSchemaType.String, JsonSchemaType.Null))
+                .Required("exitCode", JsonSchemaNode.Value(JsonSchemaType.Int32))
+                .RequiredObject(
+                    "counts",
+                    static counts => counts
+                        .Required("passed", JsonSchemaNode.Value(JsonSchemaType.Int32))
+                        .Required("failed", JsonSchemaNode.Value(JsonSchemaType.Int32)))
+                .RequiredObject(
+                    "flags",
+                    static flags => flags
+                        .Required("hasRetries", JsonSchemaNode.Value(JsonSchemaType.Boolean)))
+                .RequiredArrayOfObject(
+                    "tests",
+                    static tests => tests
+                        .Required("fullName", JsonSchemaNode.Value(JsonSchemaType.String))));
+    }
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonPathResolverTests.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonPathResolverTests.cs
@@ -1,0 +1,95 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Tests;
+using Xunit.Sdk;
+
+public sealed class JsonPathResolverTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolvePropertyOrThrow_ReturnsResolvedContext_ForNestedPath ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+
+        var resolved = JsonPathResolver.ResolvePropertyOrThrow(rootContext, "counts.failed");
+
+        Assert.Equal("$.counts.failed", resolved.Path);
+        Assert.Equal(1, resolved.Value.GetInt32());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolvePropertyOrThrow_ReturnsResolvedContext_ForArrayPath ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+
+        var resolved = JsonPathResolver.ResolvePropertyOrThrow(rootContext, "tests[1].fullName");
+
+        Assert.Equal("$.tests[1].fullName", resolved.Path);
+        Assert.Equal("Cafe.Tests.Fail", resolved.Value.GetString());
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData(".status", "Unexpected '.' at index 0.")]
+    [InlineData("counts.", "Path must not end with '.'.")]
+    [InlineData("tests[0.fullName", "Expected ']'")]
+    [InlineData("tests[2].fullName", "Array index 2 is out of range")]
+    [InlineData("counts.missing", "Property 'missing' was not found.")]
+    public void ResolvePropertyOrThrow_Throws_WhenPathIsInvalid (
+        string path,
+        string expectedMessage)
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+
+        var exception = Assert.Throws<XunitException>(
+            () => JsonPathResolver.ResolvePropertyOrThrow(rootContext, path));
+
+        Assert.Contains(expectedMessage, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolveIndexOrThrow_ReturnsResolvedContext_ForArrayElement ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+        var arrayContext = JsonPathResolver.ResolvePropertyOrThrow(rootContext, "tests");
+
+        var resolved = JsonPathResolver.ResolveIndexOrThrow(arrayContext, 0);
+
+        Assert.Equal("$.tests[0]", resolved.Path);
+        Assert.Equal("Cafe.Tests.Pass", resolved.Value.GetProperty("fullName").GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolveIndexOrThrow_Throws_WhenCurrentValueIsNotArray ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+        var statusContext = JsonPathResolver.ResolvePropertyOrThrow(rootContext, "status");
+
+        var exception = Assert.Throws<XunitException>(
+            () => JsonPathResolver.ResolveIndexOrThrow(statusContext, 0));
+
+        Assert.Contains("expected array before index access", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolveIndexOrThrow_Throws_WhenIndexIsNegative ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var rootContext = new JsonAssertionContext(document.RootElement, "$");
+        var arrayContext = JsonPathResolver.ResolvePropertyOrThrow(rootContext, "tests");
+
+        var exception = Assert.Throws<XunitException>(
+            () => JsonPathResolver.ResolveIndexOrThrow(arrayContext, -1));
+
+        Assert.Contains("Array index must be non-negative", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonSchemaValidationMessageBuilderTests.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonSchemaValidationMessageBuilderTests.cs
@@ -1,0 +1,41 @@
+namespace MackySoft.Ucli.Tests;
+
+using MackySoft.Tests;
+
+public sealed class JsonSchemaValidationMessageBuilderTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Build_UsesSchemaNamePrefixAndBulletList ()
+    {
+        var errors = new[]
+        {
+            "path '$.errorKind' is missing.",
+            "path '$.exitCode' expected one of [Int32] but was Number(non-Int32).",
+        };
+
+        var message = JsonSchemaValidationMessageBuilder.Build(errors, "sampleSchema");
+
+        Assert.StartsWith("JSON schema validation failed. schema=sampleSchema", message, StringComparison.Ordinal);
+        Assert.Contains($"{Environment.NewLine}- path '$.errorKind' is missing.", message, StringComparison.Ordinal);
+        Assert.Contains(
+            $"{Environment.NewLine}- path '$.exitCode' expected one of [Int32] but was Number(non-Int32).",
+            message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Build_UsesDefaultPrefix_WhenSchemaNameIsNull ()
+    {
+        var errors = new[]
+        {
+            "path '$.status' expected one of [String] but was Null.",
+        };
+
+        var message = JsonSchemaValidationMessageBuilder.Build(errors, null);
+
+        Assert.StartsWith("JSON schema validation failed.", message, StringComparison.Ordinal);
+        Assert.Contains($"{Environment.NewLine}- path '$.status' expected one of [String] but was Null.", message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonSchemaValidatorTests.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonSchemaValidatorTests.cs
@@ -1,0 +1,110 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Tests;
+
+public sealed class JsonSchemaValidatorTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_ReturnsNoError_WhenSchemaMatches ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+
+        var errors = JsonSchemaValidator.Validate(document.RootElement, JsonAssertionTestData.CreateSampleSchema(), "$");
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_ReturnsMissingPropertyError_WhenRequiredPropertyIsMissing ()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "status": "pass"
+            }
+            """);
+        var errors = JsonSchemaValidator.Validate(document.RootElement, JsonAssertionTestData.CreateSampleSchema(), "$");
+
+        Assert.Contains("path '$.errorKind' is missing.", errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_ReturnsTypeError_WhenValueTypeDoesNotMatch ()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "status": "pass",
+              "errorKind": null,
+              "exitCode": 1.5,
+              "counts": {
+                "passed": 10,
+                "failed": 1
+              },
+              "flags": {
+                "hasRetries": true
+              },
+              "tests": [
+                {
+                  "fullName": "Cafe.Tests.Pass"
+                }
+              ]
+            }
+            """);
+        var errors = JsonSchemaValidator.Validate(document.RootElement, JsonAssertionTestData.CreateSampleSchema(), "$");
+
+        Assert.Contains("path '$.exitCode' expected one of [Int32] but was Number(non-Int32).", errors, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_ReturnsArrayItemTypeError_WhenArrayItemTypeDoesNotMatch ()
+    {
+        using var document = JsonDocument.Parse(
+            """
+            {
+              "status": "pass",
+              "errorKind": null,
+              "exitCode": 0,
+              "counts": {
+                "passed": 10,
+                "failed": 1
+              },
+              "flags": {
+                "hasRetries": true
+              },
+              "tests": [
+                {
+                  "fullName": "Cafe.Tests.Pass"
+                },
+                {
+                  "fullName": 42
+                }
+              ]
+            }
+            """);
+        var errors = JsonSchemaValidator.Validate(document.RootElement, JsonAssertionTestData.CreateSampleSchema(), "$");
+
+        Assert.Contains(
+            "path '$.tests[1].fullName' expected one of [String] but was Number.",
+            errors,
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_ReturnsAdditionalPropertyError_WhenAdditionalPropertiesAreDisallowed ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var schema = JsonSchemaNode.Object(
+            static root => root.Required("status", JsonSchemaNode.Value(JsonSchemaType.String)),
+            allowAdditionalProperties: false);
+        var errors = JsonSchemaValidator.Validate(document.RootElement, schema, "$");
+
+        Assert.Contains("path '$.errorKind' is not allowed by schema.", errors, StringComparer.Ordinal);
+    }
+}

--- a/tests/Ucli.Tests/Helpers/JsonAssertions/JsonValueAssertionTests.cs
+++ b/tests/Ucli.Tests/Helpers/JsonAssertions/JsonValueAssertionTests.cs
@@ -1,0 +1,72 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Tests;
+using Xunit.Sdk;
+
+public sealed class JsonValueAssertionTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void AssertString_Succeeds_WhenActualMatchesExpected ()
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var context = new JsonAssertionContext(document.RootElement.GetProperty("status"), "$.status");
+
+        JsonValueAssertion.AssertString(context, "pass");
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("String", "counts", "$.counts", "expected string but was 'Object'")]
+    [InlineData("Boolean", "status", "$.status", "expected boolean but was 'String'")]
+    [InlineData("Null", "status", "$.status", "expected null but was 'String'")]
+    [InlineData("ArrayLength", "status", "$.status", "expected array but was 'String'")]
+    [InlineData("ValueKind", "tests", "$.tests", "expected kind 'Object' but was 'Array'")]
+    public void Assertion_Throws_WhenActualTypeDoesNotMatch (
+        string assertionType,
+        string propertyName,
+        string path,
+        string expectedMessage)
+    {
+        using var document = JsonAssertionTestData.CreateSampleDocument();
+        var context = new JsonAssertionContext(document.RootElement.GetProperty(propertyName), path);
+        XunitException exception;
+
+        switch (assertionType)
+        {
+            case "String":
+                exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertString(context, "x"));
+                break;
+            case "Boolean":
+                exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertBoolean(context, true));
+                break;
+            case "Null":
+                exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertNull(context));
+                break;
+            case "ArrayLength":
+                exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertArrayLength(context, 1));
+                break;
+            case "ValueKind":
+                exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertValueKind(context, JsonValueKind.Object));
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported assertion type '{assertionType}'.");
+        }
+
+        Assert.Contains(expectedMessage, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void AssertInt32_Throws_WhenActualNumberIsNotInt32Compatible ()
+    {
+        using var document = JsonDocument.Parse("""{"exitCode": 1.5}""");
+        var context = new JsonAssertionContext(document.RootElement.GetProperty("exitCode"), "$.exitCode");
+
+        var exception = Assert.Throws<XunitException>(() => JsonValueAssertion.AssertInt32(context, 1));
+
+        Assert.Contains("Int32-compatible number", exception.Message, StringComparison.Ordinal);
+    }
+
+}


### PR DESCRIPTION
## Summary
- `JsonAssert` の責務を Facade に限定し、パス解決・値検証・スキーマ検証・メッセージ整形を専用モジュールへ分離しました。
- 既存の fluent API シグネチャを維持したまま、内部実装を静的委譲へ整理しました。
- テストを責務単位に再編し、`Theory` を使って重複ケースを統合しました。

## Scope
- `tests/Tests.Helper/Helpers/JsonAssertions/`:
  `JsonAssertionContext` / `JsonPathResolver` / `JsonValueAssertion` / `JsonSchemaValidator` / `JsonSchemaValidationMessageBuilder` を追加し、`JsonAssert` を委譲型へ再構成。
- `tests/Ucli.Tests/Helpers/JsonAssertions/`:
  `JsonAssertTests` を統合観点へ絞り、責務別テスト (`JsonPathResolverTests` など) と共通データ `JsonAssertionTestData` を追加。

## Verification
- Gate level: Standard
- Diff budget: FAIL (12 files, +965/-689; Medium threshold over)
- Spec drift: Skipped (`docs/agents/chore_json-assert-cohesion-static-theory/spec.md` not found)
- Format: PASS
  - `dotnet format tests/Tests.Helper/Tests.Helper.csproj --verify-no-changes --no-restore`
  - `dotnet format tests/Ucli.Tests/Ucli.Tests.csproj --verify-no-changes --no-restore`
- Tests: PASS
  - `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --nologo`
  - `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --nologo`
- Coverage: N/A

## Risks / Rollback
- リスク: テストヘルパーの内部責務分割により、例外メッセージ互換の見落としがあると既存テストが失敗する可能性があります。
- ロールバック: 本PRの2コミットを `git revert` することで、旧 `JsonAssert` 実装と旧テスト構造へ戻せます。

## Checklist
- [ ] Diff budget 超過のため、分割PR化または Split waived 方針を決定する
- [ ] 追加した責務別テスト観点の妥当性をレビューする

Issue: none (ad-hoc task)
