### PR TITLE
fix(unity): make idempotency decision type C# 9 compatible

### DIFF
--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/RequestIdempotency/ExecuteRequestIdempotencyStoreDecision.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/RequestIdempotency/ExecuteRequestIdempotencyStoreDecision.cs
@@ -4,14 +4,22 @@ using MackySoft.Ucli.Contracts.Ipc;
 namespace MackySoft.Ucli.Unity.Execution.RequestIdempotency
 {
     /// <summary> Represents one store decision used by request-id idempotency coordination flows. </summary>
-    /// <param name="Kind"> The decision kind. </param>
-    /// <param name="Response"> The completed response for replay decisions. </param>
-    /// <param name="SharedResponseTask"> The owner response task for wait decisions. </param>
-    internal readonly record struct ExecuteRequestIdempotencyStoreDecision (
-        ExecuteRequestIdempotencyStoreDecision.DecisionKind Kind,
-        IpcResponse? Response,
-        Task<IpcResponse>? SharedResponseTask)
+    internal readonly struct ExecuteRequestIdempotencyStoreDecision
     {
+        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestIdempotencyStoreDecision" /> struct. </summary>
+        /// <param name="kind"> The decision kind. </param>
+        /// <param name="response"> The completed response for replay decisions. </param>
+        /// <param name="sharedResponseTask"> The owner response task for wait decisions. </param>
+        public ExecuteRequestIdempotencyStoreDecision (
+            ExecuteRequestIdempotencyStoreDecision.DecisionKind kind,
+            IpcResponse? response,
+            Task<IpcResponse>? sharedResponseTask)
+        {
+            Kind = kind;
+            Response = response;
+            SharedResponseTask = sharedResponseTask;
+        }
+
         /// <summary> Defines one idempotency decision kind. </summary>
         internal enum DecisionKind
         {
@@ -20,6 +28,15 @@ namespace MackySoft.Ucli.Unity.Execution.RequestIdempotency
             WaitInFlight,
             Conflict,
         }
+
+        /// <summary> Gets the decision kind. </summary>
+        public DecisionKind Kind { get; }
+
+        /// <summary> Gets the completed response for replay decisions. </summary>
+        public IpcResponse? Response { get; }
+
+        /// <summary> Gets the owner response task for wait decisions. </summary>
+        public Task<IpcResponse>? SharedResponseTask { get; }
 
         /// <summary> Creates one owner-execution decision. </summary>
         /// <returns> The owner-execution decision. </returns>


### PR DESCRIPTION
## Summary
- Unity 側で発生していた `CS8773`（`record struct` が C# 10 以降必須）を解消するため、該当型を C# 9 互換の `readonly struct` に置換しました。
- 既存の判定フロー（DecisionKind と factory メソッド）は維持し、互換性を保ったままコンパイル要件のみ調整しています。

## Scope
- `src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/RequestIdempotency/ExecuteRequestIdempotencyStoreDecision.cs`
  - `record struct` から `readonly struct` へ変更
  - 明示コンストラクタと読み取り専用プロパティを追加
  - 既存 factory メソッドを維持

## Verification
- Gate level: Standard
- Diff budget: PASS（1 file changed, +24/-7）
- Spec drift: Skipped（`docs/agents/fix_unity-csharp9-idempotency-decision/spec.md` が存在しないため）
- Format: PASS（`dotnet format Ucli.slnx --include <target>` + `--verify-no-changes`）
- Tests: PASS（`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore --verbosity minimal` / 335 passed）
- Coverage: N/A

## Risks / Rollback
- リスク: 実行時分岐の意図は維持していますが、型定義の変更に伴い Unity 実行環境での最終確認は別途必要です。
- ロールバック: 本コミットを revert すれば即時に元へ戻せます。

## Checklist
- [ ] Unity batchmode での最終コンパイル確認

Issue: none (ad-hoc task)
