### PR TITLE
feat(go): implement create and describe operations

### DIFF
--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using MackySoft.Ucli.Contracts.Text;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides shared readers for strict operation-argument values. </summary>
+    internal static class OperationArgumentValueReader
+    {
+        /// <summary> Reads one required strict string property. </summary>
+        /// <param name="property"> The JSON property. </param>
+        /// <param name="value"> The parsed value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the property is valid; otherwise <see langword="false" />. </returns>
+        public static bool TryReadRequiredString (
+            JsonProperty property,
+            out string? value,
+            out string errorMessage)
+        {
+            return TryReadRequiredString(
+                property.Value,
+                $"args.{property.Name}",
+                expectedTypeDescription: "a string",
+                out value,
+                out errorMessage);
+        }
+
+        /// <summary> Reads one required strict string value using the specified logical property path. </summary>
+        /// <param name="valueElement"> The JSON element that stores the value. </param>
+        /// <param name="propertyPath"> The logical property path used in diagnostics. </param>
+        /// <param name="expectedTypeDescription"> The expected type description used in diagnostics. </param>
+        /// <param name="value"> The parsed value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the value is valid; otherwise <see langword="false" />. </returns>
+        public static bool TryReadRequiredString (
+            JsonElement valueElement,
+            string propertyPath,
+            string expectedTypeDescription,
+            out string? value,
+            out string errorMessage)
+        {
+            value = null;
+            if (valueElement.ValueKind != JsonValueKind.String)
+            {
+                errorMessage = $"Operation '{propertyPath}' must be {expectedTypeDescription}.";
+                return false;
+            }
+
+            var parsedValue = valueElement.GetString();
+            if (string.IsNullOrWhiteSpace(parsedValue))
+            {
+                errorMessage = $"Operation '{propertyPath}' must not be empty or whitespace.";
+                return false;
+            }
+
+            if (StringValueValidator.HasOuterWhitespace(parsedValue))
+            {
+                errorMessage = $"Operation '{propertyPath}' must not contain leading or trailing whitespace.";
+                return false;
+            }
+
+            value = parsedValue;
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Reads one non-negative integer-or-null property. </summary>
+        /// <param name="property"> The JSON property. </param>
+        /// <param name="value"> The parsed value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the property is valid; otherwise <see langword="false" />. </returns>
+        public static bool TryReadNonNegativeInt32OrNull (
+            JsonProperty property,
+            out int? value,
+            out string errorMessage)
+        {
+            return TryReadNonNegativeInt32OrNull(
+                property.Value,
+                $"args.{property.Name}",
+                out value,
+                out errorMessage);
+        }
+
+        /// <summary> Reads one non-negative integer-or-null value using the specified logical property path. </summary>
+        /// <param name="valueElement"> The JSON element that stores the value. </param>
+        /// <param name="propertyPath"> The logical property path used in diagnostics. </param>
+        /// <param name="value"> The parsed value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the value is valid; otherwise <see langword="false" />. </returns>
+        public static bool TryReadNonNegativeInt32OrNull (
+            JsonElement valueElement,
+            string propertyPath,
+            out int? value,
+            out string errorMessage)
+        {
+            value = null;
+            if (valueElement.ValueKind == JsonValueKind.Null)
+            {
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            if (valueElement.ValueKind != JsonValueKind.Number || !valueElement.TryGetInt32(out var parsedValue))
+            {
+                errorMessage = $"Operation '{propertyPath}' must be an integer or null.";
+                return false;
+            }
+
+            if (parsedValue < 0)
+            {
+                errorMessage = $"Operation '{propertyPath}' must be greater than or equal to 0.";
+                return false;
+            }
+
+            value = parsedValue;
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f855fe3cb267a46e9a6c70cde2d3e06e

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReference.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReference.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one parsed Unity-object reference used by operation arguments. </summary>
+    internal readonly struct UnityObjectReference
+    {
+        public UnityObjectReference (
+            UnityObjectReferenceKind kind,
+            string? alias,
+            ResolveSelector selector)
+        {
+            Kind = kind;
+            Alias = alias;
+            Selector = selector;
+        }
+
+        public UnityObjectReferenceKind Kind { get; }
+
+        public string? Alias { get; }
+
+        public ResolveSelector Selector { get; }
+
+        public static UnityObjectReference FromAlias (string alias)
+        {
+            return new UnityObjectReference(
+                kind: UnityObjectReferenceKind.Alias,
+                alias: alias,
+                selector: default);
+        }
+
+        public static UnityObjectReference FromSelector (ResolveSelector selector)
+        {
+            return new UnityObjectReference(
+                kind: UnityObjectReferenceKind.Selector,
+                alias: null,
+                selector: selector);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReference.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReference.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba16343e3620f4acea54de5ee632f8b1

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceCodec.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Text.Json;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Parses operation-argument references that can point to Unity objects through aliases or selectors. </summary>
+    internal static class UnityObjectReferenceCodec
+    {
+        private const string AliasPropertyName = "var";
+
+        /// <summary> Parses one Unity-object reference from a JSON element. </summary>
+        /// <param name="element"> The JSON element to parse. </param>
+        /// <param name="propertyPath"> The logical property path used in diagnostics. </param>
+        /// <param name="reference"> The parsed reference when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryParse (
+            JsonElement element,
+            string propertyPath,
+            out UnityObjectReference reference,
+            out string errorMessage)
+        {
+            reference = default;
+            errorMessage = string.Empty;
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = $"Operation '{propertyPath}' must be an object.";
+                return false;
+            }
+
+            var hasAlias = false;
+            var hasSelectorProperty = false;
+            string? alias = null;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, AliasPropertyName, StringComparison.Ordinal))
+                {
+                    if (!TryReadUniqueAlias(property, propertyPath, ref hasAlias, out alias, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                if (IsSelectorProperty(property.Name))
+                {
+                    hasSelectorProperty = true;
+                    continue;
+                }
+
+                errorMessage = $"Operation '{propertyPath}' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            if (hasAlias)
+            {
+                if (hasSelectorProperty)
+                {
+                    errorMessage =
+                        $"Operation '{propertyPath}' must specify exactly one reference form: '{{ \"var\": string }}' or selector properties.";
+                    return false;
+                }
+
+                reference = UnityObjectReference.FromAlias(alias!);
+                return true;
+            }
+
+            if (!hasSelectorProperty)
+            {
+                errorMessage =
+                    $"Operation '{propertyPath}' must specify exactly one reference form: '{{ \"var\": string }}' or selector properties.";
+                return false;
+            }
+
+            if (!ResolveSelectorCodec.TryParse(element, out var selector, out errorMessage))
+            {
+                errorMessage = RewriteArgsPath(errorMessage, propertyPath);
+                return false;
+            }
+
+            reference = UnityObjectReference.FromSelector(selector);
+            return true;
+        }
+
+        /// <summary> Determines whether one raw property name belongs to selector syntax. </summary>
+        /// <param name="propertyName"> The raw property name. </param>
+        /// <returns> <see langword="true" /> when the property name belongs to selector syntax; otherwise <see langword="false" />. </returns>
+        private static bool IsSelectorProperty (string propertyName)
+        {
+            return string.Equals(propertyName, ResolveSelectorPropertyNames.GlobalObjectId, StringComparison.Ordinal)
+                || string.Equals(propertyName, ResolveSelectorPropertyNames.AssetGuid, StringComparison.Ordinal)
+                || string.Equals(propertyName, ResolveSelectorPropertyNames.AssetPath, StringComparison.Ordinal)
+                || string.Equals(propertyName, ResolveSelectorPropertyNames.Scene, StringComparison.Ordinal)
+                || string.Equals(propertyName, ResolveSelectorPropertyNames.HierarchyPath, StringComparison.Ordinal);
+        }
+
+        /// <summary> Reads one unique alias property. </summary>
+        /// <param name="property"> The JSON property. </param>
+        /// <param name="propertyPath"> The logical property path used in diagnostics. </param>
+        /// <param name="hasAlias"> The alias-presence flag. </param>
+        /// <param name="alias"> The alias value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the alias property is valid; otherwise <see langword="false" />. </returns>
+        private static bool TryReadUniqueAlias (
+            JsonProperty property,
+            string propertyPath,
+            ref bool hasAlias,
+            out string? alias,
+            out string errorMessage)
+        {
+            alias = null;
+            if (hasAlias)
+            {
+                errorMessage = $"Operation '{propertyPath}' contains duplicated property: {AliasPropertyName}.";
+                return false;
+            }
+
+            if (!OperationArgumentValueReader.TryReadRequiredString(
+                property.Value,
+                $"{propertyPath}.{AliasPropertyName}",
+                expectedTypeDescription: "a string",
+                out alias,
+                out errorMessage))
+            {
+                return false;
+            }
+
+            hasAlias = true;
+            return true;
+        }
+
+        /// <summary> Rewrites <c>ResolveSelectorCodec</c> diagnostics to the specified property path. </summary>
+        /// <param name="errorMessage"> The original error message. </param>
+        /// <param name="propertyPath"> The target property path. </param>
+        /// <returns> The rewritten error message. </returns>
+        private static string RewriteArgsPath (
+            string errorMessage,
+            string propertyPath)
+        {
+            return errorMessage.Replace("Operation 'args'", $"Operation '{propertyPath}'");
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceCodec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0209a47f6437c49429bd47ac6c83cb6a

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceKind.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceKind.cs
@@ -1,0 +1,9 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents supported reference forms for operation arguments that point to Unity objects. </summary>
+    internal enum UnityObjectReferenceKind
+    {
+        Alias = 1,
+        Selector = 2,
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceKind.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceKind.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5c3b7d572b9b4574b74a027281fc68c

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs
@@ -1,0 +1,144 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Resolves parsed Unity-object references to live Unity objects. </summary>
+    internal static class UnityObjectReferenceResolver
+    {
+        /// <summary> Tries to resolve one Unity-object reference to a live Unity object. </summary>
+        /// <param name="reference"> The parsed reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="unityObject"> The resolved Unity object when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when resolution succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryResolve (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            out UnityEngine.Object? unityObject,
+            out string errorMessage)
+        {
+            if (executionContext == null)
+            {
+                throw new ArgumentNullException(nameof(executionContext));
+            }
+
+            switch (reference.Kind)
+            {
+                case UnityObjectReferenceKind.Alias:
+                    return TryResolveAlias(reference.Alias!, executionContext, out unityObject, out errorMessage);
+
+                case UnityObjectReferenceKind.Selector:
+                    if (!ResolveReferenceResolver.TryResolve(reference.Selector, out var resolvedReference, out errorMessage))
+                    {
+                        unityObject = null;
+                        return false;
+                    }
+
+                    return TryResolveResolvedReference(resolvedReference!, out unityObject, out errorMessage);
+
+                default:
+                    unityObject = null;
+                    errorMessage = $"Unsupported Unity-object reference kind '{reference.Kind}'.";
+                    return false;
+            }
+        }
+
+        /// <summary> Tries to resolve one Unity-object reference to a live <see cref="GameObject" />. </summary>
+        /// <param name="reference"> The parsed reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="gameObject"> The resolved GameObject when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when resolution succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveGameObject (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            out GameObject? gameObject,
+            out string errorMessage)
+        {
+            gameObject = null;
+            if (!TryResolve(reference, executionContext, out var unityObject, out errorMessage))
+            {
+                return false;
+            }
+
+            gameObject = unityObject as GameObject;
+            if (gameObject == null)
+            {
+                errorMessage = "Reference did not resolve to a GameObject.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Creates one normalized resolved reference from a live Unity object. </summary>
+        /// <param name="unityObject"> The live Unity object. </param>
+        /// <returns> The normalized resolved reference. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityObject" /> is <see langword="null" />. </exception>
+        public static ResolvedReference CreateResolvedReference (UnityEngine.Object unityObject)
+        {
+            if (unityObject == null)
+            {
+                throw new ArgumentNullException(nameof(unityObject));
+            }
+
+            var globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(unityObject);
+            return new ResolvedReference(globalObjectId.ToString());
+        }
+
+        /// <summary> Tries to resolve one alias to a live Unity object. </summary>
+        /// <param name="alias"> The alias name. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="unityObject"> The resolved Unity object when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when resolution succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveAlias (
+            string alias,
+            OperationExecutionContext executionContext,
+            out UnityEngine.Object? unityObject,
+            out string errorMessage)
+        {
+            unityObject = null;
+            if (!executionContext.AliasStore.TryGet(alias, out var resolvedReference) || resolvedReference == null)
+            {
+                errorMessage = $"Reference alias was not found: {alias}.";
+                return false;
+            }
+
+            return TryResolveResolvedReference(resolvedReference, out unityObject, out errorMessage);
+        }
+
+        /// <summary> Tries to resolve one normalized resolved reference to a live Unity object. </summary>
+        /// <param name="resolvedReference"> The normalized resolved reference. </param>
+        /// <param name="unityObject"> The resolved Unity object when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when resolution succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryResolveResolvedReference (
+            ResolvedReference resolvedReference,
+            out UnityEngine.Object? unityObject,
+            out string errorMessage)
+        {
+            unityObject = null;
+            if (!GlobalObjectId.TryParse(resolvedReference.GlobalObjectId, out var globalObjectId))
+            {
+                errorMessage = $"Resolved reference is malformed: {resolvedReference.GlobalObjectId}.";
+                return false;
+            }
+
+            unityObject = GlobalObjectId.GlobalObjectIdentifierToObjectSlow(globalObjectId);
+            if (unityObject == null)
+            {
+                errorMessage = $"Resolved reference is not available in current project state: {resolvedReference.GlobalObjectId}.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63577881cd0d34d83b8271ed78a541de

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: caeb2c258898c461589d487809290efd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationPropertyNames.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationPropertyNames.cs
@@ -1,0 +1,16 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Defines JSON property names accepted by <c>ucli.go.*</c> operations. </summary>
+    internal static class GoOperationPropertyNames
+    {
+        public const string Name = "name";
+
+        public const string Scene = "scene";
+
+        public const string Parent = "parent";
+
+        public const string Target = "target";
+
+        public const string Depth = "depth";
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationPropertyNames.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationPropertyNames.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6921512be6aa34864961f308820ca3da

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides reusable helpers shared by GameObject-domain operations. </summary>
+    internal static class GoOperationUtilities
+    {
+        /// <summary> Resolves one scene path to a loaded scene. </summary>
+        /// <param name="scenePath"> The project-relative scene path. </param>
+        /// <param name="scene"> The resolved loaded scene when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the scene exists and is loaded; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveLoadedScene (
+            string scenePath,
+            out Scene scene,
+            out string errorMessage)
+        {
+            scene = default;
+            if (!SceneOperationUtilities.TryEnsureSceneAssetExists(scenePath, out errorMessage))
+            {
+                return false;
+            }
+
+            return SceneOperationUtilities.TryGetLoadedScene(scenePath, out scene, out errorMessage);
+        }
+
+        /// <summary> Resolves one reference to a GameObject that belongs to a loaded scene. </summary>
+        /// <param name="reference"> The parsed Unity-object reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="gameObject"> The resolved GameObject when successful. </param>
+        /// <param name="scene"> The owning loaded scene when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the reference resolves to one loaded-scene GameObject; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveLoadedSceneGameObject (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            out GameObject? gameObject,
+            out Scene scene,
+            out string errorMessage)
+        {
+            gameObject = null;
+            scene = default;
+            if (!UnityObjectReferenceResolver.TryResolveGameObject(reference, executionContext, out gameObject, out errorMessage))
+            {
+                return false;
+            }
+
+            return TryGetLoadedSceneFromGameObject(gameObject!, out scene, out errorMessage);
+        }
+
+        /// <summary> Resolves the owning scene for one GameObject and ensures the scene is loaded. </summary>
+        /// <param name="gameObject"> The GameObject whose owning scene is required. </param>
+        /// <param name="scene"> The owning loaded scene when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the GameObject belongs to a loaded scene; otherwise <see langword="false" />. </returns>
+        public static bool TryGetLoadedSceneFromGameObject (
+            GameObject gameObject,
+            out Scene scene,
+            out string errorMessage)
+        {
+            scene = gameObject.scene;
+            if (!scene.IsValid() || !scene.isLoaded || string.IsNullOrWhiteSpace(scene.path))
+            {
+                errorMessage = "GameObject is not part of a loaded scene.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7cbb6461b28c4066a6250df1b7ea56c

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0f4756fe753a44488c4934b5fc89d03
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArguments.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArguments.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents parsed arguments for <c>ucli.go.create</c>. </summary>
+    internal readonly struct GoCreateArguments
+    {
+        public GoCreateArguments (
+            string name,
+            string? scenePath,
+            UnityObjectReference parentReference,
+            bool hasParentReference)
+        {
+            Name = name;
+            ScenePath = scenePath;
+            ParentReference = parentReference;
+            HasParentReference = hasParentReference;
+        }
+
+        public string Name { get; }
+
+        public string? ScenePath { get; }
+
+        public UnityObjectReference ParentReference { get; }
+
+        public bool HasParentReference { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArguments.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArguments.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4e8dbb83e4174be09176a62315af727

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArgumentsCodec.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Text.Json;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Parses and validates argument contracts for <c>ucli.go.create</c>. </summary>
+    internal static class GoCreateArgumentsCodec
+    {
+        /// <summary> Parses one <c>ucli.go.create</c> argument object. </summary>
+        /// <param name="args"> The operation argument element. </param>
+        /// <param name="parsedArguments"> The parsed arguments when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryParse (
+            JsonElement args,
+            out GoCreateArguments parsedArguments,
+            out string errorMessage)
+        {
+            parsedArguments = default;
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            var hasName = false;
+            var hasScene = false;
+            var hasParent = false;
+            string? name = null;
+            string? scenePath = null;
+            var parentReference = default(UnityObjectReference);
+            foreach (var property in args.EnumerateObject())
+            {
+                if (string.Equals(property.Name, GoOperationPropertyNames.Name, StringComparison.Ordinal))
+                {
+                    if (!TryReadUniqueRequiredString(property, ref hasName, out name, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                if (string.Equals(property.Name, GoOperationPropertyNames.Scene, StringComparison.Ordinal))
+                {
+                    if (!TryReadUniqueRequiredString(property, ref hasScene, out scenePath, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                if (string.Equals(property.Name, GoOperationPropertyNames.Parent, StringComparison.Ordinal))
+                {
+                    if (hasParent)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {GoOperationPropertyNames.Parent}.";
+                        return false;
+                    }
+
+                    if (!UnityObjectReferenceCodec.TryParse(
+                        property.Value,
+                        "args.parent",
+                        out parentReference,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasParent = true;
+                    continue;
+                }
+
+                errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            if (!hasName)
+            {
+                errorMessage = $"Operation 'args' requires property '{GoOperationPropertyNames.Name}'.";
+                return false;
+            }
+
+            if (hasScene == hasParent)
+            {
+                errorMessage =
+                    $"Operation 'args' must specify exactly one of '{GoOperationPropertyNames.Scene}' or '{GoOperationPropertyNames.Parent}'.";
+                return false;
+            }
+
+            parsedArguments = new GoCreateArguments(
+                name: name!,
+                scenePath: scenePath,
+                parentReference: parentReference,
+                hasParentReference: hasParent);
+            return true;
+        }
+
+        /// <summary> Reads one unique required string property. </summary>
+        /// <param name="property"> The JSON property. </param>
+        /// <param name="hasProperty"> The presence flag that guards against duplicates. </param>
+        /// <param name="value"> The parsed property value when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when the property is valid; otherwise <see langword="false" />. </returns>
+        private static bool TryReadUniqueRequiredString (
+            JsonProperty property,
+            ref bool hasProperty,
+            out string? value,
+            out string errorMessage)
+        {
+            value = null;
+            if (hasProperty)
+            {
+                errorMessage = $"Operation 'args' contains duplicated property: {property.Name}.";
+                return false;
+            }
+
+            if (!OperationArgumentValueReader.TryReadRequiredString(property, out value, out errorMessage))
+            {
+                return false;
+            }
+
+            hasProperty = true;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArgumentsCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateArgumentsCodec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8189de84da9674b488dc273e1a04c3bd

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreatePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreatePhaseOperation.cs
@@ -1,0 +1,167 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.go.create</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class GoCreatePhaseOperation : IUcliOperation
+    {
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.go.create",
+            kind: UcliOperationKind.Mutation,
+            policy: OperationPolicy.Advanced);
+
+        /// <summary> Executes validate phase for <c>ucli.go.create</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(operation, executionContext, out _, out _, out _, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes plan phase for <c>ucli.go.create</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(operation, executionContext, out _, out var scene, out _, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: false,
+                changed: true,
+                touched: new[]
+                {
+                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                }));
+        }
+
+        /// <summary> Executes call phase for <c>ucli.go.create</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(operation, executionContext, out var name, out var scene, out var parent, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            var createdGameObject = new GameObject(name);
+            SceneManager.MoveGameObjectToScene(createdGameObject, scene);
+            if (parent != null)
+            {
+                createdGameObject.transform.SetParent(parent.transform, worldPositionStays: false);
+            }
+
+            StoreAliasIfNeeded(operation.As, executionContext, createdGameObject);
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: true,
+                changed: true,
+                touched: new[]
+                {
+                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                }));
+        }
+
+        /// <summary> Validates arguments and resolves the destination scene and optional parent. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="name"> The GameObject name when validation succeeds. </param>
+        /// <param name="scene"> The destination loaded scene when validation succeeds. </param>
+        /// <param name="parent"> The optional parent GameObject when validation succeeds. </param>
+        /// <param name="failure"> The failure result when validation fails. </param>
+        /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryValidateArguments (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            out string name,
+            out Scene scene,
+            out GameObject? parent,
+            out OperationPhaseStepResult? failure)
+        {
+            name = string.Empty;
+            scene = default;
+            parent = null;
+            failure = null;
+            if (!GoCreateArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var parseErrorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
+                return false;
+            }
+
+            name = parsedArguments.Name;
+            if (!parsedArguments.HasParentReference)
+            {
+                if (!GoOperationUtilities.TryResolveLoadedScene(parsedArguments.ScenePath!, out scene, out var sceneErrorMessage))
+                {
+                    failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
+                    return false;
+                }
+
+                return true;
+            }
+
+            if (!GoOperationUtilities.TryResolveLoadedSceneGameObject(
+                parsedArguments.ParentReference,
+                executionContext,
+                out parent,
+                out scene,
+                out var parentErrorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parentErrorMessage);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary> Stores one alias for the created GameObject when the request specifies <c>as</c>. </summary>
+        /// <param name="alias"> The optional alias name. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="createdGameObject"> The created GameObject. </param>
+        private static void StoreAliasIfNeeded (
+            string? alias,
+            OperationExecutionContext executionContext,
+            GameObject createdGameObject)
+        {
+            if (alias == null)
+            {
+                return;
+            }
+
+            executionContext.AliasStore.Set(alias, UnityObjectReferenceResolver.CreateResolvedReference(createdGameObject));
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreatePhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreatePhaseOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa0e1ea307d884c4e87b3d6fcf1b5327

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc017ef2fbe4947ea9ca74fc0bc26d66
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectComponentDescription.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectComponentDescription.cs
@@ -1,0 +1,7 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one component entry captured from a GameObject description. </summary>
+    internal sealed record GameObjectComponentDescription (string? TypeName);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectComponentDescription.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectComponentDescription.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da61a360ee0aa405abf4652f8414f2fe

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescription.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescription.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one GameObject description snapshot. </summary>
+    internal sealed record GameObjectDescription (
+        string Name,
+        string GlobalObjectId,
+        IReadOnlyList<GameObjectComponentDescription> Components,
+        IReadOnlyList<GameObjectDescription> Children);
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescription.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescription.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 465747307ca8b4340a90b345ce5c11d9

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescriptionBuilder.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescriptionBuilder.cs
@@ -1,0 +1,78 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Builds structural GameObject descriptions for <c>ucli.go.describe</c>. </summary>
+    internal static class GameObjectDescriptionBuilder
+    {
+        /// <summary> Builds one structural description from the specified root GameObject. </summary>
+        /// <param name="root"> The root GameObject to describe. </param>
+        /// <param name="depth"> The maximum child depth to include. <see langword="null" /> means unlimited depth. </param>
+        /// <returns> The built GameObject description. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="root" /> is <see langword="null" />. </exception>
+        public static GameObjectDescription Build (
+            GameObject root,
+            int? depth)
+        {
+            if (root == null)
+            {
+                throw new ArgumentNullException(nameof(root));
+            }
+
+            var maxDepth = depth ?? int.MaxValue;
+            return Build(root.transform, currentDepth: 0, maxDepth);
+        }
+
+        /// <summary> Builds one description node from the specified transform. </summary>
+        /// <param name="transform"> The transform to describe. </param>
+        /// <param name="currentDepth"> The current recursion depth. </param>
+        /// <param name="maxDepth"> The maximum recursion depth. </param>
+        /// <returns> The built description node. </returns>
+        private static GameObjectDescription Build (
+            Transform transform,
+            int currentDepth,
+            int maxDepth)
+        {
+            var gameObject = transform.gameObject;
+            var components = gameObject.GetComponents<Component>();
+            var componentDescriptions = new GameObjectComponentDescription[components.Length];
+            for (var componentIndex = 0; componentIndex < components.Length; componentIndex++)
+            {
+                var component = components[componentIndex];
+                componentDescriptions[componentIndex] = new GameObjectComponentDescription(component != null ? component.GetType().FullName : null);
+            }
+
+            var children = currentDepth >= maxDepth
+                ? Array.Empty<GameObjectDescription>()
+                : BuildChildren(transform, currentDepth, maxDepth);
+            return new GameObjectDescription(
+                Name: gameObject.name,
+                GlobalObjectId: GlobalObjectId.GetGlobalObjectIdSlow(gameObject).ToString(),
+                Components: componentDescriptions,
+                Children: children);
+        }
+
+        /// <summary> Builds child descriptions for the specified transform. </summary>
+        /// <param name="transform"> The parent transform. </param>
+        /// <param name="currentDepth"> The current recursion depth. </param>
+        /// <param name="maxDepth"> The maximum recursion depth. </param>
+        /// <returns> The built child description list. </returns>
+        private static GameObjectDescription[] BuildChildren (
+            Transform transform,
+            int currentDepth,
+            int maxDepth)
+        {
+            var childDescriptions = new GameObjectDescription[transform.childCount];
+            for (var childIndex = 0; childIndex < transform.childCount; childIndex++)
+            {
+                childDescriptions[childIndex] = Build(transform.GetChild(childIndex), currentDepth + 1, maxDepth);
+            }
+
+            return childDescriptions;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescriptionBuilder.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GameObjectDescriptionBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 690691082b51545d4862f0afd87fdc3d

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArguments.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArguments.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents parsed arguments for <c>ucli.go.describe</c>. </summary>
+    internal readonly struct GoDescribeArguments
+    {
+        public GoDescribeArguments (
+            UnityObjectReference targetReference,
+            int? depth)
+        {
+            TargetReference = targetReference;
+            Depth = depth;
+        }
+
+        public UnityObjectReference TargetReference { get; }
+
+        public int? Depth { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArguments.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArguments.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ad7a4ee9ef6d45a8b13edd3695b1e50

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArgumentsCodec.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Text.Json;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Parses and validates argument contracts for <c>ucli.go.describe</c>. </summary>
+    internal static class GoDescribeArgumentsCodec
+    {
+        /// <summary> Parses one <c>ucli.go.describe</c> argument object. </summary>
+        /// <param name="args"> The operation argument element. </param>
+        /// <param name="parsedArguments"> The parsed arguments when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryParse (
+            JsonElement args,
+            out GoDescribeArguments parsedArguments,
+            out string errorMessage)
+        {
+            parsedArguments = default;
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            var hasTarget = false;
+            var hasDepth = false;
+            var targetReference = default(UnityObjectReference);
+            var depth = default(int?);
+            foreach (var property in args.EnumerateObject())
+            {
+                if (string.Equals(property.Name, GoOperationPropertyNames.Target, StringComparison.Ordinal))
+                {
+                    if (hasTarget)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {GoOperationPropertyNames.Target}.";
+                        return false;
+                    }
+
+                    if (!UnityObjectReferenceCodec.TryParse(
+                        property.Value,
+                        "args.target",
+                        out targetReference,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasTarget = true;
+                    continue;
+                }
+
+                if (string.Equals(property.Name, GoOperationPropertyNames.Depth, StringComparison.Ordinal))
+                {
+                    if (hasDepth)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {GoOperationPropertyNames.Depth}.";
+                        return false;
+                    }
+
+                    if (!OperationArgumentValueReader.TryReadNonNegativeInt32OrNull(property, out depth, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasDepth = true;
+                    continue;
+                }
+
+                errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            if (!hasTarget)
+            {
+                errorMessage = $"Operation 'args' requires property '{GoOperationPropertyNames.Target}'.";
+                return false;
+            }
+
+            parsedArguments = new GoDescribeArguments(targetReference, depth);
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArgumentsCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeArgumentsCodec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: def213d024e49428f976ce7f25a7aad9

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribePhaseOperation.cs
@@ -1,0 +1,135 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.go.describe</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class GoDescribePhaseOperation : IUcliOperation
+    {
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.go.describe",
+            kind: UcliOperationKind.Query,
+            policy: OperationPolicy.Safe);
+
+        /// <summary> Executes validate phase for <c>ucli.go.describe</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(operation, executionContext, out _, out _, out _, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes plan phase for <c>ucli.go.describe</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Execute(operation, executionContext, applied: false);
+        }
+
+        /// <summary> Executes call phase for <c>ucli.go.describe</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Execute(operation, executionContext, applied: true);
+        }
+
+        /// <summary> Executes the shared plan/call flow. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="applied"> The applied flag for the successful phase result. </param>
+        /// <returns> The phase-step result. </returns>
+        private static Task<OperationPhaseStepResult> Execute (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            bool applied)
+        {
+            if (!TryValidateArguments(operation, executionContext, out var target, out var scene, out var depth, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            _ = GameObjectDescriptionBuilder.Build(target, depth);
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: applied,
+                changed: false,
+                touched: new[]
+                {
+                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                }));
+        }
+
+        /// <summary> Validates arguments and resolves the target loaded-scene GameObject. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="target"> The resolved target GameObject when validation succeeds. </param>
+        /// <param name="scene"> The owning loaded scene when validation succeeds. </param>
+        /// <param name="depth"> The requested depth value when validation succeeds. </param>
+        /// <param name="failure"> The failure result when validation fails. </param>
+        /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
+        private static bool TryValidateArguments (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            out GameObject target,
+            out Scene scene,
+            out int? depth,
+            out OperationPhaseStepResult? failure)
+        {
+            target = null!;
+            scene = default;
+            depth = null;
+            failure = null;
+            if (!GoDescribeArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var parseErrorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
+                return false;
+            }
+
+            depth = parsedArguments.Depth;
+            if (!GoOperationUtilities.TryResolveLoadedSceneGameObject(
+                parsedArguments.TargetReference,
+                executionContext,
+                out var resolvedTarget,
+                out scene,
+                out var targetErrorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, targetErrorMessage);
+                return false;
+            }
+
+            target = resolvedTarget!;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribePhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribePhaseOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fc475045bb7a948b5858625ceeb106c0

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/resolve/ResolveReferenceResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/resolve/ResolveReferenceResolver.cs
@@ -150,8 +150,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> The normalized resolved reference. </returns>
         private static ResolvedReference CreateResolvedReference (UnityEngine.Object unityObject)
         {
-            var globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(unityObject);
-            return new ResolvedReference(globalObjectId.ToString());
+            return UnityObjectReferenceResolver.CreateResolvedReference(unityObject);
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/resolve/ResolveSelectorCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/resolve/ResolveSelectorCodec.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text.Json;
-using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Unity.Execution.Phases
 {
@@ -242,7 +241,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            if (!TryReadRequiredString(property, out value, out errorMessage))
+            if (!OperationArgumentValueReader.TryReadRequiredString(property, out value, out errorMessage))
             {
                 return false;
             }
@@ -278,41 +277,6 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
 
             return selectorCount;
-        }
-
-        /// <summary> Reads one required strict string property from selector arguments. </summary>
-        /// <param name="property"> The JSON property to parse. </param>
-        /// <param name="value"> The parsed string when successful. </param>
-        /// <param name="errorMessage"> The parse error message when failed. </param>
-        /// <returns> <see langword="true" /> when property is a valid strict string; otherwise <see langword="false" />. </returns>
-        private static bool TryReadRequiredString (
-            JsonProperty property,
-            out string? value,
-            out string errorMessage)
-        {
-            value = null;
-            if (property.Value.ValueKind != JsonValueKind.String)
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must be a string.";
-                return false;
-            }
-
-            var parsedValue = property.Value.GetString();
-            if (string.IsNullOrWhiteSpace(parsedValue))
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must not be empty or whitespace.";
-                return false;
-            }
-
-            if (StringValueValidator.HasOuterWhitespace(parsedValue))
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must not contain leading or trailing whitespace.";
-                return false;
-            }
-
-            value = parsedValue;
-            errorMessage = string.Empty;
-            return true;
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/SceneOperationArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/SceneOperationArgumentsCodec.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Text.Json;
-using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Unity.Execution.Phases
 {
@@ -36,7 +35,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                         return false;
                     }
 
-                    if (!TryReadRequiredString(property, out scenePath, out errorMessage))
+                    if (!OperationArgumentValueReader.TryReadRequiredString(property, out scenePath, out errorMessage))
                     {
                         return false;
                     }
@@ -91,7 +90,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                         return false;
                     }
 
-                    if (!TryReadRequiredString(property, out scenePath, out errorMessage))
+                    if (!OperationArgumentValueReader.TryReadRequiredString(property, out scenePath, out errorMessage))
                     {
                         return false;
                     }
@@ -108,7 +107,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                         return false;
                     }
 
-                    if (!TryReadDepth(property, out depth, out errorMessage))
+                    if (!OperationArgumentValueReader.TryReadNonNegativeInt32OrNull(property, out depth, out errorMessage))
                     {
                         return false;
                     }
@@ -127,81 +126,6 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            return true;
-        }
-
-        /// <summary> Reads one required strict string property. </summary>
-        /// <param name="property"> The source JSON property. </param>
-        /// <param name="value"> The parsed value when successful. </param>
-        /// <param name="errorMessage"> The parse error message when failed. </param>
-        /// <returns> <see langword="true" /> when property is valid; otherwise <see langword="false" />. </returns>
-        private static bool TryReadRequiredString (
-            JsonProperty property,
-            out string value,
-            out string errorMessage)
-        {
-            value = string.Empty;
-            if (property.Value.ValueKind != JsonValueKind.String)
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must be a string.";
-                return false;
-            }
-
-            var parsedValue = property.Value.GetString();
-            if (string.IsNullOrWhiteSpace(parsedValue))
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must not be empty or whitespace.";
-                return false;
-            }
-
-            if (StringValueValidator.HasOuterWhitespace(parsedValue))
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must not contain leading or trailing whitespace.";
-                return false;
-            }
-
-            value = parsedValue;
-            errorMessage = string.Empty;
-            return true;
-        }
-
-        /// <summary> Reads one scene-tree depth property. </summary>
-        /// <param name="property"> The source JSON property. </param>
-        /// <param name="depth"> The parsed depth value. <see langword="null" /> means unlimited depth. </param>
-        /// <param name="errorMessage"> The parse error message when failed. </param>
-        /// <returns> <see langword="true" /> when property is valid; otherwise <see langword="false" />. </returns>
-        private static bool TryReadDepth (
-            JsonProperty property,
-            out int? depth,
-            out string errorMessage)
-        {
-            depth = null;
-            if (property.Value.ValueKind == JsonValueKind.Null)
-            {
-                errorMessage = string.Empty;
-                return true;
-            }
-
-            if (property.Value.ValueKind != JsonValueKind.Number)
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must be an integer or null.";
-                return false;
-            }
-
-            if (!property.Value.TryGetInt32(out var parsedDepth))
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must be an integer or null.";
-                return false;
-            }
-
-            if (parsedDepth < 0)
-            {
-                errorMessage = $"Operation 'args.{property.Name}' must be greater than or equal to 0.";
-                return false;
-            }
-
-            depth = parsedDepth;
-            errorMessage = string.Empty;
             return true;
         }
     }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoPhaseOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoPhaseOperationTests.cs
@@ -1,0 +1,457 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class GoPhaseOperationTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Call_WhenScenePathIsValid_CreatesRootGameObjectAndStoresAlias ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "CreatedRoot",
+                        scene = scenePath,
+                    },
+                    alias: "created");
+                var context = new OperationExecutionContext();
+
+                var result = operation.Call(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                var loadedScene = SceneManager.GetSceneByPath(scenePath);
+                Assert.That(loadedScene.IsValid(), Is.True);
+                Assert.That(loadedScene.isLoaded, Is.True);
+                Assert.That(loadedScene.GetRootGameObjects().Any(static gameObject => gameObject.name == "CreatedRoot"), Is.True);
+                Assert.That(context.AliasStore.TryGet("created", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Call_WhenParentUsesAlias_CreatesChildUnderParent ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var parent = new GameObject("Parent");
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var context = new OperationExecutionContext();
+                context.AliasStore.Set("parent", UnityObjectReferenceResolver.CreateResolvedReference(parent));
+                var requestOperation = CreateOperation(
+                    opId: "op-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "CreatedChild",
+                        parent = new
+                        {
+                            @var = "parent",
+                        },
+                    },
+                    alias: "created");
+
+                var result = operation.Call(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                Assert.That(parent.transform.childCount, Is.EqualTo(1));
+                Assert.That(parent.transform.GetChild(0).name, Is.EqualTo("CreatedChild"));
+                Assert.That(context.AliasStore.TryGet("created", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference, Is.Not.Null);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Call_WhenParentUsesSelector_CreatesChildUnderParent ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var parent = new GameObject("Parent");
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "CreatedChild",
+                        parent = new
+                        {
+                            scene = scenePath,
+                            hierarchyPath = "Parent",
+                        },
+                    });
+
+                var result = operation.Call(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                Assert.That(parent.transform.childCount, Is.EqualTo(1));
+                Assert.That(parent.transform.GetChild(0).name, Is.EqualTo("CreatedChild"));
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Plan_WhenAliasIsSpecified_DoesNotStoreAlias ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "CreatedRoot",
+                        scene = scenePath,
+                    },
+                    alias: "created");
+                var context = new OperationExecutionContext();
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: true);
+                Assert.That(context.AliasStore.TryGet("created", out _), Is.False);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Validate_WhenSceneAndParentAreBothSpecified_ReturnsInvalidArgument ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-create",
+                opName: "ucli.go.create",
+                args: new
+                {
+                    name = "CreatedRoot",
+                    scene = "Assets/Scenes/Main.unity",
+                    parent = new
+                    {
+                        @var = "parent",
+                    },
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-create");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Validate_WhenSceneAndParentAreBothMissing_ReturnsInvalidArgument ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-create",
+                opName: "ucli.go.create",
+                args: new
+                {
+                    name = "CreatedRoot",
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-create");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Validate_WhenParentResolvesAsset_ReturnsInvalidArgument ()
+        {
+            var operation = new GoCreatePhaseOperation();
+            var assetPath = CreateTemporaryAssetPath();
+            var asset = ScriptableObject.CreateInstance<IndexCatalogTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var requestOperation = CreateOperation(
+                    opId: "op-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "CreatedChild",
+                        parent = new
+                        {
+                            assetPath,
+                        },
+                    });
+
+                var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertInvalidArgument(result, "op-create");
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Describe_Plan_WhenTargetUsesAlias_ReturnsSuccess ()
+        {
+            var operation = new GoDescribePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                root.AddComponent<BoxCollider>();
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var context = new OperationExecutionContext();
+                context.AliasStore.Set("target", UnityObjectReferenceResolver.CreateResolvedReference(root));
+                var requestOperation = CreateOperation(
+                    opId: "op-describe",
+                    opName: "ucli.go.describe",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "target",
+                        },
+                        depth = 1,
+                    });
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Describe_Plan_WhenTargetUsesSelector_ReturnsSuccess ()
+        {
+            var operation = new GoDescribePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                var child = new GameObject("Child");
+                child.transform.SetParent(root.transform, worldPositionStays: false);
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var requestOperation = CreateOperation(
+                    opId: "op-describe",
+                    opName: "ucli.go.describe",
+                    args: new
+                    {
+                        target = new
+                        {
+                            scene = scenePath,
+                            hierarchyPath = "Root/Child",
+                        },
+                    });
+
+                var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Describe_Validate_WhenDepthIsNegative_ReturnsInvalidArgument ()
+        {
+            var operation = new GoDescribePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-describe",
+                opName: "ucli.go.describe",
+                args: new
+                {
+                    target = new
+                    {
+                        @var = "target",
+                    },
+                    depth = -1,
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-describe");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Describe_Validate_WhenTargetResolvesAsset_ReturnsInvalidArgument ()
+        {
+            var operation = new GoDescribePhaseOperation();
+            var assetPath = CreateTemporaryAssetPath();
+            var asset = ScriptableObject.CreateInstance<IndexCatalogTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+                var requestOperation = CreateOperation(
+                    opId: "op-describe",
+                    opName: "ucli.go.describe",
+                    args: new
+                    {
+                        target = new
+                        {
+                            assetPath,
+                        },
+                    });
+
+                var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertInvalidArgument(result, "op-describe");
+            }
+            finally
+            {
+                if (AssetDatabase.Contains(asset))
+                {
+                    AssetDatabase.DeleteAsset(assetPath);
+                }
+
+                UnityEngine.Object.DestroyImmediate(asset);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void DescriptionBuilder_Build_WhenDepthIsOne_CapturesComponentsAndChildren ()
+        {
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                _ = root.AddComponent<BoxCollider>();
+                var child = new GameObject("Child");
+                _ = child.AddComponent<SphereCollider>();
+                child.transform.SetParent(root.transform, worldPositionStays: false);
+                EditorSceneManager.SaveScene(scene, scenePath);
+
+                var description = GameObjectDescriptionBuilder.Build(root, depth: 1);
+
+                Assert.That(description.Name, Is.EqualTo("Root"));
+                Assert.That(description.Components.Select(static component => component.TypeName), Does.Contain(typeof(Transform).FullName));
+                Assert.That(description.Components.Select(static component => component.TypeName), Does.Contain(typeof(BoxCollider).FullName));
+                Assert.That(description.Children.Count, Is.EqualTo(1));
+                Assert.That(description.Children[0].Name, Is.EqualTo("Child"));
+                Assert.That(description.Children[0].Components.Select(static component => component.TypeName), Does.Contain(typeof(SphereCollider).FullName));
+                Assert.That(description.Children[0].Children.Count, Is.EqualTo(0));
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        private static string CreateTemporaryScenePath ()
+        {
+            return $"Assets/GoPhaseOperationTests_{Guid.NewGuid():N}.unity";
+        }
+
+        private static string CreateTemporaryAssetPath ()
+        {
+            return $"Assets/GoPhaseOperationTests_{Guid.NewGuid():N}.asset";
+        }
+
+        private static NormalizedOperation CreateOperation (
+            string opId,
+            string opName,
+            object args,
+            string? alias = null)
+        {
+            return new NormalizedOperation(
+                Id: opId,
+                Op: opName,
+                Args: JsonSerializer.SerializeToElement(args),
+                As: alias,
+                Expect: null);
+        }
+
+        private static void AssertInvalidArgument (
+            OperationPhaseStepResult result,
+            string expectedOperationId)
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.Not.Null);
+            Assert.That(result.Failure!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(result.Failure.OpId, Is.EqualTo(expectedOperationId));
+        }
+
+        private static void AssertSuccess (
+            OperationPhaseStepResult result,
+            bool applied,
+            bool changed)
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Applied, Is.EqualTo(applied));
+            Assert.That(result.Changed, Is.EqualTo(changed));
+            Assert.That(result.Touched.Count, Is.EqualTo(1));
+            Assert.That(result.Touched[0].Kind, Is.EqualTo(OperationTouchKind.Scene));
+            Assert.That(result.Failure, Is.Null);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoPhaseOperationTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoPhaseOperationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3057474bbc26443db78f3ecc1a6858c

--- a/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
+++ b/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
@@ -56,6 +56,68 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
         }
         """;
 
+    private const string GoCreateArgsSchemaJson =
+        """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string", "minLength": 1 },
+            "scene": { "type": "string", "minLength": 1 },
+            "parent": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "var": { "type": "string", "minLength": 1 },
+                "globalObjectId": { "type": "string", "minLength": 1 },
+                "scene": { "type": "string", "minLength": 1 },
+                "hierarchyPath": { "type": "string", "minLength": 1 }
+              },
+              "oneOf": [
+                { "required": ["var"] },
+                { "required": ["globalObjectId"] },
+                { "required": ["scene", "hierarchyPath"] }
+              ]
+            }
+          },
+          "required": ["name"],
+          "oneOf": [
+            { "required": ["scene"] },
+            { "required": ["parent"] }
+          ]
+        }
+        """;
+
+    private const string GoDescribeArgsSchemaJson =
+        """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "target": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "var": { "type": "string", "minLength": 1 },
+                "globalObjectId": { "type": "string", "minLength": 1 },
+                "scene": { "type": "string", "minLength": 1 },
+                "hierarchyPath": { "type": "string", "minLength": 1 }
+              },
+              "oneOf": [
+                { "required": ["var"] },
+                { "required": ["globalObjectId"] },
+                { "required": ["scene", "hierarchyPath"] }
+              ]
+            },
+            "depth": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            }
+          },
+          "required": ["target"]
+        }
+        """;
+
     private static readonly IReadOnlyList<UcliOperationDescriptor> Operations =
     [
         new UcliOperationDescriptor("ucli.asset.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
@@ -70,8 +132,8 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
 
         new UcliOperationDescriptor("ucli.cs.invoke", UcliOperationKind.Mutation, OperationPolicy.Dangerous, DefaultArgsSchemaJson),
 
-        new UcliOperationDescriptor("ucli.go.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
-        new UcliOperationDescriptor("ucli.go.describe", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.go.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, GoCreateArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.go.describe", UcliOperationKind.Query, OperationPolicy.Safe, GoDescribeArgsSchemaJson),
 
         new UcliOperationDescriptor("ucli.prefab.create", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
         new UcliOperationDescriptor("ucli.prefab.open", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),

--- a/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
+++ b/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
@@ -75,6 +75,64 @@ public sealed class OperationCatalogTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Get_WhenOperationIsGoCreate_ReturnsSceneOrParentSchema ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var descriptor = await catalog.Get("ucli.go.create", CancellationToken.None);
+
+        Assert.NotNull(descriptor);
+        using var schemaDocument = JsonDocument.Parse(descriptor.ArgsSchemaJson);
+        var schemaRoot = schemaDocument.RootElement;
+        Assert.Equal(JsonValueKind.Object, schemaRoot.ValueKind);
+        Assert.True(schemaRoot.TryGetProperty("required", out var required));
+        Assert.True(ContainsArrayLiteral(required, "name"));
+        Assert.True(schemaRoot.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("scene", out _));
+        Assert.True(properties.TryGetProperty("parent", out var parentProperty));
+        Assert.True(parentProperty.TryGetProperty("oneOf", out var parentOneOf));
+        Assert.Equal(3, parentOneOf.GetArrayLength());
+        Assert.True(ContainsRequiredProperty(parentOneOf, "var"));
+        Assert.True(ContainsRequiredProperty(parentOneOf, "globalObjectId"));
+        Assert.True(ContainsRequiredProperties(parentOneOf, "scene", "hierarchyPath"));
+        Assert.True(schemaRoot.TryGetProperty("oneOf", out var rootOneOf));
+        Assert.Equal(2, rootOneOf.GetArrayLength());
+        Assert.True(ContainsRequiredProperty(rootOneOf, "scene"));
+        Assert.True(ContainsRequiredProperty(rootOneOf, "parent"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Get_WhenOperationIsGoDescribe_ReturnsTargetAndDepthSchema ()
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var descriptor = await catalog.Get("ucli.go.describe", CancellationToken.None);
+
+        Assert.NotNull(descriptor);
+        using var schemaDocument = JsonDocument.Parse(descriptor.ArgsSchemaJson);
+        var schemaRoot = schemaDocument.RootElement;
+        Assert.Equal(JsonValueKind.Object, schemaRoot.ValueKind);
+        Assert.True(schemaRoot.TryGetProperty("required", out var required));
+        Assert.True(ContainsArrayLiteral(required, "target"));
+        Assert.True(schemaRoot.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("target", out var targetProperty));
+        Assert.True(targetProperty.TryGetProperty("oneOf", out var targetOneOf));
+        Assert.Equal(3, targetOneOf.GetArrayLength());
+        Assert.True(ContainsRequiredProperty(targetOneOf, "var"));
+        Assert.True(ContainsRequiredProperty(targetOneOf, "globalObjectId"));
+        Assert.True(ContainsRequiredProperties(targetOneOf, "scene", "hierarchyPath"));
+        Assert.True(properties.TryGetProperty("depth", out var depthProperty));
+        Assert.True(depthProperty.TryGetProperty("type", out var depthType));
+        Assert.Equal(JsonValueKind.Array, depthType.ValueKind);
+        Assert.True(ContainsArrayLiteral(depthType, "integer"));
+        Assert.True(ContainsArrayLiteral(depthType, "null"));
+        Assert.True(depthProperty.TryGetProperty("minimum", out var depthMinimum));
+        Assert.Equal(0, depthMinimum.GetInt32());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task GetAll_ReturnsOperationsOrderedByName ()
     {
         var provider = new TestOperationCatalogProvider(


### PR DESCRIPTION
## Summary
- add `ucli.go.create` and `ucli.go.describe` phase operations for loaded scene GameObjects
- introduce shared Unity object reference parsing and resolution for alias and selector inputs
- add catalog and EditMode tests, and restrict go reference schemas to scene-resolvable forms only

## Testing
- `dotnet format src/Ucli/Ucli.csproj --verbosity minimal --verify-no-changes --no-restore --include src/Ucli/Operations/InMemoryOperationCatalogProvider.cs`
- `dotnet format tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal --verify-no-changes --no-restore --include tests/Ucli.Tests/Operations/OperationCatalogTests.cs`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore`
- `"/Applications/Unity/Hub/Editor/2023.2.22f1/Unity.app/Contents/MacOS/Unity" -batchmode -nographics -projectPath "/Users/makihiro/.codex/worktrees/cbb8/ucli/src/Ucli.Unity" -runTests -testPlatform EditMode -assemblyNames "MackySoft.Ucli.Unity.Tests.Editor" -testResults "/tmp/ucli-unity-editmode-results.xml" -logFile "/tmp/ucli-unity-editmode.log"`

Closes #23