### PR TITLE
feat: execute responseをopResults契約に再設計

### DIFF
--- a/src/Ucli.Contracts/Ipc/Execute/IpcExecuteOperationPhaseNames.cs
+++ b/src/Ucli.Contracts/Ipc/Execute/IpcExecuteOperationPhaseNames.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Defines operation-phase literal values used by <c>execute</c> response payload contracts. </summary>
+public static class IpcExecuteOperationPhaseNames
+{
+    /// <summary> Gets the phase literal for <c>validate</c>. </summary>
+    public const string Validate = "validate";
+
+    /// <summary> Gets the phase literal for <c>plan</c>. </summary>
+    public const string Plan = "plan";
+
+    /// <summary> Gets the phase literal for <c>call</c>. </summary>
+    public const string Call = "call";
+
+    /// <summary> Gets the phase literal for <c>skipped</c>. </summary>
+    public const string Skipped = "skipped";
+}

--- a/src/Ucli.Contracts/Ipc/Execute/IpcExecuteTouchedResourceKindNames.cs
+++ b/src/Ucli.Contracts/Ipc/Execute/IpcExecuteTouchedResourceKindNames.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Defines touched-resource kind literal values used by <c>execute</c> response payload contracts. </summary>
+public static class IpcExecuteTouchedResourceKindNames
+{
+    /// <summary> Gets the touched kind literal for scene resources. </summary>
+    public const string Scene = "scene";
+
+    /// <summary> Gets the touched kind literal for prefab resources. </summary>
+    public const string Prefab = "prefab";
+
+    /// <summary> Gets the touched kind literal for generic asset resources. </summary>
+    public const string Asset = "asset";
+
+    /// <summary> Gets the touched kind literal for project settings resources. </summary>
+    public const string ProjectSettings = "projectSettings";
+}

--- a/src/Ucli.Contracts/Ipc/Responses/IpcExecuteOperationResult.cs
+++ b/src/Ucli.Contracts/Ipc/Responses/IpcExecuteOperationResult.cs
@@ -1,0 +1,16 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Represents one operation result within an <c>execute</c> response payload. </summary>
+/// <param name="OpId"> The operation identifier that corresponds to request <c>ops[].id</c>. </param>
+/// <param name="Op"> The operation name. </param>
+/// <param name="Phase"> The final phase reached by the operation. </param>
+/// <param name="Applied"> Whether the operation has been applied. </param>
+/// <param name="Changed"> Whether the operation produced persistent changes. </param>
+/// <param name="Touched"> The touched persistence-unit resources. </param>
+public sealed record IpcExecuteOperationResult (
+    string OpId,
+    string Op,
+    string Phase,
+    bool Applied,
+    bool Changed,
+    IReadOnlyList<IpcExecuteTouchedResource> Touched);

--- a/src/Ucli.Contracts/Ipc/Responses/IpcExecuteResponse.cs
+++ b/src/Ucli.Contracts/Ipc/Responses/IpcExecuteResponse.cs
@@ -1,8 +1,6 @@
-using System.Text.Json;
-
 namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Represents an <c>execute</c> IPC response payload. </summary>
-/// <param name="Result"> The command execution result payload. </param>
+/// <param name="OpResults"> The per-operation execution results. </param>
 public sealed record IpcExecuteResponse (
-    JsonElement Result);
+    IReadOnlyList<IpcExecuteOperationResult> OpResults);

--- a/src/Ucli.Contracts/Ipc/Responses/IpcExecuteTouchedResource.cs
+++ b/src/Ucli.Contracts/Ipc/Responses/IpcExecuteTouchedResource.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Represents one touched persistence-unit resource in an operation result. </summary>
+/// <param name="Kind"> The touched resource kind. </param>
+/// <param name="Path"> The project-relative path for the touched resource. </param>
+/// <param name="Guid"> The optional asset guid when available. </param>
+public sealed record IpcExecuteTouchedResource (
+    string Kind,
+    string Path,
+    string? Guid);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestOperationElementReader.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Requests/ExecuteRequestOperationElementReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e293de1b35fa46a2b89c832c2f78734
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestCommandResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestCommandResolver.cs
@@ -1,0 +1,41 @@
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Resolves phase-execution command from execute request command name. </summary>
+    internal static class ExecuteRequestCommandResolver
+    {
+        /// <summary> Attempts to resolve one phase-execution command from protocol command name. </summary>
+        /// <param name="commandName"> The execute request command name. </param>
+        /// <param name="command"> The resolved phase command. </param>
+        /// <returns> <see langword="true" /> when command is supported in the dispatcher; otherwise <see langword="false" />. </returns>
+        public static bool TryResolve (
+            string commandName,
+            out PhaseExecutionCommand command)
+        {
+            switch (commandName)
+            {
+                case IpcExecuteCommandNames.Plan:
+                    command = PhaseExecutionCommand.Plan;
+                    return true;
+
+                case IpcExecuteCommandNames.Call:
+                    command = PhaseExecutionCommand.Call;
+                    return true;
+
+                case IpcExecuteCommandNames.Resolve:
+                case IpcExecuteCommandNames.Query:
+                case IpcExecuteCommandNames.Refresh:
+                    command = default;
+                    return false;
+
+                default:
+                    command = default;
+                    return false;
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestCommandResolver.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestCommandResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 131439a89c00342b4b6dac6f912ef7e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteRequestDispatcher.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -15,14 +13,10 @@ namespace MackySoft.Ucli.Unity.Ipc
     /// <summary> Dispatches execute requests to operation-phase execution pipelines. </summary>
     internal sealed class ExecuteRequestDispatcher : IExecuteRequestDispatcher
     {
-        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        private static readonly JsonSerializerOptions SerializerOptions = new ()
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = false,
-            Converters =
-            {
-                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
-            },
         };
 
         private readonly IExecuteRequestNormalizer requestNormalizer;
@@ -64,43 +58,32 @@ namespace MackySoft.Ucli.Unity.Ipc
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!TryResolveExecutionCommand(request.Command, out var executionCommand))
+            if (!ExecuteRequestCommandResolver.TryResolve(request.Command, out PhaseExecutionCommand executionCommand))
             {
-                return CreateErrorResponse(
+                return ExecuteResponseBuilder.CreateErrorResponse(
                     context,
                     IpcErrorCodes.CommandNotImplemented,
                     $"Execute command '{request.Command}' is not implemented.",
-                    null);
+                    null,
+                    SerializerOptions);
             }
 
             var normalizationResult = requestNormalizer.Normalize(request, cancellationToken);
             if (!normalizationResult.IsSuccess)
             {
                 var normalizationError = normalizationResult.Error!;
-                return CreateErrorResponse(
+                return ExecuteResponseBuilder.CreateErrorResponse(
                     context,
                     normalizationError.Code,
                     normalizationError.Message,
-                    normalizationError.OpId);
+                    normalizationError.OpId,
+                    SerializerOptions);
             }
 
             try
             {
                 var trace = await operationPhaseExecutor.Execute(executionCommand, normalizationResult.Request!, cancellationToken);
-                var payload = JsonSerializer.SerializeToElement(new
-                {
-                    operationTraces = trace.OperationTraces,
-                    errors = trace.Errors,
-                }, SerializerOptions);
-                var errors = trace.Errors
-                    .Select(error => new IpcError(error.Code, error.Message, error.OpId))
-                    .ToArray();
-                return new IpcResponse(
-                    ProtocolVersion: context.ProtocolVersion,
-                    RequestId: context.RequestId,
-                    Status: trace.IsSuccess ? IpcProtocol.StatusOk : IpcProtocol.StatusError,
-                    Payload: payload,
-                    Errors: errors);
+                return ExecuteResponseBuilder.CreateExecutionResponse(context, trace, SerializerOptions);
             }
             catch (OperationCanceledException)
             {
@@ -108,65 +91,13 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
             catch (Exception exception)
             {
-                return CreateErrorResponse(
+                return ExecuteResponseBuilder.CreateErrorResponse(
                     context,
                     IpcErrorCodes.InternalError,
                     $"Unexpected error occurred while dispatching execute request. {exception.Message}",
-                    null);
+                    null,
+                    SerializerOptions);
             }
-        }
-
-        /// <summary> Resolves phase-execution command from execute request command name. </summary>
-        /// <param name="commandName"> The execute request command name. </param>
-        /// <param name="command"> The resolved phase command. </param>
-        /// <returns> <see langword="true" /> when command is supported in this dispatcher; otherwise <see langword="false" />. </returns>
-        private static bool TryResolveExecutionCommand (
-            string commandName,
-            out PhaseExecutionCommand command)
-        {
-            switch (commandName)
-            {
-                case IpcExecuteCommandNames.Plan:
-                    command = PhaseExecutionCommand.Plan;
-                    return true;
-
-                case IpcExecuteCommandNames.Call:
-                    command = PhaseExecutionCommand.Call;
-                    return true;
-
-                case IpcExecuteCommandNames.Resolve:
-                case IpcExecuteCommandNames.Query:
-                case IpcExecuteCommandNames.Refresh:
-                    command = default;
-                    return false;
-
-                default:
-                    command = default;
-                    return false;
-            }
-        }
-
-        /// <summary> Creates an error response with one error entry. </summary>
-        /// <param name="context"> The request-level dispatch context. </param>
-        /// <param name="code"> The error code. </param>
-        /// <param name="message"> The error message. </param>
-        /// <param name="opId"> The related operation identifier. </param>
-        /// <returns> The error response envelope. </returns>
-        private static IpcResponse CreateErrorResponse (
-            ExecuteDispatchContext context,
-            string code,
-            string message,
-            string? opId)
-        {
-            return new IpcResponse(
-                ProtocolVersion: context.ProtocolVersion,
-                RequestId: context.RequestId,
-                Status: IpcProtocol.StatusError,
-                Payload: JsonSerializer.SerializeToElement(new { }, SerializerOptions),
-                Errors: new[]
-                {
-                    new IpcError(code, message, opId),
-                });
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteResponseBuilder.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteResponseBuilder.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Builds execute-dispatch response envelopes from internal execution models. </summary>
+    internal static class ExecuteResponseBuilder
+    {
+        /// <summary> Creates one execution response from phase execution trace. </summary>
+        /// <param name="context"> The request-level dispatch context. </param>
+        /// <param name="trace"> The phase execution trace. </param>
+        /// <param name="serializerOptions"> The serializer options for payload conversion. </param>
+        /// <returns> The mapped execution response. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when any reference argument is <see langword="null" />. </exception>
+        public static IpcResponse CreateExecutionResponse (
+            ExecuteDispatchContext context,
+            PhaseExecutionTrace trace,
+            JsonSerializerOptions serializerOptions)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (trace == null)
+            {
+                throw new ArgumentNullException(nameof(trace));
+            }
+
+            if (serializerOptions == null)
+            {
+                throw new ArgumentNullException(nameof(serializerOptions));
+            }
+
+            var payloadModel = CreateExecutePayload(trace.OperationTraces);
+            var errors = CreateErrors(trace.Errors);
+            return new IpcResponse(
+                ProtocolVersion: context.ProtocolVersion,
+                RequestId: context.RequestId,
+                Status: errors.Length == 0 ? IpcProtocol.StatusOk : IpcProtocol.StatusError,
+                Payload: JsonSerializer.SerializeToElement(payloadModel, serializerOptions),
+                Errors: errors);
+        }
+
+        /// <summary> Creates an error response with one error entry. </summary>
+        /// <param name="context"> The request-level dispatch context. </param>
+        /// <param name="code"> The error code. </param>
+        /// <param name="message"> The error message. </param>
+        /// <param name="opId"> The related operation identifier. </param>
+        /// <param name="serializerOptions"> The serializer options for payload conversion. </param>
+        /// <returns> The error response envelope. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="context" /> or <paramref name="serializerOptions" /> is <see langword="null" />. </exception>
+        public static IpcResponse CreateErrorResponse (
+            ExecuteDispatchContext context,
+            string code,
+            string message,
+            string? opId,
+            JsonSerializerOptions serializerOptions)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (serializerOptions == null)
+            {
+                throw new ArgumentNullException(nameof(serializerOptions));
+            }
+
+            return new IpcResponse(
+                ProtocolVersion: context.ProtocolVersion,
+                RequestId: context.RequestId,
+                Status: IpcProtocol.StatusError,
+                Payload: JsonSerializer.SerializeToElement(CreateEmptyExecutePayload(), serializerOptions),
+                Errors: new[]
+                {
+                    new IpcError(code, message, opId),
+                });
+        }
+
+        /// <summary> Creates one execute payload from operation traces. </summary>
+        /// <param name="operationTraces"> The operation traces to map. </param>
+        /// <returns> The execute payload contract model. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationTraces" /> is <see langword="null" />. </exception>
+        private static IpcExecuteResponse CreateExecutePayload (IReadOnlyList<OperationPhaseTrace> operationTraces)
+        {
+            if (operationTraces == null)
+            {
+                throw new ArgumentNullException(nameof(operationTraces));
+            }
+
+            var opResults = new IpcExecuteOperationResult[operationTraces.Count];
+            for (var i = 0; i < operationTraces.Count; i++)
+            {
+                var operationTrace = operationTraces[i];
+                var touchedResources = new IpcExecuteTouchedResource[operationTrace.Touched.Count];
+                for (var touchedIndex = 0; touchedIndex < operationTrace.Touched.Count; touchedIndex++)
+                {
+                    var touchedResource = operationTrace.Touched[touchedIndex];
+                    touchedResources[touchedIndex] = new IpcExecuteTouchedResource(
+                        Kind: ToTouchedResourceKindName(touchedResource.Kind),
+                        Path: touchedResource.Path,
+                        Guid: touchedResource.Guid);
+                }
+
+                opResults[i] = new IpcExecuteOperationResult(
+                    OpId: operationTrace.OpId,
+                    Op: operationTrace.Op,
+                    Phase: ToOperationPhaseName(operationTrace.Phase),
+                    Applied: operationTrace.Applied,
+                    Changed: operationTrace.Changed,
+                    Touched: touchedResources);
+            }
+
+            return new IpcExecuteResponse(opResults);
+        }
+
+        /// <summary> Creates one empty execute payload. </summary>
+        /// <returns> The empty execute payload contract model. </returns>
+        private static IpcExecuteResponse CreateEmptyExecutePayload ()
+        {
+            return new IpcExecuteResponse(Array.Empty<IpcExecuteOperationResult>());
+        }
+
+        /// <summary> Creates IPC errors from operation failures. </summary>
+        /// <param name="failures"> The operation failures to map. </param>
+        /// <returns> The mapped IPC errors. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="failures" /> is <see langword="null" />. </exception>
+        private static IpcError[] CreateErrors (IReadOnlyList<OperationFailure> failures)
+        {
+            if (failures == null)
+            {
+                throw new ArgumentNullException(nameof(failures));
+            }
+
+            var errors = new IpcError[failures.Count];
+            for (var i = 0; i < failures.Count; i++)
+            {
+                var failure = failures[i];
+                errors[i] = new IpcError(failure.Code, failure.Message, failure.OpId);
+            }
+
+            return errors;
+        }
+
+        /// <summary> Converts one operation phase to protocol literal. </summary>
+        /// <param name="phase"> The operation phase. </param>
+        /// <returns> The protocol phase literal. </returns>
+        /// <exception cref="InvalidOperationException"> Thrown when phase has unsupported value. </exception>
+        private static string ToOperationPhaseName (OperationPhase phase)
+        {
+            switch (phase)
+            {
+                case OperationPhase.Validate:
+                    return IpcExecuteOperationPhaseNames.Validate;
+
+                case OperationPhase.Plan:
+                    return IpcExecuteOperationPhaseNames.Plan;
+
+                case OperationPhase.Call:
+                    return IpcExecuteOperationPhaseNames.Call;
+
+                case OperationPhase.Skipped:
+                    return IpcExecuteOperationPhaseNames.Skipped;
+
+                default:
+                    throw new InvalidOperationException($"Unsupported operation phase '{phase}'.");
+            }
+        }
+
+        /// <summary> Converts one touched resource kind to protocol literal. </summary>
+        /// <param name="kind"> The touched resource kind. </param>
+        /// <returns> The protocol touched kind literal. </returns>
+        /// <exception cref="InvalidOperationException"> Thrown when kind has unsupported value. </exception>
+        private static string ToTouchedResourceKindName (OperationTouchKind kind)
+        {
+            switch (kind)
+            {
+                case OperationTouchKind.Scene:
+                    return IpcExecuteTouchedResourceKindNames.Scene;
+
+                case OperationTouchKind.Prefab:
+                    return IpcExecuteTouchedResourceKindNames.Prefab;
+
+                case OperationTouchKind.Asset:
+                    return IpcExecuteTouchedResourceKindNames.Asset;
+
+                case OperationTouchKind.ProjectSettings:
+                    return IpcExecuteTouchedResourceKindNames.ProjectSettings;
+
+                default:
+                    throw new InvalidOperationException($"Unsupported touched resource kind '{kind}'.");
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteResponseBuilder.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/ExecuteResponseBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11e69ab9feff54c94a078cba5cf859cc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ExecuteRequestDispatcherTests.cs
@@ -73,7 +73,58 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
             Assert.That(response.Errors[0].OpId, Is.EqualTo("op-1"));
+            AssertEmptyOpResultsPayload(response.Payload);
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Dispatch_WhenPhaseExecutionFails_ReturnsOpResultsAndErrors () => UniTask.ToCoroutine(async () =>
+        {
+            var normalizedRequest = CreateNormalizedRequest();
+            var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
+            var phaseExecutor = new SpyOperationPhaseExecutor(PhaseExecutionTrace.Failure(
+                protocolVersion: IpcProtocol.CurrentVersion,
+                requestId: "req-1",
+                operationTraces: new[]
+                {
+                    new OperationPhaseTrace(
+                        "op-1",
+                        "ucli.resolve",
+                        OperationPhase.Call,
+                        true,
+                        true,
+                        new[]
+                        {
+                            new OperationTouch(OperationTouchKind.Scene, "Assets/Scenes/Main.unity", "11111111111111111111111111111111"),
+                        },
+                        new OperationFailure(IpcErrorCodes.InvalidArgument, "call failed", "op-1")),
+                    new OperationPhaseTrace(
+                        "op-2",
+                        "ucli.scene.open",
+                        OperationPhase.Skipped,
+                        false,
+                        false,
+                        System.Array.Empty<OperationTouch>(),
+                        null),
+                },
+                errors: new[]
+                {
+                    new OperationFailure(IpcErrorCodes.InvalidArgument, "call failed", "op-1"),
+                }));
+            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
+            var request = CreateExecuteRequest(IpcExecuteCommandNames.Call);
+
+            var response = await dispatcher.Dispatch(request, context, CancellationToken.None).AsUniTask();
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(response.Errors[0].OpId, Is.EqualTo("op-1"));
+            Assert.That(response.Payload.TryGetProperty("opResults", out var opResults), Is.True);
+            Assert.That(opResults.GetArrayLength(), Is.EqualTo(2));
+            Assert.That(response.Payload.TryGetProperty("operationTraces", out _), Is.False);
         });
 
         [UnityTest]
@@ -109,7 +160,17 @@ namespace MackySoft.Ucli.Unity.Tests
                 requestId: "req-1",
                 operationTraces: new[]
                 {
-                    new OperationPhaseTrace("op-1", "ucli.resolve", OperationPhase.Plan, false, false, System.Array.Empty<OperationTouch>(), null),
+                    new OperationPhaseTrace(
+                        "op-1",
+                        "ucli.resolve",
+                        OperationPhase.Plan,
+                        false,
+                        true,
+                        new[]
+                        {
+                            new OperationTouch(OperationTouchKind.Scene, "Assets/Scenes/Main.unity", "11111111111111111111111111111111"),
+                        },
+                        null),
                 }));
             var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
@@ -118,8 +179,26 @@ namespace MackySoft.Ucli.Unity.Tests
             var response = await dispatcher.Dispatch(request, context, CancellationToken.None).AsUniTask();
 
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusOk));
+            Assert.That(response.Errors.Count, Is.EqualTo(0));
             Assert.That(phaseExecutor.ReceivedCommand, Is.EqualTo(expectedCommand));
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(1));
+            Assert.That(response.Payload.TryGetProperty("opResults", out var opResults), Is.True);
+            Assert.That(opResults.GetArrayLength(), Is.EqualTo(1));
+            Assert.That(response.Payload.TryGetProperty("operationTraces", out _), Is.False);
+
+            var opResult = GetSingleArrayElement(opResults);
+            Assert.That(opResult.GetProperty("opId").GetString(), Is.EqualTo("op-1"));
+            Assert.That(opResult.GetProperty("op").GetString(), Is.EqualTo("ucli.resolve"));
+            Assert.That(opResult.GetProperty("phase").GetString(), Is.EqualTo(IpcExecuteOperationPhaseNames.Plan));
+            Assert.That(opResult.GetProperty("applied").GetBoolean(), Is.False);
+            Assert.That(opResult.GetProperty("changed").GetBoolean(), Is.True);
+
+            var touched = opResult.GetProperty("touched");
+            Assert.That(touched.GetArrayLength(), Is.EqualTo(1));
+            var touchedElement = GetSingleArrayElement(touched);
+            Assert.That(touchedElement.GetProperty("kind").GetString(), Is.EqualTo(IpcExecuteTouchedResourceKindNames.Scene));
+            Assert.That(touchedElement.GetProperty("path").GetString(), Is.EqualTo("Assets/Scenes/Main.unity"));
+            Assert.That(touchedElement.GetProperty("guid").GetString(), Is.EqualTo("11111111111111111111111111111111"));
         }
 
         private static async UniTask AssertReturnsCommandNotImplementedError (string commandName)
@@ -139,8 +218,27 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcErrorCodes.CommandNotImplemented));
+            AssertEmptyOpResultsPayload(response.Payload);
             Assert.That(normalizer.CallCount, Is.EqualTo(0));
             Assert.That(phaseExecutor.CallCount, Is.EqualTo(0));
+        }
+
+        private static void AssertEmptyOpResultsPayload (JsonElement payload)
+        {
+            Assert.That(payload.ValueKind, Is.EqualTo(JsonValueKind.Object));
+            Assert.That(payload.TryGetProperty("opResults", out var opResults), Is.True);
+            Assert.That(opResults.ValueKind, Is.EqualTo(JsonValueKind.Array));
+            Assert.That(opResults.GetArrayLength(), Is.EqualTo(0));
+            Assert.That(payload.TryGetProperty("operationTraces", out _), Is.False);
+        }
+
+        private static JsonElement GetSingleArrayElement (JsonElement arrayElement)
+        {
+            var enumerator = arrayElement.EnumerateArray();
+            Assert.That(enumerator.MoveNext(), Is.True);
+            var first = enumerator.Current;
+            Assert.That(enumerator.MoveNext(), Is.False);
+            return first;
         }
 
         private static IpcExecuteRequest CreateExecuteRequest (string commandName)

--- a/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Tests/Ipc/IpcContractSerializationTests.cs
@@ -75,6 +75,43 @@ public sealed class IpcContractSerializationTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void IpcExecuteResponse_SerializesWithOpResultsContract ()
+    {
+        var response = new IpcExecuteResponse(new[]
+        {
+            new IpcExecuteOperationResult(
+                OpId: "op-1",
+                Op: "ucli.resolve",
+                Phase: IpcExecuteOperationPhaseNames.Call,
+                Applied: true,
+                Changed: true,
+                Touched: new[]
+                {
+                    new IpcExecuteTouchedResource(
+                        Kind: IpcExecuteTouchedResourceKindNames.Scene,
+                        Path: "Assets/Scenes/Main.unity",
+                        Guid: "11111111111111111111111111111111"),
+                }),
+        });
+
+        using var jsonDocument = JsonDocument.Parse(JsonSerializer.Serialize(response, SerializerOptions));
+        JsonAssert.For(jsonDocument.RootElement)
+            .HasArrayLength("opResults", 1)
+            .HasProperty("opResults", 0, opResult => opResult
+                .HasString("opId", "op-1")
+                .HasString("op", "ucli.resolve")
+                .HasString("phase", IpcExecuteOperationPhaseNames.Call)
+                .HasBoolean("applied", true)
+                .HasBoolean("changed", true)
+                .HasArrayLength("touched", 1)
+                .HasProperty("touched", 0, touched => touched
+                    .HasString("kind", IpcExecuteTouchedResourceKindNames.Scene)
+                    .HasString("path", "Assets/Scenes/Main.unity")
+                    .HasString("guid", "11111111111111111111111111111111")));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void IpcExecuteCommandNames_ExposeExpectedCommandLiterals ()
     {
         Assert.Equal("validate", IpcExecuteCommandNames.Validate);
@@ -104,6 +141,26 @@ public sealed class IpcContractSerializationTests
         Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Query));
         Assert.True(IpcExecuteCommandNames.IsOperationPipelineCommand(IpcExecuteCommandNames.Refresh));
         Assert.False(IpcExecuteCommandNames.IsOperationPipelineCommand("unknown"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IpcExecuteOperationPhaseNames_ExposeExpectedLiterals ()
+    {
+        Assert.Equal("validate", IpcExecuteOperationPhaseNames.Validate);
+        Assert.Equal("plan", IpcExecuteOperationPhaseNames.Plan);
+        Assert.Equal("call", IpcExecuteOperationPhaseNames.Call);
+        Assert.Equal("skipped", IpcExecuteOperationPhaseNames.Skipped);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IpcExecuteTouchedResourceKindNames_ExposeExpectedLiterals ()
+    {
+        Assert.Equal("scene", IpcExecuteTouchedResourceKindNames.Scene);
+        Assert.Equal("prefab", IpcExecuteTouchedResourceKindNames.Prefab);
+        Assert.Equal("asset", IpcExecuteTouchedResourceKindNames.Asset);
+        Assert.Equal("projectSettings", IpcExecuteTouchedResourceKindNames.ProjectSettings);
     }
 
 }


### PR DESCRIPTION
## Summary
- `IpcExecuteResponse` を `result` から `opResults` 契約へ変更し、`IpcExecuteOperationResult` / `IpcExecuteTouchedResource` を追加
- `IpcExecuteOperationPhaseNames` と `IpcExecuteTouchedResourceKindNames` を追加し、phase/kind 文字列を契約として固定
- `ExecuteRequestDispatcher` からコマンド解決とレスポンス組み立てを分離し、`ExecuteRequestCommandResolver` と `ExecuteResponseBuilder` を新設
- Unity側の新規C#ファイルに対応する `.meta` を追加し、既存 `ExecuteRequestOperationElementReader.cs` の `.meta` 欠落を補完
- Contract/Dispatcher テストを `opResults` 仕様に合わせて更新

## Verification
- `dotnet format "Ucli.slnx" --verbosity minimal --verify-no-changes --no-restore`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal --no-restore`
- `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --verbosity minimal --no-restore`

Closes #16
