### PR TITLE
refactor(codec): centralize IPC response and literal conversion helpers

### DIFF
--- a/src/Ucli.Contracts/Configuration/OperationPolicyCodec.cs
+++ b/src/Ucli.Contracts/Configuration/OperationPolicyCodec.cs
@@ -1,21 +1,28 @@
+using MackySoft.Ucli.Contracts.Text;
+
 namespace MackySoft.Ucli.Contracts.Configuration;
 
 /// <summary> Converts operation-policy values between enum and contract literals. </summary>
 public static class OperationPolicyCodec
 {
+    private static readonly (OperationPolicy Value, string Literal)[] Mappings =
+    {
+        (OperationPolicy.Safe, OperationPolicyValues.Safe),
+        (OperationPolicy.Advanced, OperationPolicyValues.Advanced),
+        (OperationPolicy.Dangerous, OperationPolicyValues.Dangerous),
+    };
+
     /// <summary> Converts one operation-policy enum value to config literal. </summary>
     /// <param name="operationPolicy"> The operation-policy enum value. </param>
     /// <returns> The config literal value. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="operationPolicy" /> is unsupported. </exception>
     public static string ToValue (OperationPolicy operationPolicy)
     {
-        return operationPolicy switch
-        {
-            OperationPolicy.Safe => OperationPolicyValues.Safe,
-            OperationPolicy.Advanced => OperationPolicyValues.Advanced,
-            OperationPolicy.Dangerous => OperationPolicyValues.Dangerous,
-            _ => throw new ArgumentOutOfRangeException(nameof(operationPolicy), operationPolicy, "Unsupported operationPolicy."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            operationPolicy,
+            Mappings,
+            nameof(operationPolicy),
+            "Unsupported operationPolicy.");
     }
 
     /// <summary> Tries to parse config literal to operation-policy enum. </summary>
@@ -26,25 +33,10 @@ public static class OperationPolicyCodec
         string? value,
         out OperationPolicy operationPolicy)
     {
-        if (string.Equals(value, OperationPolicyValues.Safe, StringComparison.OrdinalIgnoreCase))
-        {
-            operationPolicy = OperationPolicy.Safe;
-            return true;
-        }
-
-        if (string.Equals(value, OperationPolicyValues.Advanced, StringComparison.OrdinalIgnoreCase))
-        {
-            operationPolicy = OperationPolicy.Advanced;
-            return true;
-        }
-
-        if (string.Equals(value, OperationPolicyValues.Dangerous, StringComparison.OrdinalIgnoreCase))
-        {
-            operationPolicy = OperationPolicy.Dangerous;
-            return true;
-        }
-
-        operationPolicy = default;
-        return false;
+        return LiteralCodecUtilities.TryParse(
+            value,
+            Mappings,
+            StringComparison.OrdinalIgnoreCase,
+            out operationPolicy);
     }
 }

--- a/src/Ucli.Contracts/Configuration/PlanTokenModeCodec.cs
+++ b/src/Ucli.Contracts/Configuration/PlanTokenModeCodec.cs
@@ -1,20 +1,27 @@
+using MackySoft.Ucli.Contracts.Text;
+
 namespace MackySoft.Ucli.Contracts.Configuration;
 
 /// <summary> Converts plan-token mode values between enum and contract literals. </summary>
 public static class PlanTokenModeCodec
 {
+    private static readonly (PlanTokenMode Value, string Literal)[] Mappings =
+    {
+        (PlanTokenMode.Optional, PlanTokenModeValues.Optional),
+        (PlanTokenMode.Required, PlanTokenModeValues.Required),
+    };
+
     /// <summary> Converts one plan-token mode enum value to config literal. </summary>
     /// <param name="planTokenMode"> The plan-token mode enum value. </param>
     /// <returns> The config literal value. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="planTokenMode" /> is unsupported. </exception>
     public static string ToValue (PlanTokenMode planTokenMode)
     {
-        return planTokenMode switch
-        {
-            PlanTokenMode.Optional => PlanTokenModeValues.Optional,
-            PlanTokenMode.Required => PlanTokenModeValues.Required,
-            _ => throw new ArgumentOutOfRangeException(nameof(planTokenMode), planTokenMode, "Unsupported planTokenMode."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            planTokenMode,
+            Mappings,
+            nameof(planTokenMode),
+            "Unsupported planTokenMode.");
     }
 
     /// <summary> Tries to parse config literal to plan-token mode enum. </summary>
@@ -25,19 +32,10 @@ public static class PlanTokenModeCodec
         string? value,
         out PlanTokenMode planTokenMode)
     {
-        if (string.Equals(value, PlanTokenModeValues.Optional, StringComparison.OrdinalIgnoreCase))
-        {
-            planTokenMode = PlanTokenMode.Optional;
-            return true;
-        }
-
-        if (string.Equals(value, PlanTokenModeValues.Required, StringComparison.OrdinalIgnoreCase))
-        {
-            planTokenMode = PlanTokenMode.Required;
-            return true;
-        }
-
-        planTokenMode = default;
-        return false;
+        return LiteralCodecUtilities.TryParse(
+            value,
+            Mappings,
+            StringComparison.OrdinalIgnoreCase,
+            out planTokenMode);
     }
 }

--- a/src/Ucli.Contracts/Configuration/ReadIndexModeCodec.cs
+++ b/src/Ucli.Contracts/Configuration/ReadIndexModeCodec.cs
@@ -1,21 +1,28 @@
+using MackySoft.Ucli.Contracts.Text;
+
 namespace MackySoft.Ucli.Contracts.Configuration;
 
 /// <summary> Converts read-index mode values between enum and contract literals. </summary>
 public static class ReadIndexModeCodec
 {
+    private static readonly (ReadIndexMode Value, string Literal)[] Mappings =
+    {
+        (ReadIndexMode.Disabled, ReadIndexModeValues.Disabled),
+        (ReadIndexMode.AllowStale, ReadIndexModeValues.AllowStale),
+        (ReadIndexMode.RequireFresh, ReadIndexModeValues.RequireFresh),
+    };
+
     /// <summary> Converts one read-index mode enum value to config literal. </summary>
     /// <param name="readIndexMode"> The read-index mode enum value. </param>
     /// <returns> The config literal value. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="readIndexMode" /> is unsupported. </exception>
     public static string ToValue (ReadIndexMode readIndexMode)
     {
-        return readIndexMode switch
-        {
-            ReadIndexMode.Disabled => ReadIndexModeValues.Disabled,
-            ReadIndexMode.AllowStale => ReadIndexModeValues.AllowStale,
-            ReadIndexMode.RequireFresh => ReadIndexModeValues.RequireFresh,
-            _ => throw new ArgumentOutOfRangeException(nameof(readIndexMode), readIndexMode, "Unsupported readIndexMode."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            readIndexMode,
+            Mappings,
+            nameof(readIndexMode),
+            "Unsupported readIndexMode.");
     }
 
     /// <summary> Tries to parse config literal to read-index mode enum. </summary>
@@ -26,25 +33,10 @@ public static class ReadIndexModeCodec
         string? value,
         out ReadIndexMode readIndexMode)
     {
-        if (string.Equals(value, ReadIndexModeValues.Disabled, StringComparison.OrdinalIgnoreCase))
-        {
-            readIndexMode = ReadIndexMode.Disabled;
-            return true;
-        }
-
-        if (string.Equals(value, ReadIndexModeValues.AllowStale, StringComparison.OrdinalIgnoreCase))
-        {
-            readIndexMode = ReadIndexMode.AllowStale;
-            return true;
-        }
-
-        if (string.Equals(value, ReadIndexModeValues.RequireFresh, StringComparison.OrdinalIgnoreCase))
-        {
-            readIndexMode = ReadIndexMode.RequireFresh;
-            return true;
-        }
-
-        readIndexMode = default;
-        return false;
+        return LiteralCodecUtilities.TryParse(
+            value,
+            Mappings,
+            StringComparison.OrdinalIgnoreCase,
+            out readIndexMode);
     }
 }

--- a/src/Ucli.Contracts/Configuration/UcliConfigJsonContractReader.cs
+++ b/src/Ucli.Contracts/Configuration/UcliConfigJsonContractReader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using MackySoft.Ucli.Contracts.Json;
 using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Contracts.Configuration;
@@ -35,39 +36,80 @@ internal static class UcliConfigJsonContractReader
             return false;
         }
 
-        var unknownProperty = FindUnknownProperty(root, StrictAllowedProperties);
+        var unknownProperty = JsonObjectPropertyReader.FindUnknownProperty(root, StrictAllowedProperties);
         if (!string.IsNullOrWhiteSpace(unknownProperty))
         {
             error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.UnknownProperty, unknownProperty);
             return false;
         }
 
-        if (!TryReadRequiredInt32(root, UcliConfigJsonPropertyNames.SchemaVersion, out var schemaVersion, out error))
+        if (!JsonObjectPropertyReader.TryReadRequiredInt32(
+            root,
+            UcliConfigJsonPropertyNames.SchemaVersion,
+            CreateMissingPropertyError,
+            CreatePropertyTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var schemaVersion,
+            out error))
         {
             return false;
         }
 
-        if (!TryReadRequiredString(root, UcliConfigJsonPropertyNames.OperationPolicy, out var operationPolicy, out error))
+        if (!JsonObjectPropertyReader.TryReadRequiredString(
+            root,
+            UcliConfigJsonPropertyNames.OperationPolicy,
+            CreateMissingPropertyError,
+            CreatePropertyTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var operationPolicy,
+            out error))
         {
             return false;
         }
 
-        if (!TryReadRequiredString(root, UcliConfigJsonPropertyNames.PlanTokenMode, out var planTokenMode, out error))
+        if (!JsonObjectPropertyReader.TryReadRequiredString(
+            root,
+            UcliConfigJsonPropertyNames.PlanTokenMode,
+            CreateMissingPropertyError,
+            CreatePropertyTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var planTokenMode,
+            out error))
         {
             return false;
         }
 
-        if (!TryReadOptionalString(root, UcliConfigJsonPropertyNames.ReadIndexDefaultMode, out var readIndexDefaultMode, out error))
+        if (!JsonObjectPropertyReader.TryReadOptionalString(
+            root,
+            UcliConfigJsonPropertyNames.ReadIndexDefaultMode,
+            CreatePropertyTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var readIndexDefaultMode,
+            out error))
         {
             return false;
         }
 
-        if (!TryReadRequiredStringArray(root, UcliConfigJsonPropertyNames.OperationAllowlist, out var operationAllowlist, out error))
+        if (!JsonObjectPropertyReader.TryReadRequiredStringArray(
+            root,
+            UcliConfigJsonPropertyNames.OperationAllowlist,
+            CreateMissingPropertyError,
+            CreatePropertyTypeMismatchError,
+            CreateArrayElementTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var operationAllowlist,
+            out error))
         {
             return false;
         }
 
-        if (!TryReadOptionalNullableInt32(root, UcliConfigJsonPropertyNames.IpcDefaultTimeoutMilliseconds, out var ipcDefaultTimeoutMilliseconds, out error))
+        if (!JsonObjectPropertyReader.TryReadOptionalNullableInt32(
+            root,
+            UcliConfigJsonPropertyNames.IpcDefaultTimeoutMilliseconds,
+            CreatePropertyTypeMismatchError,
+            UcliConfigJsonReadError.None,
+            out var ipcDefaultTimeoutMilliseconds,
+            out error))
         {
             return false;
         }
@@ -122,141 +164,19 @@ internal static class UcliConfigJsonContractReader
         return true;
     }
 
-    private static bool TryReadRequiredInt32 (
-        JsonElement root,
-        string propertyName,
-        out int value,
-        out UcliConfigJsonReadError error)
+    private static UcliConfigJsonReadError CreateMissingPropertyError (string propertyName)
     {
-        value = default;
-        if (!root.TryGetProperty(propertyName, out var propertyElement))
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.MissingProperty, propertyName);
-            return false;
-        }
-
-        if (propertyElement.ValueKind != JsonValueKind.Number || !propertyElement.TryGetInt32(out value))
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
-            return false;
-        }
-
-        error = UcliConfigJsonReadError.None;
-        return true;
+        return new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.MissingProperty, propertyName);
     }
 
-    private static bool TryReadRequiredString (
-        JsonElement root,
-        string propertyName,
-        out string value,
-        out UcliConfigJsonReadError error)
+    private static UcliConfigJsonReadError CreatePropertyTypeMismatchError (string propertyName)
     {
-        value = string.Empty;
-        if (!root.TryGetProperty(propertyName, out var propertyElement))
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.MissingProperty, propertyName);
-            return false;
-        }
-
-        if (propertyElement.ValueKind != JsonValueKind.String)
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
-            return false;
-        }
-
-        value = propertyElement.GetString() ?? string.Empty;
-        error = UcliConfigJsonReadError.None;
-        return true;
+        return new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
     }
 
-    private static bool TryReadOptionalString (
-        JsonElement root,
-        string propertyName,
-        out string? value,
-        out UcliConfigJsonReadError error)
+    private static UcliConfigJsonReadError CreateArrayElementTypeMismatchError (string propertyName)
     {
-        value = null;
-        if (!root.TryGetProperty(propertyName, out var propertyElement))
-        {
-            error = UcliConfigJsonReadError.None;
-            return true;
-        }
-
-        if (propertyElement.ValueKind != JsonValueKind.String)
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
-            return false;
-        }
-
-        value = propertyElement.GetString();
-        error = UcliConfigJsonReadError.None;
-        return true;
-    }
-
-    private static bool TryReadRequiredStringArray (
-        JsonElement root,
-        string propertyName,
-        out string[] values,
-        out UcliConfigJsonReadError error)
-    {
-        values = Array.Empty<string>();
-        if (!root.TryGetProperty(propertyName, out var propertyElement))
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.MissingProperty, propertyName);
-            return false;
-        }
-
-        if (propertyElement.ValueKind != JsonValueKind.Array)
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
-            return false;
-        }
-
-        var list = new List<string>();
-        foreach (var element in propertyElement.EnumerateArray())
-        {
-            if (element.ValueKind != JsonValueKind.String)
-            {
-                error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.ArrayElementTypeMismatch, propertyName);
-                return false;
-            }
-
-            list.Add(element.GetString() ?? string.Empty);
-        }
-
-        values = list.ToArray();
-        error = UcliConfigJsonReadError.None;
-        return true;
-    }
-
-    private static bool TryReadOptionalNullableInt32 (
-        JsonElement root,
-        string propertyName,
-        out int? value,
-        out UcliConfigJsonReadError error)
-    {
-        value = null;
-        if (!root.TryGetProperty(propertyName, out var propertyElement))
-        {
-            error = UcliConfigJsonReadError.None;
-            return true;
-        }
-
-        if (propertyElement.ValueKind == JsonValueKind.Null)
-        {
-            error = UcliConfigJsonReadError.None;
-            return true;
-        }
-
-        if (propertyElement.ValueKind != JsonValueKind.Number || !propertyElement.TryGetInt32(out var parsedValue))
-        {
-            error = new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.PropertyTypeMismatch, propertyName);
-            return false;
-        }
-
-        value = parsedValue;
-        error = UcliConfigJsonReadError.None;
-        return true;
+        return new UcliConfigJsonReadError(UcliConfigJsonReadErrorKind.ArrayElementTypeMismatch, propertyName);
     }
 
     private static bool TryReadOptionalInt32Dictionary (
@@ -351,18 +271,4 @@ internal static class UcliConfigJsonContractReader
         return values.ToArray();
     }
 
-    private static string? FindUnknownProperty (
-        JsonElement root,
-        HashSet<string> allowedProperties)
-    {
-        foreach (var property in root.EnumerateObject())
-        {
-            if (!allowedProperties.Contains(property.Name))
-            {
-                return property.Name;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/Ucli.Contracts/Ipc/Common/IpcCompileStateCodec.cs
+++ b/src/Ucli.Contracts/Ipc/Common/IpcCompileStateCodec.cs
@@ -11,6 +11,12 @@ public static class IpcCompileStateCodec
     /// <summary> Gets the compile-state value used when editor is compiling. </summary>
     public const string Compiling = "compiling";
 
+    private static readonly string[] CanonicalLiterals =
+    {
+        Ready,
+        Compiling,
+    };
+
     /// <summary> Converts one compile-activity flag to the IPC compile-state literal. </summary>
     /// <param name="isCompiling"> Whether the editor is currently compiling. </param>
     /// <returns> <see cref="Compiling" /> when <paramref name="isCompiling" /> is <see langword="true" />; otherwise <see cref="Ready" />. </returns>
@@ -29,25 +35,10 @@ public static class IpcCompileStateCodec
         string? value,
         out string? compileState)
     {
-        if (!StringValueNormalizer.TryTrimToNonEmpty(value, out var normalized))
-        {
-            compileState = null;
-            return false;
-        }
-
-        if (string.Equals(normalized, Ready, StringComparison.Ordinal))
-        {
-            compileState = Ready;
-            return true;
-        }
-
-        if (string.Equals(normalized, Compiling, StringComparison.Ordinal))
-        {
-            compileState = Compiling;
-            return true;
-        }
-
-        compileState = null;
-        return false;
+        return LiteralCodecUtilities.TryNormalizeLiteral(
+            value,
+            CanonicalLiterals,
+            StringComparison.Ordinal,
+            out compileState);
     }
 }

--- a/src/Ucli.Contracts/Ipc/Common/IpcTestRunPlatformCodec.cs
+++ b/src/Ucli.Contracts/Ipc/Common/IpcTestRunPlatformCodec.cs
@@ -17,18 +17,29 @@ public static class IpcTestRunPlatformCodec
     /// <summary> Gets the Unity command-line value for PlayMode runs. </summary>
     public const string UnityPlayMode = "PlayMode";
 
+    private static readonly (IpcTestRunPlatform Value, string Literal)[] CanonicalMappings =
+    {
+        (IpcTestRunPlatform.EditMode, EditMode),
+        (IpcTestRunPlatform.PlayMode, PlayMode),
+    };
+
+    private static readonly (IpcTestRunPlatform Value, string Literal)[] UnityMappings =
+    {
+        (IpcTestRunPlatform.EditMode, UnityEditMode),
+        (IpcTestRunPlatform.PlayMode, UnityPlayMode),
+    };
+
     /// <summary> Converts one test-run platform enum value to canonical IPC literal. </summary>
     /// <param name="testPlatform"> The test-run platform enum value. </param>
     /// <returns> The canonical IPC literal. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="testPlatform" /> is unsupported. </exception>
     public static string ToValue (IpcTestRunPlatform testPlatform)
     {
-        return testPlatform switch
-        {
-            IpcTestRunPlatform.EditMode => EditMode,
-            IpcTestRunPlatform.PlayMode => PlayMode,
-            _ => throw new ArgumentOutOfRangeException(nameof(testPlatform), testPlatform, "Unsupported test platform."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            testPlatform,
+            CanonicalMappings,
+            nameof(testPlatform),
+            "Unsupported test platform.");
     }
 
     /// <summary> Converts one test-run platform enum value to Unity command-line literal. </summary>
@@ -37,12 +48,11 @@ public static class IpcTestRunPlatformCodec
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="testPlatform" /> is unsupported. </exception>
     public static string ToUnityValue (IpcTestRunPlatform testPlatform)
     {
-        return testPlatform switch
-        {
-            IpcTestRunPlatform.EditMode => UnityEditMode,
-            IpcTestRunPlatform.PlayMode => UnityPlayMode,
-            _ => throw new ArgumentOutOfRangeException(nameof(testPlatform), testPlatform, "Unsupported test platform."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            testPlatform,
+            UnityMappings,
+            nameof(testPlatform),
+            "Unsupported test platform.");
     }
 
     /// <summary> Tries to parse one test-platform literal to canonical IPC value. </summary>
@@ -53,25 +63,10 @@ public static class IpcTestRunPlatformCodec
         string? value,
         out IpcTestRunPlatform testPlatform)
     {
-        if (!StringValueNormalizer.TryTrimToNonEmpty(value, out var normalized))
-        {
-            testPlatform = default;
-            return false;
-        }
-
-        if (string.Equals(normalized, EditMode, StringComparison.OrdinalIgnoreCase))
-        {
-            testPlatform = IpcTestRunPlatform.EditMode;
-            return true;
-        }
-
-        if (string.Equals(normalized, PlayMode, StringComparison.OrdinalIgnoreCase))
-        {
-            testPlatform = IpcTestRunPlatform.PlayMode;
-            return true;
-        }
-
-        testPlatform = default;
-        return false;
+        return LiteralCodecUtilities.TryParseTrimmed(
+            value,
+            CanonicalMappings,
+            StringComparison.OrdinalIgnoreCase,
+            out testPlatform);
     }
 }

--- a/src/Ucli.Contracts/Ipc/Common/IpcTransportKindCodec.cs
+++ b/src/Ucli.Contracts/Ipc/Common/IpcTransportKindCodec.cs
@@ -1,20 +1,27 @@
+using MackySoft.Ucli.Contracts.Text;
+
 namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Converts transport-kind values between enum and contract literals. </summary>
 public static class IpcTransportKindCodec
 {
+    private static readonly (IpcTransportKind Value, string Literal)[] Mappings =
+    {
+        (IpcTransportKind.NamedPipe, IpcTransportKindValues.NamedPipe),
+        (IpcTransportKind.UnixDomainSocket, IpcTransportKindValues.UnixDomainSocket),
+    };
+
     /// <summary> Converts one transport enum value to contract literal. </summary>
     /// <param name="transportKind"> The transport enum value. </param>
     /// <returns> The transport literal value. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="transportKind" /> is unsupported. </exception>
     public static string ToValue (IpcTransportKind transportKind)
     {
-        return transportKind switch
-        {
-            IpcTransportKind.NamedPipe => IpcTransportKindValues.NamedPipe,
-            IpcTransportKind.UnixDomainSocket => IpcTransportKindValues.UnixDomainSocket,
-            _ => throw new ArgumentOutOfRangeException(nameof(transportKind), transportKind, "Unsupported transport kind."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            transportKind,
+            Mappings,
+            nameof(transportKind),
+            "Unsupported transport kind.");
     }
 
     /// <summary> Tries to parse contract literal to transport enum value. </summary>
@@ -25,19 +32,10 @@ public static class IpcTransportKindCodec
         string? value,
         out IpcTransportKind transportKind)
     {
-        if (string.Equals(value, IpcTransportKindValues.NamedPipe, StringComparison.Ordinal))
-        {
-            transportKind = IpcTransportKind.NamedPipe;
-            return true;
-        }
-
-        if (string.Equals(value, IpcTransportKindValues.UnixDomainSocket, StringComparison.Ordinal))
-        {
-            transportKind = IpcTransportKind.UnixDomainSocket;
-            return true;
-        }
-
-        transportKind = default;
-        return false;
+        return LiteralCodecUtilities.TryParse(
+            value,
+            Mappings,
+            StringComparison.Ordinal,
+            out transportKind);
     }
 }

--- a/src/Ucli.Contracts/Json/JsonObjectPropertyReader.cs
+++ b/src/Ucli.Contracts/Json/JsonObjectPropertyReader.cs
@@ -1,0 +1,290 @@
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Contracts.Json;
+
+/// <summary> Provides reusable JSON object property readers for strict contract parsing. </summary>
+internal static class JsonObjectPropertyReader
+{
+    /// <summary> Finds the first unknown property in one JSON object. </summary>
+    /// <param name="jsonObject"> The source JSON object. </param>
+    /// <param name="allowedProperties"> The allowed property-name set. </param>
+    /// <returns> The unknown property name, or <see langword="null" /> when all properties are allowed. </returns>
+    public static string? FindUnknownProperty (
+        JsonElement jsonObject,
+        ISet<string> allowedProperties)
+    {
+        foreach (var property in jsonObject.EnumerateObject())
+        {
+            if (!allowedProperties.Contains(property.Name))
+            {
+                return property.Name;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary> Reads one required property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The required property name. </param>
+    /// <param name="missingErrorFactory"> The error factory used when property is missing. </param>
+    /// <param name="property"> The parsed property value when successful. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" /> from caller-level chain. </param>
+    /// <returns> <see langword="true" /> when property exists; otherwise <see langword="false" />. </returns>
+    public static bool TryReadRequiredProperty<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> missingErrorFactory,
+        out JsonElement property,
+        out TError error)
+    {
+        if (!root.TryGetProperty(propertyName, out property))
+        {
+            error = missingErrorFactory(propertyName);
+            return false;
+        }
+
+        error = default!;
+        return true;
+    }
+
+    /// <summary> Reads one required int32 property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The required property name. </param>
+    /// <param name="missingErrorFactory"> The error factory used when property is missing. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="value"> The parsed int32 value when successful. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is valid int32; otherwise <see langword="false" />. </returns>
+    public static bool TryReadRequiredInt32<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> missingErrorFactory,
+        Func<string, TError> typeMismatchErrorFactory,
+        TError noError,
+        out int value,
+        out TError error)
+    {
+        value = default;
+        if (!TryReadRequiredProperty(root, propertyName, missingErrorFactory, out var property, out error))
+        {
+            return false;
+        }
+
+        if (property.ValueKind != JsonValueKind.Number || !property.TryGetInt32(out value))
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        error = noError;
+        return true;
+    }
+
+    /// <summary> Reads one required string property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The required property name. </param>
+    /// <param name="missingErrorFactory"> The error factory used when property is missing. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="value"> The parsed string value when successful. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is valid string; otherwise <see langword="false" />. </returns>
+    public static bool TryReadRequiredString<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> missingErrorFactory,
+        Func<string, TError> typeMismatchErrorFactory,
+        TError noError,
+        out string value,
+        out TError error)
+    {
+        value = string.Empty;
+        if (!TryReadRequiredProperty(root, propertyName, missingErrorFactory, out var property, out error))
+        {
+            return false;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        value = property.GetString() ?? string.Empty;
+        error = noError;
+        return true;
+    }
+
+    /// <summary> Reads one required nullable-string property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The required property name. </param>
+    /// <param name="missingErrorFactory"> The error factory used when property is missing. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="value"> The parsed nullable-string value when successful. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is valid string or null; otherwise <see langword="false" />. </returns>
+    public static bool TryReadRequiredNullableString<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> missingErrorFactory,
+        Func<string, TError> typeMismatchErrorFactory,
+        TError noError,
+        out string? value,
+        out TError error)
+    {
+        value = null;
+        if (!TryReadRequiredProperty(root, propertyName, missingErrorFactory, out var property, out error))
+        {
+            return false;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            error = noError;
+            return true;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        value = property.GetString();
+        error = noError;
+        return true;
+    }
+
+    /// <summary> Reads one optional string property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The optional property name. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="value"> The parsed value when present; otherwise <see langword="null" />. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is absent or valid string; otherwise <see langword="false" />. </returns>
+    public static bool TryReadOptionalString<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> typeMismatchErrorFactory,
+        TError noError,
+        out string? value,
+        out TError error)
+    {
+        value = null;
+        if (!root.TryGetProperty(propertyName, out var property))
+        {
+            error = noError;
+            return true;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        value = property.GetString();
+        error = noError;
+        return true;
+    }
+
+    /// <summary> Reads one optional nullable-int32 property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The optional property name. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="value"> The parsed value when present and valid; otherwise <see langword="null" />. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is absent or valid int32/null; otherwise <see langword="false" />. </returns>
+    public static bool TryReadOptionalNullableInt32<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> typeMismatchErrorFactory,
+        TError noError,
+        out int? value,
+        out TError error)
+    {
+        value = null;
+        if (!root.TryGetProperty(propertyName, out var property))
+        {
+            error = noError;
+            return true;
+        }
+
+        if (property.ValueKind == JsonValueKind.Null)
+        {
+            error = noError;
+            return true;
+        }
+
+        if (property.ValueKind != JsonValueKind.Number || !property.TryGetInt32(out var parsedValue))
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        value = parsedValue;
+        error = noError;
+        return true;
+    }
+
+    /// <summary> Reads one required string-array property from JSON object. </summary>
+    /// <typeparam name="TError"> The parse error type. </typeparam>
+    /// <param name="root"> The source JSON root object. </param>
+    /// <param name="propertyName"> The required property name. </param>
+    /// <param name="missingErrorFactory"> The error factory used when property is missing. </param>
+    /// <param name="typeMismatchErrorFactory"> The error factory used when property type is invalid. </param>
+    /// <param name="arrayElementTypeMismatchErrorFactory"> The error factory used when array element type is invalid. </param>
+    /// <param name="noError"> The no-error value for <typeparamref name="TError" />. </param>
+    /// <param name="values"> The parsed string array when successful. </param>
+    /// <param name="error"> The parse error when reading fails; otherwise <paramref name="noError" />. </param>
+    /// <returns> <see langword="true" /> when property is valid string array; otherwise <see langword="false" />. </returns>
+    public static bool TryReadRequiredStringArray<TError> (
+        JsonElement root,
+        string propertyName,
+        Func<string, TError> missingErrorFactory,
+        Func<string, TError> typeMismatchErrorFactory,
+        Func<string, TError> arrayElementTypeMismatchErrorFactory,
+        TError noError,
+        out string[] values,
+        out TError error)
+    {
+        values = Array.Empty<string>();
+        if (!TryReadRequiredProperty(root, propertyName, missingErrorFactory, out var property, out error))
+        {
+            return false;
+        }
+
+        if (property.ValueKind != JsonValueKind.Array)
+        {
+            error = typeMismatchErrorFactory(propertyName);
+            return false;
+        }
+
+        var parsedValues = new List<string>();
+        foreach (var element in property.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.String)
+            {
+                error = arrayElementTypeMismatchErrorFactory(propertyName);
+                return false;
+            }
+
+            parsedValues.Add(element.GetString() ?? string.Empty);
+        }
+
+        values = parsedValues.ToArray();
+        error = noError;
+        return true;
+    }
+}

--- a/src/Ucli.Contracts/Text/LiteralCodecUtilities.cs
+++ b/src/Ucli.Contracts/Text/LiteralCodecUtilities.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Contracts.Text;
+
+/// <summary> Provides reusable conversion helpers for enum/string literal codecs. </summary>
+internal static class LiteralCodecUtilities
+{
+    /// <summary> Converts one enum value to mapped literal string. </summary>
+    /// <typeparam name="TValue"> The enum-like value type. </typeparam>
+    /// <param name="value"> The value to convert. </param>
+    /// <param name="mappings"> The value-literal mapping table. </param>
+    /// <param name="paramName"> The original parameter name for out-of-range errors. </param>
+    /// <param name="unsupportedMessage"> The error message for unsupported values. </param>
+    /// <returns> The mapped literal string. </returns>
+    /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="value" /> is not mapped. </exception>
+    public static string ToValue<TValue> (
+        TValue value,
+        ReadOnlySpan<(TValue Value, string Literal)> mappings,
+        string paramName,
+        string unsupportedMessage)
+        where TValue : struct
+    {
+        foreach (var mapping in mappings)
+        {
+            if (EqualityComparer<TValue>.Default.Equals(mapping.Value, value))
+            {
+                return mapping.Literal;
+            }
+        }
+
+        throw new ArgumentOutOfRangeException(paramName, value, unsupportedMessage);
+    }
+
+    /// <summary> Tries to parse one raw literal string to mapped enum value. </summary>
+    /// <typeparam name="TValue"> The enum-like value type. </typeparam>
+    /// <param name="value"> The raw literal string. </param>
+    /// <param name="mappings"> The value-literal mapping table. </param>
+    /// <param name="comparison"> The string comparison strategy. </param>
+    /// <param name="parsedValue"> The parsed enum value on success; otherwise default value. </param>
+    /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+    public static bool TryParse<TValue> (
+        string? value,
+        ReadOnlySpan<(TValue Value, string Literal)> mappings,
+        StringComparison comparison,
+        out TValue parsedValue)
+        where TValue : struct
+    {
+        foreach (var mapping in mappings)
+        {
+            if (string.Equals(value, mapping.Literal, comparison))
+            {
+                parsedValue = mapping.Value;
+                return true;
+            }
+        }
+
+        parsedValue = default;
+        return false;
+    }
+
+    /// <summary> Tries to trim one input literal and parse to mapped enum value. </summary>
+    /// <typeparam name="TValue"> The enum-like value type. </typeparam>
+    /// <param name="value"> The raw literal string. </param>
+    /// <param name="mappings"> The value-literal mapping table. </param>
+    /// <param name="comparison"> The string comparison strategy. </param>
+    /// <param name="parsedValue"> The parsed enum value on success; otherwise default value. </param>
+    /// <returns> <see langword="true" /> when trimming and parsing succeed; otherwise <see langword="false" />. </returns>
+    public static bool TryParseTrimmed<TValue> (
+        string? value,
+        ReadOnlySpan<(TValue Value, string Literal)> mappings,
+        StringComparison comparison,
+        out TValue parsedValue)
+        where TValue : struct
+    {
+        if (!StringValueNormalizer.TryTrimToNonEmpty(value, out var normalized))
+        {
+            parsedValue = default;
+            return false;
+        }
+
+        return TryParse(normalized, mappings, comparison, out parsedValue);
+    }
+
+    /// <summary> Tries to trim one input literal and normalize it to canonical mapped literal. </summary>
+    /// <param name="value"> The raw literal string. </param>
+    /// <param name="literals"> The canonical literal set. </param>
+    /// <param name="comparison"> The string comparison strategy. </param>
+    /// <param name="normalizedLiteral"> The canonical literal on success; otherwise <see langword="null" />. </param>
+    /// <returns> <see langword="true" /> when one canonical literal is matched; otherwise <see langword="false" />. </returns>
+    public static bool TryNormalizeLiteral (
+        string? value,
+        ReadOnlySpan<string> literals,
+        StringComparison comparison,
+        out string? normalizedLiteral)
+    {
+        if (!StringValueNormalizer.TryTrimToNonEmpty(value, out var normalized))
+        {
+            normalizedLiteral = null;
+            return false;
+        }
+
+        foreach (var literal in literals)
+        {
+            if (string.Equals(normalized, literal, comparison))
+            {
+                normalizedLiteral = literal;
+                return true;
+            }
+        }
+
+        normalizedLiteral = null;
+        return false;
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/ResolveSelectorCodec.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text.Json;
 using MackySoft.Ucli.Contracts.Text;
 
@@ -8,14 +7,37 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
     /// <summary> Decodes and validates selector arguments for <c>ucli.resolve</c>. </summary>
     internal static class ResolveSelectorCodec
     {
-        private static readonly HashSet<string> AllowedPropertyNames = new HashSet<string>(StringComparer.Ordinal)
+        private static readonly (string Name, SelectorPropertyKind Kind)[] PropertyDefinitions =
         {
-            ResolveSelectorPropertyNames.GlobalObjectId,
-            ResolveSelectorPropertyNames.AssetGuid,
-            ResolveSelectorPropertyNames.AssetPath,
-            ResolveSelectorPropertyNames.Scene,
-            ResolveSelectorPropertyNames.HierarchyPath,
+            (ResolveSelectorPropertyNames.GlobalObjectId, SelectorPropertyKind.GlobalObjectId),
+            (ResolveSelectorPropertyNames.AssetGuid, SelectorPropertyKind.AssetGuid),
+            (ResolveSelectorPropertyNames.AssetPath, SelectorPropertyKind.AssetPath),
+            (ResolveSelectorPropertyNames.Scene, SelectorPropertyKind.Scene),
+            (ResolveSelectorPropertyNames.HierarchyPath, SelectorPropertyKind.HierarchyPath),
         };
+
+        private enum SelectorPropertyKind
+        {
+            GlobalObjectId,
+            AssetGuid,
+            AssetPath,
+            Scene,
+            HierarchyPath,
+        }
+
+        private struct SelectorParseState
+        {
+            public bool HasGlobalObjectId;
+            public bool HasAssetGuid;
+            public bool HasAssetPath;
+            public bool HasScenePath;
+            public bool HasHierarchyPath;
+            public string? GlobalObjectId;
+            public string? AssetGuid;
+            public string? AssetPath;
+            public string? ScenePath;
+            public string? HierarchyPath;
+        }
 
         /// <summary> Parses one selector from operation arguments. </summary>
         /// <param name="args"> The operation arguments element. </param>
@@ -35,131 +57,33 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            var hasGlobalObjectId = false;
-            var hasAssetGuid = false;
-            var hasAssetPath = false;
-            var hasScenePath = false;
-            var hasHierarchyPath = false;
-            string? globalObjectId = null;
-            string? assetGuid = null;
-            string? assetPath = null;
-            string? scenePath = null;
-            string? hierarchyPath = null;
+            var state = default(SelectorParseState);
 
             foreach (var property in args.EnumerateObject())
             {
-                if (!AllowedPropertyNames.Contains(property.Name))
+                if (!TryResolvePropertyKind(property.Name, out var propertyKind))
                 {
                     errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
                     return false;
                 }
 
-                switch (property.Name)
+                if (!TryAssignPropertyValue(
+                    propertyKind,
+                    property,
+                    ref state,
+                    out errorMessage))
                 {
-                    case ResolveSelectorPropertyNames.GlobalObjectId:
-                        if (hasGlobalObjectId)
-                        {
-                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.GlobalObjectId}.";
-                            return false;
-                        }
-
-                        if (!TryReadRequiredString(property, out globalObjectId, out errorMessage))
-                        {
-                            return false;
-                        }
-
-                        hasGlobalObjectId = true;
-                        break;
-
-                    case ResolveSelectorPropertyNames.AssetGuid:
-                        if (hasAssetGuid)
-                        {
-                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.AssetGuid}.";
-                            return false;
-                        }
-
-                        if (!TryReadRequiredString(property, out assetGuid, out errorMessage))
-                        {
-                            return false;
-                        }
-
-                        hasAssetGuid = true;
-                        break;
-
-                    case ResolveSelectorPropertyNames.AssetPath:
-                        if (hasAssetPath)
-                        {
-                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.AssetPath}.";
-                            return false;
-                        }
-
-                        if (!TryReadRequiredString(property, out assetPath, out errorMessage))
-                        {
-                            return false;
-                        }
-
-                        hasAssetPath = true;
-                        break;
-
-                    case ResolveSelectorPropertyNames.Scene:
-                        if (hasScenePath)
-                        {
-                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.Scene}.";
-                            return false;
-                        }
-
-                        if (!TryReadRequiredString(property, out scenePath, out errorMessage))
-                        {
-                            return false;
-                        }
-
-                        hasScenePath = true;
-                        break;
-
-                    case ResolveSelectorPropertyNames.HierarchyPath:
-                        if (hasHierarchyPath)
-                        {
-                            errorMessage = $"Operation 'args' contains duplicated property: {ResolveSelectorPropertyNames.HierarchyPath}.";
-                            return false;
-                        }
-
-                        if (!TryReadRequiredString(property, out hierarchyPath, out errorMessage))
-                        {
-                            return false;
-                        }
-
-                        hasHierarchyPath = true;
-                        break;
+                    return false;
                 }
             }
 
-            if (hasScenePath != hasHierarchyPath)
+            if (state.HasScenePath != state.HasHierarchyPath)
             {
                 errorMessage = $"Operation 'args' requires both '{ResolveSelectorPropertyNames.Scene}' and '{ResolveSelectorPropertyNames.HierarchyPath}' when one is specified.";
                 return false;
             }
 
-            var selectorCount = 0;
-            if (hasGlobalObjectId)
-            {
-                selectorCount++;
-            }
-
-            if (hasAssetGuid)
-            {
-                selectorCount++;
-            }
-
-            if (hasAssetPath)
-            {
-                selectorCount++;
-            }
-
-            if (hasScenePath)
-            {
-                selectorCount++;
-            }
-
+            var selectorCount = CountSpecifiedSelectorKinds(in state);
             if (selectorCount != 1)
             {
                 errorMessage =
@@ -167,26 +91,193 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            if (hasGlobalObjectId)
+            if (state.HasGlobalObjectId)
             {
-                selector = ResolveSelector.FromGlobalObjectId(globalObjectId!);
+                selector = ResolveSelector.FromGlobalObjectId(state.GlobalObjectId!);
                 return true;
             }
 
-            if (hasAssetGuid)
+            if (state.HasAssetGuid)
             {
-                selector = ResolveSelector.FromAssetGuid(assetGuid!);
+                selector = ResolveSelector.FromAssetGuid(state.AssetGuid!);
                 return true;
             }
 
-            if (hasAssetPath)
+            if (state.HasAssetPath)
             {
-                selector = ResolveSelector.FromAssetPath(assetPath!);
+                selector = ResolveSelector.FromAssetPath(state.AssetPath!);
                 return true;
             }
 
-            selector = ResolveSelector.FromSceneHierarchy(scenePath!, hierarchyPath!);
+            selector = ResolveSelector.FromSceneHierarchy(state.ScenePath!, state.HierarchyPath!);
             return true;
+        }
+
+        /// <summary> Resolves selector property kind from one raw property name. </summary>
+        /// <param name="propertyName"> The property name. </param>
+        /// <param name="kind"> The resolved property kind. </param>
+        /// <returns> <see langword="true" /> when property name is supported; otherwise <see langword="false" />. </returns>
+        private static bool TryResolvePropertyKind (
+            string propertyName,
+            out SelectorPropertyKind kind)
+        {
+            foreach (var definition in PropertyDefinitions)
+            {
+                if (!string.Equals(definition.Name, propertyName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                kind = definition.Kind;
+                return true;
+            }
+
+            kind = default;
+            return false;
+        }
+
+        /// <summary> Assigns one selector property value while validating duplicate declarations. </summary>
+        /// <param name="kind"> The selector property kind. </param>
+        /// <param name="property"> The source JSON property. </param>
+        /// <param name="state"> The mutable selector parse state. </param>
+        /// <param name="errorMessage"> The parse error message when assignment fails. </param>
+        /// <returns> <see langword="true" /> when assignment succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryAssignPropertyValue (
+            SelectorPropertyKind kind,
+            JsonProperty property,
+            ref SelectorParseState state,
+            out string errorMessage)
+        {
+            errorMessage = string.Empty;
+            switch (kind)
+            {
+                case SelectorPropertyKind.GlobalObjectId:
+                    if (!TryReadUniqueRequiredString(
+                        property,
+                        ResolveSelectorPropertyNames.GlobalObjectId,
+                        ref state.HasGlobalObjectId,
+                        out var globalObjectId,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    state.GlobalObjectId = globalObjectId;
+                    return true;
+                case SelectorPropertyKind.AssetGuid:
+                    if (!TryReadUniqueRequiredString(
+                        property,
+                        ResolveSelectorPropertyNames.AssetGuid,
+                        ref state.HasAssetGuid,
+                        out var assetGuid,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    state.AssetGuid = assetGuid;
+                    return true;
+                case SelectorPropertyKind.AssetPath:
+                    if (!TryReadUniqueRequiredString(
+                        property,
+                        ResolveSelectorPropertyNames.AssetPath,
+                        ref state.HasAssetPath,
+                        out var assetPath,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    state.AssetPath = assetPath;
+                    return true;
+                case SelectorPropertyKind.Scene:
+                    if (!TryReadUniqueRequiredString(
+                        property,
+                        ResolveSelectorPropertyNames.Scene,
+                        ref state.HasScenePath,
+                        out var scenePath,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    state.ScenePath = scenePath;
+                    return true;
+                case SelectorPropertyKind.HierarchyPath:
+                    if (!TryReadUniqueRequiredString(
+                        property,
+                        ResolveSelectorPropertyNames.HierarchyPath,
+                        ref state.HasHierarchyPath,
+                        out var hierarchyPath,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    state.HierarchyPath = hierarchyPath;
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported selector property kind.");
+            }
+        }
+
+        /// <summary> Reads one unique required string selector property. </summary>
+        /// <param name="property"> The source JSON property. </param>
+        /// <param name="propertyName"> The canonical property name used by diagnostics. </param>
+        /// <param name="hasProperty"> The property-presence flag for duplicate validation. </param>
+        /// <param name="value"> The parsed value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when failed. </param>
+        /// <returns> <see langword="true" /> when property is unique and valid; otherwise <see langword="false" />. </returns>
+        private static bool TryReadUniqueRequiredString (
+            JsonProperty property,
+            string propertyName,
+            ref bool hasProperty,
+            out string? value,
+            out string errorMessage)
+        {
+            if (hasProperty)
+            {
+                value = null;
+                errorMessage = $"Operation 'args' contains duplicated property: {propertyName}.";
+                return false;
+            }
+
+            if (!TryReadRequiredString(property, out value, out errorMessage))
+            {
+                return false;
+            }
+
+            hasProperty = true;
+            return true;
+        }
+
+        /// <summary> Counts how many selector kinds are specified in one parse state. </summary>
+        /// <param name="state"> The selector parse state. </param>
+        /// <returns> The number of selector kinds currently specified. </returns>
+        private static int CountSpecifiedSelectorKinds (in SelectorParseState state)
+        {
+            var selectorCount = 0;
+            if (state.HasGlobalObjectId)
+            {
+                selectorCount++;
+            }
+
+            if (state.HasAssetGuid)
+            {
+                selectorCount++;
+            }
+
+            if (state.HasAssetPath)
+            {
+                selectorCount++;
+            }
+
+            if (state.HasScenePath)
+            {
+                selectorCount++;
+            }
+
+            return selectorCount;
         }
 
         /// <summary> Reads one required strict string property from selector arguments. </summary>

--- a/src/Ucli/Daemon/DaemonShutdownClient.cs
+++ b/src/Ucli/Daemon/DaemonShutdownClient.cs
@@ -55,12 +55,10 @@ internal sealed class DaemonShutdownClient : IDaemonShutdownClient
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            if (!string.Equals(response.Status, IpcProtocol.StatusOk, StringComparison.Ordinal)
-                || response.Errors.Count > 0)
+            if (IpcResponseFailureReader.TryRead(response, out var firstError, out var status))
             {
-                if (response.Errors.Count > 0)
+                if (firstError is not null)
                 {
-                    var firstError = response.Errors[0];
                     if (IsSessionTokenErrorCode(firstError.Code))
                     {
                         return DaemonShutdownAttemptResult.NotRunning();
@@ -71,7 +69,7 @@ internal sealed class DaemonShutdownClient : IDaemonShutdownClient
                 }
 
                 return DaemonShutdownAttemptResult.Failure(ExecutionError.InternalError(
-                    $"Daemon shutdown request failed with status '{response.Status}'."));
+                    $"Daemon shutdown request failed with status '{status}'."));
             }
 
             return DaemonShutdownAttemptResult.Success();

--- a/src/Ucli/Execution/UnityExecutionMode/Probe/DaemonPingResponseCodec.cs
+++ b/src/Ucli/Execution/UnityExecutionMode/Probe/DaemonPingResponseCodec.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Ipc;
 
 namespace MackySoft.Ucli.Execution;
 
@@ -15,27 +16,17 @@ internal static class DaemonPingResponseCodec
     {
         ArgumentNullException.ThrowIfNull(response);
 
-        if (!string.Equals(response.Status, IpcProtocol.StatusOk, StringComparison.Ordinal))
+        if (IpcResponseFailureReader.TryRead(response, out var firstError, out var status))
         {
-            if (response.Errors.Count > 0)
+            if (firstError is not null)
             {
-                var firstError = response.Errors[0];
                 error = new DaemonPingResponseException(
                     $"Daemon ping failed with error code '{firstError.Code}'.",
                     firstError.Code);
                 return false;
             }
 
-            error = new DaemonPingResponseException($"Daemon ping failed with status '{response.Status}'.");
-            return false;
-        }
-
-        if (response.Errors.Count > 0)
-        {
-            var firstError = response.Errors[0];
-            error = new DaemonPingResponseException(
-                $"Daemon ping failed with error code '{firstError.Code}'.",
-                firstError.Code);
+            error = new DaemonPingResponseException($"Daemon ping failed with status '{status}'.");
             return false;
         }
 

--- a/src/Ucli/Ipc/IpcResponseFailureReader.cs
+++ b/src/Ucli/Ipc/IpcResponseFailureReader.cs
@@ -1,0 +1,41 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Ipc;
+
+/// <summary> Reads protocol-level failure signals from IPC response envelopes. </summary>
+internal static class IpcResponseFailureReader
+{
+    /// <summary> Tries to read one response failure from status and error entries. </summary>
+    /// <param name="response"> The IPC response envelope. </param>
+    /// <param name="firstError"> The first response error when present; otherwise <see langword="null" />. </param>
+    /// <param name="status"> The non-success status when error entries are absent; otherwise <see langword="null" />. </param>
+    /// <returns> <see langword="true" /> when response indicates failure; otherwise <see langword="false" />. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="response" /> is <see langword="null" />. </exception>
+    public static bool TryRead (
+        IpcResponse response,
+        out IpcError? firstError,
+        out string? status)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var hasSuccessStatus = string.Equals(response.Status, IpcProtocol.StatusOk, StringComparison.Ordinal);
+        var hasErrorEntries = response.Errors.Count > 0;
+        if (hasSuccessStatus && !hasErrorEntries)
+        {
+            firstError = null;
+            status = null;
+            return false;
+        }
+
+        if (hasErrorEntries)
+        {
+            firstError = response.Errors[0];
+            status = null;
+            return true;
+        }
+
+        firstError = null;
+        status = response.Status;
+        return true;
+    }
+}

--- a/src/Ucli/Status/StatusDaemonStateCodec.cs
+++ b/src/Ucli/Status/StatusDaemonStateCodec.cs
@@ -15,19 +15,24 @@ internal static class StatusDaemonStateCodec
     /// <summary> Gets the daemon-status value used when daemon session is stale. </summary>
     public const string Stale = "stale";
 
+    private static readonly (DaemonStatusKind Value, string Literal)[] Mappings =
+    {
+        (DaemonStatusKind.Running, Running),
+        (DaemonStatusKind.NotRunning, NotRunning),
+        (DaemonStatusKind.Stale, Stale),
+    };
+
     /// <summary> Converts one daemon status enum value to a status contract literal. </summary>
     /// <param name="daemonStatus"> The daemon status enum value. </param>
     /// <returns> The daemon-status contract literal. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="daemonStatus" /> is unsupported. </exception>
     public static string ToValue (DaemonStatusKind daemonStatus)
     {
-        return daemonStatus switch
-        {
-            DaemonStatusKind.Running => Running,
-            DaemonStatusKind.NotRunning => NotRunning,
-            DaemonStatusKind.Stale => Stale,
-            _ => throw new ArgumentOutOfRangeException(nameof(daemonStatus), daemonStatus, "Unsupported daemon status."),
-        };
+        return LiteralCodecUtilities.ToValue(
+            daemonStatus,
+            Mappings,
+            nameof(daemonStatus),
+            "Unsupported daemon status.");
     }
 
     /// <summary> Tries to parse one daemon-status literal to daemon status enum value. </summary>
@@ -38,31 +43,10 @@ internal static class StatusDaemonStateCodec
         string? value,
         out DaemonStatusKind daemonStatus)
     {
-        if (!StringValueNormalizer.TryTrimToNonEmpty(value, out var normalized))
-        {
-            daemonStatus = default;
-            return false;
-        }
-
-        if (string.Equals(normalized, Running, StringComparison.Ordinal))
-        {
-            daemonStatus = DaemonStatusKind.Running;
-            return true;
-        }
-
-        if (string.Equals(normalized, NotRunning, StringComparison.Ordinal))
-        {
-            daemonStatus = DaemonStatusKind.NotRunning;
-            return true;
-        }
-
-        if (string.Equals(normalized, Stale, StringComparison.Ordinal))
-        {
-            daemonStatus = DaemonStatusKind.Stale;
-            return true;
-        }
-
-        daemonStatus = default;
-        return false;
+        return LiteralCodecUtilities.TryParseTrimmed(
+            value,
+            Mappings,
+            StringComparison.Ordinal,
+            out daemonStatus);
     }
 }

--- a/src/Ucli/TestRun/Configuration/TestRunProfileLoader.cs
+++ b/src/Ucli/TestRun/Configuration/TestRunProfileLoader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MackySoft.Ucli.Contracts.Json;
 using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Foundation;
 
@@ -105,16 +106,21 @@ internal sealed class TestRunProfileLoader : ITestRunProfileLoader
             return false;
         }
 
-        foreach (var property in root.EnumerateObject())
+        var unknownProperty = JsonObjectPropertyReader.FindUnknownProperty(root, AllowedProperties);
+        if (!string.IsNullOrEmpty(unknownProperty))
         {
-            if (!AllowedProperties.Contains(property.Name))
-            {
-                errorMessage = $"profile contains unknown property: {property.Name}";
-                return false;
-            }
+            errorMessage = $"profile contains unknown property: {unknownProperty}";
+            return false;
         }
 
-        if (!TryReadRequiredInt32(root, "schemaVersion", out var schemaVersion, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredInt32(
+            root,
+            "schemaVersion",
+            CreateMissingRequiredPropertyError,
+            CreateInt32TypeMismatchError,
+            noError: null,
+            out var schemaVersion,
+            out errorMessage))
         {
             return false;
         }
@@ -125,47 +131,112 @@ internal sealed class TestRunProfileLoader : ITestRunProfileLoader
             return false;
         }
 
-        if (!TryReadRequiredString(root, "projectPath", out var projectPath, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredString(
+            root,
+            "projectPath",
+            CreateMissingRequiredPropertyError,
+            CreateStringTypeMismatchError,
+            noError: null,
+            out var projectPath,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredNullableString(root, "unityVersion", out var unityVersion, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredNullableString(
+            root,
+            "unityVersion",
+            CreateMissingRequiredPropertyError,
+            CreateNullableStringTypeMismatchError,
+            noError: null,
+            out var unityVersion,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredNullableString(root, "unityEditorPath", out var unityEditorPath, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredNullableString(
+            root,
+            "unityEditorPath",
+            CreateMissingRequiredPropertyError,
+            CreateNullableStringTypeMismatchError,
+            noError: null,
+            out var unityEditorPath,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredString(root, "testPlatform", out var testPlatform, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredString(
+            root,
+            "testPlatform",
+            CreateMissingRequiredPropertyError,
+            CreateStringTypeMismatchError,
+            noError: null,
+            out var testPlatform,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredNullableString(root, "buildTarget", out var buildTarget, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredNullableString(
+            root,
+            "buildTarget",
+            CreateMissingRequiredPropertyError,
+            CreateNullableStringTypeMismatchError,
+            noError: null,
+            out var buildTarget,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredNullableString(root, "testFilter", out var testFilter, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredNullableString(
+            root,
+            "testFilter",
+            CreateMissingRequiredPropertyError,
+            CreateNullableStringTypeMismatchError,
+            noError: null,
+            out var testFilter,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredStringArray(root, "testCategories", out var testCategories, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredStringArray(
+            root,
+            "testCategories",
+            CreateMissingRequiredPropertyError,
+            CreateStringArrayTypeMismatchError,
+            CreateStringArrayTypeMismatchError,
+            noError: null,
+            out var testCategories,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredStringArray(root, "assemblyNames", out var assemblyNames, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredStringArray(
+            root,
+            "assemblyNames",
+            CreateMissingRequiredPropertyError,
+            CreateStringArrayTypeMismatchError,
+            CreateStringArrayTypeMismatchError,
+            noError: null,
+            out var assemblyNames,
+            out errorMessage))
         {
             return false;
         }
 
-        if (!TryReadRequiredNullableString(root, "testSettingsPath", out var testSettingsPath, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredNullableString(
+            root,
+            "testSettingsPath",
+            CreateMissingRequiredPropertyError,
+            CreateNullableStringTypeMismatchError,
+            noError: null,
+            out var testSettingsPath,
+            out errorMessage))
         {
             return false;
         }
@@ -192,54 +263,12 @@ internal sealed class TestRunProfileLoader : ITestRunProfileLoader
         return true;
     }
 
-    /// <summary> Reads one required object property. </summary>
-    /// <param name="root"> The source object. </param>
-    /// <param name="propertyName"> The required property name. </param>
-    /// <param name="property"> The property value when found. </param>
-    /// <param name="errorMessage"> The error message when missing. </param>
-    /// <returns> <see langword="true" /> when property exists; otherwise <see langword="false" />. </returns>
-    private static bool TryReadRequiredProperty (
-        JsonElement root,
-        string propertyName,
-        out JsonElement property,
-        out string? errorMessage)
+    /// <summary> Creates error text for missing required profile property. </summary>
+    /// <param name="propertyName"> The missing property name. </param>
+    /// <returns> The missing-property error text. </returns>
+    private static string CreateMissingRequiredPropertyError (string propertyName)
     {
-        if (!root.TryGetProperty(propertyName, out property))
-        {
-            errorMessage = $"profile is missing required property: {propertyName}";
-            return false;
-        }
-
-        errorMessage = null;
-        return true;
-    }
-
-    /// <summary> Reads one required int32 property. </summary>
-    /// <param name="root"> The source object. </param>
-    /// <param name="propertyName"> The required property name. </param>
-    /// <param name="value"> The parsed value when successful. </param>
-    /// <param name="errorMessage"> The error message when parsing fails. </param>
-    /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
-    private static bool TryReadRequiredInt32 (
-        JsonElement root,
-        string propertyName,
-        out int value,
-        out string? errorMessage)
-    {
-        value = default;
-        if (!TryReadRequiredProperty(root, propertyName, out var property, out errorMessage))
-        {
-            return false;
-        }
-
-        if (property.ValueKind != JsonValueKind.Number || !property.TryGetInt32(out value))
-        {
-            errorMessage = $"profile property '{propertyName}' must be int32.";
-            return false;
-        }
-
-        errorMessage = null;
-        return true;
+        return $"profile is missing required property: {propertyName}";
     }
 
     /// <summary> Reads one required positive int32 property. </summary>
@@ -254,7 +283,14 @@ internal sealed class TestRunProfileLoader : ITestRunProfileLoader
         out int value,
         out string? errorMessage)
     {
-        if (!TryReadRequiredInt32(root, propertyName, out value, out errorMessage))
+        if (!JsonObjectPropertyReader.TryReadRequiredInt32(
+            root,
+            propertyName,
+            CreateMissingRequiredPropertyError,
+            CreateInt32TypeMismatchError,
+            noError: null,
+            out value,
+            out errorMessage))
         {
             return false;
         }
@@ -269,108 +305,35 @@ internal sealed class TestRunProfileLoader : ITestRunProfileLoader
         return true;
     }
 
-    /// <summary> Reads one required string property. </summary>
-    /// <param name="root"> The source object. </param>
-    /// <param name="propertyName"> The required property name. </param>
-    /// <param name="value"> The parsed value when successful. </param>
-    /// <param name="errorMessage"> The error message when parsing fails. </param>
-    /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
-    private static bool TryReadRequiredString (
-        JsonElement root,
-        string propertyName,
-        out string value,
-        out string? errorMessage)
+    /// <summary> Creates error text for int32 type mismatch. </summary>
+    /// <param name="propertyName"> The property name. </param>
+    /// <returns> The type-mismatch error text. </returns>
+    private static string CreateInt32TypeMismatchError (string propertyName)
     {
-        value = string.Empty;
-        if (!TryReadRequiredProperty(root, propertyName, out var property, out errorMessage))
-        {
-            return false;
-        }
-
-        if (property.ValueKind != JsonValueKind.String)
-        {
-            errorMessage = $"profile property '{propertyName}' must be string.";
-            return false;
-        }
-
-        value = property.GetString() ?? string.Empty;
-        errorMessage = null;
-        return true;
+        return $"profile property '{propertyName}' must be int32.";
     }
 
-    /// <summary> Reads one required nullable string property. </summary>
-    /// <param name="root"> The source object. </param>
-    /// <param name="propertyName"> The required property name. </param>
-    /// <param name="value"> The parsed value when successful. </param>
-    /// <param name="errorMessage"> The error message when parsing fails. </param>
-    /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
-    private static bool TryReadRequiredNullableString (
-        JsonElement root,
-        string propertyName,
-        out string? value,
-        out string? errorMessage)
+    /// <summary> Creates error text for string type mismatch. </summary>
+    /// <param name="propertyName"> The property name. </param>
+    /// <returns> The type-mismatch error text. </returns>
+    private static string CreateStringTypeMismatchError (string propertyName)
     {
-        value = null;
-        if (!TryReadRequiredProperty(root, propertyName, out var property, out errorMessage))
-        {
-            return false;
-        }
-
-        if (property.ValueKind == JsonValueKind.Null)
-        {
-            errorMessage = null;
-            return true;
-        }
-
-        if (property.ValueKind != JsonValueKind.String)
-        {
-            errorMessage = $"profile property '{propertyName}' must be string or null.";
-            return false;
-        }
-
-        value = property.GetString();
-        errorMessage = null;
-        return true;
+        return $"profile property '{propertyName}' must be string.";
     }
 
-    /// <summary> Reads one required string-array property. </summary>
-    /// <param name="root"> The source object. </param>
-    /// <param name="propertyName"> The required property name. </param>
-    /// <param name="value"> The parsed value when successful. </param>
-    /// <param name="errorMessage"> The error message when parsing fails. </param>
-    /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
-    private static bool TryReadRequiredStringArray (
-        JsonElement root,
-        string propertyName,
-        out string[] value,
-        out string? errorMessage)
+    /// <summary> Creates error text for nullable-string type mismatch. </summary>
+    /// <param name="propertyName"> The property name. </param>
+    /// <returns> The type-mismatch error text. </returns>
+    private static string CreateNullableStringTypeMismatchError (string propertyName)
     {
-        value = Array.Empty<string>();
-        if (!TryReadRequiredProperty(root, propertyName, out var property, out errorMessage))
-        {
-            return false;
-        }
+        return $"profile property '{propertyName}' must be string or null.";
+    }
 
-        if (property.ValueKind != JsonValueKind.Array)
-        {
-            errorMessage = $"profile property '{propertyName}' must be string array.";
-            return false;
-        }
-
-        var parsedValues = new List<string>();
-        foreach (var element in property.EnumerateArray())
-        {
-            if (element.ValueKind != JsonValueKind.String)
-            {
-                errorMessage = $"profile property '{propertyName}' must be string array.";
-                return false;
-            }
-
-            parsedValues.Add(element.GetString() ?? string.Empty);
-        }
-
-        value = parsedValues.ToArray();
-        errorMessage = null;
-        return true;
+    /// <summary> Creates error text for string-array type mismatch. </summary>
+    /// <param name="propertyName"> The property name. </param>
+    /// <returns> The type-mismatch error text. </returns>
+    private static string CreateStringArrayTypeMismatchError (string propertyName)
+    {
+        return $"profile property '{propertyName}' must be string array.";
     }
 }

--- a/src/Ucli/TestRun/Execution/IpcDaemonTestRunResponseCodec.cs
+++ b/src/Ucli/TestRun/Execution/IpcDaemonTestRunResponseCodec.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Ipc;
 
 namespace MackySoft.Ucli.TestRun.Execution;
 
@@ -18,26 +19,17 @@ internal static class IpcDaemonTestRunResponseCodec
     {
         ArgumentNullException.ThrowIfNull(response);
 
-        if (!string.Equals(response.Status, IpcProtocol.StatusOk, StringComparison.Ordinal))
+        if (IpcResponseFailureReader.TryRead(response, out var firstError, out var status))
         {
-            if (response.Errors.Count > 0)
+            if (firstError is not null)
             {
-                var firstError = response.Errors[0];
                 exitCode = default;
                 errorMessage = $"Unity daemon test run failed with error code '{firstError.Code}'. {firstError.Message}";
                 return false;
             }
 
             exitCode = default;
-            errorMessage = $"Unity daemon test run failed with status '{response.Status}'.";
-            return false;
-        }
-
-        if (response.Errors.Count > 0)
-        {
-            var firstError = response.Errors[0];
-            exitCode = default;
-            errorMessage = $"Unity daemon test run failed with error code '{firstError.Code}'. {firstError.Message}";
+            errorMessage = $"Unity daemon test run failed with status '{status}'.";
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Centralized protocol-level IPC response failure reading and removed duplicated status/error-branch logic in daemon response codecs.
- Added reusable literal codec utilities and replaced repetitive enum/literal conversion branches across configuration, IPC, and status codecs.
- Kept public contracts and literal values unchanged while reducing duplicated branching code.

## Scope
- IPC response failure commonization
  - `src/Ucli/Ipc/IpcResponseFailureReader.cs`
  - `src/Ucli/Execution/UnityExecutionMode/Probe/DaemonPingResponseCodec.cs`
  - `src/Ucli/TestRun/Execution/IpcDaemonTestRunResponseCodec.cs`
  - `src/Ucli/Daemon/DaemonShutdownClient.cs`
- Literal codec commonization
  - `src/Ucli.Contracts/Text/LiteralCodecUtilities.cs`
  - `src/Ucli.Contracts/Configuration/OperationPolicyCodec.cs`
  - `src/Ucli.Contracts/Configuration/PlanTokenModeCodec.cs`
  - `src/Ucli.Contracts/Configuration/ReadIndexModeCodec.cs`
  - `src/Ucli.Contracts/Ipc/Common/IpcTransportKindCodec.cs`
  - `src/Ucli.Contracts/Ipc/Common/IpcCompileStateCodec.cs`
  - `src/Ucli.Contracts/Ipc/Common/IpcTestRunPlatformCodec.cs`
  - `src/Ucli/Status/StatusDaemonStateCodec.cs`

## Verification
- Gate level: Standard
- Diff budget: PASS (12 files changed, +295/-209)
- Spec drift: Skipped (`docs/agents/refactor_ipc-response-failure-reader/spec.md` was not found)
- Format: PASS
  - `dotnet format Ucli.slnx --verbosity minimal --no-restore`
  - `dotnet format Ucli.slnx --verbosity minimal --verify-no-changes --no-restore`
- Tests: PASS
  - `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --no-restore -v minimal`
    - Result: 206 passed, 0 failed
  - `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore -v minimal`
    - Result: 378 passed, 0 failed
- Coverage: N/A

## Risks / Rollback
- Risk: low to medium. Shared helpers are now used by multiple codecs; a defect would impact several conversion paths.
- Rollback: revert commits `212dd4a` and `066e811`.

## Checklist
- [x] Kept existing literal constants and parsing semantics.
- [x] Preserved daemon shutdown session-token specific handling.
- [ ] Reviewer check: confirm no additional enum/literal codecs should be migrated in this PR.

Issue: none (ad-hoc task)
