### PR TITLE
ci: auto-sync NuGet usage versions after contracts publish

### DIFF
--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -64,7 +64,7 @@ jobs:
           --api-key "${{ secrets.GITHUB_TOKEN }}"
           --skip-duplicate
 
-      - name: Sync contracts csproj version
+      - name: Sync contracts package versions in repository
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
@@ -76,14 +76,33 @@ jobs:
           git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
 
           csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
-          current_version="$(sed -n 's#.*<Version>\(.*\)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-          if [[ "${current_version}" == "${PACKAGE_VERSION}" ]]; then
-            echo "No csproj version update required."
+          unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
+
+          csproj_current_version="$(sed -n 's#.*<Version>\(.*\)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+          if [[ -z "${csproj_current_version}" ]]; then
+            echo "Failed to resolve contracts csproj version from ${csproj_path}." >&2
+            exit 1
+          fi
+
+          unity_current_version="$(sed -n 's#.*<package id="MackySoft.Ucli.Contracts" version="\([^"]\+\)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
+          if [[ -z "${unity_current_version}" ]]; then
+            echo "Failed to resolve Unity contracts package version from ${unity_packages_config_path}." >&2
+            exit 1
+          fi
+
+          if [[ "${csproj_current_version}" != "${PACKAGE_VERSION}" ]]; then
+            sed -i -E "0,/<Version>[^<]+<\/Version>/s//<Version>${PACKAGE_VERSION}<\/Version>/" "${csproj_path}"
+          fi
+
+          if [[ "${unity_current_version}" != "${PACKAGE_VERSION}" ]]; then
+            sed -i -E "s#(<package id=\"MackySoft.Ucli.Contracts\" version=\")[^\"]+(\".*)#\\1${PACKAGE_VERSION}\\2#" "${unity_packages_config_path}"
+          fi
+
+          if git diff --quiet -- "${csproj_path}" "${unity_packages_config_path}"; then
+            echo "No repository version sync required."
             exit 0
           fi
 
-          sed -i -E "0,/<Version>[^<]+<\/Version>/s//<Version>${PACKAGE_VERSION}<\/Version>/" "${csproj_path}"
-
-          git add "${csproj_path}"
+          git add "${csproj_path}" "${unity_packages_config_path}"
           git commit -m "chore(contracts): sync package version to ${PACKAGE_VERSION}"
           git push origin "HEAD:${DEFAULT_BRANCH}"

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -102,6 +102,7 @@ done
 ## Release Workflow
 - `contracts-package-verify`: `src/Ucli.Contracts` または workflow 自体に変更がある PR で、restore/build/pack を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグ push、または `workflow_dispatch` の `package_version` 指定で GitHub Packages へ公開する。
+- `contracts-package-publish` は公開後に `src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の `MackySoft.Ucli.Contracts` バージョンを同一値へ自動同期する。
 - タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`）。
 
 ```bash


### PR DESCRIPTION
## Summary
- Contracts パッケージ公開後に、利用側 NuGet バージョンも自動同期されるよう CI を拡張しました。
- これまでの `Ucli.Contracts.csproj` 同期に加えて、Unity 側 `packages.config` も同一バージョンへ揃えます。

## Scope
- `.github/workflows/contracts-package-publish.yaml`
  - `src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の両方を `PACKAGE_VERSION` へ同期
  - バージョン抽出失敗時は明示エラー
  - 差分が無い場合は commit/push をスキップ
- `docs/package-operations.md`
  - 上記の自動同期挙動を Release Workflow セクションに追記

## Verification
- Gate level: Standard
- Diff budget: PASS (2 files changed, 27 insertions, 7 deletions)
- Spec drift: Skipped (`docs/agents/chore_ci-auto-sync-contracts-nuget/spec.md` が存在しないため)
- Format: PASS (N/A: YAML/Markdownの運用変更のみ)
- Tests: PASS (Skipped: 実行コード変更なし)
- Coverage: N/A
- Extra check: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/contracts-package-publish.yaml")'` => `YAML_OK`

## Risks / Rollback
- リスク: `sed` パターンが将来の `packages.config` 形式変更に追従できない場合、同期コミットに失敗する可能性がある。
- ロールバック: 当該2コミットをリバートし、従来の csproj 同期のみに戻す。

## Checklist
- [ ] 次回 `contracts/x.y.z` タグリリースで `master` へ自動同期コミットが作成されることを確認する

Issue: none (ad-hoc task)
