### PR TITLE
refactor(core): add TryTrimToNonEmpty string normalization helper

### DIFF
--- a/src/Ucli.Contracts/Configuration/UcliConfigJsonContractReader.cs
+++ b/src/Ucli.Contracts/Configuration/UcliConfigJsonContractReader.cs
@@ -340,8 +340,7 @@ internal static class UcliConfigJsonContractReader
                 return null;
             }
 
-            var value = StringValueNormalizer.TrimToNull(element.GetString());
-            if (value is null)
+            if (!StringValueNormalizer.TryTrimToNonEmpty(element.GetString(), out var value))
             {
                 continue;
             }

--- a/src/Ucli.Contracts/Storage/UcliStoragePathResolver.cs
+++ b/src/Ucli.Contracts/Storage/UcliStoragePathResolver.cs
@@ -173,11 +173,11 @@ public static class UcliStoragePathResolver
 
     private static string NormalizeProjectFingerprint (string projectFingerprint)
     {
-        if (string.IsNullOrWhiteSpace(projectFingerprint))
+        if (!StringValueNormalizer.TryTrimToNonEmpty(projectFingerprint, out var normalizedProjectFingerprint))
         {
             throw new ArgumentException("Project fingerprint must not be empty.", nameof(projectFingerprint));
         }
 
-        return StringValueNormalizer.TrimToNull(projectFingerprint)!;
+        return normalizedProjectFingerprint;
     }
 }

--- a/src/Ucli.Contracts/Text/Base64UrlCodec.cs
+++ b/src/Ucli.Contracts/Text/Base64UrlCodec.cs
@@ -38,8 +38,7 @@ internal static class Base64UrlCodec
     {
         bytes = Array.Empty<byte>();
 
-        var normalized = StringValueNormalizer.TrimToNull(text);
-        if (normalized is null)
+        if (!StringValueNormalizer.TryTrimToNonEmpty(text, out var normalized))
         {
             return false;
         }

--- a/src/Ucli.Contracts/Text/StringValueNormalizer.cs
+++ b/src/Ucli.Contracts/Text/StringValueNormalizer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace MackySoft.Ucli.Contracts.Text;
 
 /// <summary> Provides reusable normalization helpers for optional string values. </summary>
@@ -14,6 +16,18 @@ internal static class StringValueNormalizer
         }
 
         return value.Trim();
+    }
+
+    /// <summary> Trims one string and returns whether the result contains non-whitespace characters. </summary>
+    /// <param name="value"> The input string value. </param>
+    /// <param name="normalizedValue"> The trimmed value when input contains non-whitespace characters; otherwise <see langword="null" />. </param>
+    /// <returns> <see langword="true" /> when input contains non-whitespace characters; otherwise <see langword="false" />. </returns>
+    public static bool TryTrimToNonEmpty (
+        string? value,
+        [NotNullWhen(true)] out string? normalizedValue)
+    {
+        normalizedValue = TrimToNull(value);
+        return normalizedValue is not null;
     }
 
     /// <summary> Trims one string and returns an empty string when input is null, empty, or whitespace-only. </summary>

--- a/src/Ucli/Configuration/UcliConfigStore.cs
+++ b/src/Ucli/Configuration/UcliConfigStore.cs
@@ -246,13 +246,12 @@ internal sealed class UcliConfigStore : IUcliConfigStore
         var normalizedAllowlist = new List<string>(document.OperationAllowlist.Length);
         foreach (var pattern in document.OperationAllowlist)
         {
-            if (string.IsNullOrWhiteSpace(pattern))
+            if (!StringValueNormalizer.TryTrimToNonEmpty(pattern, out var normalizedPattern))
             {
                 return ConfigParseResult.Failure(ExecutionError.InvalidArgument(
                     $"Config operationAllowlist contains an empty pattern: {configPath}."));
             }
 
-            var normalizedPattern = StringValueNormalizer.TrimToNull(pattern)!;
             if (!RegexPatternUtilities.TryValidatePattern(normalizedPattern, out var patternErrorMessage))
             {
                 return ConfigParseResult.Failure(ExecutionError.InvalidArgument(

--- a/src/Ucli/Daemon/InMemoryDaemonLifecycleLockProvider.cs
+++ b/src/Ucli/Daemon/InMemoryDaemonLifecycleLockProvider.cs
@@ -24,12 +24,12 @@ internal sealed class InMemoryDaemonLifecycleLockProvider : IDaemonLifecycleLock
             throw new ArgumentException("Storage root must not be empty.", nameof(storageRoot));
         }
 
-        if (string.IsNullOrWhiteSpace(projectFingerprint))
+        if (!StringValueNormalizer.TryTrimToNonEmpty(projectFingerprint, out var normalizedProjectFingerprint))
         {
             throw new ArgumentException("Project fingerprint must not be empty.", nameof(projectFingerprint));
         }
 
-        var lockKey = $"{Path.GetFullPath(storageRoot)}\n{StringValueNormalizer.TrimToNull(projectFingerprint)!}";
+        var lockKey = $"{Path.GetFullPath(storageRoot)}\n{normalizedProjectFingerprint}";
         var semaphore = LocksByFingerprint.GetOrAdd(
             lockKey,
             static _ => new SemaphoreSlim(1, 1));

--- a/src/Ucli/Execution/Timeout/IpcCommandTimeoutResolver.cs
+++ b/src/Ucli/Execution/Timeout/IpcCommandTimeoutResolver.cs
@@ -40,13 +40,12 @@ internal static class IpcCommandTimeoutResolver
             return ResolveMilliseconds(config.IpcDefaultTimeoutMilliseconds, "config ipcDefaultTimeoutMilliseconds");
         }
 
-        if (string.IsNullOrWhiteSpace(optionValue))
+        if (!StringValueNormalizer.TryTrimToNonEmpty(optionValue, out var normalizedOptionValue))
         {
             return IpcCommandTimeoutResolutionResult.Failure(ExecutionError.InvalidArgument(
                 $"timeout must be a positive integer milliseconds value. Actual: {optionValue}."));
         }
 
-        var normalizedOptionValue = StringValueNormalizer.TrimToNull(optionValue)!;
         if (!int.TryParse(normalizedOptionValue, NumberStyles.None, CultureInfo.InvariantCulture, out var timeoutMilliseconds))
         {
             return IpcCommandTimeoutResolutionResult.Failure(ExecutionError.InvalidArgument(

--- a/src/Ucli/Ipc/IpcEndpointResolver.cs
+++ b/src/Ucli/Ipc/IpcEndpointResolver.cs
@@ -33,13 +33,12 @@ internal sealed class IpcEndpointResolver : IIpcEndpointResolver
             throw new ArgumentException("Storage root must not be empty.", nameof(storageRoot));
         }
 
-        if (string.IsNullOrWhiteSpace(projectFingerprint))
+        if (!StringValueNormalizer.TryTrimToNonEmpty(projectFingerprint, out var normalizedProjectFingerprint))
         {
             throw new ArgumentException("Project fingerprint must not be empty.", nameof(projectFingerprint));
         }
 
         var normalizedStorageRoot = Path.GetFullPath(storageRoot);
-        var normalizedProjectFingerprint = StringValueNormalizer.TrimToNull(projectFingerprint)!;
 
         if (OperatingSystem.IsWindows())
         {

--- a/src/Ucli/Operations/RequestStaticValidator.cs
+++ b/src/Ucli/Operations/RequestStaticValidator.cs
@@ -83,8 +83,7 @@ internal sealed class RequestStaticValidator : IRequestStaticValidator
                 continue;
             }
 
-            var normalizedOpId = StringValueNormalizer.TrimToNull(operationRequest.OpId);
-            if (normalizedOpId is null)
+            if (!StringValueNormalizer.TryTrimToNonEmpty(operationRequest.OpId, out var normalizedOpId))
             {
                 errors.Add(new ValidationError(
                     Code: ValidationErrorCodes.OpIdRequired,
@@ -99,8 +98,7 @@ internal sealed class RequestStaticValidator : IRequestStaticValidator
                     OpId: normalizedOpId));
             }
 
-            var normalizedOperationName = StringValueNormalizer.TrimToNull(operationRequest.Op);
-            if (normalizedOperationName is null)
+            if (!StringValueNormalizer.TryTrimToNonEmpty(operationRequest.Op, out var normalizedOperationName))
             {
                 errors.Add(new ValidationError(
                     Code: ValidationErrorCodes.OpNameRequired,

--- a/src/Ucli/TestProfile/TestProfileInitService.cs
+++ b/src/Ucli/TestProfile/TestProfileInitService.cs
@@ -139,18 +139,14 @@ internal sealed class TestProfileInitService : ITestProfileInitService
     /// <returns> A normalized path value, or an invalid-input error message. </returns>
     private static PathValueResolution ResolveOutputPathValue (string? outputPath)
     {
-        var normalizedPath = DefaultOutputPath;
-        if (StringValueNormalizer.TryTrimToNonEmpty(outputPath, out var normalizedInputPath))
+        var normalizedPath = StringValueNormalizer.TrimToNull(outputPath);
+        if (normalizedPath is not null && IsDirectoryPathDefinition(normalizedPath))
         {
-            normalizedPath = normalizedInputPath;
-            if (IsDirectoryPathDefinition(normalizedPath))
-            {
-                return PathValueResolution.Failure(
-                    $"Output path must be a file path. Directory-style path is not allowed: {normalizedPath}");
-            }
+            return PathValueResolution.Failure(
+                $"Output path must be a file path. Directory-style path is not allowed: {normalizedPath}");
         }
 
-        var pathWithExtension = EnsureJsonExtension(normalizedPath);
+        var pathWithExtension = EnsureJsonExtension(normalizedPath ?? DefaultOutputPath);
         return PathValueResolution.Success(pathWithExtension);
     }
 

--- a/src/Ucli/TestProfile/TestProfileInitService.cs
+++ b/src/Ucli/TestProfile/TestProfileInitService.cs
@@ -139,12 +139,15 @@ internal sealed class TestProfileInitService : ITestProfileInitService
     /// <returns> A normalized path value, or an invalid-input error message. </returns>
     private static PathValueResolution ResolveOutputPathValue (string? outputPath)
     {
-        var normalizedInputPath = StringValueNormalizer.TrimToNull(outputPath);
-        var normalizedPath = normalizedInputPath ?? DefaultOutputPath;
-        if (normalizedInputPath is not null && IsDirectoryPathDefinition(normalizedPath))
+        var normalizedPath = DefaultOutputPath;
+        if (StringValueNormalizer.TryTrimToNonEmpty(outputPath, out var normalizedInputPath))
         {
-            return PathValueResolution.Failure(
-                $"Output path must be a file path. Directory-style path is not allowed: {normalizedPath}");
+            normalizedPath = normalizedInputPath;
+            if (IsDirectoryPathDefinition(normalizedPath))
+            {
+                return PathValueResolution.Failure(
+                    $"Output path must be a file path. Directory-style path is not allowed: {normalizedPath}");
+            }
         }
 
         var pathWithExtension = EnsureJsonExtension(normalizedPath);

--- a/tests/Ucli.Contracts.Tests/Text/StringValueNormalizerTests.cs
+++ b/tests/Ucli.Contracts.Tests/Text/StringValueNormalizerTests.cs
@@ -26,6 +26,30 @@ public sealed class StringValueNormalizerTests
         Assert.Equal("value", result);
     }
 
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void TryTrimToNonEmpty_ReturnsFalse_WhenValueIsNullOrWhitespace (string? value)
+    {
+        var result = StringValueNormalizer.TryTrimToNonEmpty(value, out var normalizedValue);
+
+        Assert.False(result);
+        Assert.Null(normalizedValue);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void TryTrimToNonEmpty_ReturnsTrueAndTrimmedValue_WhenValueContainsNonWhitespaceCharacters ()
+    {
+        var result = StringValueNormalizer.TryTrimToNonEmpty("  value  ", out var normalizedValue);
+
+        Assert.True(result);
+        Assert.Equal("value", normalizedValue);
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public void TrimOrEmpty_ReturnsEmpty_WhenValueIsNull ()


### PR DESCRIPTION
## Summary
- `StringValueNormalizer` に `TryTrimToNonEmpty` を追加し、trim 後に有効文字列があるかを `bool + out` で扱えるようにしました。
- `TrimToNull` 戻り値への `is null` 判定を、`Try` パターンへ置換して呼び出し側の分岐責務を簡素化しました。
- 新規ヘルパーの契約をテストで固定し、境界条件の回帰を防止しました。

## Scope
- 文字列正規化ヘルパー追加
  - `src/Ucli.Contracts/Text/StringValueNormalizer.cs`
- 呼び出し側の置換
  - `src/Ucli.Contracts/Text/Base64UrlCodec.cs`
  - `src/Ucli/Operations/RequestStaticValidator.cs`
  - `src/Ucli/TestProfile/TestProfileInitService.cs`
  - `src/Ucli.Contracts/Configuration/UcliConfigJsonContractReader.cs`
- 契約テスト追加
  - `tests/Ucli.Contracts.Tests/Text/StringValueNormalizerTests.cs`

## Verification
- Gate level: Standard
- Diff budget: PASS (`6 files changed, 51 insertions(+), 14 deletions(-)`)
- Spec drift: Skipped (`docs/agents/refactor_try-trim-to-non-empty-normalizer/spec.md` が存在しないため)
- Format: PASS
  - `dotnet format Ucli.slnx --verbosity minimal --no-restore`
  - `dotnet format Ucli.slnx --verbosity minimal --verify-no-changes --no-restore`
- Tests: PASS
  - `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore --filter "FullyQualifiedName~RequestStaticValidatorTests|FullyQualifiedName~TestProfileInitServiceTests"` (18 passed)
  - `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --no-restore --filter "FullyQualifiedName~StringValueNormalizerTests|FullyQualifiedName~Base64UrlCodecTests|FullyQualifiedName~UcliConfigJsonContractReaderTests"` (28 passed)
- Coverage: N/A

## Risks / Rollback
- リスク: `TrimToNull` 直接利用と `TryTrimToNonEmpty` 利用が混在するため、呼び出し方針の統一が今後のレビュー観点になります。
- ロールバック: `f7e95a0` と `7389c7c` を revert すれば変更全体を安全に戻せます。

## Checklist
- [ ] `TrimToNull` の残存利用箇所に対して、`TryTrimToNonEmpty` へ置換すべき箇所がないかを継続確認する。

Issue: none (ad-hoc task)
