### PR TITLE
chore: sync Unity contracts package usage to 0.5.0

### DIFF
--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.4.2" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.5.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.Extensions.DependencyInjection" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="netstandard2.0" />


### PR DESCRIPTION
## Summary
- Unity 側の `MackySoft.Ucli.Contracts` 参照バージョンを、公開済みの `0.5.0` に同期しました。
- Contracts リリース後の使用バージョン不一致（0.4.2参照）を解消しました。

## Scope
- `src/Ucli.Unity/Assets/packages.config`
  - `MackySoft.Ucli.Contracts` の version を `0.4.2` から `0.5.0` に更新

## Verification
- Gate level: Standard
- Diff budget: PASS (1 file changed, 1 insertion, 1 deletion)
- Spec drift: Skipped (`docs/agents/chore_contracts-usage-version-sync/spec.md` が存在しないため)
- Format: PASS (N/A: packages.config の単一バージョン更新のみ)
- Tests: PASS (Skipped: コード変更を含まない設定同期のため)
- Coverage: N/A

## Risks / Rollback
- リスク: Unity 側の依存復元時に `0.5.0` を取得できない環境では復元失敗の可能性がある。
- ロールバック: 当該1行を `0.4.2` に戻すリバートで即時復旧できる。

## Checklist
- [ ] Unity 側の次回依存復元で `MackySoft.Ucli.Contracts 0.5.0` が解決されることを確認する

Issue: none (ad-hoc task)
