### PR TITLE
[v1.0][O1] ucli.resolve を実装する

### DIFF
--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationCallPassExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationCallPassExecutor.cs
@@ -11,10 +11,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
     {
         /// <summary> Executes call phase for prevalidated and preplanned operations. </summary>
         /// <param name="preparedOperations"> The prepared operations. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The call-pass result. </returns>
         Task<CallPassResult> Execute (
             IReadOnlyList<PreparedOperation> preparedOperations,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPlanPassExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IOperationPlanPassExecutor.cs
@@ -11,10 +11,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
     {
         /// <summary> Executes validate/plan phases for all operations with fail-fast semantics. </summary>
         /// <param name="request"> The normalized request model. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The plan-pass result. </returns>
         Task<PlanPassResult> Execute (
             NormalizedExecuteRequest request,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/IPhaseOperation.cs
@@ -12,26 +12,32 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         /// <summary> Executes the validate phase for one operation. </summary>
         /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The phase-step result. </returns>
         Task<OperationPhaseStepResult> Validate (
             NormalizedOperation operation,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default);
 
         /// <summary> Executes the plan phase for one operation. </summary>
         /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The phase-step result. </returns>
         Task<OperationPhaseStepResult> Plan (
             NormalizedOperation operation,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default);
 
         /// <summary> Executes the call phase for one operation. </summary>
         /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The phase-step result. </returns>
         Task<OperationPhaseStepResult> Call (
             NormalizedOperation operation,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationAliasStore.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationAliasStore.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using MackySoft.Ucli.Contracts.Text;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Stores operation alias values resolved during one request execution. </summary>
+    internal sealed class OperationAliasStore
+    {
+        private readonly Dictionary<string, ResolvedReference> resolvedReferencesByAlias =
+            new Dictionary<string, ResolvedReference>(StringComparer.Ordinal);
+
+        /// <summary> Stores or replaces one resolved reference for the specified alias. </summary>
+        /// <param name="alias"> The alias name. </param>
+        /// <param name="resolvedReference"> The resolved reference value. </param>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="alias" /> is null, empty, whitespace, or contains outer whitespace. </exception>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="resolvedReference" /> is <see langword="null" />. </exception>
+        public void Set (
+            string alias,
+            ResolvedReference resolvedReference)
+        {
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                throw new ArgumentException("Alias must not be null, empty, or whitespace.", nameof(alias));
+            }
+
+            if (StringValueValidator.HasOuterWhitespace(alias))
+            {
+                throw new ArgumentException("Alias must not contain leading or trailing whitespace.", nameof(alias));
+            }
+
+            if (resolvedReference == null)
+            {
+                throw new ArgumentNullException(nameof(resolvedReference));
+            }
+
+            resolvedReferencesByAlias[alias] = resolvedReference;
+        }
+
+        /// <summary> Tries to get one previously stored resolved reference by alias. </summary>
+        /// <param name="alias"> The alias name. </param>
+        /// <param name="resolvedReference"> The resolved reference when found. </param>
+        /// <returns> <see langword="true" /> when alias exists; otherwise <see langword="false" />. </returns>
+        public bool TryGet (
+            string alias,
+            out ResolvedReference? resolvedReference)
+        {
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                resolvedReference = null;
+                return false;
+            }
+
+            return resolvedReferencesByAlias.TryGetValue(alias, out resolvedReference);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationAliasStore.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationAliasStore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78df027ef0b1949578c0ace48ac629d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationCallPassExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationCallPassExecutor.cs
@@ -12,15 +12,22 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
     {
         /// <summary> Executes call phase for prevalidated and preplanned operations. </summary>
         /// <param name="preparedOperations"> The prepared operations. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The call-pass result. </returns>
         public async Task<CallPassResult> Execute (
             IReadOnlyList<PreparedOperation> preparedOperations,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
             if (preparedOperations == null)
             {
                 throw new ArgumentNullException(nameof(preparedOperations));
+            }
+
+            if (executionContext == null)
+            {
+                throw new ArgumentNullException(nameof(executionContext));
             }
 
             var operationTraces = new List<OperationPhaseTrace>(preparedOperations.Count);
@@ -49,7 +56,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     var replayedPlanStepResult = await OperationPhaseExecutionUtilities.ExecutePhaseStep(
                         preparedOperation.Operation,
                         OperationPhase.Plan,
-                        ct => preparedOperation.PhaseOperation.Plan(preparedOperation.Operation, ct),
+                        ct => preparedOperation.PhaseOperation.Plan(preparedOperation.Operation, executionContext, ct),
                         cancellationToken).ConfigureAwait(false);
                     OperationPhaseExecutionUtilities.MergeTouched(touched, replayedPlanStepResult.Touched);
 
@@ -73,7 +80,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 var callStepResult = await OperationPhaseExecutionUtilities.ExecutePhaseStep(
                     preparedOperation.Operation,
                     OperationPhase.Call,
-                    ct => preparedOperation.PhaseOperation.Call(preparedOperation.Operation, ct),
+                    ct => preparedOperation.PhaseOperation.Call(preparedOperation.Operation, executionContext, ct),
                     cancellationToken).ConfigureAwait(false);
 
                 OperationPhaseExecutionUtilities.MergeTouched(touched, callStepResult.Touched);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
@@ -1,0 +1,27 @@
+using System;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one per-request execution context shared by operation phases. </summary>
+    internal sealed class OperationExecutionContext
+    {
+        /// <summary> Initializes a new instance of the <see cref="OperationExecutionContext" /> class. </summary>
+        public OperationExecutionContext ()
+            : this(new OperationAliasStore())
+        {
+        }
+
+        /// <summary> Initializes a new instance of the <see cref="OperationExecutionContext" /> class. </summary>
+        /// <param name="aliasStore"> The alias-store dependency. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="aliasStore" /> is <see langword="null" />. </exception>
+        internal OperationExecutionContext (OperationAliasStore aliasStore)
+        {
+            AliasStore = aliasStore ?? throw new ArgumentNullException(nameof(aliasStore));
+        }
+
+        /// <summary> Gets the alias store used to share resolved references within one request. </summary>
+        public OperationAliasStore AliasStore { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a82d3027cf38d467980f93e36a7fdd15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
@@ -73,7 +73,8 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var planPassResult = await planPassExecutor.Execute(request, cancellationToken).ConfigureAwait(false);
+            var executionContext = new OperationExecutionContext();
+            var planPassResult = await planPassExecutor.Execute(request, executionContext, cancellationToken).ConfigureAwait(false);
             if (!planPassResult.IsSuccess)
             {
                 return PhaseExecutionTrace.Failure(
@@ -118,7 +119,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     });
             }
 
-            var callPassResult = await callPassExecutor.Execute(planPassResult.PreparedOperations, cancellationToken).ConfigureAwait(false);
+            var callPassResult = await callPassExecutor.Execute(planPassResult.PreparedOperations, executionContext, cancellationToken).ConfigureAwait(false);
             return callPassResult.IsSuccess
                 ? PhaseExecutionTrace.Success(request.ProtocolVersion, request.RequestId, callPassResult.OperationTraces)
                 : PhaseExecutionTrace.Failure(request.ProtocolVersion, request.RequestId, callPassResult.OperationTraces, callPassResult.Errors);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPlanPassExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPlanPassExecutor.cs
@@ -24,15 +24,22 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         /// <summary> Executes validate and plan phases for all operations with fail-fast semantics. </summary>
         /// <param name="request"> The normalized request model. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
         /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
         /// <returns> The plan-pass result. </returns>
         public async Task<PlanPassResult> Execute (
             NormalizedExecuteRequest request,
+            OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
+            }
+
+            if (executionContext == null)
+            {
+                throw new ArgumentNullException(nameof(executionContext));
             }
 
             var operationTraces = new List<OperationPhaseTrace>(request.Ops.Count);
@@ -75,7 +82,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 var validateStepResult = await OperationPhaseExecutionUtilities.ExecutePhaseStep(
                     operation,
                     OperationPhase.Validate,
-                    ct => phaseOperation.Validate(operation, ct),
+                    ct => phaseOperation.Validate(operation, executionContext, ct),
                     cancellationToken).ConfigureAwait(false);
                 OperationPhaseExecutionUtilities.MergeTouched(touched, validateStepResult.Touched);
                 if (!validateStepResult.IsSuccess)
@@ -97,7 +104,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 var planStepResult = await OperationPhaseExecutionUtilities.ExecutePhaseStep(
                     operation,
                     OperationPhase.Plan,
-                    ct => phaseOperation.Plan(operation, ct),
+                    ct => phaseOperation.Plan(operation, executionContext, ct),
                     cancellationToken).ConfigureAwait(false);
                 OperationPhaseExecutionUtilities.MergeTouched(touched, planStepResult.Touched);
                 if (!planStepResult.IsSuccess)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Text;
+using MackySoft.Ucli.Unity.Execution.Requests;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements selector resolution flow for the <c>ucli.resolve</c> operation. </summary>
+    internal sealed class ResolvePhaseOperation : IPhaseOperation
+    {
+        /// <summary> Gets the operation name served by this implementation. </summary>
+        public string OperationName => "ucli.resolve";
+
+        /// <summary> Executes validate phase for <c>ucli.resolve</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> or <paramref name="executionContext" /> is <see langword="null" />. </exception>
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureArguments(operation, executionContext);
+
+            if (!ResolveSelectorCodec.TryParse(operation.Args, out var selector, out var errorMessage))
+            {
+                return Task.FromResult(CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            if (selector.Kind == ResolveSelectorKind.GlobalObjectId
+                && !ResolveReferenceResolver.IsValidGlobalObjectIdText(selector.GlobalObjectId!))
+            {
+                return Task.FromResult(CreateInvalidArgumentFailure(
+                    operation.Id,
+                    $"'{ResolveSelectorPropertyNames.GlobalObjectId}' must be a valid GlobalObjectId string."));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes plan phase for <c>ucli.resolve</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> or <paramref name="executionContext" /> is <see langword="null" />. </exception>
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            return ExecuteResolve(operation, executionContext, applied: false, cancellationToken);
+        }
+
+        /// <summary> Executes call phase for <c>ucli.resolve</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operation" /> or <paramref name="executionContext" /> is <see langword="null" />. </exception>
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            return ExecuteResolve(operation, executionContext, applied: true, cancellationToken);
+        }
+
+        /// <summary> Executes selector parse/resolve flow shared by plan and call phases. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="applied"> The applied flag for successful phase result. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        private static Task<OperationPhaseStepResult> ExecuteResolve (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            bool applied,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            EnsureArguments(operation, executionContext);
+
+            if (!ResolveSelectorCodec.TryParse(operation.Args, out var selector, out var parseErrorMessage))
+            {
+                return Task.FromResult(CreateInvalidArgumentFailure(operation.Id, parseErrorMessage));
+            }
+
+            if (!ResolveReferenceResolver.TryResolve(selector, out var resolvedReference, out var resolveErrorMessage))
+            {
+                return Task.FromResult(CreateInvalidArgumentFailure(operation.Id, resolveErrorMessage));
+            }
+
+            StoreAliasIfNeeded(operation.As, executionContext, resolvedReference!);
+            return Task.FromResult(OperationPhaseStepResult.Success(applied, changed: false));
+        }
+
+        /// <summary> Stores one resolved reference to alias store when alias is specified. </summary>
+        /// <param name="alias"> The operation alias. </param>
+        /// <param name="executionContext"> The execution context that owns the alias store. </param>
+        /// <param name="resolvedReference"> The resolved reference value. </param>
+        private static void StoreAliasIfNeeded (
+            string? alias,
+            OperationExecutionContext executionContext,
+            ResolvedReference resolvedReference)
+        {
+            if (StringValueNormalizer.TrimToNull(alias) == null)
+            {
+                return;
+            }
+
+            executionContext.AliasStore.Set(alias!, resolvedReference);
+        }
+
+        /// <summary> Throws for null operation/context arguments. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when an argument is <see langword="null" />. </exception>
+        private static void EnsureArguments (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext)
+        {
+            if (operation == null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+
+            if (executionContext == null)
+            {
+                throw new ArgumentNullException(nameof(executionContext));
+            }
+        }
+
+        /// <summary> Creates a standardized INVALID_ARGUMENT failure result for one operation. </summary>
+        /// <param name="operationId"> The operation identifier. </param>
+        /// <param name="message"> The error message. </param>
+        /// <returns> The failed phase-step result. </returns>
+        private static OperationPhaseStepResult CreateInvalidArgumentFailure (
+            string operationId,
+            string message)
+        {
+            return OperationPhaseStepResult.Failed(new OperationFailure(
+                Code: IpcErrorCodes.InvalidArgument,
+                Message: message,
+                OpId: operationId));
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Contracts.Text;
 using MackySoft.Ucli.Unity.Execution.Requests;
 
 #nullable enable
@@ -111,12 +110,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             ResolvedReference resolvedReference)
         {
-            if (StringValueNormalizer.TrimToNull(alias) == null)
+            if (alias == null)
             {
                 return;
             }
 
-            executionContext.AliasStore.Set(alias!, resolvedReference);
+            executionContext.AliasStore.Set(alias, resolvedReference);
         }
 
         /// <summary> Throws for null operation/context arguments. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvePhaseOperation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec6bbae35a7f746daabfa24c741f140f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveReferenceResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveReferenceResolver.cs
@@ -1,0 +1,157 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Resolves parsed selectors to GlobalObjectId-normalized references. </summary>
+    internal static class ResolveReferenceResolver
+    {
+        /// <summary> Determines whether GlobalObjectId text is syntactically valid. </summary>
+        /// <param name="globalObjectIdText"> The GlobalObjectId text value. </param>
+        /// <returns> <see langword="true" /> when text is syntactically valid; otherwise <see langword="false" />. </returns>
+        public static bool IsValidGlobalObjectIdText (string globalObjectIdText)
+        {
+            return GlobalObjectId.TryParse(globalObjectIdText, out _);
+        }
+
+        /// <summary> Tries to resolve one selector to a GlobalObjectId-normalized reference. </summary>
+        /// <param name="selector"> The parsed selector. </param>
+        /// <param name="resolvedReference"> The resolved reference when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when resolution succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryResolve (
+            ResolveSelector selector,
+            out ResolvedReference? resolvedReference,
+            out string errorMessage)
+        {
+            switch (selector.Kind)
+            {
+                case ResolveSelectorKind.GlobalObjectId:
+                    return TryResolveFromGlobalObjectId(selector.GlobalObjectId!, out resolvedReference, out errorMessage);
+
+                case ResolveSelectorKind.AssetGuid:
+                    return TryResolveFromAssetGuid(selector.AssetGuid!, out resolvedReference, out errorMessage);
+
+                case ResolveSelectorKind.AssetPath:
+                    return TryResolveFromAssetPath(selector.AssetPath!, out resolvedReference, out errorMessage);
+
+                case ResolveSelectorKind.SceneHierarchyPath:
+                    return TryResolveFromSceneHierarchyPath(
+                        selector.ScenePath!,
+                        selector.HierarchyPath!,
+                        out resolvedReference,
+                        out errorMessage);
+
+                default:
+                    resolvedReference = null;
+                    errorMessage = "Operation selector kind is not supported.";
+                    return false;
+            }
+        }
+
+        /// <summary> Tries to resolve one GlobalObjectId selector. </summary>
+        /// <param name="globalObjectIdText"> The GlobalObjectId text value. </param>
+        /// <param name="resolvedReference"> The resolved reference when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when selector resolves successfully; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveFromGlobalObjectId (
+            string globalObjectIdText,
+            out ResolvedReference? resolvedReference,
+            out string errorMessage)
+        {
+            resolvedReference = null;
+            if (!GlobalObjectId.TryParse(globalObjectIdText, out var globalObjectId))
+            {
+                errorMessage = $"'{ResolveSelectorPropertyNames.GlobalObjectId}' must be a valid GlobalObjectId string.";
+                return false;
+            }
+
+            var unityObject = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(globalObjectId);
+            if (unityObject == null)
+            {
+                errorMessage = $"GlobalObjectId is not resolvable in current project state: {globalObjectIdText}.";
+                return false;
+            }
+
+            resolvedReference = CreateResolvedReference(unityObject);
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Tries to resolve one asset-guid selector. </summary>
+        /// <param name="assetGuid"> The asset GUID value. </param>
+        /// <param name="resolvedReference"> The resolved reference when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when selector resolves successfully; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveFromAssetGuid (
+            string assetGuid,
+            out ResolvedReference? resolvedReference,
+            out string errorMessage)
+        {
+            resolvedReference = null;
+            var assetPath = AssetDatabase.GUIDToAssetPath(assetGuid);
+            if (string.IsNullOrWhiteSpace(assetPath))
+            {
+                errorMessage = $"Asset GUID could not be resolved: {assetGuid}.";
+                return false;
+            }
+
+            return TryResolveFromAssetPath(assetPath, out resolvedReference, out errorMessage);
+        }
+
+        /// <summary> Tries to resolve one asset-path selector. </summary>
+        /// <param name="assetPath"> The asset path value. </param>
+        /// <param name="resolvedReference"> The resolved reference when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when selector resolves successfully; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveFromAssetPath (
+            string assetPath,
+            out ResolvedReference? resolvedReference,
+            out string errorMessage)
+        {
+            resolvedReference = null;
+            var unityObject = AssetDatabase.LoadMainAssetAtPath(assetPath);
+            if (unityObject == null)
+            {
+                errorMessage = $"Asset path could not be resolved to a main asset: {assetPath}.";
+                return false;
+            }
+
+            resolvedReference = CreateResolvedReference(unityObject);
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Tries to resolve one scene + hierarchy-path selector. </summary>
+        /// <param name="scenePath"> The scene path value. </param>
+        /// <param name="hierarchyPath"> The hierarchy path value. </param>
+        /// <param name="resolvedReference"> The resolved reference when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when selector resolves successfully; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveFromSceneHierarchyPath (
+            string scenePath,
+            string hierarchyPath,
+            out ResolvedReference? resolvedReference,
+            out string errorMessage)
+        {
+            resolvedReference = null;
+            if (!SceneHierarchyPathResolver.TryResolveLoadedSceneObject(scenePath, hierarchyPath, out var gameObject, out errorMessage))
+            {
+                return false;
+            }
+
+            resolvedReference = CreateResolvedReference(gameObject!);
+            return true;
+        }
+
+        /// <summary> Converts one Unity object into a GlobalObjectId-normalized reference. </summary>
+        /// <param name="unityObject"> The Unity object to normalize. </param>
+        /// <returns> The normalized resolved reference. </returns>
+        private static ResolvedReference CreateResolvedReference (UnityEngine.Object unityObject)
+        {
+            var globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(unityObject);
+            return new ResolvedReference(globalObjectId.ToString());
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveReferenceResolver.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveReferenceResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3420e745389bd4ad38d81a2f4a43380e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelector.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelector.cs
@@ -1,0 +1,80 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one parsed <c>ucli.resolve</c> selector. </summary>
+    internal readonly struct ResolveSelector
+    {
+        public ResolveSelector (
+            ResolveSelectorKind kind,
+            string? globalObjectId,
+            string? assetGuid,
+            string? assetPath,
+            string? scenePath,
+            string? hierarchyPath)
+        {
+            Kind = kind;
+            GlobalObjectId = globalObjectId;
+            AssetGuid = assetGuid;
+            AssetPath = assetPath;
+            ScenePath = scenePath;
+            HierarchyPath = hierarchyPath;
+        }
+
+        public ResolveSelectorKind Kind { get; }
+
+        public string? GlobalObjectId { get; }
+
+        public string? AssetGuid { get; }
+
+        public string? AssetPath { get; }
+
+        public string? ScenePath { get; }
+
+        public string? HierarchyPath { get; }
+
+        public static ResolveSelector FromGlobalObjectId (string globalObjectId)
+        {
+            return new ResolveSelector(
+                kind: ResolveSelectorKind.GlobalObjectId,
+                globalObjectId: globalObjectId,
+                assetGuid: null,
+                assetPath: null,
+                scenePath: null,
+                hierarchyPath: null);
+        }
+
+        public static ResolveSelector FromAssetGuid (string assetGuid)
+        {
+            return new ResolveSelector(
+                kind: ResolveSelectorKind.AssetGuid,
+                globalObjectId: null,
+                assetGuid: assetGuid,
+                assetPath: null,
+                scenePath: null,
+                hierarchyPath: null);
+        }
+
+        public static ResolveSelector FromAssetPath (string assetPath)
+        {
+            return new ResolveSelector(
+                kind: ResolveSelectorKind.AssetPath,
+                globalObjectId: null,
+                assetGuid: null,
+                assetPath: assetPath,
+                scenePath: null,
+                hierarchyPath: null);
+        }
+
+        public static ResolveSelector FromSceneHierarchy (
+            string scenePath,
+            string hierarchyPath)
+        {
+            return new ResolveSelector(
+                kind: ResolveSelectorKind.SceneHierarchyPath,
+                globalObjectId: null,
+                assetGuid: null,
+                assetPath: null,
+                scenePath: scenePath,
+                hierarchyPath: hierarchyPath);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelector.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c260a425d870644dc92dafe35eb8775d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Decodes and validates selector arguments for <c>ucli.resolve</c>. </summary>
+    internal static class ResolveSelectorCodec
+    {
+        private static readonly HashSet<string> AllowedPropertyNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            ResolveSelectorPropertyNames.GlobalObjectId,
+            ResolveSelectorPropertyNames.AssetGuid,
+            ResolveSelectorPropertyNames.AssetPath,
+            ResolveSelectorPropertyNames.Scene,
+            ResolveSelectorPropertyNames.HierarchyPath,
+        };
+
+        /// <summary> Parses one selector from operation arguments. </summary>
+        /// <param name="args"> The operation arguments element. </param>
+        /// <param name="selector"> The parsed selector when successful. </param>
+        /// <param name="errorMessage"> The parse error message when failed. </param>
+        /// <returns> <see langword="true" /> when selector was parsed successfully; otherwise <see langword="false" />. </returns>
+        public static bool TryParse (
+            JsonElement args,
+            out ResolveSelector selector,
+            out string errorMessage)
+        {
+            selector = default;
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            var hasGlobalObjectId = false;
+            var hasAssetGuid = false;
+            var hasAssetPath = false;
+            var hasScenePath = false;
+            var hasHierarchyPath = false;
+            string? globalObjectId = null;
+            string? assetGuid = null;
+            string? assetPath = null;
+            string? scenePath = null;
+            string? hierarchyPath = null;
+
+            foreach (var property in args.EnumerateObject())
+            {
+                if (!AllowedPropertyNames.Contains(property.Name))
+                {
+                    errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                    return false;
+                }
+
+                switch (property.Name)
+                {
+                    case ResolveSelectorPropertyNames.GlobalObjectId:
+                        if (hasGlobalObjectId)
+                        {
+                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.GlobalObjectId}.";
+                            return false;
+                        }
+
+                        if (!TryReadRequiredString(property, out globalObjectId, out errorMessage))
+                        {
+                            return false;
+                        }
+
+                        hasGlobalObjectId = true;
+                        break;
+
+                    case ResolveSelectorPropertyNames.AssetGuid:
+                        if (hasAssetGuid)
+                        {
+                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.AssetGuid}.";
+                            return false;
+                        }
+
+                        if (!TryReadRequiredString(property, out assetGuid, out errorMessage))
+                        {
+                            return false;
+                        }
+
+                        hasAssetGuid = true;
+                        break;
+
+                    case ResolveSelectorPropertyNames.AssetPath:
+                        if (hasAssetPath)
+                        {
+                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.AssetPath}.";
+                            return false;
+                        }
+
+                        if (!TryReadRequiredString(property, out assetPath, out errorMessage))
+                        {
+                            return false;
+                        }
+
+                        hasAssetPath = true;
+                        break;
+
+                    case ResolveSelectorPropertyNames.Scene:
+                        if (hasScenePath)
+                        {
+                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.Scene}.";
+                            return false;
+                        }
+
+                        if (!TryReadRequiredString(property, out scenePath, out errorMessage))
+                        {
+                            return false;
+                        }
+
+                        hasScenePath = true;
+                        break;
+
+                    case ResolveSelectorPropertyNames.HierarchyPath:
+                        if (hasHierarchyPath)
+                        {
+                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.HierarchyPath}.";
+                            return false;
+                        }
+
+                        if (!TryReadRequiredString(property, out hierarchyPath, out errorMessage))
+                        {
+                            return false;
+                        }
+
+                        hasHierarchyPath = true;
+                        break;
+                }
+            }
+
+            if (hasScenePath != hasHierarchyPath)
+            {
+                errorMessage = $"Operation 'args' requires both '{ResolveSelectorPropertyNames.Scene}' and '{ResolveSelectorPropertyNames.HierarchyPath}' when one is specified.";
+                return false;
+            }
+
+            var selectorCount = 0;
+            if (hasGlobalObjectId)
+            {
+                selectorCount++;
+            }
+
+            if (hasAssetGuid)
+            {
+                selectorCount++;
+            }
+
+            if (hasAssetPath)
+            {
+                selectorCount++;
+            }
+
+            if (hasScenePath)
+            {
+                selectorCount++;
+            }
+
+            if (selectorCount != 1)
+            {
+                errorMessage =
+                    $"Operation 'args' must specify exactly one selector: '{ResolveSelectorPropertyNames.GlobalObjectId}', '{ResolveSelectorPropertyNames.AssetGuid}', '{ResolveSelectorPropertyNames.AssetPath}', or '{ResolveSelectorPropertyNames.Scene}' + '{ResolveSelectorPropertyNames.HierarchyPath}'.";
+                return false;
+            }
+
+            if (hasGlobalObjectId)
+            {
+                selector = ResolveSelector.FromGlobalObjectId(globalObjectId!);
+                return true;
+            }
+
+            if (hasAssetGuid)
+            {
+                selector = ResolveSelector.FromAssetGuid(assetGuid!);
+                return true;
+            }
+
+            if (hasAssetPath)
+            {
+                selector = ResolveSelector.FromAssetPath(assetPath!);
+                return true;
+            }
+
+            selector = ResolveSelector.FromSceneHierarchy(scenePath!, hierarchyPath!);
+            return true;
+        }
+
+        /// <summary> Reads one required strict string property from selector arguments. </summary>
+        /// <param name="property"> The JSON property to parse. </param>
+        /// <param name="value"> The parsed string when successful. </param>
+        /// <param name="errorMessage"> The parse error message when failed. </param>
+        /// <returns> <see langword="true" /> when property is a valid strict string; otherwise <see langword="false" />. </returns>
+        private static bool TryReadRequiredString (
+            JsonProperty property,
+            out string? value,
+            out string errorMessage)
+        {
+            value = null;
+            if (property.Value.ValueKind != JsonValueKind.String)
+            {
+                errorMessage = $"Operation 'args.{property.Name}' must be a string.";
+                return false;
+            }
+
+            var parsedValue = property.Value.GetString();
+            if (string.IsNullOrWhiteSpace(parsedValue))
+            {
+                errorMessage = $"Operation 'args.{property.Name}' must not be empty or whitespace.";
+                return false;
+            }
+
+            if (StringValueValidator.HasOuterWhitespace(parsedValue))
+            {
+                errorMessage = $"Operation 'args.{property.Name}' must not contain leading or trailing whitespace.";
+                return false;
+            }
+
+            value = parsedValue;
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bad430da1edae4ff68e01829c5fe2d5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorKind.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorKind.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents selector kinds supported by <c>ucli.resolve</c>. </summary>
+    internal enum ResolveSelectorKind
+    {
+        GlobalObjectId = 1,
+        AssetGuid = 2,
+        AssetPath = 3,
+        SceneHierarchyPath = 4,
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorKind.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorKind.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 996722a734fd34c2abe6e0396f77ffe8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorPropertyNames.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorPropertyNames.cs
@@ -1,0 +1,16 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Defines JSON property names accepted by <c>ucli.resolve</c> selectors. </summary>
+    internal static class ResolveSelectorPropertyNames
+    {
+        public const string GlobalObjectId = "globalObjectId";
+
+        public const string AssetGuid = "assetGuid";
+
+        public const string AssetPath = "assetPath";
+
+        public const string Scene = "scene";
+
+        public const string HierarchyPath = "hierarchyPath";
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorPropertyNames.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorPropertyNames.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abc2e1c40a4f54e72ac710abdff7a149
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
@@ -24,12 +24,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 throw new ArgumentException("GlobalObjectId must not contain leading or trailing whitespace.", nameof(globalObjectId));
             }
 
-            if (!UnityEditor.GlobalObjectId.TryParse(globalObjectId, out _))
+            if (!UnityEditor.GlobalObjectId.TryParse(globalObjectId, out var parsedGlobalObjectId))
             {
                 throw new ArgumentException("GlobalObjectId must be a valid GlobalObjectId string.", nameof(globalObjectId));
             }
 
-            GlobalObjectId = globalObjectId;
+            GlobalObjectId = parsedGlobalObjectId.ToString();
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
@@ -1,8 +1,35 @@
-#nullable enable
+using System;
+using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Unity.Execution.Phases
 {
     /// <summary> Represents one resolved selector target normalized as a GlobalObjectId string. </summary>
-    /// <param name="GlobalObjectId"> The normalized GlobalObjectId string. </param>
-    internal sealed record ResolvedReference (string GlobalObjectId);
+    internal sealed record ResolvedReference
+    {
+        /// <summary> Gets the normalized GlobalObjectId string. </summary>
+        public string GlobalObjectId { get; }
+
+        /// <summary> Initializes a new instance of the <see cref="ResolvedReference" /> class. </summary>
+        /// <param name="globalObjectId"> The normalized GlobalObjectId string. </param>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="globalObjectId" /> is null, empty, whitespace, has outer whitespace, or is malformed. </exception>
+        public ResolvedReference (string globalObjectId)
+        {
+            if (string.IsNullOrWhiteSpace(globalObjectId))
+            {
+                throw new ArgumentException("GlobalObjectId must not be null, empty, or whitespace.", nameof(globalObjectId));
+            }
+
+            if (StringValueValidator.HasOuterWhitespace(globalObjectId))
+            {
+                throw new ArgumentException("GlobalObjectId must not contain leading or trailing whitespace.", nameof(globalObjectId));
+            }
+
+            if (!UnityEditor.GlobalObjectId.TryParse(globalObjectId, out _))
+            {
+                throw new ArgumentException("GlobalObjectId must be a valid GlobalObjectId string.", nameof(globalObjectId));
+            }
+
+            GlobalObjectId = globalObjectId;
+        }
+    }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs
@@ -1,0 +1,8 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one resolved selector target normalized as a GlobalObjectId string. </summary>
+    /// <param name="GlobalObjectId"> The normalized GlobalObjectId string. </param>
+    internal sealed record ResolvedReference (string GlobalObjectId);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolvedReference.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e4d2b265a003453fb7fb1d67317c65a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/SceneHierarchyPathResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/SceneHierarchyPathResolver.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Resolves one hierarchy path to a unique GameObject in a loaded scene. </summary>
+    internal static class SceneHierarchyPathResolver
+    {
+        /// <summary> Tries to resolve one unique GameObject from a loaded scene path and hierarchy path. </summary>
+        /// <param name="scenePath"> The scene path value. </param>
+        /// <param name="hierarchyPath"> The hierarchy path value. </param>
+        /// <param name="gameObject"> The resolved GameObject when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when path resolves uniquely; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveLoadedSceneObject (
+            string scenePath,
+            string hierarchyPath,
+            out GameObject? gameObject,
+            out string errorMessage)
+        {
+            gameObject = null;
+            var scene = SceneManager.GetSceneByPath(scenePath);
+            if (!scene.IsValid() || !scene.isLoaded)
+            {
+                errorMessage =
+                    $"Scene is not loaded: {scenePath}. Resolve with '{ResolveSelectorPropertyNames.Scene}' + '{ResolveSelectorPropertyNames.HierarchyPath}' requires the scene to be opened first.";
+                return false;
+            }
+
+            return TryResolveUniqueGameObject(scene, hierarchyPath, out gameObject, out errorMessage);
+        }
+
+        /// <summary> Resolves one unique GameObject under the specified scene and hierarchy path. </summary>
+        /// <param name="scene"> The loaded scene. </param>
+        /// <param name="hierarchyPath"> The hierarchy path value. </param>
+        /// <param name="gameObject"> The resolved GameObject when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when path resolves uniquely; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveUniqueGameObject (
+            Scene scene,
+            string hierarchyPath,
+            out GameObject? gameObject,
+            out string errorMessage)
+        {
+            gameObject = null;
+            var segments = hierarchyPath.Split('/');
+            if (segments.Length == 0)
+            {
+                errorMessage = $"Hierarchy path is invalid: {hierarchyPath}.";
+                return false;
+            }
+
+            for (var i = 0; i < segments.Length; i++)
+            {
+                if (segments[i].Length == 0)
+                {
+                    errorMessage = $"Hierarchy path contains empty segment: {hierarchyPath}.";
+                    return false;
+                }
+            }
+
+            var current = new List<Transform>();
+            var roots = scene.GetRootGameObjects();
+            for (var rootIndex = 0; rootIndex < roots.Length; rootIndex++)
+            {
+                var root = roots[rootIndex];
+                if (string.Equals(root.name, segments[0], StringComparison.Ordinal))
+                {
+                    current.Add(root.transform);
+                }
+            }
+
+            if (current.Count == 0)
+            {
+                errorMessage = $"Hierarchy path was not found in loaded scene '{scene.path}': {hierarchyPath}.";
+                return false;
+            }
+
+            for (var segmentIndex = 1; segmentIndex < segments.Length; segmentIndex++)
+            {
+                var targetName = segments[segmentIndex];
+                var next = new List<Transform>();
+                for (var parentIndex = 0; parentIndex < current.Count; parentIndex++)
+                {
+                    var parent = current[parentIndex];
+                    for (var childIndex = 0; childIndex < parent.childCount; childIndex++)
+                    {
+                        var child = parent.GetChild(childIndex);
+                        if (string.Equals(child.name, targetName, StringComparison.Ordinal))
+                        {
+                            next.Add(child);
+                        }
+                    }
+                }
+
+                if (next.Count == 0)
+                {
+                    errorMessage = $"Hierarchy path was not found in loaded scene '{scene.path}': {hierarchyPath}.";
+                    return false;
+                }
+
+                current = next;
+            }
+
+            if (current.Count > 1)
+            {
+                errorMessage = $"Hierarchy path resolved to multiple objects in loaded scene '{scene.path}': {hierarchyPath}.";
+                return false;
+            }
+
+            gameObject = current[0].gameObject;
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/SceneHierarchyPathResolver.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/SceneHierarchyPathResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 220fad22a79bc4ad9895c85ed59070e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityDaemonBootstrap.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityDaemonBootstrap.cs
@@ -97,7 +97,10 @@ namespace MackySoft.Ucli.Unity.Ipc
         private static IExecuteRequestDispatcher CreateExecuteRequestDispatcher ()
         {
             var normalizer = new ExecuteRequestNormalizer();
-            var operationRegistry = new InMemoryPhaseOperationRegistry(Array.Empty<IPhaseOperation>());
+            var operationRegistry = new InMemoryPhaseOperationRegistry(new IPhaseOperation[]
+            {
+                new ResolvePhaseOperation(),
+            });
             var phaseExecutor = new OperationPhaseExecutor(operationRegistry);
             return new ExecuteRequestDispatcher(normalizer, phaseExecutor);
         }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/OperationPhaseExecutorTests.cs
@@ -124,6 +124,22 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [UnityTest]
         [Category("Size.Small")]
+        public IEnumerator Execute_WhenCommandIsCall_UsesSharedExecutionContextAcrossAllPhases () => UniTask.ToCoroutine(async () =>
+        {
+            var operation = new ContextCapturingPhaseOperation("ucli.resolve");
+            var executor = CreateExecutor(operation);
+            var request = CreateRequest("op-1", "ucli.resolve");
+
+            var trace = await executor.Execute(PhaseExecutionCommand.Call, request).AsUniTask();
+
+            Assert.That(trace.IsSuccess, Is.True);
+            Assert.That(operation.ValidateContext, Is.Not.Null);
+            Assert.That(operation.ValidateContext, Is.SameAs(operation.PlanContext));
+            Assert.That(operation.PlanContext, Is.SameAs(operation.CallContext));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
         public IEnumerator Execute_WhenPlanSucceeds_IssuesPlanToken () => UniTask.ToCoroutine(async () =>
         {
             var operation = new RecordingPhaseOperation(
@@ -738,6 +754,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Validate (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -747,6 +764,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Plan (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -756,6 +774,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Call (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -777,6 +796,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Validate (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -785,6 +805,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Plan (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -794,6 +815,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public Task<OperationPhaseStepResult> Call (
                 NormalizedOperation operation,
+                OperationExecutionContext executionContext,
                 CancellationToken cancellationToken = default)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -806,6 +828,52 @@ namespace MackySoft.Ucli.Unity.Tests
                 }
 
                 return Task.FromResult(OperationPhaseStepResult.Success());
+            }
+        }
+
+        private sealed class ContextCapturingPhaseOperation : IPhaseOperation
+        {
+            public ContextCapturingPhaseOperation (string operationName)
+            {
+                OperationName = operationName;
+            }
+
+            public string OperationName { get; }
+
+            public OperationExecutionContext? ValidateContext { get; private set; }
+
+            public OperationExecutionContext? PlanContext { get; private set; }
+
+            public OperationExecutionContext? CallContext { get; private set; }
+
+            public Task<OperationPhaseStepResult> Validate (
+                NormalizedOperation operation,
+                OperationExecutionContext executionContext,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ValidateContext = executionContext;
+                return Task.FromResult(OperationPhaseStepResult.Success());
+            }
+
+            public Task<OperationPhaseStepResult> Plan (
+                NormalizedOperation operation,
+                OperationExecutionContext executionContext,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                PlanContext = executionContext;
+                return Task.FromResult(OperationPhaseStepResult.Success());
+            }
+
+            public Task<OperationPhaseStepResult> Call (
+                NormalizedOperation operation,
+                OperationExecutionContext executionContext,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                CallContext = executionContext;
+                return Task.FromResult(OperationPhaseStepResult.Success(applied: true, changed: false));
             }
         }
     }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs
@@ -1,0 +1,398 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class ResolvePhaseOperationTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public void Validate_WhenArgsContainMultipleSelectors_ReturnsInvalidArgument ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-1",
+                args: new
+                {
+                    assetPath = "Assets/sample.asset",
+                    assetGuid = "11111111111111111111111111111111",
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-1");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Validate_WhenGlobalObjectIdIsMalformed_ReturnsInvalidArgument ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-1",
+                args: new
+                {
+                    globalObjectId = "invalid-global-object-id",
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-1");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenArgsContainGlobalObjectId_StoresResolvedReferenceToAliasStore ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var assetPath = CreateTemporaryAssetPath();
+            var asset = ScriptableObject.CreateInstance<ResolveTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var expectedGlobalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(asset).ToString();
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    alias: "resolved",
+                    args: new
+                    {
+                        globalObjectId = expectedGlobalObjectId,
+                    });
+                var context = new OperationExecutionContext();
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+                Assert.That(context.AliasStore.TryGet("resolved", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+                Assert.That(resolvedReference!.GlobalObjectId, Is.EqualTo(expectedGlobalObjectId));
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenArgsContainAssetGuid_ResolvesMainAsset ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var assetPath = $"Assets/ResolvePhaseOperationTests_{Guid.NewGuid():N}.asset";
+            var asset = ScriptableObject.CreateInstance<ResolveTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+                var expectedGlobalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(asset).ToString();
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    alias: "resolved",
+                    args: new
+                    {
+                        assetGuid,
+                    });
+                var context = new OperationExecutionContext();
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+                Assert.That(context.AliasStore.TryGet("resolved", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+                Assert.That(resolvedReference!.GlobalObjectId, Is.EqualTo(expectedGlobalObjectId));
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenArgsContainAssetPath_ResolvesMainAsset ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var assetPath = $"Assets/ResolvePhaseOperationTests_{Guid.NewGuid():N}.asset";
+            var asset = ScriptableObject.CreateInstance<ResolveTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var expectedGlobalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(asset).ToString();
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    alias: "resolved",
+                    args: new
+                    {
+                        assetPath,
+                    });
+                var context = new OperationExecutionContext();
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+                Assert.That(context.AliasStore.TryGet("resolved", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+                Assert.That(resolvedReference!.GlobalObjectId, Is.EqualTo(expectedGlobalObjectId));
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenArgsContainSceneHierarchyPath_ResolvesGameObjectInLoadedScene ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            var fallbackScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                var enemies = new GameObject("Enemies");
+                enemies.transform.SetParent(root.transform, worldPositionStays: false);
+                var spawner = new GameObject("Spawner");
+                spawner.transform.SetParent(enemies.transform, worldPositionStays: false);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var expectedGlobalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(spawner).ToString();
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    alias: "resolved",
+                    args: new
+                    {
+                        scene = scenePath,
+                        hierarchyPath = "Root/Enemies/Spawner",
+                    });
+                var context = new OperationExecutionContext();
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+                Assert.That(context.AliasStore.TryGet("resolved", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+                Assert.That(resolvedReference!.GlobalObjectId, Is.EqualTo(expectedGlobalObjectId));
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+                if (fallbackScene.IsValid())
+                {
+                    EditorSceneManager.CloseScene(fallbackScene, removeScene: true);
+                }
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenSceneIsNotLoaded_ReturnsInvalidArgument ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                var child = new GameObject("Child");
+                child.transform.SetParent(root.transform, worldPositionStays: false);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    args: new
+                    {
+                        scene = scenePath,
+                        hierarchyPath = "Root/Child",
+                    });
+
+                var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertInvalidArgument(result, "op-1");
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenHierarchyPathResolvesNoObject_ReturnsInvalidArgument ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                _ = new GameObject("Root");
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    args: new
+                    {
+                        scene = scenePath,
+                        hierarchyPath = "Root/Missing",
+                    });
+
+                var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertInvalidArgument(result, "op-1");
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Plan_WhenHierarchyPathResolvesMultipleObjects_ReturnsInvalidArgument ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                var duplicateA = new GameObject("Dup");
+                duplicateA.transform.SetParent(root.transform, worldPositionStays: false);
+                var duplicateB = new GameObject("Dup");
+                duplicateB.transform.SetParent(root.transform, worldPositionStays: false);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    args: new
+                    {
+                        scene = scenePath,
+                        hierarchyPath = "Root/Dup",
+                    });
+
+                var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertInvalidArgument(result, "op-1");
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Call_WhenResolutionSucceeds_ReturnsAppliedTrueAndChangedFalse ()
+        {
+            var operation = new ResolvePhaseOperation();
+            var assetPath = CreateTemporaryAssetPath();
+            var asset = ScriptableObject.CreateInstance<ResolveTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var requestOperation = CreateOperation(
+                    opId: "op-1",
+                    alias: "resolved",
+                    args: new
+                    {
+                        globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(asset).ToString(),
+                    });
+                var context = new OperationExecutionContext();
+
+                var result = operation.Call(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: false);
+                Assert.That(context.AliasStore.TryGet("resolved", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        private static string CreateTemporaryScenePath ()
+        {
+            return $"Assets/ResolvePhaseOperationTests_{Guid.NewGuid():N}.unity";
+        }
+
+        private static string CreateTemporaryAssetPath ()
+        {
+            return $"Assets/ResolvePhaseOperationTests_{Guid.NewGuid():N}.asset";
+        }
+
+        private static NormalizedOperation CreateOperation (
+            string opId,
+            object args,
+            string? alias = null)
+        {
+            return new NormalizedOperation(
+                Id: opId,
+                Op: "ucli.resolve",
+                Args: JsonSerializer.SerializeToElement(args),
+                As: alias,
+                Expect: null);
+        }
+
+        private static void AssertInvalidArgument (
+            OperationPhaseStepResult result,
+            string expectedOperationId)
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.Not.Null);
+            Assert.That(result.Failure!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(result.Failure.OpId, Is.EqualTo(expectedOperationId));
+        }
+
+        private static void AssertSuccess (
+            OperationPhaseStepResult result,
+            bool applied,
+            bool changed)
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Applied, Is.EqualTo(applied));
+            Assert.That(result.Changed, Is.EqualTo(changed));
+            Assert.That(result.Touched.Count, Is.EqualTo(0));
+            Assert.That(result.Failure, Is.Null);
+        }
+
+        private sealed class ResolveTestAsset : ScriptableObject
+        {
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs
@@ -52,6 +52,27 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [Test]
         [Category("Size.Small")]
+        public void ResolvedReference_WhenGlobalObjectIdIsWhitespace_ThrowsArgumentException ()
+        {
+            Assert.Throws<ArgumentException>(() => _ = new ResolvedReference(" "));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void ResolvedReference_WhenGlobalObjectIdHasOuterWhitespace_ThrowsArgumentException ()
+        {
+            Assert.Throws<ArgumentException>(() => _ = new ResolvedReference(" GlobalObjectId_V1-2-3-4-5-6-7"));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void ResolvedReference_WhenGlobalObjectIdIsMalformed_ThrowsArgumentException ()
+        {
+            Assert.Throws<ArgumentException>(() => _ = new ResolvedReference("invalid-global-object-id"));
+        }
+
+        [Test]
+        [Category("Size.Small")]
         public void Plan_WhenArgsContainGlobalObjectId_StoresResolvedReferenceToAliasStore ()
         {
             var operation = new ResolvePhaseOperation();

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ResolvePhaseOperationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d576bceb1507a4610af409526e861a9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
+++ b/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
@@ -7,6 +7,27 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
 {
     private const string DefaultArgsSchemaJson = """{"type":"object"}""";
 
+    private const string ResolveArgsSchemaJson =
+        """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "globalObjectId": { "type": "string", "minLength": 1 },
+            "assetGuid": { "type": "string", "minLength": 1 },
+            "assetPath": { "type": "string", "minLength": 1 },
+            "scene": { "type": "string", "minLength": 1 },
+            "hierarchyPath": { "type": "string", "minLength": 1 }
+          },
+          "oneOf": [
+            { "required": ["globalObjectId"] },
+            { "required": ["assetGuid"] },
+            { "required": ["assetPath"] },
+            { "required": ["scene", "hierarchyPath"] }
+          ]
+        }
+        """;
+
     private static readonly IReadOnlyList<UcliOperationDescriptor> Operations =
     [
         new UcliOperationDescriptor("ucli.asset.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
@@ -31,7 +52,7 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
         new UcliOperationDescriptor("ucli.project.refresh", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
         new UcliOperationDescriptor("ucli.project.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
 
-        new UcliOperationDescriptor("ucli.resolve", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.resolve", UcliOperationKind.Query, OperationPolicy.Safe, ResolveArgsSchemaJson),
 
         new UcliOperationDescriptor("ucli.scene.open", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
         new UcliOperationDescriptor("ucli.scene.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),

--- a/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
+++ b/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
@@ -1,5 +1,6 @@
 namespace MackySoft.Ucli.Tests;
 
+using System.Text.Json;
 using MackySoft.Ucli.Configuration;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Operations;
@@ -20,6 +21,29 @@ public sealed class OperationCatalogTests
         Assert.Equal("ucli.scene.open", descriptor.Name);
         Assert.Equal(UcliOperationKind.Query, descriptor.Kind);
         Assert.Equal(OperationPolicy.Safe, descriptor.Policy);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Get_WhenOperationIsResolve_ReturnsSelectorSchema ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var descriptor = await catalog.Get("ucli.resolve", CancellationToken.None);
+
+        Assert.NotNull(descriptor);
+        using var schemaDocument = JsonDocument.Parse(descriptor.ArgsSchemaJson);
+        var schemaRoot = schemaDocument.RootElement;
+        Assert.Equal(JsonValueKind.Object, schemaRoot.ValueKind);
+        Assert.True(schemaRoot.TryGetProperty("additionalProperties", out var additionalProperties));
+        Assert.False(additionalProperties.GetBoolean());
+        Assert.True(schemaRoot.TryGetProperty("oneOf", out var oneOf));
+        Assert.Equal(JsonValueKind.Array, oneOf.ValueKind);
+        Assert.Equal(4, oneOf.GetArrayLength());
+        Assert.True(ContainsRequiredProperty(oneOf, "globalObjectId"));
+        Assert.True(ContainsRequiredProperty(oneOf, "assetGuid"));
+        Assert.True(ContainsRequiredProperty(oneOf, "assetPath"));
+        Assert.True(ContainsRequiredProperties(oneOf, "scene", "hierarchyPath"));
     }
 
     [Fact]
@@ -82,5 +106,60 @@ public sealed class OperationCatalogTests
             cancellationToken.ThrowIfCancellationRequested();
             return ValueTask.FromResult(operations);
         }
+    }
+
+    private static bool ContainsRequiredProperty (
+        JsonElement oneOfArray,
+        string propertyName)
+    {
+        foreach (var schema in oneOfArray.EnumerateArray())
+        {
+            if (!schema.TryGetProperty("required", out var requiredProperties))
+            {
+                continue;
+            }
+
+            if (requiredProperties.ValueKind != JsonValueKind.Array || requiredProperties.GetArrayLength() != 1)
+            {
+                continue;
+            }
+
+            var requiredProperty = requiredProperties[0].GetString();
+            if (string.Equals(requiredProperty, propertyName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsRequiredProperties (
+        JsonElement oneOfArray,
+        string firstPropertyName,
+        string secondPropertyName)
+    {
+        foreach (var schema in oneOfArray.EnumerateArray())
+        {
+            if (!schema.TryGetProperty("required", out var requiredProperties))
+            {
+                continue;
+            }
+
+            if (requiredProperties.ValueKind != JsonValueKind.Array || requiredProperties.GetArrayLength() != 2)
+            {
+                continue;
+            }
+
+            var firstRequired = requiredProperties[0].GetString();
+            var secondRequired = requiredProperties[1].GetString();
+            if (string.Equals(firstRequired, firstPropertyName, StringComparison.Ordinal)
+                && string.Equals(secondRequired, secondPropertyName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- #21 (O1) として `ucli.resolve` を Unity 側 `IPhaseOperation` 実装に追加し、4 selector（`globalObjectId` / `assetGuid` / `assetPath` / `scene + hierarchyPath`）を単一 `GlobalObjectId` へ解決する実行経路を実装しました。
- 同一 request 内で `as` を保持する `OperationExecutionContext` / `OperationAliasStore` を導入し、Plan/Call フェーズで解決値を再利用できる基盤を追加しました。
- command 境界（`resolve` command 未実装）は維持し、#39 以降の責務境界を崩さない構成にしています。

## Scope
- 実行フェーズ基盤: `IPhaseOperation` と Plan/Call executor 群に `OperationExecutionContext` 伝搬を追加。
- resolve 実装: `ResolvePhaseOperation`、selector codec、参照 resolver、scene hierarchy resolver、正規化済み参照型を新規追加。
- 起動/カタログ: `UnityDaemonBootstrap` への operation 登録、`InMemoryOperationCatalogProvider` の `ucli.resolve` `argsSchema` を 4 selector `oneOf` に更新。
- テスト: `ResolvePhaseOperationTests` 新規追加、`OperationPhaseExecutorTests` / `OperationCatalogTests` 更新。

## Verification
- Gate level: Standard
- Diff budget: PASS (32 files / +1581 -8。Issue #21 に Split waived を追記済み)
- Spec drift: Skipped (`docs/agents/feature_issue-21-ucli-resolve/spec.md` が存在しないため)
- Format: PASS
  - `dotnet format "Ucli.slnx" --verbosity minimal --no-restore`
  - `dotnet format "Ucli.slnx" --verbosity minimal --verify-no-changes --no-restore`
- Tests: PASS
  - `dotnet test "tests/Ucli.Tests/Ucli.Tests.csproj" --verbosity minimal --no-restore`
  - `dotnet test "tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj" --verbosity minimal --no-restore`
  - `"/Applications/Unity/Hub/Editor/2021.3.45f2/Unity.app/Contents/MacOS/Unity" -batchmode -nographics -projectPath "src/Ucli.Unity" -runTests -testPlatform EditMode -assemblyNames "MackySoft.Ucli.Unity.Tests.Editor" -testFilter "ResolvePhaseOperationTests|OperationPhaseExecutorTests|ExecuteRequestDispatcherTests" ...`
- Coverage: N/A

## Risks / Rollback
- Risk: Unity EditMode 全件実行は既知の `UnityIpcServerTests` 系の不安定性でハングするケースがあり、今回は #21 受け入れに必要な対象テストへ絞って実行しています。
- Rollback: `git revert c51ed06` と `git revert 6b62e7f` で #21 の変更を段階的に取り消し可能です。

## Checklist
- [ ] Issue #21 の Acceptance Criteria チェック更新
- [ ] Draft 解除前にレビューコメント反映

Closes #21
