### PR TITLE
ci: sync contracts csproj version after publish

### DIFF
--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -61,3 +63,27 @@ jobs:
           --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
           --api-key "${{ secrets.GITHUB_TOKEN }}"
           --skip-duplicate
+
+      - name: Sync contracts csproj version
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "${DEFAULT_BRANCH}"
+          git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
+
+          csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
+          current_version="$(sed -n 's#.*<Version>\(.*\)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+          if [[ "${current_version}" == "${PACKAGE_VERSION}" ]]; then
+            echo "No csproj version update required."
+            exit 0
+          fi
+
+          sed -i -E "0,/<Version>[^<]+<\/Version>/s//<Version>${PACKAGE_VERSION}<\/Version>/" "${csproj_path}"
+
+          git add "${csproj_path}"
+          git commit -m "chore(contracts): sync package version to ${PACKAGE_VERSION}"
+          git push origin "HEAD:${DEFAULT_BRANCH}"


### PR DESCRIPTION
## Summary
- `contracts-package-publish` に、公開後の `Ucli.Contracts.csproj` バージョン同期処理を追加しました。
- タグ/dispatch で解決した `package_version` をデフォルトブランチへ反映し、手動更新を不要化します。

## Scope
- `.github/workflows/contracts-package-publish.yaml`
  - `contents: write` へ変更
  - `checkout` を `fetch-depth: 0` 化
  - 公開後に `src/Ucli.Contracts/Ucli.Contracts.csproj` の `<Version>` を同期して commit/push する step を追加

## Verification
- Gate level: Standard
- Diff budget: PASS（1 file changed, 27 insertions(+), 1 deletion(-)）
- Spec drift: Skipped（`docs/agents/chore_contracts-publish-sync-version/spec.md` が存在しないため）
- Format: PASS（`dotnet format "Ucli.slnx" --verbosity minimal --verify-no-changes --no-restore`）
- Tests: Skipped（workflow変更のみで受け入れ判定に不要）
- Coverage: N/A

## Risks / Rollback
- リスク: ワークフロー内の自動コミットが保護ルールで拒否される可能性があります。
- ロールバック: 追加した `Sync contracts csproj version` step を削除し、従来運用へ戻します。

## Checklist
- [ ] `contracts/x.y.z` タグでワークフローを実行し、同期コミットが発生することを確認

Issue: none (ad-hoc task)
