### PR TITLE
[v1.0][O9] projectドメイン（refresh/save）を実装する

### DIFF
--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 042375b4da84a41e0b45efce0b66645b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationCallbackRegistry.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationCallbackRegistry.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Collects asset-path notifications emitted by Unity editor callbacks during project-domain operations. </summary>
+    internal static class ProjectOperationCallbackRegistry
+    {
+        private static readonly CallbackScopeState RefreshState = new();
+
+        private static readonly CallbackScopeState SaveState = new();
+
+        /// <summary> Begins one refresh callback-capture scope. </summary>
+        /// <returns> The scope identifier used to finish capture. </returns>
+        public static int BeginRefreshCapture ()
+        {
+            return RefreshState.BeginScope();
+        }
+
+        /// <summary> Ends one refresh callback-capture scope. </summary>
+        /// <param name="scopeId"> The capture scope identifier. </param>
+        /// <returns> The stable, deduplicated callback path list. </returns>
+        public static IReadOnlyList<string> EndRefreshCapture (int scopeId)
+        {
+            return RefreshState.EndScope(scopeId);
+        }
+
+        /// <summary> Records refresh callback paths into all active refresh scopes. </summary>
+        /// <param name="importedAssets"> The imported asset paths. </param>
+        /// <param name="deletedAssets"> The deleted asset paths. </param>
+        /// <param name="movedAssets"> The moved-to asset paths. </param>
+        /// <param name="movedFromAssetPaths"> The moved-from asset paths. </param>
+        public static void RecordRefreshPaths (
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            RefreshState.Record(importedAssets);
+            RefreshState.Record(deletedAssets);
+            RefreshState.Record(movedAssets);
+            RefreshState.Record(movedFromAssetPaths);
+        }
+
+        /// <summary> Begins one save callback-capture scope. </summary>
+        /// <returns> The scope identifier used to finish capture. </returns>
+        public static int BeginSaveCapture ()
+        {
+            return SaveState.BeginScope();
+        }
+
+        /// <summary> Ends one save callback-capture scope. </summary>
+        /// <param name="scopeId"> The capture scope identifier. </param>
+        /// <returns> The stable, deduplicated callback path list. </returns>
+        public static IReadOnlyList<string> EndSaveCapture (int scopeId)
+        {
+            return SaveState.EndScope(scopeId);
+        }
+
+        /// <summary> Records save callback paths into all active save scopes. </summary>
+        /// <param name="paths"> The save callback paths. </param>
+        /// <returns> The original path array required by Unity callback contract. </returns>
+        public static string[] RecordSavePaths (string[] paths)
+        {
+            SaveState.Record(paths);
+            return paths;
+        }
+
+        private sealed class CallbackScopeState
+        {
+            private readonly object gate = new();
+
+            private readonly Dictionary<int, HashSet<string>> activeScopes = new();
+
+            private int nextScopeId;
+
+            /// <summary> Begins one callback-capture scope. </summary>
+            /// <returns> The scope identifier. </returns>
+            public int BeginScope ()
+            {
+                lock (gate)
+                {
+                    checked
+                    {
+                        nextScopeId++;
+                    }
+
+                    activeScopes.Add(nextScopeId, new HashSet<string>(StringComparer.Ordinal));
+                    return nextScopeId;
+                }
+            }
+
+            /// <summary> Ends one callback-capture scope and returns collected paths. </summary>
+            /// <param name="scopeId"> The scope identifier. </param>
+            /// <returns> The stable collected path list. </returns>
+            public IReadOnlyList<string> EndScope (int scopeId)
+            {
+                lock (gate)
+                {
+                    if (!activeScopes.Remove(scopeId, out var collectedPaths))
+                    {
+                        return Array.Empty<string>();
+                    }
+
+                    var result = new string[collectedPaths.Count];
+                    collectedPaths.CopyTo(result);
+                    Array.Sort(result, StringComparer.Ordinal);
+                    return result;
+                }
+            }
+
+            /// <summary> Records callback paths into all currently active scopes. </summary>
+            /// <param name="paths"> The callback path batch. </param>
+            public void Record (string[]? paths)
+            {
+                if (paths == null || paths.Length == 0)
+                {
+                    return;
+                }
+
+                lock (gate)
+                {
+                    if (activeScopes.Count == 0)
+                    {
+                        return;
+                    }
+
+                    foreach (var path in paths)
+                    {
+                        if (string.IsNullOrWhiteSpace(path))
+                        {
+                            continue;
+                        }
+
+                        foreach (var scope in activeScopes.Values)
+                        {
+                            scope.Add(path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationCallbackRegistry.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationCallbackRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f281a188ced449c180d4056e1d0c56b

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationFileSnapshot.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationFileSnapshot.cs
@@ -1,0 +1,50 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one captured project-settings file state used by project-domain operations. </summary>
+    internal readonly struct ProjectOperationFileSnapshot : System.IEquatable<ProjectOperationFileSnapshot>
+    {
+        /// <summary> Initializes a new instance of the <see cref="ProjectOperationFileSnapshot" /> struct. </summary>
+        /// <param name="size"> The file size in bytes. </param>
+        /// <param name="lastWriteUtcTicks"> The last-write timestamp in UTC ticks. </param>
+        public ProjectOperationFileSnapshot (
+            long size,
+            long lastWriteUtcTicks)
+        {
+            Size = size;
+            LastWriteUtcTicks = lastWriteUtcTicks;
+        }
+
+        /// <summary> Gets the file size in bytes. </summary>
+        public long Size { get; }
+
+        /// <summary> Gets the last-write timestamp in UTC ticks. </summary>
+        public long LastWriteUtcTicks { get; }
+
+        /// <summary> Determines whether the current value equals the specified snapshot. </summary>
+        /// <param name="other"> The other snapshot value. </param>
+        /// <returns> <see langword="true" /> when both values are equal; otherwise <see langword="false" />. </returns>
+        public bool Equals (ProjectOperationFileSnapshot other)
+        {
+            return Size == other.Size
+                && LastWriteUtcTicks == other.LastWriteUtcTicks;
+        }
+
+        /// <summary> Determines whether the current value equals the specified object. </summary>
+        /// <param name="obj"> The other object instance. </param>
+        /// <returns> <see langword="true" /> when both values are equal; otherwise <see langword="false" />. </returns>
+        public override bool Equals (object obj)
+        {
+            return obj is ProjectOperationFileSnapshot other && Equals(other);
+        }
+
+        /// <summary> Returns one hash code for the current value. </summary>
+        /// <returns> The hash code value. </returns>
+        public override int GetHashCode ()
+        {
+            unchecked
+            {
+                return (Size.GetHashCode() * 397) ^ LastWriteUtcTicks.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationFileSnapshot.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationFileSnapshot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86449bf390037469080d0e07bd30b3fb

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using UnityEditor;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides shared helpers for project-domain phase operations. </summary>
+    internal static class ProjectOperationUtilities
+    {
+        private const string AssetsRootPrefix = "Assets/";
+
+        private const string ProjectSettingsRootPrefix = "ProjectSettings/";
+
+        private const string MetaExtension = ".meta";
+
+        /// <summary> Validates that one operation argument payload is a strict empty object. </summary>
+        /// <param name="args"> The operation argument element. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryValidateEmptyArguments (
+            JsonElement args,
+            out string errorMessage)
+        {
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            foreach (var property in args.EnumerateObject())
+            {
+                errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary> Resolves the current Unity project root path. </summary>
+        /// <returns> The absolute Unity project root path. </returns>
+        public static string ResolveProjectRootPath ()
+        {
+            var dataPath = Application.dataPath;
+            if (string.IsNullOrWhiteSpace(dataPath))
+            {
+                return Directory.GetCurrentDirectory();
+            }
+
+            var projectRoot = Path.GetDirectoryName(Path.GetFullPath(dataPath));
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                return Directory.GetCurrentDirectory();
+            }
+
+            return projectRoot;
+        }
+
+        /// <summary> Captures the current file-state snapshot under <c>ProjectSettings/</c>. </summary>
+        /// <param name="projectRoot"> The absolute Unity project root path. </param>
+        /// <returns> The snapshot keyed by project-relative path. </returns>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="projectRoot" /> is null, empty, or whitespace. </exception>
+        public static IReadOnlyDictionary<string, ProjectOperationFileSnapshot> CaptureProjectSettingsSnapshot (string projectRoot)
+        {
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                throw new ArgumentException("Project root must not be empty.", nameof(projectRoot));
+            }
+
+            var projectSettingsDirectoryPath = Path.Combine(projectRoot, "ProjectSettings");
+            var snapshot = new Dictionary<string, ProjectOperationFileSnapshot>(StringComparer.Ordinal);
+            if (!Directory.Exists(projectSettingsDirectoryPath))
+            {
+                return snapshot;
+            }
+
+            foreach (var filePath in Directory.EnumerateFiles(projectSettingsDirectoryPath, "*", SearchOption.AllDirectories))
+            {
+                var fileInfo = new FileInfo(filePath);
+                var relativePath = NormalizeProjectRelativePath(Path.GetRelativePath(projectRoot, filePath));
+                snapshot[relativePath] = new ProjectOperationFileSnapshot(
+                    fileInfo.Length,
+                    fileInfo.LastWriteTimeUtc.Ticks);
+            }
+
+            return snapshot;
+        }
+
+        /// <summary> Computes the stable changed-path list between two project-settings snapshots. </summary>
+        /// <param name="before"> The pre-operation snapshot. </param>
+        /// <param name="after"> The post-operation snapshot. </param>
+        /// <returns> The stable changed-path list. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="before" /> or <paramref name="after" /> is <see langword="null" />. </exception>
+        public static IReadOnlyList<string> GetChangedProjectSettingsPaths (
+            IReadOnlyDictionary<string, ProjectOperationFileSnapshot> before,
+            IReadOnlyDictionary<string, ProjectOperationFileSnapshot> after)
+        {
+            if (before == null)
+            {
+                throw new ArgumentNullException(nameof(before));
+            }
+
+            if (after == null)
+            {
+                throw new ArgumentNullException(nameof(after));
+            }
+
+            var changedPaths = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var beforeEntry in before)
+            {
+                if (!after.TryGetValue(beforeEntry.Key, out var afterSnapshot)
+                    || !afterSnapshot.Equals(beforeEntry.Value))
+                {
+                    changedPaths.Add(beforeEntry.Key);
+                }
+            }
+
+            foreach (var afterEntry in after)
+            {
+                if (!before.TryGetValue(afterEntry.Key, out var beforeSnapshot)
+                    || !beforeSnapshot.Equals(afterEntry.Value))
+                {
+                    changedPaths.Add(afterEntry.Key);
+                }
+            }
+
+            var result = new string[changedPaths.Count];
+            changedPaths.CopyTo(result);
+            return result;
+        }
+
+        /// <summary> Creates the stable touched-resource list from callback paths and project-settings diffs. </summary>
+        /// <param name="callbackPaths"> The paths collected from Unity editor callbacks. </param>
+        /// <param name="projectSettingsPaths"> The changed project-settings paths. </param>
+        /// <returns> The stable touched-resource list. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when any argument is <see langword="null" />. </exception>
+        public static IReadOnlyList<OperationTouch> CreateTouchedResources (
+            IReadOnlyList<string> callbackPaths,
+            IReadOnlyList<string> projectSettingsPaths)
+        {
+            if (callbackPaths == null)
+            {
+                throw new ArgumentNullException(nameof(callbackPaths));
+            }
+
+            if (projectSettingsPaths == null)
+            {
+                throw new ArgumentNullException(nameof(projectSettingsPaths));
+            }
+
+            // NOTE:
+            // Unity exposes asset import/save paths through editor callbacks, but project-settings writes are not
+            // surfaced consistently through the same callbacks. We merge callback output with an explicit
+            // ProjectSettings snapshot diff so touched results stay precise without broad filesystem scans under Assets/.
+            var touchedByPath = new SortedDictionary<string, OperationTouch>(StringComparer.Ordinal);
+            AddTouchedCandidates(callbackPaths, touchedByPath);
+            AddTouchedCandidates(projectSettingsPaths, touchedByPath);
+
+            var touched = new OperationTouch[touchedByPath.Count];
+            var index = 0;
+            foreach (var entry in touchedByPath.Values)
+            {
+                touched[index] = entry;
+                index++;
+            }
+
+            return touched;
+        }
+
+        /// <summary> Adds touched candidates into the deduplication map. </summary>
+        /// <param name="candidatePaths"> The candidate path collection. </param>
+        /// <param name="touchedByPath"> The deduplication map keyed by touched path. </param>
+        private static void AddTouchedCandidates (
+            IReadOnlyList<string> candidatePaths,
+            SortedDictionary<string, OperationTouch> touchedByPath)
+        {
+            for (var index = 0; index < candidatePaths.Count; index++)
+            {
+                if (!TryCreateTouchedResource(candidatePaths[index], out var touchedResource))
+                {
+                    continue;
+                }
+
+                if (touchedByPath.TryGetValue(touchedResource.Path, out var existing)
+                    && existing.Guid != null)
+                {
+                    continue;
+                }
+
+                touchedByPath[touchedResource.Path] = touchedResource;
+            }
+        }
+
+        /// <summary> Tries to create one touched-resource entry from one project-relative path candidate. </summary>
+        /// <param name="candidatePath"> The candidate project-relative path. </param>
+        /// <param name="touchedResource"> The touched-resource entry when successful. </param>
+        /// <returns> <see langword="true" /> when the path maps to a supported persistence unit; otherwise <see langword="false" />. </returns>
+        private static bool TryCreateTouchedResource (
+            string? candidatePath,
+            out OperationTouch touchedResource)
+        {
+            touchedResource = default!;
+            if (string.IsNullOrWhiteSpace(candidatePath))
+            {
+                return false;
+            }
+
+            var normalizedPath = NormalizeProjectRelativePath(candidatePath!);
+            if (normalizedPath.EndsWith(MetaExtension, StringComparison.Ordinal))
+            {
+                normalizedPath = normalizedPath.Substring(0, normalizedPath.Length - MetaExtension.Length);
+            }
+
+            if (string.IsNullOrEmpty(normalizedPath))
+            {
+                return false;
+            }
+
+            if (normalizedPath.StartsWith(ProjectSettingsRootPrefix, StringComparison.Ordinal))
+            {
+                touchedResource = new OperationTouch(
+                    Kind: OperationTouchKind.ProjectSettings,
+                    Path: normalizedPath,
+                    Guid: null);
+                return true;
+            }
+
+            if (!normalizedPath.StartsWith(AssetsRootPrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            touchedResource = new OperationTouch(
+                Kind: ResolveAssetTouchKind(normalizedPath),
+                Path: normalizedPath,
+                Guid: ResolveAssetGuid(normalizedPath));
+            return true;
+        }
+
+        /// <summary> Resolves one asset touch kind from its project-relative path. </summary>
+        /// <param name="assetPath"> The asset path. </param>
+        /// <returns> The touched resource kind. </returns>
+        private static OperationTouchKind ResolveAssetTouchKind (string assetPath)
+        {
+            if (assetPath.EndsWith(".unity", StringComparison.Ordinal))
+            {
+                return OperationTouchKind.Scene;
+            }
+
+            if (assetPath.EndsWith(".prefab", StringComparison.Ordinal))
+            {
+                return OperationTouchKind.Prefab;
+            }
+
+            return OperationTouchKind.Asset;
+        }
+
+        /// <summary> Resolves one asset guid when the asset currently exists. </summary>
+        /// <param name="assetPath"> The asset path. </param>
+        /// <returns> The asset guid when available; otherwise <see langword="null" />. </returns>
+        private static string? ResolveAssetGuid (string assetPath)
+        {
+            var assetGuid = AssetDatabase.AssetPathToGUID(assetPath);
+            return string.IsNullOrWhiteSpace(assetGuid) ? null : assetGuid;
+        }
+
+        /// <summary> Normalizes one project-relative path to the protocol slash format. </summary>
+        /// <param name="path"> The source path. </param>
+        /// <returns> The normalized project-relative path. </returns>
+        private static string NormalizeProjectRelativePath (string path)
+        {
+            var normalizedPath = path.Replace('\\', '/');
+            if (normalizedPath.StartsWith("./", StringComparison.Ordinal))
+            {
+                return normalizedPath.Substring(2);
+            }
+
+            return normalizedPath;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using MackySoft.Ucli.Contracts.Paths;
 using UnityEditor;
-using UnityEngine;
 
 #nullable enable
 
@@ -40,25 +40,6 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
 
             return true;
-        }
-
-        /// <summary> Resolves the current Unity project root path. </summary>
-        /// <returns> The absolute Unity project root path. </returns>
-        public static string ResolveProjectRootPath ()
-        {
-            var dataPath = Application.dataPath;
-            if (string.IsNullOrWhiteSpace(dataPath))
-            {
-                return Directory.GetCurrentDirectory();
-            }
-
-            var projectRoot = Path.GetDirectoryName(Path.GetFullPath(dataPath));
-            if (string.IsNullOrWhiteSpace(projectRoot))
-            {
-                return Directory.GetCurrentDirectory();
-            }
-
-            return projectRoot;
         }
 
         /// <summary> Captures the current file-state snapshot under <c>ProjectSettings/</c>. </summary>
@@ -274,7 +255,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> The normalized project-relative path. </returns>
         private static string NormalizeProjectRelativePath (string path)
         {
-            var normalizedPath = path.Replace('\\', '/');
+            var normalizedPath = PathStringNormalizer.ToSlashSeparated(path);
             if (normalizedPath.StartsWith("./", StringComparison.Ordinal))
             {
                 return normalizedPath.Substring(2);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/ProjectOperationUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7084e20c6544a484985814f6aa589117

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcd118c05cc32485b8ceb069b43ad157
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshAssetPostprocessor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshAssetPostprocessor.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Reports asset refresh changes to the active project refresh capture scope. </summary>
+    internal sealed class ProjectRefreshAssetPostprocessor : AssetPostprocessor
+    {
+        /// <summary> Captures imported, deleted, and moved asset paths after one refresh cycle. </summary>
+        /// <param name="importedAssets"> The imported asset paths. </param>
+        /// <param name="deletedAssets"> The deleted asset paths. </param>
+        /// <param name="movedAssets"> The moved-to asset paths. </param>
+        /// <param name="movedFromAssetPaths"> The moved-from asset paths. </param>
+        private static void OnPostprocessAllAssets (
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            ProjectOperationCallbackRegistry.RecordRefreshPaths(
+                importedAssets,
+                deletedAssets,
+                movedAssets,
+                movedFromAssetPaths);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshAssetPostprocessor.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshAssetPostprocessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb65f9e51b7734a269db244447c6fc81

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEditor;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.project.refresh</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class ProjectRefreshPhaseOperation : IUcliOperation
+    {
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.project.refresh",
+            kind: UcliOperationKind.Mutation,
+            policy: OperationPolicy.Advanced);
+
+        /// <summary> Executes validate phase for <c>ucli.project.refresh</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes plan phase for <c>ucli.project.refresh</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes call phase for <c>ucli.project.refresh</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            var projectRoot = ProjectOperationUtilities.ResolveProjectRootPath();
+            var beforeSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
+            var scopeId = ProjectOperationCallbackRegistry.BeginRefreshCapture();
+            IReadOnlyList<string> callbackPaths;
+            try
+            {
+                AssetDatabase.Refresh();
+            }
+            finally
+            {
+                callbackPaths = ProjectOperationCallbackRegistry.EndRefreshCapture(scopeId);
+            }
+
+            var afterSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
+            var changedProjectSettingsPaths = ProjectOperationUtilities.GetChangedProjectSettingsPaths(beforeSnapshot, afterSnapshot);
+            var touched = ProjectOperationUtilities.CreateTouchedResources(callbackPaths, changedProjectSettingsPaths);
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: true,
+                changed: touched.Count != 0,
+                touched: touched));
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs
@@ -72,7 +72,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
             }
 
-            var projectRoot = ProjectOperationUtilities.ResolveProjectRootPath();
+            var projectRoot = UnityProjectPathResolver.ResolveProjectRootPath();
             var beforeSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
             var scopeId = ProjectOperationCallbackRegistry.BeginRefreshCapture();
             IReadOnlyList<string> callbackPaths;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/refresh/ProjectRefreshPhaseOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06d9ba65ff0294872b53b438bb5cc923

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47f4750dfb18945f1950674c66c622c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSaveAssetModificationProcessor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSaveAssetModificationProcessor.cs
@@ -1,0 +1,18 @@
+using UnityEditor;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Reports asset-save paths to the active project save capture scope. </summary>
+    internal sealed class ProjectSaveAssetModificationProcessor : AssetModificationProcessor
+    {
+        /// <summary> Captures asset paths just before Unity persists them. </summary>
+        /// <param name="paths"> The asset paths Unity is about to save. </param>
+        /// <returns> The unchanged path array required by Unity callback contract. </returns>
+        private static string[] OnWillSaveAssets (string[] paths)
+        {
+            return ProjectOperationCallbackRegistry.RecordSavePaths(paths);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSaveAssetModificationProcessor.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSaveAssetModificationProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9c60a3cffedd4ad3bfd597929599851

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEditor;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.project.save</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class ProjectSavePhaseOperation : IUcliOperation
+    {
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.project.save",
+            kind: UcliOperationKind.Mutation,
+            policy: OperationPolicy.Advanced);
+
+        /// <summary> Executes validate phase for <c>ucli.project.save</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes plan phase for <c>ucli.project.save</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        /// <summary> Executes call phase for <c>ucli.project.save</c>. </summary>
+        /// <param name="operation"> The normalized operation. </param>
+        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
+        /// <returns> The phase-step result. </returns>
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!ProjectOperationUtilities.TryValidateEmptyArguments(operation.Args, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            var projectRoot = ProjectOperationUtilities.ResolveProjectRootPath();
+            var beforeSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
+            var scopeId = ProjectOperationCallbackRegistry.BeginSaveCapture();
+            IReadOnlyList<string> callbackPaths;
+            bool executed;
+            try
+            {
+                executed = EditorApplication.ExecuteMenuItem("File/Save Project");
+            }
+            finally
+            {
+                callbackPaths = ProjectOperationCallbackRegistry.EndSaveCapture(scopeId);
+            }
+
+            if (!executed)
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
+                    operation.Id,
+                    "Project could not be saved."));
+            }
+
+            var afterSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
+            var changedProjectSettingsPaths = ProjectOperationUtilities.GetChangedProjectSettingsPaths(beforeSnapshot, afterSnapshot);
+            var touched = ProjectOperationUtilities.CreateTouchedResources(callbackPaths, changedProjectSettingsPaths);
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: true,
+                changed: touched.Count != 0,
+                touched: touched));
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs
@@ -72,7 +72,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
             }
 
-            var projectRoot = ProjectOperationUtilities.ResolveProjectRootPath();
+            var projectRoot = UnityProjectPathResolver.ResolveProjectRootPath();
             var beforeSnapshot = ProjectOperationUtilities.CaptureProjectSettingsSnapshot(projectRoot);
             var scopeId = ProjectOperationCallbackRegistry.BeginSaveCapture();
             IReadOnlyList<string> callbackPaths;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/project/save/ProjectSavePhaseOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1cba1376fc1454c4198f008e146daa4c

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Environment/DefaultPlanTokenEnvironment.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Environment/DefaultPlanTokenEnvironment.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Project;
 using MackySoft.Ucli.Contracts.Storage;
@@ -20,7 +19,7 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
         /// <returns> The captured snapshot. </returns>
         public PlanTokenEnvironmentSnapshot Capture ()
         {
-            var projectRoot = ResolveProjectRoot();
+            var projectRoot = UnityProjectPathResolver.ResolveProjectRootPath();
             var repositoryRoot = UcliStoragePathResolver.ResolveStorageRoot(projectRoot);
             var projectFingerprint = UnityProjectFingerprintCalculator.Create(repositoryRoot, projectRoot);
 
@@ -37,25 +36,5 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
                 CompileState: compileState,
                 DomainReloadGeneration: "na");
         }
-
-        /// <summary> Resolves the current Unity project root path. </summary>
-        /// <returns> The project root path. </returns>
-        private static string ResolveProjectRoot ()
-        {
-            var dataPath = Application.dataPath;
-            if (string.IsNullOrWhiteSpace(dataPath))
-            {
-                return Directory.GetCurrentDirectory();
-            }
-
-            var projectRoot = Path.GetDirectoryName(Path.GetFullPath(dataPath));
-            if (string.IsNullOrWhiteSpace(projectRoot))
-            {
-                return Directory.GetCurrentDirectory();
-            }
-
-            return projectRoot;
-        }
-
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityProjectPathResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityProjectPathResolver.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution
+{
+    /// <summary> Resolves common Unity project paths from the current editor process. </summary>
+    internal static class UnityProjectPathResolver
+    {
+        /// <summary> Resolves the current Unity project root path. </summary>
+        /// <returns> The absolute Unity project root path. </returns>
+        public static string ResolveProjectRootPath ()
+        {
+            var dataPath = Application.dataPath;
+            if (string.IsNullOrWhiteSpace(dataPath))
+            {
+                return Directory.GetCurrentDirectory();
+            }
+
+            var projectRoot = Path.GetDirectoryName(Path.GetFullPath(dataPath));
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                return Directory.GetCurrentDirectory();
+            }
+
+            return projectRoot;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityProjectPathResolver.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityProjectPathResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2dc490ed7828445a28f636a9cabb297a

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Index/IndexCatalogBuilderTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Index/IndexCatalogBuilderTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Unity.Execution;
 using MackySoft.Ucli.Unity.Index;
 using NUnit.Framework;
 using UnityEditor;
@@ -324,7 +325,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
         private static string ResolveProjectRootPath ()
         {
-            return Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+            return UnityProjectPathResolver.ResolveProjectRootPath();
         }
 
         private static IndexCatalogBuilder CreateBuilder (

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectOperationUtilitiesTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectOperationUtilitiesTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using NUnit.Framework;
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class ProjectOperationUtilitiesTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public void TryValidateEmptyArguments_WhenArgsContainUnknownProperty_ReturnsFalse ()
+        {
+            var args = JsonSerializer.SerializeToElement(new
+            {
+                unexpected = true,
+            });
+
+            var result = ProjectOperationUtilities.TryValidateEmptyArguments(args, out var errorMessage);
+
+            Assert.That(result, Is.False);
+            Assert.That(errorMessage, Is.EqualTo("Operation 'args' contains an unknown property: unexpected."));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void CreateTouchedResources_WhenPathsIncludeMetaAndProjectSettings_NormalizesAndClassifiesPaths ()
+        {
+            var touched = ProjectOperationUtilities.CreateTouchedResources(
+                new[]
+                {
+                    "Assets/Scenes/Main.unity",
+                    "Assets/Prefabs/Enemy.prefab.meta",
+                    "Assets/Data/Config.asset",
+                    "Assets/Data/Config.asset.meta",
+                    "Packages/com.example/ignored.asset",
+                },
+                new[]
+                {
+                    "ProjectSettings/TagManager.asset",
+                });
+
+            Assert.That(touched.Count, Is.EqualTo(4));
+            Assert.That(touched[0].Path, Is.EqualTo("Assets/Data/Config.asset"));
+            Assert.That(touched[0].Kind, Is.EqualTo(OperationTouchKind.Asset));
+            Assert.That(touched[1].Path, Is.EqualTo("Assets/Prefabs/Enemy.prefab"));
+            Assert.That(touched[1].Kind, Is.EqualTo(OperationTouchKind.Prefab));
+            Assert.That(touched[2].Path, Is.EqualTo("Assets/Scenes/Main.unity"));
+            Assert.That(touched[2].Kind, Is.EqualTo(OperationTouchKind.Scene));
+            Assert.That(touched[3].Path, Is.EqualTo("ProjectSettings/TagManager.asset"));
+            Assert.That(touched[3].Kind, Is.EqualTo(OperationTouchKind.ProjectSettings));
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void GetChangedProjectSettingsPaths_WhenSnapshotsDiffer_ReturnsStableUnion ()
+        {
+            var before = new Dictionary<string, ProjectOperationFileSnapshot>(System.StringComparer.Ordinal)
+            {
+                ["ProjectSettings/A.asset"] = new ProjectOperationFileSnapshot(10, 100),
+                ["ProjectSettings/B.asset"] = new ProjectOperationFileSnapshot(20, 200),
+            };
+            var after = new Dictionary<string, ProjectOperationFileSnapshot>(System.StringComparer.Ordinal)
+            {
+                ["ProjectSettings/B.asset"] = new ProjectOperationFileSnapshot(21, 201),
+                ["ProjectSettings/C.asset"] = new ProjectOperationFileSnapshot(30, 300),
+            };
+
+            var changedPaths = ProjectOperationUtilities.GetChangedProjectSettingsPaths(before, after);
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "ProjectSettings/A.asset",
+                    "ProjectSettings/B.asset",
+                    "ProjectSettings/C.asset",
+                },
+                changedPaths);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectOperationUtilitiesTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectOperationUtilitiesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec400cf35dd4645b4928a5bc8b838b5f

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class ProjectPhaseOperationTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public void Refresh_Validate_WhenArgsContainUnknownProperty_ReturnsInvalidArgument ()
+        {
+            var operation = new ProjectRefreshPhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-refresh",
+                opName: "ucli.project.refresh",
+                args: new
+                {
+                    unexpected = true,
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-refresh");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Refresh_Plan_WhenArgsAreEmpty_ReturnsNoTouchedResources ()
+        {
+            var operation = new ProjectRefreshPhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-refresh",
+                opName: "ucli.project.refresh",
+                args: new { });
+
+            var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertSuccess(result, applied: false, changed: false);
+            Assert.That(result.Touched, Is.Empty);
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Refresh_Call_WhenExternalAssetIsCreated_ImportsAssetAndReturnsTouchedAsset ()
+        {
+            var operation = new ProjectRefreshPhaseOperation();
+            var assetPath = CreateTemporaryTextAssetPath();
+            var absoluteAssetPath = ToAbsolutePath(assetPath);
+            var assetDirectoryPath = Path.GetDirectoryName(absoluteAssetPath);
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(assetDirectoryPath))
+                {
+                    Directory.CreateDirectory(assetDirectoryPath);
+                }
+
+                File.WriteAllText(absoluteAssetPath, "refresh-test");
+                var requestOperation = CreateOperation(
+                    opId: "op-refresh",
+                    opName: "ucli.project.refresh",
+                    args: new { });
+
+                var result = operation.Call(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                Assert.That(AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath), Is.Not.Null);
+                Assert.That(result.Touched.Any(touched => touched.Path == assetPath && touched.Kind == OperationTouchKind.Asset), Is.True);
+            }
+            finally
+            {
+                DeleteAssetAndFiles(assetPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Save_Plan_WhenArgsAreEmpty_ReturnsNoTouchedResources ()
+        {
+            var operation = new ProjectSavePhaseOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-save",
+                opName: "ucli.project.save",
+                args: new { });
+
+            var result = operation.Plan(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertSuccess(result, applied: false, changed: false);
+            Assert.That(result.Touched, Is.Empty);
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Save_Call_WhenScriptableObjectAssetIsDirty_SavesAssetAndReturnsTouchedAsset ()
+        {
+            var operation = new ProjectSavePhaseOperation();
+            var assetPath = CreateTemporaryAssetPath();
+            var asset = ScriptableObject.CreateInstance<IndexCatalogTestAsset>();
+            try
+            {
+                AssetDatabase.CreateAsset(asset, assetPath);
+                AssetDatabase.SaveAssets();
+
+                var serializedObject = new SerializedObject(asset);
+                serializedObject.FindProperty("speed").floatValue = 42.0f;
+                serializedObject.ApplyModifiedPropertiesWithoutUndo();
+                EditorUtility.SetDirty(asset);
+                Assert.That(EditorUtility.IsDirty(asset), Is.True);
+
+                var requestOperation = CreateOperation(
+                    opId: "op-save",
+                    opName: "ucli.project.save",
+                    args: new { });
+
+                var result = operation.Call(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                Assert.That(EditorUtility.IsDirty(asset), Is.False);
+                Assert.That(result.Touched.Any(touched => touched.Path == assetPath && touched.Kind == OperationTouchKind.Asset), Is.True);
+            }
+            finally
+            {
+                ScriptableObject.DestroyImmediate(asset, allowDestroyingAssets: true);
+                DeleteAssetAndFiles(assetPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Save_Call_WhenOnlySceneIsDirty_DoesNotSaveScene ()
+        {
+            var operation = new ProjectSavePhaseOperation();
+            var scenePath = CreateTemporaryScenePath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                _ = new GameObject("Root");
+                EditorSceneManager.SaveScene(scene, scenePath);
+                _ = new GameObject("DirtySceneObject");
+                EditorSceneManager.MarkSceneDirty(scene);
+                Assert.That(scene.isDirty, Is.True);
+                var requestOperation = CreateOperation(
+                    opId: "op-save",
+                    opName: "ucli.project.save",
+                    args: new { });
+
+                var result = operation.Call(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: false);
+                Assert.That(scene.isDirty, Is.True);
+                Assert.That(result.Touched.Any(touched => touched.Kind == OperationTouchKind.Scene), Is.False);
+            }
+            finally
+            {
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+            }
+        }
+
+        private static string CreateTemporaryTextAssetPath ()
+        {
+            return $"Assets/ProjectPhaseOperationTests_{Guid.NewGuid():N}.txt";
+        }
+
+        private static string CreateTemporaryAssetPath ()
+        {
+            return $"Assets/ProjectPhaseOperationTests_{Guid.NewGuid():N}.asset";
+        }
+
+        private static string CreateTemporaryScenePath ()
+        {
+            return $"Assets/ProjectPhaseOperationTests_{Guid.NewGuid():N}.unity";
+        }
+
+        private static string ToAbsolutePath (string assetPath)
+        {
+            return Path.Combine(
+                Directory.GetParent(Application.dataPath)!.FullName,
+                assetPath.Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        private static void DeleteAssetAndFiles (string assetPath)
+        {
+            _ = AssetDatabase.DeleteAsset(assetPath);
+            var absolutePath = ToAbsolutePath(assetPath);
+            var metaPath = absolutePath + ".meta";
+            if (File.Exists(absolutePath))
+            {
+                File.Delete(absolutePath);
+            }
+
+            if (File.Exists(metaPath))
+            {
+                File.Delete(metaPath);
+            }
+
+            AssetDatabase.Refresh();
+        }
+
+        private static NormalizedOperation CreateOperation (
+            string opId,
+            string opName,
+            object args)
+        {
+            return new NormalizedOperation(
+                Id: opId,
+                Op: opName,
+                Args: JsonSerializer.SerializeToElement(args),
+                As: null,
+                Expect: null);
+        }
+
+        private static void AssertInvalidArgument (
+            OperationPhaseStepResult result,
+            string expectedOperationId)
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.Not.Null);
+            Assert.That(result.Failure!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(result.Failure.OpId, Is.EqualTo(expectedOperationId));
+        }
+
+        private static void AssertSuccess (
+            OperationPhaseStepResult result,
+            bool applied,
+            bool changed)
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Applied, Is.EqualTo(applied));
+            Assert.That(result.Changed, Is.EqualTo(changed));
+            Assert.That(result.Failure, Is.Null);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Paths;
+using MackySoft.Ucli.Unity.Execution;
 using MackySoft.Ucli.Unity.Execution.Phases;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using NUnit.Framework;
@@ -185,8 +187,8 @@ namespace MackySoft.Ucli.Unity.Tests
         private static string ToAbsolutePath (string assetPath)
         {
             return Path.Combine(
-                Directory.GetParent(Application.dataPath)!.FullName,
-                assetPath.Replace('/', Path.DirectorySeparatorChar));
+                UnityProjectPathResolver.ResolveProjectRootPath(),
+                PathStringNormalizer.ToPlatformSeparated(assetPath));
         }
 
         private static void DeleteAssetAndFiles (string assetPath)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/ProjectPhaseOperationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec3cffe4d97014f4fb4ee92ccd2aa3b3

--- a/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
+++ b/src/Ucli/Operations/InMemoryOperationCatalogProvider.cs
@@ -7,6 +7,14 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
 {
     private const string DefaultArgsSchemaJson = """{"type":"object"}""";
 
+    private const string EmptyObjectArgsSchemaJson =
+        """
+        {
+          "type": "object",
+          "additionalProperties": false
+        }
+        """;
+
     private const string ResolveArgsSchemaJson =
         """
         {
@@ -139,8 +147,8 @@ internal sealed class InMemoryOperationCatalogProvider : IOperationCatalogProvid
         new UcliOperationDescriptor("ucli.prefab.open", UcliOperationKind.Query, OperationPolicy.Safe, DefaultArgsSchemaJson),
         new UcliOperationDescriptor("ucli.prefab.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
 
-        new UcliOperationDescriptor("ucli.project.refresh", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
-        new UcliOperationDescriptor("ucli.project.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, DefaultArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.project.refresh", UcliOperationKind.Mutation, OperationPolicy.Advanced, EmptyObjectArgsSchemaJson),
+        new UcliOperationDescriptor("ucli.project.save", UcliOperationKind.Mutation, OperationPolicy.Advanced, EmptyObjectArgsSchemaJson),
 
         new UcliOperationDescriptor("ucli.resolve", UcliOperationKind.Query, OperationPolicy.Safe, ResolveArgsSchemaJson),
 

--- a/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
+++ b/tests/Ucli.Tests/Operations/OperationCatalogTests.cs
@@ -131,6 +131,27 @@ public sealed class OperationCatalogTests
         Assert.Equal(0, depthMinimum.GetInt32());
     }
 
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("ucli.project.refresh")]
+    [InlineData("ucli.project.save")]
+    public async Task Get_WhenOperationIsProjectMutation_ReturnsStrictEmptyObjectSchema (string operationName)
+    {
+        var catalog = new OperationCatalog(new InMemoryOperationCatalogProvider());
+
+        var descriptor = await catalog.Get(operationName, CancellationToken.None);
+
+        Assert.NotNull(descriptor);
+        using var schemaDocument = JsonDocument.Parse(descriptor.ArgsSchemaJson);
+        var schemaRoot = schemaDocument.RootElement;
+        Assert.Equal(JsonValueKind.Object, schemaRoot.ValueKind);
+        Assert.True(schemaRoot.TryGetProperty("type", out var typeProperty));
+        Assert.Equal("object", typeProperty.GetString());
+        Assert.True(schemaRoot.TryGetProperty("additionalProperties", out var additionalProperties));
+        Assert.False(additionalProperties.GetBoolean());
+        Assert.False(schemaRoot.TryGetProperty("properties", out _));
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task GetAll_ReturnsOperationsOrderedByName ()


### PR DESCRIPTION
## Summary
- project ドメインの `ucli.project.refresh` / `ucli.project.save` を Unity phase layer に実装しました。
- strict empty-object schema、callback 捕捉、`ProjectSettings/` スナップショット差分、touched 正規化を追加しています。
- CLI host / `ucli refresh` コマンド本体 / Unity IPC dispatcher の `Refresh` 対応は `#41` の責務として今回の範囲から外しています。

## Scope
- `ucli.project.refresh` / `ucli.project.save` の operation catalog schema を strict empty object に変更
- Unity Editor に project domain phase operation、callback registry、`ProjectSettings/` snapshot helper を追加
- Unity EditMode テストと CLI 側 catalog テストを追加

## Verification
- Gate level: Standard
- Diff budget: PASS (`#28` に Split waived を記載済み。23 files changed, 1130 insertions(+), 4 deletions(-))
- Spec drift: Skipped (`docs/agents/feature_issue-28-project-refresh-save/spec.md` が存在しないため)
- Format: PASS (`dotnet format` / `--verify-no-changes` を対象 csproj に対して実行)
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter OperationCatalogTests`, Unity EditMode `MackySoft.Ucli.Unity.Tests.Editor` 187 passed)
- Coverage: N/A

## Risks / Rollback
- `ucli refresh` の入口や dispatcher 配線は未実装のため、この PR 単体では op ドメイン実装までが有効範囲です。
- ロールバックは `a61826d` の revert で project ドメイン追加と関連テストを一括で戻せます。

## Checklist
- [ ] `ucli.project.refresh` / `ucli.project.save` の touched 契約が想定どおりか確認する
- [ ] `#41` で CLI / dispatcher を接続する際に追加の契約変更が不要か確認する

Closes #28
