### PR TITLE
chore: bump contracts package to 0.3.0

### DIFF
--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -38,9 +38,9 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
-- タグは `v` プレフィックスを付けない（例: `contracts/0.3.0`）。
+- タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`）。
 
 ```bash
-git tag contracts/0.3.0
-git push origin contracts/0.3.0
+git tag contracts/x.y.z
+git push origin contracts/x.y.z
 ```

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -38,9 +38,9 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
-- タグは `v` プレフィックスを付けない（例: `contracts/0.2.2`）。
+- タグは `v` プレフィックスを付けない（例: `contracts/0.3.0`）。
 
 ```bash
-git tag contracts/0.2.2
-git push origin contracts/0.2.2
+git tag contracts/0.3.0
+git push origin contracts/0.3.0
 ```

--- a/src/Ucli.Contracts/Ucli.Contracts.csproj
+++ b/src/Ucli.Contracts/Ucli.Contracts.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Contracts</PackageId>
-    <Version>0.2.2</Version>
+    <Version>0.3.0</Version>
     <Description>Shared contract types for uCLI IPC protocol.</Description>
     <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;ipc</PackageTags>

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.2.2" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.3.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="netstandard2.0" />
   <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="netstandard2.0" />


### PR DESCRIPTION
## Summary
- `MackySoft.Ucli.Contracts` のパッケージバージョンを `0.2.2` から `0.3.0` に更新しました。
- Unity 側の依存定義（`packages.config`）も `0.3.0` に追従させました。
- 将来の版上げ時に docs を都度更新しないため、タグ例を `contracts/x.y.z` に一般化しました。

## Scope
- `src/Ucli.Contracts/Ucli.Contracts.csproj`: `<Version>` を `0.3.0` に更新
- `src/Ucli.Unity/Assets/packages.config`: `MackySoft.Ucli.Contracts` を `0.3.0` に更新
- `docs/package-operations.md`: タグ例を `contracts/x.y.z` に変更

## Verification
- Gate level: Standard
- Diff budget: PASS（3 files changed, 5 insertions(+), 5 deletions(-)）
- Spec drift: Skipped（`docs/agents/chore_contracts-package-0.3.0/spec.md` が存在しないため）
- Format: PASS（`dotnet format "Ucli.slnx" --verbosity minimal --verify-no-changes --no-restore`）
- Tests: PASS（`dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --verbosity minimal --no-restore` / 20 passed）
- Coverage: N/A

## Risks / Rollback
- リスク: `MackySoft.Ucli.Contracts 0.3.0` が未公開の状態では、Unity 側の依存復元が失敗する可能性があります。
- ロールバック: `src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` のバージョンを `0.2.2` に戻すことで復旧できます。

## Checklist
- [ ] マージ後に `contracts/0.3.0` タグ（実運用バージョン）で `contracts-package-publish` を起動する

Issue: none (ad-hoc task)
