### PR TITLE
[v1.0][O6] prefabドメイン（create/open/save）を実装する

### DIFF
--- a/docs/ops-catalog.md
+++ b/docs/ops-catalog.md
@@ -39,9 +39,9 @@
 
 | op | kind | policy | status | 概要 | argsSchema |
 | --- | --- | --- | --- | --- | --- |
-| `ucli.prefab.create` | mutation | advanced | mvp-core | GameObjectからPrefabを新規作成する。 | 予定 |
-| `ucli.prefab.open` | query | safe | mvp-core | 指定Prefabを編集コンテキストとして開く。 | 予定 |
-| `ucli.prefab.save` | mutation | advanced | mvp-core | 編集中のPrefabを保存する。 | 予定 |
+| `ucli.prefab.create` | mutation | advanced | mvp-core | Loaded Scene 上の GameObject から Prefab を新規作成する。`target` 必須、空 Prefab は作らない。 | 予定 |
+| `ucli.prefab.open` | query | safe | mvp-core | 指定 Prefab を編集コンテキストとして開く。`as` 指定時は Prefab root を alias 保存する。 | 予定 |
+| `ucli.prefab.save` | mutation | advanced | mvp-core | 現在開いている指定 Prefab を保存する。 | 予定 |
 
 ## project
 

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -538,6 +538,19 @@ public static class RebuildNavmesh
 
 `ucli.comp.set` は常に atomic に評価・適用し、`mode` 引数は受け付けない。
 
+### Prefab op 契約
+- `ucli.prefab.create`
+  - `args = { "target": <GameObjectRef>, "path": "<Assets/...>.prefab" }`
+  - `target` は必須。Loaded Scene 上の既存 GameObject だけを受け付ける
+  - 空の Prefab を新規作成する用途は扱わない
+- `ucli.prefab.open`
+  - `args = { "path": "<Assets/...>.prefab" }`
+  - `as` を指定した場合は、開いた Prefab の root GameObject を alias 保存する
+- `ucli.prefab.save`
+  - `args = { "path": "<Assets/...>.prefab" }`
+  - `path` は、現在開いている Prefab と一致しなければならない
+- `prefab.open` 後の編集は、`as` で受けた root alias を起点に `ucli.go.create` / `ucli.comp.ensure` / `ucli.comp.set` を連鎖させる
+
 ## コマンド
 Unityプロジェクトを対象に実行するコマンドは、CWDがUnityプロジェクトと判定可能な場合はそれを使う。そうでない場合は `--projectPath` を指定する。
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
@@ -19,6 +19,9 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         private readonly Dictionary<EnsuredComponentKey, EnsuredComponentValue> ensuredComponentsByKey =
             new Dictionary<EnsuredComponentKey, EnsuredComponentValue>();
 
+        private readonly Dictionary<string, GameObject> temporaryPrefabContentsRootsByPath =
+            new Dictionary<string, GameObject>(StringComparer.Ordinal);
+
         private readonly List<UnityEngine.Object> temporaryObjects = new List<UnityEngine.Object>();
 
         /// <summary> Initializes a new instance of the <see cref="OperationExecutionContext" /> class. </summary>
@@ -41,11 +44,29 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <summary> Stores or replaces one temporary alias value used during plan execution. </summary>
         /// <param name="alias"> The alias name. </param>
         /// <param name="unityObject"> The temporary live object. </param>
-        /// <param name="scenePath"> The logical scene path associated with the temporary object. </param>
+        /// <param name="scenePath"> The logical resource path associated with the temporary object. </param>
         internal void SetTemporaryAlias (
             string alias,
             UnityEngine.Object unityObject,
             string scenePath,
+            string? sourceGlobalObjectId = null)
+        {
+            SetTemporaryAlias(
+                alias,
+                unityObject,
+                new OperationResource(OperationTouchKind.Scene, scenePath),
+                sourceGlobalObjectId);
+        }
+
+        /// <summary> Stores or replaces one temporary alias value used during plan execution. </summary>
+        /// <param name="alias"> The alias name. </param>
+        /// <param name="unityObject"> The temporary live object. </param>
+        /// <param name="resource"> The logical owner resource associated with the temporary object. </param>
+        /// <param name="sourceGlobalObjectId"> The optional source GlobalObjectId used to synchronize shadows. </param>
+        internal void SetTemporaryAlias (
+            string alias,
+            UnityEngine.Object unityObject,
+            OperationResource resource,
             string? sourceGlobalObjectId = null)
         {
             ValidateAlias(alias);
@@ -54,48 +75,25 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 throw new ArgumentNullException(nameof(unityObject));
             }
 
-            if (string.IsNullOrWhiteSpace(scenePath))
-            {
-                throw new ArgumentException("Scene path must not be null, empty, or whitespace.", nameof(scenePath));
-            }
-
+            ValidateResource(resource, nameof(resource));
             if (sourceGlobalObjectId != null
                 && string.IsNullOrWhiteSpace(sourceGlobalObjectId))
             {
                 throw new ArgumentException("Source GlobalObjectId must not be empty when provided.", nameof(sourceGlobalObjectId));
             }
 
-            temporaryAliasesByName[alias] = new TemporaryAliasValue(unityObject, scenePath, sourceGlobalObjectId);
+            temporaryAliasesByName[alias] = new TemporaryAliasValue(unityObject, resource, sourceGlobalObjectId);
         }
 
-        /// <summary> Tries to get one temporary alias value. </summary>
+        /// <summary> Tries to get one temporary alias state. </summary>
         /// <param name="alias"> The alias name. </param>
-        /// <param name="unityObject"> The temporary live object when found. </param>
-        /// <param name="scenePath"> The logical scene path when found. </param>
+        /// <param name="state"> The tracked alias state when found. </param>
         /// <returns> <see langword="true" /> when temporary alias exists; otherwise <see langword="false" />. </returns>
-        internal bool TryGetTemporaryAlias (
+        internal bool TryGetTemporaryAliasState (
             string alias,
-            out UnityEngine.Object? unityObject,
-            out string scenePath)
+            out TemporaryAliasState state)
         {
-            return TryGetTemporaryAlias(alias, out unityObject, out scenePath, out _);
-        }
-
-        /// <summary> Tries to get one temporary alias value together with the tracked source GlobalObjectId. </summary>
-        /// <param name="alias"> The alias name. </param>
-        /// <param name="unityObject"> The temporary live object when found. </param>
-        /// <param name="scenePath"> The logical scene path when found. </param>
-        /// <param name="sourceGlobalObjectId"> The source GlobalObjectId when tracked; otherwise <see langword="null" />. </param>
-        /// <returns> <see langword="true" /> when temporary alias exists; otherwise <see langword="false" />. </returns>
-        internal bool TryGetTemporaryAlias (
-            string alias,
-            out UnityEngine.Object? unityObject,
-            out string scenePath,
-            out string? sourceGlobalObjectId)
-        {
-            unityObject = null;
-            scenePath = string.Empty;
-            sourceGlobalObjectId = null;
+            state = default;
             if (string.IsNullOrWhiteSpace(alias))
             {
                 return false;
@@ -112,9 +110,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            unityObject = value.UnityObject;
-            scenePath = value.ScenePath;
-            sourceGlobalObjectId = value.SourceGlobalObjectId;
+            state = new TemporaryAliasState(value.UnityObject, value.Resource, value.SourceGlobalObjectId);
             return true;
         }
 
@@ -122,12 +118,30 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <param name="targetGlobalObjectId"> The source GameObject GlobalObjectId. </param>
         /// <param name="componentType"> The ensured component runtime type. </param>
         /// <param name="component"> The temporary ensured component. </param>
-        /// <param name="scenePath"> The owning scene path. </param>
+        /// <param name="scenePath"> The owning resource path. </param>
         internal void SetEnsuredComponent (
             string targetGlobalObjectId,
             Type componentType,
             Component component,
             string scenePath)
+        {
+            SetEnsuredComponent(
+                targetGlobalObjectId,
+                componentType,
+                component,
+                new OperationResource(OperationTouchKind.Scene, scenePath));
+        }
+
+        /// <summary> Stores or replaces one plan-time ensured component keyed by target GameObject and component type. </summary>
+        /// <param name="targetGlobalObjectId"> The source GameObject GlobalObjectId. </param>
+        /// <param name="componentType"> The ensured component runtime type. </param>
+        /// <param name="component"> The temporary ensured component. </param>
+        /// <param name="resource"> The owning resource. </param>
+        internal void SetEnsuredComponent (
+            string targetGlobalObjectId,
+            Type componentType,
+            Component component,
+            OperationResource resource)
         {
             if (string.IsNullOrWhiteSpace(targetGlobalObjectId))
             {
@@ -144,29 +158,22 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 throw new ArgumentNullException(nameof(component));
             }
 
-            if (string.IsNullOrWhiteSpace(scenePath))
-            {
-                throw new ArgumentException("Scene path must not be null, empty, or whitespace.", nameof(scenePath));
-            }
-
+            ValidateResource(resource, nameof(resource));
             ensuredComponentsByKey[new EnsuredComponentKey(targetGlobalObjectId, componentType)] =
-                new EnsuredComponentValue(component, scenePath);
+                new EnsuredComponentValue(component, resource);
         }
 
-        /// <summary> Tries to get one plan-time ensured component keyed by target GameObject and component type. </summary>
+        /// <summary> Tries to get one plan-time ensured component state keyed by target GameObject and component type. </summary>
         /// <param name="targetGlobalObjectId"> The source GameObject GlobalObjectId. </param>
         /// <param name="componentType"> The ensured component runtime type. </param>
-        /// <param name="component"> The temporary ensured component when found. </param>
-        /// <param name="scenePath"> The owning scene path when found. </param>
+        /// <param name="state"> The ensured component state when found. </param>
         /// <returns> <see langword="true" /> when ensured component exists; otherwise <see langword="false" />. </returns>
-        internal bool TryGetEnsuredComponent (
+        internal bool TryGetEnsuredComponentState (
             string targetGlobalObjectId,
             Type componentType,
-            out Component? component,
-            out string scenePath)
+            out EnsuredComponentState state)
         {
-            component = null;
-            scenePath = string.Empty;
+            state = default;
             if (string.IsNullOrWhiteSpace(targetGlobalObjectId) || componentType == null)
             {
                 return false;
@@ -183,19 +190,33 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            component = value.Component;
-            scenePath = value.ScenePath;
+            state = new EnsuredComponentState(value.Component, value.Resource);
             return true;
         }
 
         /// <summary> Stores or replaces one temporary component shadow keyed by source GlobalObjectId. </summary>
         /// <param name="globalObjectId"> The source component GlobalObjectId. </param>
         /// <param name="component"> The temporary shadow component. </param>
-        /// <param name="scenePath"> The owning scene path. </param>
+        /// <param name="scenePath"> The owning resource path. </param>
         internal void SetComponentShadow (
             string globalObjectId,
             Component component,
             string scenePath)
+        {
+            SetComponentShadow(
+                globalObjectId,
+                component,
+                new OperationResource(OperationTouchKind.Scene, scenePath));
+        }
+
+        /// <summary> Stores or replaces one temporary component shadow keyed by source GlobalObjectId. </summary>
+        /// <param name="globalObjectId"> The source component GlobalObjectId. </param>
+        /// <param name="component"> The temporary shadow component. </param>
+        /// <param name="resource"> The owning resource. </param>
+        internal void SetComponentShadow (
+            string globalObjectId,
+            Component component,
+            OperationResource resource)
         {
             if (string.IsNullOrWhiteSpace(globalObjectId))
             {
@@ -207,23 +228,34 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 throw new ArgumentNullException(nameof(component));
             }
 
-            if (string.IsNullOrWhiteSpace(scenePath))
-            {
-                throw new ArgumentException("Scene path must not be null, empty, or whitespace.", nameof(scenePath));
-            }
-
-            componentShadowsByGlobalObjectId[globalObjectId] = new ComponentShadowValue(component, scenePath);
-            SynchronizeTemporaryAliases(globalObjectId, component, scenePath);
+            ValidateResource(resource, nameof(resource));
+            componentShadowsByGlobalObjectId[globalObjectId] = new ComponentShadowValue(component, resource);
+            SynchronizeTemporaryAliases(globalObjectId, component, resource);
         }
 
         /// <summary> Replaces tracked temporary component references that still point to an older plan-time component instance. </summary>
         /// <param name="sourceComponent"> The previous temporary component instance. </param>
         /// <param name="replacementComponent"> The replacement temporary component instance. </param>
-        /// <param name="scenePath"> The owning scene path. </param>
+        /// <param name="scenePath"> The owning resource path. </param>
         internal void ReplaceTrackedTemporaryComponent (
             Component sourceComponent,
             Component replacementComponent,
             string scenePath)
+        {
+            ReplaceTrackedTemporaryComponent(
+                sourceComponent,
+                replacementComponent,
+                new OperationResource(OperationTouchKind.Scene, scenePath));
+        }
+
+        /// <summary> Replaces tracked temporary component references that still point to an older plan-time component instance. </summary>
+        /// <param name="sourceComponent"> The previous temporary component instance. </param>
+        /// <param name="replacementComponent"> The replacement temporary component instance. </param>
+        /// <param name="resource"> The owning resource. </param>
+        internal void ReplaceTrackedTemporaryComponent (
+            Component sourceComponent,
+            Component replacementComponent,
+            OperationResource resource)
         {
             if (sourceComponent == null)
             {
@@ -235,31 +267,24 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 throw new ArgumentNullException(nameof(replacementComponent));
             }
 
-            if (string.IsNullOrWhiteSpace(scenePath))
-            {
-                throw new ArgumentException("Scene path must not be null, empty, or whitespace.", nameof(scenePath));
-            }
-
+            ValidateResource(resource, nameof(resource));
             // NOTE:
             // Plan-time component mutations replace the temporary component instance with a cloned sandbox.
             // Every tracked state that still points at the previous clone must advance together or later
             // plan steps can observe stale serialized data.
-            SynchronizeTemporaryAliases(sourceComponent, replacementComponent, scenePath);
-            SynchronizeEnsuredComponents(sourceComponent, replacementComponent, scenePath);
+            SynchronizeTemporaryAliases(sourceComponent, replacementComponent, resource);
+            SynchronizeEnsuredComponents(sourceComponent, replacementComponent, resource);
         }
 
-        /// <summary> Tries to get one temporary component shadow. </summary>
+        /// <summary> Tries to get one temporary component shadow state. </summary>
         /// <param name="globalObjectId"> The source component GlobalObjectId. </param>
-        /// <param name="component"> The temporary shadow component when found. </param>
-        /// <param name="scenePath"> The owning scene path when found. </param>
+        /// <param name="state"> The component shadow state when found. </param>
         /// <returns> <see langword="true" /> when shadow exists; otherwise <see langword="false" />. </returns>
-        internal bool TryGetComponentShadow (
+        internal bool TryGetComponentShadowState (
             string globalObjectId,
-            out Component? component,
-            out string scenePath)
+            out ComponentShadowState state)
         {
-            component = null;
-            scenePath = string.Empty;
+            state = default;
             if (string.IsNullOrWhiteSpace(globalObjectId))
             {
                 return false;
@@ -276,8 +301,56 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            component = value.Component;
-            scenePath = value.ScenePath;
+            state = new ComponentShadowState(value.Component, value.Resource);
+            return true;
+        }
+
+        /// <summary> Tracks one temporary prefab-contents root for unload at the end of request execution. </summary>
+        /// <param name="prefabPath"> The prefab asset path associated with the loaded contents. </param>
+        /// <param name="prefabContentsRoot"> The loaded prefab-contents root. </param>
+        internal void TrackTemporaryPrefabContentsRoot (
+            string prefabPath,
+            GameObject prefabContentsRoot)
+        {
+            if (string.IsNullOrWhiteSpace(prefabPath))
+            {
+                throw new ArgumentException("Prefab path must not be null, empty, or whitespace.", nameof(prefabPath));
+            }
+
+            if (prefabContentsRoot == null)
+            {
+                throw new ArgumentNullException(nameof(prefabContentsRoot));
+            }
+
+            temporaryPrefabContentsRootsByPath[prefabPath] = prefabContentsRoot;
+        }
+
+        /// <summary> Tries to get one request-local temporary prefab-contents root. </summary>
+        /// <param name="prefabPath"> The prefab asset path. </param>
+        /// <param name="prefabContentsRoot"> The loaded prefab-contents root when found. </param>
+        /// <returns> <see langword="true" /> when tracked root exists; otherwise <see langword="false" />. </returns>
+        internal bool TryGetTemporaryPrefabContentsRoot (
+            string prefabPath,
+            out GameObject? prefabContentsRoot)
+        {
+            prefabContentsRoot = null;
+            if (string.IsNullOrWhiteSpace(prefabPath))
+            {
+                return false;
+            }
+
+            if (!temporaryPrefabContentsRootsByPath.TryGetValue(prefabPath, out var value))
+            {
+                return false;
+            }
+
+            if (value == null)
+            {
+                temporaryPrefabContentsRootsByPath.Remove(prefabPath);
+                return false;
+            }
+
+            prefabContentsRoot = value;
             return true;
         }
 
@@ -296,6 +369,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <summary> Destroys all tracked temporary objects and clears temporary state. </summary>
         internal void CleanupTemporaryObjects ()
         {
+            foreach (var pair in temporaryPrefabContentsRootsByPath)
+            {
+                var prefabContentsRoot = pair.Value;
+                if (prefabContentsRoot != null)
+                {
+                    UnityEditor.PrefabUtility.UnloadPrefabContents(prefabContentsRoot);
+                }
+            }
+
+            temporaryPrefabContentsRootsByPath.Clear();
+
             for (var i = temporaryObjects.Count - 1; i >= 0; i--)
             {
                 var temporaryObject = temporaryObjects[i];
@@ -324,10 +408,20 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
         }
 
+        private static void ValidateResource (
+            OperationResource resource,
+            string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(resource.Path))
+            {
+                throw new ArgumentException("Operation resource path must not be null, empty, or whitespace.", parameterName);
+            }
+        }
+
         private void SynchronizeTemporaryAliases (
             string globalObjectId,
             Component component,
-            string scenePath)
+            OperationResource resource)
         {
             List<string>? aliasesToSynchronize = null;
             foreach (var pair in temporaryAliasesByName)
@@ -349,14 +443,14 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             for (var i = 0; i < aliasesToSynchronize.Count; i++)
             {
                 var alias = aliasesToSynchronize[i];
-                temporaryAliasesByName[alias] = new TemporaryAliasValue(component, scenePath, globalObjectId);
+                temporaryAliasesByName[alias] = new TemporaryAliasValue(component, resource, globalObjectId);
             }
         }
 
         private void SynchronizeTemporaryAliases (
             Component sourceComponent,
             Component replacementComponent,
-            string scenePath)
+            OperationResource resource)
         {
             List<string>? aliasesToSynchronize = null;
             foreach (var pair in temporaryAliasesByName)
@@ -379,14 +473,14 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             {
                 var alias = aliasesToSynchronize[i];
                 var sourceGlobalObjectId = temporaryAliasesByName[alias].SourceGlobalObjectId;
-                temporaryAliasesByName[alias] = new TemporaryAliasValue(replacementComponent, scenePath, sourceGlobalObjectId);
+                temporaryAliasesByName[alias] = new TemporaryAliasValue(replacementComponent, resource, sourceGlobalObjectId);
             }
         }
 
         private void SynchronizeEnsuredComponents (
             Component sourceComponent,
             Component replacementComponent,
-            string scenePath)
+            OperationResource resource)
         {
             List<EnsuredComponentKey>? keysToSynchronize = null;
             foreach (var pair in ensuredComponentsByKey)
@@ -408,7 +502,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             for (var i = 0; i < keysToSynchronize.Count; i++)
             {
                 var key = keysToSynchronize[i];
-                ensuredComponentsByKey[key] = new EnsuredComponentValue(replacementComponent, scenePath);
+                ensuredComponentsByKey[key] = new EnsuredComponentValue(replacementComponent, resource);
             }
         }
 
@@ -416,17 +510,36 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         {
             public TemporaryAliasValue (
                 UnityEngine.Object unityObject,
-                string scenePath,
+                OperationResource resource,
                 string? sourceGlobalObjectId)
             {
                 UnityObject = unityObject;
-                ScenePath = scenePath;
+                Resource = resource;
                 SourceGlobalObjectId = sourceGlobalObjectId;
             }
 
             public UnityEngine.Object UnityObject { get; }
 
-            public string ScenePath { get; }
+            public OperationResource Resource { get; }
+
+            public string? SourceGlobalObjectId { get; }
+        }
+
+        internal readonly struct TemporaryAliasState
+        {
+            public TemporaryAliasState (
+                UnityEngine.Object unityObject,
+                OperationResource resource,
+                string? sourceGlobalObjectId)
+            {
+                UnityObject = unityObject;
+                Resource = resource;
+                SourceGlobalObjectId = sourceGlobalObjectId;
+            }
+
+            public UnityEngine.Object? UnityObject { get; }
+
+            public OperationResource Resource { get; }
 
             public string? SourceGlobalObjectId { get; }
         }
@@ -435,15 +548,30 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         {
             public ComponentShadowValue (
                 Component component,
-                string scenePath)
+                OperationResource resource)
             {
                 Component = component;
-                ScenePath = scenePath;
+                Resource = resource;
             }
 
             public Component Component { get; }
 
-            public string ScenePath { get; }
+            public OperationResource Resource { get; }
+        }
+
+        internal readonly struct ComponentShadowState
+        {
+            public ComponentShadowState (
+                Component component,
+                OperationResource resource)
+            {
+                Component = component;
+                Resource = resource;
+            }
+
+            public Component? Component { get; }
+
+            public OperationResource Resource { get; }
         }
 
         private readonly struct EnsuredComponentKey : IEquatable<EnsuredComponentKey>
@@ -485,15 +613,30 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         {
             public EnsuredComponentValue (
                 Component component,
-                string scenePath)
+                OperationResource resource)
             {
                 Component = component;
-                ScenePath = scenePath;
+                Resource = resource;
             }
 
             public Component Component { get; }
 
-            public string ScenePath { get; }
+            public OperationResource Resource { get; }
+        }
+
+        internal readonly struct EnsuredComponentState
+        {
+            public EnsuredComponentState (
+                Component component,
+                OperationResource resource)
+            {
+                Component = component;
+                Resource = resource;
+            }
+
+            public Component? Component { get; }
+
+            public OperationResource Resource { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResource.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResource.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one editable persistence-unit owner for temporary or live Unity objects. </summary>
+    internal readonly struct OperationResource
+    {
+        public OperationResource (
+            OperationTouchKind kind,
+            string path)
+        {
+            Kind = kind;
+            Path = path;
+        }
+
+        public OperationTouchKind Kind { get; }
+
+        public string Path { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResource.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 363149ddfc5104b538d3697ba339a21f

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResourceUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResourceUtilities.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides reusable helpers for owner-resource resolution and touched-resource creation. </summary>
+    internal static class OperationResourceUtilities
+    {
+        /// <summary> Creates one touched entry from the specified owner resource. </summary>
+        /// <param name="resource"> The owner resource. </param>
+        /// <returns> The touched entry. </returns>
+        public static OperationTouch CreateTouch (OperationResource resource)
+        {
+            return new OperationTouch(
+                Kind: resource.Kind,
+                Path: resource.Path,
+                Guid: ResolveGuid(resource));
+        }
+
+        /// <summary> Creates one stable touched-resource list from owner resources. </summary>
+        /// <param name="resources"> The owner resources. </param>
+        /// <returns> The stable touched-resource list. </returns>
+        public static IReadOnlyList<OperationTouch> CreateTouches (params OperationResource[] resources)
+        {
+            if (resources == null)
+            {
+                throw new ArgumentNullException(nameof(resources));
+            }
+
+            var touchesByPath = new SortedDictionary<string, OperationTouch>(StringComparer.Ordinal);
+            for (var index = 0; index < resources.Length; index++)
+            {
+                var touch = CreateTouch(resources[index]);
+                if (touchesByPath.TryGetValue(touch.Path, out var existing)
+                    && existing.Guid != null)
+                {
+                    continue;
+                }
+
+                touchesByPath[touch.Path] = touch;
+            }
+
+            var touches = new OperationTouch[touchesByPath.Count];
+            var touchIndex = 0;
+            foreach (var pair in touchesByPath)
+            {
+                touches[touchIndex] = pair.Value;
+                touchIndex++;
+            }
+
+            return touches;
+        }
+
+        /// <summary> Resolves one owner resource from a live GameObject. </summary>
+        /// <param name="gameObject"> The source GameObject. </param>
+        /// <param name="resource"> The resolved owner resource when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when owner resource was resolved; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveOwnerResource (
+            GameObject gameObject,
+            out OperationResource resource,
+            out string errorMessage)
+        {
+            if (gameObject == null)
+            {
+                throw new ArgumentNullException(nameof(gameObject));
+            }
+
+            var prefabStage = PrefabStageUtility.GetPrefabStage(gameObject);
+            if (prefabStage != null
+                && !string.IsNullOrWhiteSpace(prefabStage.assetPath))
+            {
+                resource = new OperationResource(OperationTouchKind.Prefab, prefabStage.assetPath);
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            var scene = gameObject.scene;
+            if (scene.IsValid()
+                && scene.isLoaded
+                && !string.IsNullOrWhiteSpace(scene.path))
+            {
+                resource = new OperationResource(OperationTouchKind.Scene, scene.path);
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            resource = default;
+            errorMessage = "GameObject is not part of a loaded scene or opened prefab.";
+            return false;
+        }
+
+        /// <summary> Resolves one owner resource from a live Component. </summary>
+        /// <param name="component"> The source component. </param>
+        /// <param name="resource"> The resolved owner resource when successful. </param>
+        /// <param name="errorMessage"> The resolution error message when failed. </param>
+        /// <returns> <see langword="true" /> when owner resource was resolved; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveOwnerResource (
+            Component component,
+            out OperationResource resource,
+            out string errorMessage)
+        {
+            if (component == null)
+            {
+                throw new ArgumentNullException(nameof(component));
+            }
+
+            return TryResolveOwnerResource(component.gameObject, out resource, out errorMessage);
+        }
+
+        private static string? ResolveGuid (OperationResource resource)
+        {
+            if (resource.Kind == OperationTouchKind.ProjectSettings)
+            {
+                return null;
+            }
+
+            var guid = AssetDatabase.AssetPathToGUID(resource.Path);
+            return string.IsNullOrWhiteSpace(guid) ? null : guid;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResourceUtilities.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationResourceUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 745c1a792fbf2436a9b7064d4120edfd

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/UnityObjectReferenceResolver.cs
@@ -82,13 +82,60 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityObject" /> is <see langword="null" />. </exception>
         public static ResolvedReference CreateResolvedReference (UnityEngine.Object unityObject)
         {
+            if (!TryCreateResolvedReference(unityObject, out var resolvedReference))
+            {
+                throw new InvalidOperationException("Unity object does not expose a stable GlobalObjectId in the current editor state.");
+            }
+
+            return resolvedReference!;
+        }
+
+        /// <summary> Tries to create one normalized resolved reference from a live Unity object. </summary>
+        /// <param name="unityObject"> The live Unity object. </param>
+        /// <param name="resolvedReference"> The normalized resolved reference when successful. </param>
+        /// <returns> <see langword="true" /> when the object exposes a stable GlobalObjectId; otherwise <see langword="false" />. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityObject" /> is <see langword="null" />. </exception>
+        public static bool TryCreateResolvedReference (
+            UnityEngine.Object unityObject,
+            out ResolvedReference? resolvedReference)
+        {
             if (unityObject == null)
             {
                 throw new ArgumentNullException(nameof(unityObject));
             }
 
-            var globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(unityObject);
-            return new ResolvedReference(globalObjectId.ToString());
+            var globalObjectId = GlobalObjectId.GetGlobalObjectIdSlow(unityObject).ToString();
+            if (!GlobalObjectId.TryParse(globalObjectId, out var parsedGlobalObjectId))
+            {
+                resolvedReference = null;
+                return false;
+            }
+
+            resolvedReference = new ResolvedReference(parsedGlobalObjectId.ToString());
+            return true;
+        }
+
+        /// <summary> Creates one request-local tracking key for a live Unity object. </summary>
+        /// <param name="unityObject"> The live Unity object. </param>
+        /// <returns> One stable tracking key for the current request. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityObject" /> is <see langword="null" />. </exception>
+        public static string CreateTrackingKey (UnityEngine.Object unityObject)
+        {
+            if (unityObject == null)
+            {
+                throw new ArgumentNullException(nameof(unityObject));
+            }
+
+            if (TryCreateResolvedReference(unityObject, out var resolvedReference))
+            {
+                return resolvedReference!.GlobalObjectId;
+            }
+
+            // NOTE:
+            // Objects inside prefab stages or request-local planning sandboxes can be live and editable
+            // without exposing a stable GlobalObjectId. Within one request, instance IDs are sufficient
+            // to correlate operation-local state such as ensured components and component shadows.
+            return $"instance:{unityObject.GetInstanceID()}";
         }
 
         /// <summary> Tries to resolve one alias to a live Unity object. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ComponentOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ComponentOperationUtilities.cs
@@ -13,22 +13,41 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <summary> Resolves one reference to a loaded-scene GameObject. </summary>
         /// <param name="reference"> The parsed Unity-object reference. </param>
         /// <param name="executionContext"> The request execution context. </param>
-        /// <param name="gameObject"> The resolved GameObject when successful. </param>
-        /// <param name="scene"> The owning loaded scene when successful. </param>
+        /// <param name="resolution"> The loaded-scene GameObject resolution when successful. </param>
         /// <param name="errorMessage"> The validation error message when resolution fails. </param>
         /// <returns> <see langword="true" /> when the reference resolves to one loaded-scene GameObject; otherwise <see langword="false" />. </returns>
         public static bool TryResolveLoadedSceneGameObject (
             UnityObjectReference reference,
             OperationExecutionContext executionContext,
-            out GameObject? gameObject,
-            out Scene scene,
+            out GoOperationUtilities.LoadedSceneGameObjectResolutionState resolution,
             out string errorMessage)
         {
             return GoOperationUtilities.TryResolveLoadedSceneGameObject(
                 reference,
                 executionContext,
-                out gameObject,
-                out scene,
+                out resolution,
+                out errorMessage);
+        }
+
+        /// <summary> Resolves one reference to an editable GameObject. Temporary plan aliases can be enabled when required. </summary>
+        /// <param name="reference"> The parsed Unity-object reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy the reference. </param>
+        /// <param name="resolution"> The editable GameObject resolution when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the reference resolves to one editable GameObject; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveEditableGameObject (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            bool allowTemporaryState,
+            out GoOperationUtilities.EditableGameObjectResolutionState resolution,
+            out string errorMessage)
+        {
+            return GoOperationUtilities.TryResolveEditableGameObject(
+                reference,
+                executionContext,
+                allowTemporaryState,
+                out resolution,
                 out errorMessage);
         }
 
@@ -36,31 +55,28 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <param name="reference"> The parsed Unity-object reference. </param>
         /// <param name="executionContext"> The request execution context. </param>
         /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy the reference. </param>
-        /// <param name="component"> The resolved component when successful. </param>
-        /// <param name="scenePath"> The owning scene path when successful. </param>
+        /// <param name="resolution"> The resolved component state when successful. </param>
         /// <param name="errorMessage"> The validation error message when resolution fails. </param>
         /// <returns> <see langword="true" /> when the reference resolves to one Component target; otherwise <see langword="false" />. </returns>
         public static bool TryResolveComponent (
             UnityObjectReference reference,
             OperationExecutionContext executionContext,
             bool allowTemporaryState,
-            out Component? component,
-            out string scenePath,
+            out ComponentResolutionState resolution,
             out string errorMessage)
         {
-            component = null;
-            scenePath = string.Empty;
-            if (allowTemporaryState
-                && reference.Kind == UnityObjectReferenceKind.Alias
-                && executionContext.TryGetTemporaryAlias(reference.Alias!, out var temporaryObject, out scenePath))
+            resolution = default;
+            if (reference.Kind == UnityObjectReferenceKind.Alias
+                && executionContext.TryGetTemporaryAliasState(reference.Alias!, out var temporaryAliasState))
             {
-                component = temporaryObject as Component;
-                if (component == null)
+                var temporaryComponent = temporaryAliasState.UnityObject as Component;
+                if (temporaryComponent == null)
                 {
                     errorMessage = "Reference did not resolve to a Component.";
                     return false;
                 }
 
+                resolution = new ComponentResolutionState(temporaryComponent, temporaryAliasState.Resource);
                 errorMessage = string.Empty;
                 return true;
             }
@@ -70,14 +86,20 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            component = unityObject as Component;
+            var component = unityObject as Component;
             if (component == null)
             {
                 errorMessage = "Reference did not resolve to a Component.";
                 return false;
             }
 
-            return TryGetLoadedScenePath(component, out scenePath, out errorMessage);
+            if (!TryGetOwnerResource(component, out var resource, out errorMessage))
+            {
+                return false;
+            }
+
+            resolution = new ComponentResolutionState(component, resource);
+            return true;
         }
 
         /// <summary> Resolves one reference to a Unity object. Temporary plan aliases can be enabled when required. </summary>
@@ -95,11 +117,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             out string errorMessage)
         {
             unityObject = null;
-            if (allowTemporaryState
-                && reference.Kind == UnityObjectReferenceKind.Alias
-                && executionContext.TryGetTemporaryAlias(reference.Alias!, out var temporaryObject, out _))
+            if (reference.Kind == UnityObjectReferenceKind.Alias
+                && executionContext.TryGetTemporaryAliasState(reference.Alias!, out var temporaryAliasState))
             {
-                unityObject = temporaryObject;
+                unityObject = temporaryAliasState.UnityObject;
                 errorMessage = string.Empty;
                 return true;
             }
@@ -117,21 +138,28 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             out string scenePath,
             out string errorMessage)
         {
-            scenePath = string.Empty;
+            var result = TryGetOwnerResource(component, out var resource, out errorMessage);
+            scenePath = resource.Path;
+            return result;
+        }
+
+        /// <summary> Tries to resolve one owner resource from a Component. </summary>
+        /// <param name="component"> The source component. </param>
+        /// <param name="resource"> The owning resource when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the component belongs to an editable resource; otherwise <see langword="false" />. </returns>
+        public static bool TryGetOwnerResource (
+            Component component,
+            out OperationResource resource,
+            out string errorMessage)
+        {
+            resource = default;
             if (component == null)
             {
                 throw new ArgumentNullException(nameof(component));
             }
 
-            var gameObject = component.gameObject;
-            if (!GoOperationUtilities.TryGetLoadedSceneFromGameObject(gameObject, out var scene, out errorMessage))
-            {
-                return false;
-            }
-
-            scenePath = scene.path;
-            errorMessage = string.Empty;
-            return true;
+            return OperationResourceUtilities.TryResolveOwnerResource(component, out resource, out errorMessage);
         }
 
         /// <summary> Creates one temporary component instance for plan-time simulation. </summary>
@@ -225,6 +253,21 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
 
             return host.AddComponent(componentType);
+        }
+
+        internal readonly struct ComponentResolutionState
+        {
+            public ComponentResolutionState (
+                Component component,
+                OperationResource resource)
+            {
+                Component = component;
+                Resource = resource;
+            }
+
+            public Component? Component { get; }
+
+            public OperationResource Resource { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ensure/CompEnsureOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ensure/CompEnsureOperation.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 #nullable enable
 
@@ -51,7 +50,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryValidateArguments(operation, executionContext, out _, out _, out _, out var failure))
+            if (!TryValidateArguments(operation, executionContext, allowTemporaryState: true, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -82,17 +81,21 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             bool applied)
         {
-            if (!TryValidateArguments(operation, executionContext, out var target, out var scene, out var componentType, out var failure))
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: !applied,
+                out var validationState,
+                out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
             var component = default(Component);
             var changed = false;
-            var usesTemporaryComponent = false;
             if (applied)
             {
-                var existingComponents = target.GetComponents(componentType);
+                var existingComponents = validationState.Target.GetComponents(validationState.ComponentType);
                 component = existingComponents.Length > 0
                     ? existingComponents[0]
                     : null;
@@ -100,23 +103,22 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
             else
             {
-                var targetGlobalObjectId = UnityObjectReferenceResolver.CreateResolvedReference(target).GlobalObjectId;
-                if (!string.IsNullOrWhiteSpace(targetGlobalObjectId)
-                    && executionContext.TryGetEnsuredComponent(targetGlobalObjectId, componentType, out component, out _))
+                var targetReferenceKey = UnityObjectReferenceResolver.CreateTrackingKey(validationState.Target);
+                if (executionContext.TryGetEnsuredComponentState(targetReferenceKey, validationState.ComponentType, out var ensuredComponentState))
                 {
+                    component = ensuredComponentState.Component;
                     changed = false;
-                    usesTemporaryComponent = true;
                 }
                 else
                 {
-                    var existingComponents = target.GetComponents(componentType);
+                    var existingComponents = validationState.Target.GetComponents(validationState.ComponentType);
                     component = existingComponents.Length > 0
                         ? existingComponents[0]
                         : null;
                     changed = component == null;
                     if (component == null)
                     {
-                        if (!ComponentOperationUtilities.TryCreateTemporaryComponent(componentType, executionContext, out component, out var errorMessage))
+                        if (!ComponentOperationUtilities.TryCreateTemporaryComponent(validationState.ComponentType, executionContext, out component, out var errorMessage))
                         {
                             return Task.FromResult(OperationPhaseStepResult.Failed(new OperationFailure(
                                 Code: MackySoft.Ucli.Contracts.Ipc.IpcErrorCodes.InternalError,
@@ -124,8 +126,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                                 OpId: operation.Id)));
                         }
 
-                        executionContext.SetEnsuredComponent(targetGlobalObjectId, componentType, component!, scene.path);
-                        usesTemporaryComponent = true;
+                        executionContext.SetEnsuredComponent(targetReferenceKey, validationState.ComponentType, component!, validationState.Resource);
                     }
                 }
             }
@@ -134,14 +135,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             {
                 if (component != null)
                 {
-                    if (usesTemporaryComponent)
-                    {
-                        executionContext.SetTemporaryAlias(operation.As, component, scene.path);
-                    }
-                    else
-                    {
-                        executionContext.AliasStore.Set(operation.As, UnityObjectReferenceResolver.CreateResolvedReference(component));
-                    }
+                    executionContext.SetTemporaryAlias(operation.As, component, validationState.Resource, UnityObjectReferenceResolver.CreateTrackingKey(component));
                 }
                 else
                 {
@@ -153,12 +147,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             {
                 if (component == null)
                 {
-                    component = AddComponent(target, componentType);
+                    component = AddComponent(validationState.Target, validationState.ComponentType);
                 }
 
                 if (operation.As != null)
                 {
-                    executionContext.AliasStore.Set(operation.As, UnityObjectReferenceResolver.CreateResolvedReference(component!));
+                    StoreAliasIfNeeded(operation.As, executionContext, component!, validationState.Resource);
                 }
             }
 
@@ -167,21 +161,18 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: changed,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                    OperationResourceUtilities.CreateTouch(validationState.Resource),
                 }));
         }
 
         private static bool TryValidateArguments (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out GameObject target,
-            out Scene scene,
-            out Type componentType,
+            bool allowTemporaryState,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            target = null!;
-            scene = default;
-            componentType = null!;
+            validationState = default;
             failure = null;
             if (!CompEnsureArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var errorMessage))
             {
@@ -189,11 +180,11 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            if (!ComponentOperationUtilities.TryResolveLoadedSceneGameObject(
+            if (!ComponentOperationUtilities.TryResolveEditableGameObject(
                 parsedArguments.TargetReference,
                 executionContext,
-                out var resolvedTarget,
-                out scene,
+                allowTemporaryState,
+                out var targetResolution,
                 out errorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
@@ -206,8 +197,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            target = resolvedTarget!;
-            componentType = resolvedComponentType!;
+            validationState = new ValidationState(
+                targetResolution.GameObject!,
+                targetResolution.Resource,
+                resolvedComponentType!);
             return true;
         }
 
@@ -228,6 +221,43 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }
 
             return component;
+        }
+
+        private static void StoreAliasIfNeeded (
+            string? alias,
+            OperationExecutionContext executionContext,
+            Component component,
+            OperationResource resource)
+        {
+            if (alias == null)
+            {
+                return;
+            }
+
+            executionContext.SetTemporaryAlias(alias, component, resource, UnityObjectReferenceResolver.CreateTrackingKey(component));
+            if (UnityObjectReferenceResolver.TryCreateResolvedReference(component, out var resolvedReference))
+            {
+                executionContext.AliasStore.Set(alias, resolvedReference!);
+            }
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                GameObject target,
+                OperationResource resource,
+                Type componentType)
+            {
+                Target = target;
+                Resource = resource;
+                ComponentType = componentType;
+            }
+
+            public GameObject? Target { get; }
+
+            public OperationResource Resource { get; }
+
+            public Type? ComponentType { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/schema/CompSchemaOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/schema/CompSchemaOperation.cs
@@ -69,19 +69,19 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             bool applied,
             CancellationToken cancellationToken)
         {
-            if (!TryValidateArguments(operation, out var componentType, out var failure))
+            if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return failure!;
             }
 
             var extractionResult = await schemaExtractor.Extract(
-                new[] { componentType! },
+                new[] { validationState.ComponentType! },
                 cancellationToken).ConfigureAwait(false);
             if (extractionResult.Entries.Count == 0)
             {
                 return OperationPhaseStepResult.Failed(new OperationFailure(
                     Code: IpcErrorCodes.InternalError,
-                    Message: $"Schema could not be extracted for type '{componentType!.FullName}'.",
+                    Message: $"Schema could not be extracted for type '{validationState.ComponentType!.FullName}'.",
                     OpId: operation.Id));
             }
 
@@ -93,10 +93,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         private static bool TryValidateArguments (
             NormalizedOperation operation,
-            out System.Type? componentType,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            componentType = null;
+            validationState = default;
             failure = null;
             if (!CompSchemaArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var errorMessage))
             {
@@ -104,13 +104,24 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            if (!ComponentTypeResolver.TryResolveComponentType(parsedArguments.TypeId, out componentType, out errorMessage))
+            if (!ComponentTypeResolver.TryResolveComponentType(parsedArguments.TypeId, out var componentType, out errorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
                 return false;
             }
 
+            validationState = new ValidationState(componentType);
             return true;
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (System.Type componentType)
+            {
+                ComponentType = componentType;
+            }
+
+            public System.Type? ComponentType { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/set/CompSetOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/set/CompSetOperation.cs
@@ -60,7 +60,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryResolveValidateTarget(operation, executionContext, out _, out _, out var failure))
+            if (!TryResolveValidateTarget(operation, executionContext, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -74,12 +74,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryResolvePlanBinding(operation, executionContext, out var binding, out var sets, out var failure))
+            if (!TryResolvePlanBinding(operation, executionContext, out var bindingState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            if (!ComponentOperationUtilities.TryCreateTemporaryComponentClone(binding.Component, executionContext, out var sandbox, out var cloneErrorMessage))
+            if (!ComponentOperationUtilities.TryCreateTemporaryComponentClone(bindingState.Binding.Component, executionContext, out var sandbox, out var cloneErrorMessage))
             {
                 return Task.FromResult(OperationPhaseStepResult.Failed(new OperationFailure(
                     Code: IpcErrorCodes.InternalError,
@@ -87,23 +87,23 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     OpId: operation.Id)));
             }
 
-            if (!CompSetValueApplier.TryApply(sandbox!, sets!, executionContext, allowTemporaryState: true, out var changed, out var applyErrorMessage))
+            if (!CompSetValueApplier.TryApply(sandbox!, bindingState.Sets, executionContext, allowTemporaryState: true, out var changed, out var applyErrorMessage))
             {
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, applyErrorMessage));
             }
 
             if (changed)
             {
-                executionContext.ReplaceTrackedTemporaryComponent(binding.Component, sandbox!, binding.ScenePath);
+                executionContext.ReplaceTrackedTemporaryComponent(bindingState.Binding.Component, sandbox!, bindingState.Binding.Resource);
 
-                if (binding.SourceGlobalObjectId != null)
+                if (bindingState.Binding.SourceGlobalObjectId != null)
                 {
-                    executionContext.SetComponentShadow(binding.SourceGlobalObjectId, sandbox!, binding.ScenePath);
+                    executionContext.SetComponentShadow(bindingState.Binding.SourceGlobalObjectId, sandbox!, bindingState.Binding.Resource);
                 }
 
-                if (binding.Alias != null)
+                if (bindingState.Binding.Alias != null)
                 {
-                    executionContext.SetTemporaryAlias(binding.Alias, sandbox!, binding.ScenePath, binding.SourceGlobalObjectId);
+                    executionContext.SetTemporaryAlias(bindingState.Binding.Alias, sandbox!, bindingState.Binding.Resource, bindingState.Binding.SourceGlobalObjectId);
                 }
             }
 
@@ -112,7 +112,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: changed,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(binding.ScenePath),
+                    OperationResourceUtilities.CreateTouch(bindingState.Binding.Resource),
                 }));
         }
 
@@ -122,12 +122,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryResolveCallBinding(operation, executionContext, out var binding, out var sets, out var failure))
+            if (!TryResolveCallBinding(operation, executionContext, out var bindingState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            if (!ComponentOperationUtilities.TryCreateTemporaryComponentClone(binding.Component, executionContext, out var sandbox, out var cloneErrorMessage))
+            if (!ComponentOperationUtilities.TryCreateTemporaryComponentClone(bindingState.Binding.Component, executionContext, out var sandbox, out var cloneErrorMessage))
             {
                 return Task.FromResult(OperationPhaseStepResult.Failed(new OperationFailure(
                     Code: IpcErrorCodes.InternalError,
@@ -135,13 +135,13 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     OpId: operation.Id)));
             }
 
-            if (!CompSetValueApplier.TryApply(sandbox!, sets!, executionContext, allowTemporaryState: false, out var changed, out var applyErrorMessage))
+            if (!CompSetValueApplier.TryApply(sandbox!, bindingState.Sets, executionContext, allowTemporaryState: false, out var changed, out var applyErrorMessage))
             {
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, applyErrorMessage));
             }
 
             if (changed
-                && !CompSetValueApplier.TryApply(binding.Component, sets!, executionContext, allowTemporaryState: false, out _, out var commitErrorMessage))
+                && !CompSetValueApplier.TryApply(bindingState.Binding.Component, bindingState.Sets, executionContext, allowTemporaryState: false, out _, out var commitErrorMessage))
             {
                 return Task.FromResult(OperationPhaseStepResult.Failed(new OperationFailure(
                     Code: IpcErrorCodes.InternalError,
@@ -154,19 +154,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: changed,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(binding.ScenePath),
+                    OperationResourceUtilities.CreateTouch(bindingState.Binding.Resource),
                 }));
         }
 
         private static bool TryResolveValidateTarget (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out Component? component,
-            out CompSetArguments? parsedArguments,
+            out ValidatedTargetState validatedTargetState,
             out OperationPhaseStepResult? failure)
         {
-            component = null;
-            parsedArguments = null;
+            validatedTargetState = default;
             failure = null;
             if (!CompSetArgumentsCodec.TryParse(operation.Args, out var arguments, out var errorMessage))
             {
@@ -178,41 +176,38 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 arguments.TargetReference,
                 executionContext,
                 allowTemporaryState: true,
-                out component,
-                out _,
+                out var componentResolution,
                 out errorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
                 return false;
             }
 
-            parsedArguments = arguments;
+            validatedTargetState = new ValidatedTargetState(componentResolution.Component!, arguments);
             return true;
         }
 
         private static bool TryResolvePlanBinding (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out TargetBinding binding,
-            out System.Collections.Generic.IReadOnlyList<CompSetAssignment>? sets,
+            out ResolvedBindingState bindingState,
             out OperationPhaseStepResult? failure)
         {
-            binding = default;
-            sets = null;
+            bindingState = default;
             failure = null;
-            if (!TryResolveValidateTarget(operation, executionContext, out _, out var parsedArguments, out failure))
+            if (!TryResolveValidateTarget(operation, executionContext, out var validatedTargetState, out failure))
             {
                 return false;
             }
 
-            var targetReference = parsedArguments!.Value.TargetReference;
+            var targetReference = validatedTargetState.ParsedArguments.TargetReference;
             var alias = targetReference.Kind == UnityObjectReferenceKind.Alias
                 ? targetReference.Alias
                 : null;
             if (alias != null
-                && executionContext.TryGetTemporaryAlias(alias, out var temporaryObject, out var temporaryScenePath, out var temporarySourceGlobalObjectId))
+                && executionContext.TryGetTemporaryAliasState(alias, out var temporaryAliasState))
             {
-                var temporaryComponent = temporaryObject as Component;
+                var temporaryComponent = temporaryAliasState.UnityObject as Component;
                 if (temporaryComponent == null)
                 {
                     failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
@@ -221,8 +216,13 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     return false;
                 }
 
-                binding = new TargetBinding(temporaryComponent, temporaryScenePath, temporarySourceGlobalObjectId, alias);
-                sets = parsedArguments.Value.Sets;
+                bindingState = new ResolvedBindingState(
+                    new TargetBinding(
+                        temporaryComponent,
+                        temporaryAliasState.Resource,
+                        temporaryAliasState.SourceGlobalObjectId,
+                        alias),
+                    validatedTargetState.ParsedArguments.Sets);
                 return true;
             }
 
@@ -230,38 +230,40 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 targetReference,
                 executionContext,
                 allowTemporaryState: false,
-                out var resolvedComponent,
-                out var scenePath,
+                out var componentResolution,
                 out var errorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
                 return false;
             }
 
-            var sourceGlobalObjectId = GetSourceGlobalObjectId(targetReference, resolvedComponent!);
+            var sourceGlobalObjectId = GetSourceReferenceKey(targetReference, componentResolution.Component!);
+            TargetBinding binding;
             if (!string.IsNullOrWhiteSpace(sourceGlobalObjectId)
-                && executionContext.TryGetComponentShadow(sourceGlobalObjectId, out var shadowComponent, out var shadowScenePath))
+                && executionContext.TryGetComponentShadowState(sourceGlobalObjectId, out var componentShadowState))
             {
-                binding = new TargetBinding(shadowComponent!, shadowScenePath, sourceGlobalObjectId, alias);
+                binding = new TargetBinding(
+                    componentShadowState.Component!,
+                    componentShadowState.Resource,
+                    sourceGlobalObjectId,
+                    alias);
             }
             else
             {
-                binding = new TargetBinding(resolvedComponent!, scenePath, sourceGlobalObjectId, alias);
+                binding = new TargetBinding(componentResolution.Component!, componentResolution.Resource, sourceGlobalObjectId, alias);
             }
 
-            sets = parsedArguments.Value.Sets;
+            bindingState = new ResolvedBindingState(binding, validatedTargetState.ParsedArguments.Sets);
             return true;
         }
 
         private static bool TryResolveCallBinding (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out TargetBinding binding,
-            out System.Collections.Generic.IReadOnlyList<CompSetAssignment>? sets,
+            out ResolvedBindingState bindingState,
             out OperationPhaseStepResult? failure)
         {
-            binding = default;
-            sets = null;
+            bindingState = default;
             failure = null;
             if (!CompSetArgumentsCodec.TryParse(operation.Args, out var arguments, out var errorMessage))
             {
@@ -273,20 +275,24 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 arguments.TargetReference,
                 executionContext,
                 allowTemporaryState: false,
-                out var component,
-                out var scenePath,
+                out var componentResolution,
                 out errorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
                 return false;
             }
 
-            binding = new TargetBinding(component!, scenePath, GetSourceGlobalObjectId(arguments.TargetReference, component!), alias: null);
-            sets = arguments.Sets;
+            bindingState = new ResolvedBindingState(
+                new TargetBinding(
+                    componentResolution.Component!,
+                    componentResolution.Resource,
+                    GetSourceReferenceKey(arguments.TargetReference, componentResolution.Component!),
+                    alias: null),
+                arguments.Sets);
             return true;
         }
 
-        private static string GetSourceGlobalObjectId (
+        private static string GetSourceReferenceKey (
             UnityObjectReference targetReference,
             Component component)
         {
@@ -296,30 +302,60 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return targetReference.Selector.GlobalObjectId!;
             }
 
-            return UnityObjectReferenceResolver.CreateResolvedReference(component).GlobalObjectId;
+            return UnityObjectReferenceResolver.CreateTrackingKey(component);
         }
 
         private readonly struct TargetBinding
         {
             public TargetBinding (
                 Component component,
-                string scenePath,
+                OperationResource resource,
                 string? sourceGlobalObjectId,
                 string? alias)
             {
                 Component = component;
-                ScenePath = scenePath;
+                Resource = resource;
                 SourceGlobalObjectId = sourceGlobalObjectId;
                 Alias = alias;
             }
 
             public Component Component { get; }
 
-            public string ScenePath { get; }
+            public OperationResource Resource { get; }
 
             public string? SourceGlobalObjectId { get; }
 
             public string? Alias { get; }
+        }
+
+        private readonly struct ValidatedTargetState
+        {
+            public ValidatedTargetState (
+                Component component,
+                CompSetArguments parsedArguments)
+            {
+                Component = component;
+                ParsedArguments = parsedArguments;
+            }
+
+            public Component? Component { get; }
+
+            public CompSetArguments ParsedArguments { get; }
+        }
+
+        private readonly struct ResolvedBindingState
+        {
+            public ResolvedBindingState (
+                TargetBinding binding,
+                System.Collections.Generic.IReadOnlyList<CompSetAssignment> sets)
+            {
+                Binding = binding;
+                Sets = sets;
+            }
+
+            public TargetBinding Binding { get; }
+
+            public System.Collections.Generic.IReadOnlyList<CompSetAssignment> Sets { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/set/CompSetValueApplier.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/set/CompSetValueApplier.cs
@@ -780,12 +780,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return true;
             }
 
-            if (!TryParseManagedReferenceContract(value, logicalPath, out var typeId, out var payload, out errorMessage))
+            if (!TryParseManagedReferenceContract(value, logicalPath, out var contract, out errorMessage))
             {
                 return false;
             }
 
-            if (!ComponentTypeResolver.TryResolveRuntimeType(typeId!, out var runtimeType, out errorMessage))
+            if (!ComponentTypeResolver.TryResolveRuntimeType(contract.TypeId, out var runtimeType, out errorMessage))
             {
                 errorMessage = $"Managed reference typeId is invalid for '{logicalPath}'. {errorMessage}";
                 return false;
@@ -820,7 +820,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 serializedObject,
                 rootType,
                 refreshedProperty,
-                payload!.Value,
+                contract.Payload,
                 executionContext,
                 allowTemporaryState,
                 logicalPath,
@@ -987,14 +987,14 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         {
             var propertyPath = property.propertyPath;
             var originalPropertyPath = propertyPath;
-            while (TryGetParentPropertyPath(propertyPath, out var parentPath, out var relativePath))
+            while (TryGetParentPropertyPath(propertyPath, out var parentPathState))
             {
-                var parentProperty = serializedObject.FindProperty(parentPath);
+                var parentProperty = serializedObject.FindProperty(parentPathState.ParentPath);
                 if (parentProperty != null
                     && parentProperty.propertyType == SerializedPropertyType.ManagedReference
                     && parentProperty.managedReferenceValue != null)
                 {
-                    relativePath = originalPropertyPath.Substring(parentPath.Length + 1);
+                    var relativePath = originalPropertyPath.Substring(parentPathState.ParentPath.Length + 1);
                     var resolution = IndexDeclaredTypeResolver.Resolve(parentProperty.managedReferenceValue.GetType(), relativePath);
                     if (resolution.IsResolved)
                     {
@@ -1004,7 +1004,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     }
                 }
 
-                propertyPath = parentPath;
+                propertyPath = parentPathState.ParentPath;
             }
 
             declaredType = null!;
@@ -1014,19 +1014,18 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         private static bool TryGetParentPropertyPath (
             string propertyPath,
-            out string parentPath,
-            out string relativePath)
+            out ParentPropertyPathState state)
         {
+            state = default;
             var parentSeparatorIndex = propertyPath.LastIndexOf('.');
             if (parentSeparatorIndex < 0)
             {
-                parentPath = string.Empty;
-                relativePath = string.Empty;
                 return false;
             }
 
-            parentPath = propertyPath.Substring(0, parentSeparatorIndex);
-            relativePath = propertyPath.Substring(parentSeparatorIndex + 1);
+            state = new ParentPropertyPathState(
+                propertyPath.Substring(0, parentSeparatorIndex),
+                propertyPath.Substring(parentSeparatorIndex + 1));
             return true;
         }
 
@@ -1614,18 +1613,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         private static bool TryParseManagedReferenceContract (
             JsonElement value,
             string logicalPath,
-            out string? typeId,
-            out JsonElement? payload,
+            out ManagedReferenceContract contract,
             out string errorMessage)
         {
-            typeId = null;
-            payload = null;
+            contract = default;
             errorMessage = string.Empty;
             if (!TryReadObject(value, logicalPath, out var properties, out errorMessage))
             {
                 return false;
             }
 
+            string? typeId = null;
             if (!properties.TryGetValue("type", out var typeElement)
                 || !OperationArgumentValueReader.TryReadRequiredString(
                     typeElement,
@@ -1643,7 +1641,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            payload = valueElement;
+            contract = new ManagedReferenceContract(typeId!, valueElement);
             return true;
         }
 
@@ -1667,6 +1665,36 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
             errorMessage = string.Empty;
             return true;
+        }
+
+        private readonly struct ManagedReferenceContract
+        {
+            public ManagedReferenceContract (
+                string typeId,
+                JsonElement payload)
+            {
+                TypeId = typeId;
+                Payload = payload;
+            }
+
+            public string TypeId { get; }
+
+            public JsonElement Payload { get; }
+        }
+
+        private readonly struct ParentPropertyPathState
+        {
+            public ParentPropertyPathState (
+                string parentPath,
+                string relativePath)
+            {
+                ParentPath = parentPath;
+                RelativePath = relativePath;
+            }
+
+            public string ParentPath { get; }
+
+            public string RelativePath { get; }
         }
 
         private static bool TryGetRequiredNumber (

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/GoOperationUtilities.cs
@@ -30,25 +30,105 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <summary> Resolves one reference to a GameObject that belongs to a loaded scene. </summary>
         /// <param name="reference"> The parsed Unity-object reference. </param>
         /// <param name="executionContext"> The request execution context. </param>
-        /// <param name="gameObject"> The resolved GameObject when successful. </param>
-        /// <param name="scene"> The owning loaded scene when successful. </param>
+        /// <param name="resolution"> The loaded-scene GameObject resolution when successful. </param>
         /// <param name="errorMessage"> The validation error message when resolution fails. </param>
         /// <returns> <see langword="true" /> when the reference resolves to one loaded-scene GameObject; otherwise <see langword="false" />. </returns>
         public static bool TryResolveLoadedSceneGameObject (
             UnityObjectReference reference,
             OperationExecutionContext executionContext,
-            out GameObject? gameObject,
-            out Scene scene,
+            out LoadedSceneGameObjectResolutionState resolution,
             out string errorMessage)
         {
-            gameObject = null;
-            scene = default;
-            if (!UnityObjectReferenceResolver.TryResolveGameObject(reference, executionContext, out gameObject, out errorMessage))
+            return TryResolveLoadedSceneGameObject(
+                reference,
+                executionContext,
+                allowTemporaryState: true,
+                out resolution,
+                out errorMessage);
+        }
+
+        /// <summary> Resolves one reference to a GameObject that belongs to a loaded scene. Temporary aliases can be enabled when required. </summary>
+        /// <param name="reference"> The parsed Unity-object reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy the reference. </param>
+        /// <param name="resolution"> The loaded-scene GameObject resolution when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the reference resolves to one loaded-scene GameObject; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveLoadedSceneGameObject (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            bool allowTemporaryState,
+            out LoadedSceneGameObjectResolutionState resolution,
+            out string errorMessage)
+        {
+            resolution = default;
+            if (!TryResolveEditableGameObject(
+                reference,
+                executionContext,
+                allowTemporaryState,
+                out var editableResolution,
+                out errorMessage))
             {
                 return false;
             }
 
-            return TryGetLoadedSceneFromGameObject(gameObject!, out scene, out errorMessage);
+            if (editableResolution.Resource.Kind != OperationTouchKind.Scene)
+            {
+                errorMessage = "GameObject is not part of a loaded scene.";
+                return false;
+            }
+
+            if (!TryGetLoadedSceneFromGameObject(editableResolution.GameObject!, out var scene, out errorMessage))
+            {
+                return false;
+            }
+
+            resolution = new LoadedSceneGameObjectResolutionState(editableResolution.GameObject!, scene);
+            return true;
+        }
+
+        /// <summary> Resolves one reference to a GameObject that belongs to an editable scene or opened prefab resource. </summary>
+        /// <param name="reference"> The parsed Unity-object reference. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy the reference. </param>
+        /// <param name="resolution"> The editable GameObject resolution when successful. </param>
+        /// <param name="errorMessage"> The validation error message when resolution fails. </param>
+        /// <returns> <see langword="true" /> when the reference resolves to one editable GameObject; otherwise <see langword="false" />. </returns>
+        public static bool TryResolveEditableGameObject (
+            UnityObjectReference reference,
+            OperationExecutionContext executionContext,
+            bool allowTemporaryState,
+            out EditableGameObjectResolutionState resolution,
+            out string errorMessage)
+        {
+            resolution = default;
+            if (reference.Kind == UnityObjectReferenceKind.Alias
+                && executionContext.TryGetTemporaryAliasState(reference.Alias!, out var temporaryAliasState))
+            {
+                var temporaryGameObject = temporaryAliasState.UnityObject as GameObject;
+                if (temporaryGameObject == null)
+                {
+                    errorMessage = "Reference did not resolve to a GameObject.";
+                    return false;
+                }
+
+                resolution = new EditableGameObjectResolutionState(temporaryGameObject, temporaryAliasState.Resource);
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            if (!UnityObjectReferenceResolver.TryResolveGameObject(reference, executionContext, out var gameObject, out errorMessage))
+            {
+                return false;
+            }
+
+            if (!OperationResourceUtilities.TryResolveOwnerResource(gameObject!, out var resource, out errorMessage))
+            {
+                return false;
+            }
+
+            resolution = new EditableGameObjectResolutionState(gameObject!, resource);
+            return true;
         }
 
         /// <summary> Resolves the owning scene for one GameObject and ensures the scene is loaded. </summary>
@@ -70,6 +150,57 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
             errorMessage = string.Empty;
             return true;
+        }
+
+        /// <summary> Creates one temporary GameObject for plan-time aliasing. </summary>
+        /// <param name="name"> The GameObject name. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <returns> The created temporary GameObject. </returns>
+        public static GameObject CreateTemporaryGameObject (
+            string name,
+            OperationExecutionContext executionContext)
+        {
+            if (executionContext == null)
+            {
+                throw new System.ArgumentNullException(nameof(executionContext));
+            }
+
+            var temporaryGameObject = new GameObject(name)
+            {
+                hideFlags = HideFlags.HideInHierarchy | HideFlags.DontSaveInEditor | HideFlags.DontSaveInBuild,
+            };
+            executionContext.TrackTemporaryObject(temporaryGameObject);
+            return temporaryGameObject;
+        }
+
+        internal readonly struct EditableGameObjectResolutionState
+        {
+            public EditableGameObjectResolutionState (
+                GameObject gameObject,
+                OperationResource resource)
+            {
+                GameObject = gameObject;
+                Resource = resource;
+            }
+
+            public GameObject? GameObject { get; }
+
+            public OperationResource Resource { get; }
+        }
+
+        internal readonly struct LoadedSceneGameObjectResolutionState
+        {
+            public LoadedSceneGameObjectResolutionState (
+                GameObject gameObject,
+                Scene scene)
+            {
+                GameObject = gameObject;
+                Scene = scene;
+            }
+
+            public GameObject? GameObject { get; }
+
+            public Scene Scene { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/create/GoCreateOperation.cs
@@ -60,7 +60,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryValidateArguments(operation, executionContext, out _, out _, out _, out var failure))
+            if (!TryValidateArguments(operation, executionContext, allowTemporaryState: true, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -79,9 +79,21 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryValidateArguments(operation, executionContext, out _, out var scene, out _, out var failure))
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: true,
+                out var validationState,
+                out var failure))
             {
                 return Task.FromResult(failure!);
+            }
+
+            if (operation.As != null)
+            {
+                var temporaryGameObject = GoOperationUtilities.CreateTemporaryGameObject(validationState.Name, executionContext);
+                TryParentTemporaryGameObject(validationState, executionContext, temporaryGameObject);
+                executionContext.SetTemporaryAlias(operation.As, temporaryGameObject, validationState.Resource);
             }
 
             return Task.FromResult(OperationPhaseStepResult.Success(
@@ -89,7 +101,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: true,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                    OperationResourceUtilities.CreateTouch(validationState.Resource),
                 }));
         }
 
@@ -104,47 +116,52 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryValidateArguments(operation, executionContext, out var name, out var scene, out var parent, out var failure))
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: false,
+                out var validationState,
+                out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            var createdGameObject = new GameObject(name);
-            SceneManager.MoveGameObjectToScene(createdGameObject, scene);
-            if (parent != null)
+            var createdGameObject = new GameObject(validationState.Name);
+            if (validationState.Parent != null)
             {
-                createdGameObject.transform.SetParent(parent.transform, worldPositionStays: false);
+                SceneManager.MoveGameObjectToScene(createdGameObject, validationState.Parent.scene);
+                createdGameObject.transform.SetParent(validationState.Parent.transform, worldPositionStays: false);
+            }
+            else
+            {
+                SceneManager.MoveGameObjectToScene(createdGameObject, validationState.Scene);
             }
 
-            StoreAliasIfNeeded(operation.As, executionContext, createdGameObject);
+            StoreAliasIfNeeded(operation.As, executionContext, createdGameObject, validationState.Resource);
             return Task.FromResult(OperationPhaseStepResult.Success(
                 applied: true,
                 changed: true,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                    OperationResourceUtilities.CreateTouch(validationState.Resource),
                 }));
         }
 
-        /// <summary> Validates arguments and resolves the destination scene and optional parent. </summary>
+        /// <summary> Validates arguments and resolves the destination resource and optional parent. </summary>
         /// <param name="operation"> The normalized operation. </param>
         /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
-        /// <param name="name"> The GameObject name when validation succeeds. </param>
-        /// <param name="scene"> The destination loaded scene when validation succeeds. </param>
-        /// <param name="parent"> The optional parent GameObject when validation succeeds. </param>
+        /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy parent resolution. </param>
+        /// <param name="validationState"> The validated operation state when validation succeeds. </param>
         /// <param name="failure"> The failure result when validation fails. </param>
         /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryValidateArguments (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out string name,
-            out Scene scene,
-            out GameObject? parent,
+            bool allowTemporaryState,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            name = string.Empty;
-            scene = default;
-            parent = null;
+            validationState = default;
             failure = null;
             if (!GoCreateArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var parseErrorMessage))
             {
@@ -152,47 +169,121 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            name = parsedArguments.Name;
             if (!parsedArguments.HasParentReference)
             {
-                if (!GoOperationUtilities.TryResolveLoadedScene(parsedArguments.ScenePath!, out scene, out var sceneErrorMessage))
+                if (!GoOperationUtilities.TryResolveLoadedScene(parsedArguments.ScenePath!, out var scene, out var sceneErrorMessage))
                 {
                     failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
                     return false;
                 }
 
+                validationState = new ValidationState(
+                    parsedArguments,
+                    parsedArguments.Name,
+                    scene,
+                    parent: null,
+                    new OperationResource(OperationTouchKind.Scene, scene.path));
                 return true;
             }
 
-            if (!GoOperationUtilities.TryResolveLoadedSceneGameObject(
+            if (!GoOperationUtilities.TryResolveEditableGameObject(
                 parsedArguments.ParentReference,
                 executionContext,
-                out parent,
-                out scene,
+                allowTemporaryState,
+                out var parentResolution,
                 out var parentErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parentErrorMessage);
                 return false;
             }
 
+            validationState = new ValidationState(
+                parsedArguments,
+                parsedArguments.Name,
+                default,
+                parentResolution.GameObject,
+                parentResolution.Resource);
             return true;
+        }
+
+        /// <summary> Parents one temporary GameObject under one temporary parent when the plan uses temporary aliases. </summary>
+        /// <param name="validationState"> The validated operation state. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="temporaryGameObject"> The temporary GameObject created for plan-time aliasing. </param>
+        private static void TryParentTemporaryGameObject (
+            ValidationState validationState,
+            OperationExecutionContext executionContext,
+            GameObject temporaryGameObject)
+        {
+            if (!validationState.ParsedArguments.HasParentReference
+                || validationState.Parent == null
+                || validationState.ParsedArguments.ParentReference.Kind != UnityObjectReferenceKind.Alias)
+            {
+                return;
+            }
+
+            if (!executionContext.TryGetTemporaryAliasState(validationState.ParsedArguments.ParentReference.Alias!, out var temporaryParentState))
+            {
+                return;
+            }
+
+            var temporaryParent = temporaryParentState.UnityObject as GameObject;
+            if (temporaryParent == null)
+            {
+                return;
+            }
+
+            temporaryGameObject.transform.SetParent(temporaryParent.transform, worldPositionStays: false);
         }
 
         /// <summary> Stores one alias for the created GameObject when the request specifies <c>as</c>. </summary>
         /// <param name="alias"> The optional alias name. </param>
         /// <param name="executionContext"> The request execution context. </param>
         /// <param name="createdGameObject"> The created GameObject. </param>
+        /// <param name="resource"> The owner resource for the created GameObject. </param>
         private static void StoreAliasIfNeeded (
             string? alias,
             OperationExecutionContext executionContext,
-            GameObject createdGameObject)
+            GameObject createdGameObject,
+            OperationResource resource)
         {
             if (alias == null)
             {
                 return;
             }
 
-            executionContext.AliasStore.Set(alias, UnityObjectReferenceResolver.CreateResolvedReference(createdGameObject));
+            executionContext.SetTemporaryAlias(alias, createdGameObject, resource);
+            if (UnityObjectReferenceResolver.TryCreateResolvedReference(createdGameObject, out var resolvedReference))
+            {
+                executionContext.AliasStore.Set(alias, resolvedReference!);
+            }
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                GoCreateArguments parsedArguments,
+                string name,
+                Scene scene,
+                GameObject? parent,
+                OperationResource resource)
+            {
+                ParsedArguments = parsedArguments;
+                Name = name;
+                Scene = scene;
+                Parent = parent;
+                Resource = resource;
+            }
+
+            public GoCreateArguments ParsedArguments { get; }
+
+            public string Name { get; }
+
+            public Scene Scene { get; }
+
+            public GameObject? Parent { get; }
+
+            public OperationResource Resource { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/go/describe/GoDescribeOperation.cs
@@ -4,7 +4,6 @@ using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 #nullable enable
 
@@ -59,7 +58,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!TryValidateArguments(operation, executionContext, out _, out _, out _, out var failure))
+            if (!TryValidateArguments(operation, executionContext, allowTemporaryState: true, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -105,41 +104,42 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             bool applied)
         {
-            if (!TryValidateArguments(operation, executionContext, out var target, out var scene, out var depth, out var failure))
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: !applied,
+                out var validationState,
+                out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            var description = GameObjectDescriptionBuilder.Build(target, depth);
+            var description = GameObjectDescriptionBuilder.Build(validationState.Target, validationState.Depth);
             return Task.FromResult(OperationPhaseStepResult.Success(
                 applied: applied,
                 changed: false,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scene.path),
+                    OperationResourceUtilities.CreateTouch(validationState.Resource),
                 },
                 result: IpcPayloadCodec.SerializeToElement(description)));
         }
 
-        /// <summary> Validates arguments and resolves the target loaded-scene GameObject. </summary>
+        /// <summary> Validates arguments and resolves the target editable GameObject. </summary>
         /// <param name="operation"> The normalized operation. </param>
         /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
-        /// <param name="target"> The resolved target GameObject when validation succeeds. </param>
-        /// <param name="scene"> The owning loaded scene when validation succeeds. </param>
-        /// <param name="depth"> The requested depth value when validation succeeds. </param>
+        /// <param name="allowTemporaryState"> Whether temporary plan aliases may satisfy target resolution. </param>
+        /// <param name="validationState"> The validated operation state when validation succeeds. </param>
         /// <param name="failure"> The failure result when validation fails. </param>
         /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryValidateArguments (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
-            out GameObject target,
-            out Scene scene,
-            out int? depth,
+            bool allowTemporaryState,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            target = null!;
-            scene = default;
-            depth = null;
+            validationState = default;
             failure = null;
             if (!GoDescribeArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var parseErrorMessage))
             {
@@ -147,20 +147,41 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            depth = parsedArguments.Depth;
-            if (!GoOperationUtilities.TryResolveLoadedSceneGameObject(
+            if (!GoOperationUtilities.TryResolveEditableGameObject(
                 parsedArguments.TargetReference,
                 executionContext,
-                out var resolvedTarget,
-                out scene,
+                allowTemporaryState,
+                out var targetResolution,
                 out var targetErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, targetErrorMessage);
                 return false;
             }
 
-            target = resolvedTarget!;
+            validationState = new ValidationState(
+                targetResolution.GameObject!,
+                targetResolution.Resource,
+                parsedArguments.Depth);
             return true;
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                GameObject target,
+                OperationResource resource,
+                int? depth)
+            {
+                Target = target;
+                Resource = resource;
+                Depth = depth;
+            }
+
+            public GameObject? Target { get; }
+
+            public OperationResource Resource { get; }
+
+            public int? Depth { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 283074e8bb3bb4546ae1584e57a80fd7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationArgumentsCodec.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Parses and validates argument contracts for prefab-domain path operations. </summary>
+    internal static class PrefabOperationArgumentsCodec
+    {
+        /// <summary> Parses prefab-path arguments used by <c>ucli.prefab.open</c> and <c>ucli.prefab.save</c>. </summary>
+        /// <param name="args"> The operation arguments element. </param>
+        /// <param name="prefabPath"> The parsed prefab path when successful. </param>
+        /// <param name="errorMessage"> The parse error message when failed. </param>
+        /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryParsePathArguments (
+            JsonElement args,
+            out string prefabPath,
+            out string errorMessage)
+        {
+            prefabPath = string.Empty;
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            var hasPath = false;
+            foreach (var property in args.EnumerateObject())
+            {
+                if (string.Equals(property.Name, PrefabOperationPropertyNames.Path, StringComparison.Ordinal))
+                {
+                    if (hasPath)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {PrefabOperationPropertyNames.Path}.";
+                        return false;
+                    }
+
+                    if (!OperationArgumentValueReader.TryReadRequiredString(property, out prefabPath, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasPath = true;
+                    continue;
+                }
+
+                errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            if (!hasPath)
+            {
+                errorMessage = $"Operation 'args' requires property '{PrefabOperationPropertyNames.Path}'.";
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationArgumentsCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationArgumentsCodec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78a3ae432900e4b348432ddbe1891d61

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationPropertyNames.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationPropertyNames.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Defines JSON property names accepted by <c>ucli.prefab.*</c> operations. </summary>
+    internal static class PrefabOperationPropertyNames
+    {
+        public const string Path = "path";
+
+        public const string Target = "target";
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationPropertyNames.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationPropertyNames.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8dd7b9fe46322400a8d06a86e339bfb8

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs
@@ -1,0 +1,218 @@
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Provides reusable helpers shared by prefab-domain phase operations. </summary>
+    internal static class PrefabOperationUtilities
+    {
+        private const string AssetsRootPrefix = "Assets/";
+
+        private const string PrefabExtension = ".prefab";
+
+        /// <summary> Validates that the specified path resolves to a prefab asset. </summary>
+        /// <param name="prefabPath"> The prefab path. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when prefab asset exists; otherwise <see langword="false" />. </returns>
+        public static bool TryEnsurePrefabAssetExists (
+            string prefabPath,
+            out string errorMessage)
+        {
+            if (!TryValidatePrefabAssetPathFormat(prefabPath, out errorMessage))
+            {
+                return false;
+            }
+
+            var prefabAsset = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            if (prefabAsset == null)
+            {
+                errorMessage = $"Prefab path could not be resolved to a prefab asset: {prefabPath}.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Validates that the specified path can be used to create a new prefab asset. </summary>
+        /// <param name="prefabPath"> The prefab path. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when the path is creatable; otherwise <see langword="false" />. </returns>
+        public static bool TryEnsurePrefabAssetCanBeCreated (
+            string prefabPath,
+            out string errorMessage)
+        {
+            if (!TryValidatePrefabAssetPathFormat(prefabPath, out errorMessage))
+            {
+                return false;
+            }
+
+            if (AssetDatabase.LoadMainAssetAtPath(prefabPath) != null)
+            {
+                errorMessage = $"Prefab asset already exists: {prefabPath}.";
+                return false;
+            }
+
+            var directoryPath = Path.GetDirectoryName(prefabPath);
+            if (string.IsNullOrWhiteSpace(directoryPath)
+                || !AssetDatabase.IsValidFolder(directoryPath))
+            {
+                errorMessage = $"Prefab path directory does not exist: {prefabPath}.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Creates one touched entry for the specified prefab path. </summary>
+        /// <param name="prefabPath"> The prefab path. </param>
+        /// <returns> The touched prefab entry. </returns>
+        public static OperationTouch CreatePrefabTouch (string prefabPath)
+        {
+            return OperationResourceUtilities.CreateTouch(new OperationResource(OperationTouchKind.Prefab, prefabPath));
+        }
+
+        /// <summary> Gets one currently opened prefab stage by asset path. </summary>
+        /// <param name="prefabPath"> The prefab asset path. </param>
+        /// <param name="prefabStage"> The opened prefab stage when successful. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when the target prefab stage is opened; otherwise <see langword="false" />. </returns>
+        public static bool TryGetOpenedPrefabStage (
+            string prefabPath,
+            out PrefabStage? prefabStage,
+            out string errorMessage)
+        {
+            prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage == null)
+            {
+                errorMessage = $"Prefab is not opened: {prefabPath}. Use 'ucli.prefab.open' first.";
+                return false;
+            }
+
+            if (!string.Equals(prefabStage.assetPath, prefabPath, StringComparison.Ordinal))
+            {
+                errorMessage = $"Opened prefab does not match requested path: {prefabPath}.";
+                prefabStage = null;
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Opens one prefab stage by asset path. </summary>
+        /// <param name="prefabPath"> The prefab asset path. </param>
+        /// <param name="prefabStage"> The opened prefab stage when successful. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when the prefab stage was opened successfully; otherwise <see langword="false" />. </returns>
+        public static bool TryOpenPrefabStage (
+            string prefabPath,
+            out PrefabStage? prefabStage,
+            out string errorMessage)
+        {
+            if (TryGetOpenedPrefabStage(prefabPath, out prefabStage, out errorMessage))
+            {
+                return true;
+            }
+
+            try
+            {
+                prefabStage = PrefabStageUtility.OpenPrefab(prefabPath);
+            }
+            catch (Exception exception)
+            {
+                prefabStage = null;
+                errorMessage = $"Prefab could not be opened: {prefabPath}. {exception.Message}";
+                return false;
+            }
+
+            if (prefabStage == null
+                || !string.Equals(prefabStage.assetPath, prefabPath, StringComparison.Ordinal))
+            {
+                errorMessage = $"Prefab could not be opened: {prefabPath}.";
+                prefabStage = null;
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        /// <summary> Gets one request-local prefab-contents root for plan execution, loading contents when needed. </summary>
+        /// <param name="prefabPath"> The prefab asset path. </param>
+        /// <param name="executionContext"> The request execution context. </param>
+        /// <param name="prefabContentsRoot"> The prefab-contents root when successful. </param>
+        /// <param name="errorMessage"> The validation error message when failed. </param>
+        /// <returns> <see langword="true" /> when prefab contents were obtained successfully; otherwise <see langword="false" />. </returns>
+        public static bool TryGetOrLoadTemporaryPrefabContentsRoot (
+            string prefabPath,
+            OperationExecutionContext executionContext,
+            out GameObject? prefabContentsRoot,
+            out string errorMessage)
+        {
+            if (executionContext == null)
+            {
+                throw new ArgumentNullException(nameof(executionContext));
+            }
+
+            if (executionContext.TryGetTemporaryPrefabContentsRoot(prefabPath, out prefabContentsRoot))
+            {
+                errorMessage = string.Empty;
+                return true;
+            }
+
+            try
+            {
+                prefabContentsRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+            }
+            catch (Exception exception)
+            {
+                prefabContentsRoot = null;
+                errorMessage = $"Prefab contents could not be loaded: {prefabPath}. {exception.Message}";
+                return false;
+            }
+
+            if (prefabContentsRoot == null)
+            {
+                errorMessage = $"Prefab contents could not be loaded: {prefabPath}.";
+                return false;
+            }
+
+            executionContext.TrackTemporaryPrefabContentsRoot(prefabPath, prefabContentsRoot);
+            errorMessage = string.Empty;
+            return true;
+        }
+
+        private static bool TryValidatePrefabAssetPathFormat (
+            string prefabPath,
+            out string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(prefabPath))
+            {
+                errorMessage = "Prefab path must not be null, empty, or whitespace.";
+                return false;
+            }
+
+            if (!prefabPath.StartsWith(AssetsRootPrefix, StringComparison.Ordinal))
+            {
+                errorMessage = $"Prefab path must start with '{AssetsRootPrefix}': {prefabPath}.";
+                return false;
+            }
+
+            if (!prefabPath.EndsWith(PrefabExtension, StringComparison.Ordinal))
+            {
+                errorMessage = $"Prefab path must end with '{PrefabExtension}': {prefabPath}.";
+                return false;
+            }
+
+            errorMessage = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3bcd5347e1d454db6836ef5ddc40ef84

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 194d5197f6ce04ef3ac036127479939c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArguments.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArguments.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Represents one parsed argument payload for <c>ucli.prefab.create</c>. </summary>
+    internal readonly struct PrefabCreateArguments
+    {
+        public PrefabCreateArguments (
+            UnityObjectReference targetReference,
+            string prefabPath)
+        {
+            TargetReference = targetReference;
+            PrefabPath = prefabPath;
+        }
+
+        public UnityObjectReference TargetReference { get; }
+
+        public string PrefabPath { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArguments.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArguments.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6a5a17d94e1a426f8bdec9375ced902

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArgumentsCodec.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Text.Json;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Parses and validates argument contracts for <c>ucli.prefab.create</c>. </summary>
+    internal static class PrefabCreateArgumentsCodec
+    {
+        /// <summary> Parses one <c>ucli.prefab.create</c> argument object. </summary>
+        /// <param name="args"> The operation argument element. </param>
+        /// <param name="parsedArguments"> The parsed arguments when successful. </param>
+        /// <param name="errorMessage"> The parse error message when parsing fails. </param>
+        /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
+        public static bool TryParse (
+            JsonElement args,
+            out PrefabCreateArguments parsedArguments,
+            out string errorMessage)
+        {
+            parsedArguments = default;
+            errorMessage = string.Empty;
+            if (args.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "Operation 'args' must be an object.";
+                return false;
+            }
+
+            var hasTarget = false;
+            var hasPath = false;
+            var targetReference = default(UnityObjectReference);
+            string? prefabPath = null;
+            foreach (var property in args.EnumerateObject())
+            {
+                if (string.Equals(property.Name, PrefabOperationPropertyNames.Target, StringComparison.Ordinal))
+                {
+                    if (hasTarget)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {PrefabOperationPropertyNames.Target}.";
+                        return false;
+                    }
+
+                    if (!UnityObjectReferenceCodec.TryParse(
+                        property.Value,
+                        "args.target",
+                        out targetReference,
+                        out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasTarget = true;
+                    continue;
+                }
+
+                if (string.Equals(property.Name, PrefabOperationPropertyNames.Path, StringComparison.Ordinal))
+                {
+                    if (hasPath)
+                    {
+                        errorMessage = $"Operation 'args' contains duplicated property: {PrefabOperationPropertyNames.Path}.";
+                        return false;
+                    }
+
+                    if (!OperationArgumentValueReader.TryReadRequiredString(property, out prefabPath, out errorMessage))
+                    {
+                        return false;
+                    }
+
+                    hasPath = true;
+                    continue;
+                }
+
+                errorMessage = $"Operation 'args' contains an unknown property: {property.Name}.";
+                return false;
+            }
+
+            if (!hasTarget)
+            {
+                errorMessage = $"Operation 'args' requires property '{PrefabOperationPropertyNames.Target}'.";
+                return false;
+            }
+
+            if (!hasPath)
+            {
+                errorMessage = $"Operation 'args' requires property '{PrefabOperationPropertyNames.Path}'.";
+                return false;
+            }
+
+            parsedArguments = new PrefabCreateArguments(targetReference, prefabPath!);
+            return true;
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArgumentsCodec.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateArgumentsCodec.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0fa179cd8f5344ffb992ae8f2a5efe7e

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateOperation.cs
@@ -1,0 +1,207 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEditor;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.prefab.create</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class PrefabCreateOperation : IUcliOperation
+    {
+        private const string ArgsSchemaJson =
+            @"{
+              ""type"": ""object"",
+              ""additionalProperties"": false,
+              ""properties"": {
+                ""target"": {
+                  ""type"": ""object"",
+                  ""additionalProperties"": false,
+                  ""properties"": {
+                    ""var"": { ""type"": ""string"", ""minLength"": 1 },
+                    ""globalObjectId"": { ""type"": ""string"", ""minLength"": 1 },
+                    ""scene"": { ""type"": ""string"", ""minLength"": 1 },
+                    ""hierarchyPath"": { ""type"": ""string"", ""minLength"": 1 }
+                  },
+                  ""oneOf"": [
+                    { ""required"": [""var""] },
+                    { ""required"": [""globalObjectId""] },
+                    { ""required"": [""scene"", ""hierarchyPath""] }
+                  ]
+                },
+                ""path"": { ""type"": ""string"", ""minLength"": 1 }
+              },
+              ""required"": [""target"", ""path""]
+            }";
+
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.prefab.create",
+            kind: UcliOperationKind.Mutation,
+            policy: OperationPolicy.Advanced,
+            argsSchemaJson: ArgsSchemaJson);
+
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(operation, executionContext, allowTemporaryState: true, out _, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: true,
+                out var validationState,
+                out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            if (operation.As != null)
+            {
+                executionContext.SetTemporaryAlias(operation.As, validationState.Target, validationState.SourceResource);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: false,
+                changed: true,
+                touched: OperationResourceUtilities.CreateTouches(
+                    validationState.SourceResource,
+                    new OperationResource(OperationTouchKind.Prefab, validationState.PrefabPath))));
+        }
+
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryValidateArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: false,
+                out var validationState,
+                out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            var prefabAsset = PrefabUtility.SaveAsPrefabAssetAndConnect(validationState.Target, validationState.PrefabPath, InteractionMode.AutomatedAction);
+            if (prefabAsset == null)
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
+                    operation.Id,
+                    $"Prefab could not be created: {validationState.PrefabPath}."));
+            }
+
+            StoreAliasIfNeeded(operation.As, executionContext, validationState.Target, validationState.SourceResource);
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: true,
+                changed: true,
+                touched: OperationResourceUtilities.CreateTouches(
+                    validationState.SourceResource,
+                    new OperationResource(OperationTouchKind.Prefab, validationState.PrefabPath))));
+        }
+
+        private static bool TryValidateArguments (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            bool allowTemporaryState,
+            out ValidationState validationState,
+            out OperationPhaseStepResult? failure)
+        {
+            validationState = default;
+            failure = null;
+            if (!PrefabCreateArgumentsCodec.TryParse(operation.Args, out var parsedArguments, out var errorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
+                return false;
+            }
+
+            if (!GoOperationUtilities.TryResolveEditableGameObject(
+                parsedArguments.TargetReference,
+                executionContext,
+                allowTemporaryState,
+                out var targetResolution,
+                out errorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
+                return false;
+            }
+
+            if (targetResolution.Resource.Kind != OperationTouchKind.Scene)
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
+                    operation.Id,
+                    "Prefab source must be a GameObject that belongs to a loaded scene.");
+                return false;
+            }
+
+            if (!PrefabOperationUtilities.TryEnsurePrefabAssetCanBeCreated(parsedArguments.PrefabPath, out errorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
+                return false;
+            }
+
+            validationState = new ValidationState(
+                targetResolution.GameObject!,
+                targetResolution.Resource,
+                parsedArguments.PrefabPath);
+            return true;
+        }
+
+        private static void StoreAliasIfNeeded (
+            string? alias,
+            OperationExecutionContext executionContext,
+            GameObject target,
+            OperationResource resource)
+        {
+            if (alias == null)
+            {
+                return;
+            }
+
+            executionContext.SetTemporaryAlias(alias, target, resource);
+            if (UnityObjectReferenceResolver.TryCreateResolvedReference(target, out var resolvedReference))
+            {
+                executionContext.AliasStore.Set(alias, resolvedReference!);
+            }
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                GameObject target,
+                OperationResource sourceResource,
+                string prefabPath)
+            {
+                Target = target;
+                SourceResource = sourceResource;
+                PrefabPath = prefabPath;
+            }
+
+            public GameObject? Target { get; }
+
+            public OperationResource SourceResource { get; }
+
+            public string PrefabPath { get; }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/create/PrefabCreateOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec819417aa2704d369b3a2dbc0e90717

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f9616f7e3271483a9598aa0327f2035
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open/PrefabOpenOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open/PrefabOpenOperation.cs
@@ -3,14 +3,15 @@ using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using UnityEditor.SceneManagement;
+using UnityEngine;
 
 #nullable enable
 
 namespace MackySoft.Ucli.Unity.Execution.Phases
 {
-    /// <summary> Implements <c>ucli.scene.open</c> operation flow. </summary>
+    /// <summary> Implements <c>ucli.prefab.open</c> operation flow. </summary>
     [UcliOperation]
-    internal sealed class SceneOpenOperation : IUcliOperation
+    internal sealed class PrefabOpenOperation : IUcliOperation
     {
         private const string ArgsSchemaJson =
             @"{
@@ -23,21 +24,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             }";
 
         public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
-            operationName: "ucli.scene.open",
+            operationName: "ucli.prefab.open",
             kind: UcliOperationKind.Query,
             policy: OperationPolicy.Safe,
             argsSchemaJson: ArgsSchemaJson);
 
-        /// <summary> Executes validate phase for <c>ucli.scene.open</c>. </summary>
-        /// <param name="operation"> The normalized operation. </param>
-        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
-        /// <returns> The phase-step result. </returns>
         public Task<OperationPhaseStepResult> Validate (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!TryValidateArguments(operation, out _, out var failure))
             {
                 return Task.FromResult(failure!);
@@ -46,19 +43,32 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
         }
 
-        /// <summary> Executes plan phase for <c>ucli.scene.open</c>. </summary>
-        /// <param name="operation"> The normalized operation. </param>
-        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
-        /// <returns> The phase-step result. </returns>
         public Task<OperationPhaseStepResult> Plan (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return Task.FromResult(failure!);
+            }
+
+            if (!PrefabOperationUtilities.TryGetOrLoadTemporaryPrefabContentsRoot(
+                validationState.PrefabPath,
+                executionContext,
+                out var prefabContentsRoot,
+                out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            if (operation.As != null)
+            {
+                executionContext.SetTemporaryAlias(
+                    operation.As,
+                    prefabContentsRoot!,
+                    new OperationResource(OperationTouchKind.Prefab, validationState.PrefabPath));
             }
 
             return Task.FromResult(OperationPhaseStepResult.Success(
@@ -66,31 +76,44 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: false,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(validationState.ScenePath),
+                    PrefabOperationUtilities.CreatePrefabTouch(validationState.PrefabPath),
                 }));
         }
 
-        /// <summary> Executes call phase for <c>ucli.scene.open</c>. </summary>
-        /// <param name="operation"> The normalized operation. </param>
-        /// <param name="executionContext"> The per-request execution context shared by all operations. </param>
-        /// <param name="cancellationToken"> The cancellation token propagated by request execution. </param>
-        /// <returns> The phase-step result. </returns>
         public Task<OperationPhaseStepResult> Call (
             NormalizedOperation operation,
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            var openedScene = EditorSceneManager.OpenScene(validationState.ScenePath, OpenSceneMode.Single);
-            if (!openedScene.IsValid() || !openedScene.isLoaded)
+            if (!PrefabOperationUtilities.TryOpenPrefabStage(validationState.PrefabPath, out var prefabStage, out var errorMessage))
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage));
+            }
+
+            var prefabContentsRoot = prefabStage!.prefabContentsRoot;
+            if (prefabContentsRoot == null)
             {
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
                     operation.Id,
-                    $"Scene could not be opened: {validationState.ScenePath}."));
+                    $"Prefab root is not available after open: {validationState.PrefabPath}."));
+            }
+
+            if (operation.As != null)
+            {
+                executionContext.SetTemporaryAlias(
+                    operation.As,
+                    prefabContentsRoot,
+                    new OperationResource(OperationTouchKind.Prefab, validationState.PrefabPath));
+                if (UnityObjectReferenceResolver.TryCreateResolvedReference(prefabContentsRoot, out var resolvedReference))
+                {
+                    executionContext.AliasStore.Set(operation.As, resolvedReference!);
+                }
             }
 
             return Task.FromResult(OperationPhaseStepResult.Success(
@@ -98,15 +121,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: false,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(validationState.ScenePath),
+                    PrefabOperationUtilities.CreatePrefabTouch(validationState.PrefabPath),
                 }));
         }
 
-        /// <summary> Validates operation arguments and scene path. </summary>
-        /// <param name="operation"> The normalized operation. </param>
-        /// <param name="validationState"> The validated operation state when successful. </param>
-        /// <param name="failure"> The failure result when validation fails. </param>
-        /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryValidateArguments (
             NormalizedOperation operation,
             out ValidationState validationState,
@@ -114,30 +132,30 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         {
             validationState = default;
             failure = null;
-            if (!SceneOperationArgumentsCodec.TryParsePathArguments(operation.Args, out var scenePath, out var parseErrorMessage))
+            if (!PrefabOperationArgumentsCodec.TryParsePathArguments(operation.Args, out var prefabPath, out var parseErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
                 return false;
             }
 
-            if (!SceneOperationUtilities.TryEnsureSceneAssetExists(scenePath, out var sceneErrorMessage))
+            if (!PrefabOperationUtilities.TryEnsurePrefabAssetExists(prefabPath, out var errorMessage))
             {
-                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
                 return false;
             }
 
-            validationState = new ValidationState(scenePath);
+            validationState = new ValidationState(prefabPath);
             return true;
         }
 
         private readonly struct ValidationState
         {
-            public ValidationState (string scenePath)
+            public ValidationState (string prefabPath)
             {
-                ScenePath = scenePath;
+                PrefabPath = prefabPath;
             }
 
-            public string ScenePath { get; }
+            public string PrefabPath { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open/PrefabOpenOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/open/PrefabOpenOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7938e8f90cb504d52a900364326c3a4c

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2c55d6c09ea04cee82f8db1b8db823c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save/PrefabSaveOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save/PrefabSaveOperation.cs
@@ -1,0 +1,167 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using UnityEditor;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Execution.Phases
+{
+    /// <summary> Implements <c>ucli.prefab.save</c> operation flow. </summary>
+    [UcliOperation]
+    internal sealed class PrefabSaveOperation : IUcliOperation
+    {
+        private const string ArgsSchemaJson =
+            @"{
+              ""type"": ""object"",
+              ""additionalProperties"": false,
+              ""properties"": {
+                ""path"": { ""type"": ""string"", ""minLength"": 1 }
+              },
+              ""required"": [""path""]
+            }";
+
+        public UcliOperationMetadata Metadata { get; } = new UcliOperationMetadata(
+            operationName: "ucli.prefab.save",
+            kind: UcliOperationKind.Mutation,
+            policy: OperationPolicy.Advanced,
+            argsSchemaJson: ArgsSchemaJson);
+
+        public Task<OperationPhaseStepResult> Validate (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryResolveArguments(operation, executionContext, allowTemporaryState: true, out _, out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(applied: false, changed: false));
+        }
+
+        public Task<OperationPhaseStepResult> Plan (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryResolveArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: true,
+                out var resolutionState,
+                out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: false,
+                changed: resolutionState.PrefabContentsRoot!.scene.isDirty,
+                touched: new[]
+                {
+                    PrefabOperationUtilities.CreatePrefabTouch(resolutionState.PrefabPath),
+                }));
+        }
+
+        public Task<OperationPhaseStepResult> Call (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryResolveArguments(
+                operation,
+                executionContext,
+                allowTemporaryState: false,
+                out var resolutionState,
+                out var failure))
+            {
+                return Task.FromResult(failure!);
+            }
+
+            var changedBeforeSave = resolutionState.PrefabContentsRoot!.scene.isDirty;
+            var savedPrefab = PrefabUtility.SaveAsPrefabAsset(resolutionState.PrefabContentsRoot, resolutionState.PrefabPath);
+            if (savedPrefab == null)
+            {
+                return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
+                    operation.Id,
+                    $"Prefab could not be saved: {resolutionState.PrefabPath}."));
+            }
+
+            return Task.FromResult(OperationPhaseStepResult.Success(
+                applied: true,
+                changed: changedBeforeSave,
+                touched: new[]
+                {
+                    PrefabOperationUtilities.CreatePrefabTouch(resolutionState.PrefabPath),
+                }));
+        }
+
+        private static bool TryResolveArguments (
+            NormalizedOperation operation,
+            OperationExecutionContext executionContext,
+            bool allowTemporaryState,
+            out ResolutionState resolutionState,
+            out OperationPhaseStepResult? failure)
+        {
+            resolutionState = default;
+            failure = null;
+            if (!PrefabOperationArgumentsCodec.TryParsePathArguments(operation.Args, out var prefabPath, out var parseErrorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
+                return false;
+            }
+
+            if (!PrefabOperationUtilities.TryEnsurePrefabAssetExists(prefabPath, out var errorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
+                return false;
+            }
+
+            if (allowTemporaryState
+                && executionContext.TryGetTemporaryPrefabContentsRoot(prefabPath, out var prefabContentsRoot))
+            {
+                resolutionState = new ResolutionState(prefabPath, prefabContentsRoot!);
+                return true;
+            }
+
+            if (!PrefabOperationUtilities.TryGetOpenedPrefabStage(prefabPath, out var prefabStage, out errorMessage))
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, errorMessage);
+                return false;
+            }
+
+            prefabContentsRoot = prefabStage!.prefabContentsRoot;
+            if (prefabContentsRoot == null)
+            {
+                failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
+                    operation.Id,
+                    $"Opened prefab root is not available: {prefabPath}.");
+                return false;
+            }
+
+            resolutionState = new ResolutionState(prefabPath, prefabContentsRoot);
+            return true;
+        }
+
+        private readonly struct ResolutionState
+        {
+            public ResolutionState (
+                string prefabPath,
+                GameObject prefabContentsRoot)
+            {
+                PrefabPath = prefabPath;
+                PrefabContentsRoot = prefabContentsRoot;
+            }
+
+            public string PrefabPath { get; }
+
+            public GameObject? PrefabContentsRoot { get; }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save/PrefabSaveOperation.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/save/PrefabSaveOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b0c1720f9777e41de82cbf5de30d6e4f

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/SceneOperationArgumentsCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/SceneOperationArgumentsCodec.cs
@@ -59,18 +59,15 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         /// <summary> Parses scene-tree arguments used by <c>ucli.scene.tree</c>. </summary>
         /// <param name="args"> The operation arguments element. </param>
-        /// <param name="scenePath"> The parsed scene path when successful. </param>
-        /// <param name="depth"> The parsed depth. <see langword="null" /> means unlimited depth. </param>
+        /// <param name="arguments"> The parsed tree arguments when successful. </param>
         /// <param name="errorMessage"> The parse error message when failed. </param>
         /// <returns> <see langword="true" /> when parsing succeeds; otherwise <see langword="false" />. </returns>
         public static bool TryParseTreeArguments (
             JsonElement args,
-            out string scenePath,
-            out int? depth,
+            out TreeArguments arguments,
             out string errorMessage)
         {
-            scenePath = string.Empty;
-            depth = null;
+            arguments = default;
             errorMessage = string.Empty;
             if (args.ValueKind != JsonValueKind.Object)
             {
@@ -78,6 +75,8 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
+            var scenePath = string.Empty;
+            int? depth = null;
             var hasPath = false;
             var hasDepth = false;
             foreach (var property in args.EnumerateObject())
@@ -126,7 +125,23 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
+            arguments = new TreeArguments(scenePath, depth);
             return true;
+        }
+
+        internal readonly struct TreeArguments
+        {
+            public TreeArguments (
+                string scenePath,
+                int? depth)
+            {
+                ScenePath = scenePath;
+                Depth = depth;
+            }
+
+            public string ScenePath { get; }
+
+            public int? Depth { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/save/SceneSaveOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/save/SceneSaveOperation.cs
@@ -39,7 +39,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
-            if (!TryValidateArguments(operation, out _, out _, out var failure))
+            if (!TryValidateArguments(operation, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -57,17 +57,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
-            if (!TryValidateArguments(operation, out var scenePath, out var scene, out var failure))
+            if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
             return Task.FromResult(OperationPhaseStepResult.Success(
                 applied: false,
-                changed: scene.isDirty,
+                changed: validationState.Scene.isDirty,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scenePath),
+                    SceneOperationUtilities.CreateSceneTouch(validationState.ScenePath),
                 }));
         }
 
@@ -81,17 +81,17 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
-            if (!TryValidateArguments(operation, out var scenePath, out var scene, out var failure))
+            if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            var changedBeforeSave = scene.isDirty;
-            if (!EditorSceneManager.SaveScene(scene))
+            var changedBeforeSave = validationState.Scene.isDirty;
+            if (!EditorSceneManager.SaveScene(validationState.Scene))
             {
                 return Task.FromResult(OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(
                     operation.Id,
-                    $"Scene could not be saved: {scenePath}."));
+                    $"Scene could not be saved: {validationState.ScenePath}."));
             }
 
             return Task.FromResult(OperationPhaseStepResult.Success(
@@ -99,26 +99,23 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 changed: changedBeforeSave,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scenePath),
+                    SceneOperationUtilities.CreateSceneTouch(validationState.ScenePath),
                 }));
         }
 
         /// <summary> Validates operation arguments and resolves loaded scene. </summary>
         /// <param name="operation"> The normalized operation. </param>
-        /// <param name="scenePath"> The parsed scene path when successful. </param>
-        /// <param name="scene"> The resolved loaded scene when successful. </param>
+        /// <param name="validationState"> The validated operation state when successful. </param>
         /// <param name="failure"> The failure result when validation fails. </param>
         /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryValidateArguments (
             NormalizedOperation operation,
-            out string scenePath,
-            out Scene scene,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            scenePath = string.Empty;
-            scene = default;
+            validationState = default;
             failure = null;
-            if (!SceneOperationArgumentsCodec.TryParsePathArguments(operation.Args, out scenePath, out var parseErrorMessage))
+            if (!SceneOperationArgumentsCodec.TryParsePathArguments(operation.Args, out var scenePath, out var parseErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
                 return false;
@@ -130,13 +127,29 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 return false;
             }
 
-            if (!SceneOperationUtilities.TryGetLoadedScene(scenePath, out scene, out sceneErrorMessage))
+            if (!SceneOperationUtilities.TryGetLoadedScene(scenePath, out var scene, out sceneErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
                 return false;
             }
 
+            validationState = new ValidationState(scenePath, scene);
             return true;
+        }
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                string scenePath,
+                Scene scene)
+            {
+                ScenePath = scenePath;
+                Scene = scene;
+            }
+
+            public string ScenePath { get; }
+
+            public Scene Scene { get; }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/tree/SceneTreeOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/scene/tree/SceneTreeOperation.cs
@@ -46,7 +46,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             CancellationToken cancellationToken = default)
         {
-            if (!TryValidateArguments(operation, out _, out _, out _, out var failure))
+            if (!TryValidateArguments(operation, out _, out var failure))
             {
                 return Task.FromResult(failure!);
             }
@@ -90,58 +90,54 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             OperationExecutionContext executionContext,
             bool applied)
         {
-            if (!TryValidateArguments(operation, out var scenePath, out var scene, out var depth, out var failure))
+            if (!TryValidateArguments(operation, out var validationState, out var failure))
             {
                 return Task.FromResult(failure!);
             }
 
-            var tree = BuildSceneTree(scenePath, scene, depth);
+            var tree = BuildSceneTree(validationState.ScenePath, validationState.Scene, validationState.Depth);
             return Task.FromResult(OperationPhaseStepResult.Success(
                 applied: applied,
                 changed: false,
                 touched: new[]
                 {
-                    SceneOperationUtilities.CreateSceneTouch(scenePath),
+                    SceneOperationUtilities.CreateSceneTouch(validationState.ScenePath),
                 },
                 result: IpcPayloadCodec.SerializeToElement(tree)));
         }
 
         /// <summary> Validates operation arguments and resolves loaded scene. </summary>
         /// <param name="operation"> The normalized operation. </param>
-        /// <param name="scenePath"> The parsed scene path when successful. </param>
-        /// <param name="scene"> The resolved loaded scene when successful. </param>
-        /// <param name="depth"> The parsed depth. <see langword="null" /> means unlimited. </param>
+        /// <param name="validationState"> The validated operation state when successful. </param>
         /// <param name="failure"> The failure result when validation fails. </param>
         /// <returns> <see langword="true" /> when validation succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryValidateArguments (
             NormalizedOperation operation,
-            out string scenePath,
-            out Scene scene,
-            out int? depth,
+            out ValidationState validationState,
             out OperationPhaseStepResult? failure)
         {
-            scenePath = string.Empty;
-            scene = default;
-            depth = null;
+            validationState = default;
             failure = null;
-            if (!SceneOperationArgumentsCodec.TryParseTreeArguments(operation.Args, out scenePath, out depth, out var parseErrorMessage))
+            if (!SceneOperationArgumentsCodec.TryParseTreeArguments(operation.Args, out var parsedArguments, out var parseErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, parseErrorMessage);
                 return false;
             }
 
+            var scenePath = parsedArguments.ScenePath;
             if (!SceneOperationUtilities.TryEnsureSceneAssetExists(scenePath, out var sceneErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
                 return false;
             }
 
-            if (!SceneOperationUtilities.TryGetLoadedScene(scenePath, out scene, out sceneErrorMessage))
+            if (!SceneOperationUtilities.TryGetLoadedScene(scenePath, out var scene, out sceneErrorMessage))
             {
                 failure = OperationPhaseExecutionUtilities.CreateInvalidArgumentFailure(operation.Id, sceneErrorMessage);
                 return false;
             }
 
+            validationState = new ValidationState(scenePath, scene, parsedArguments.Depth);
             return true;
         }
 
@@ -217,5 +213,24 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             string Name,
             string GlobalObjectId,
             IReadOnlyList<SceneTreeNodeDescription> Children);
+
+        private readonly struct ValidationState
+        {
+            public ValidationState (
+                string scenePath,
+                Scene scene,
+                int? depth)
+            {
+                ScenePath = scenePath;
+                Scene = scene;
+                Depth = depth;
+            }
+
+            public string ScenePath { get; }
+
+            public Scene Scene { get; }
+
+            public int? Depth { get; }
+        }
     }
 }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/CompOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/CompOperationTests.cs
@@ -45,9 +45,9 @@ namespace MackySoft.Ucli.Unity.Tests
                 var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
 
                 AssertSuccess(result, applied: false, changed: true, scenePath);
-                Assert.That(context.TryGetTemporaryAlias("ensured", out var temporaryObject, out var temporaryScenePath), Is.True);
-                Assert.That(temporaryScenePath, Is.EqualTo(scenePath));
-                Assert.That(temporaryObject, Is.TypeOf<CompOperationTestComponent>());
+                Assert.That(context.TryGetTemporaryAliasState("ensured", out var temporaryAliasState), Is.True);
+                Assert.That(temporaryAliasState.Resource.Path, Is.EqualTo(scenePath));
+                Assert.That(temporaryAliasState.UnityObject, Is.TypeOf<CompOperationTestComponent>());
             }
             finally
             {
@@ -99,9 +99,9 @@ namespace MackySoft.Ucli.Unity.Tests
 
                 AssertSuccess(firstResult, applied: false, changed: true, scenePath);
                 AssertSuccess(secondResult, applied: false, changed: false, scenePath);
-                Assert.That(context.TryGetTemporaryAlias("ensured", out var temporaryObject, out var temporaryScenePath), Is.True);
-                Assert.That(temporaryScenePath, Is.EqualTo(scenePath));
-                Assert.That(temporaryObject, Is.TypeOf<CompOperationTestComponent>());
+                Assert.That(context.TryGetTemporaryAliasState("ensured", out var temporaryAliasState), Is.True);
+                Assert.That(temporaryAliasState.Resource.Path, Is.EqualTo(scenePath));
+                Assert.That(temporaryAliasState.UnityObject, Is.TypeOf<CompOperationTestComponent>());
             }
             finally
             {
@@ -488,13 +488,12 @@ namespace MackySoft.Ucli.Unity.Tests
                     UnityObjectReference.FromAlias("target"),
                     context,
                     allowTemporaryState: false,
-                    out var resolvedComponent,
-                    out var resolvedScenePath,
+                    out var resolutionState,
                     out var errorMessage);
 
                 Assert.That(result, Is.True, errorMessage);
-                Assert.That(resolvedScenePath, Is.EqualTo(scenePath));
-                Assert.That(resolvedComponent, Is.EqualTo(target));
+                Assert.That(resolutionState.Resource.Path, Is.EqualTo(scenePath));
+                Assert.That(resolutionState.Component, Is.EqualTo(target));
             }
             finally
             {
@@ -672,8 +671,8 @@ namespace MackySoft.Ucli.Unity.Tests
 
                 AssertSuccess(ensureResult, applied: false, changed: true, scenePath);
                 AssertSuccess(setResult, applied: false, changed: true, scenePath);
-                Assert.That(context.TryGetTemporaryAlias("ensured", out var temporaryObject, out _), Is.True);
-                Assert.That(((CompOperationTestComponent)temporaryObject!).IntegerValue, Is.EqualTo(99));
+                Assert.That(context.TryGetTemporaryAliasState("ensured", out var temporaryAliasState), Is.True);
+                Assert.That(((CompOperationTestComponent)temporaryAliasState.UnityObject!).IntegerValue, Is.EqualTo(99));
             }
             finally
             {
@@ -780,8 +779,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 AssertSuccess(firstSetResult, applied: false, changed: true, scenePath);
                 AssertSuccess(secondEnsureResult, applied: false, changed: false, scenePath);
                 AssertSuccess(secondSetResult, applied: false, changed: true, scenePath);
-                Assert.That(context.TryGetTemporaryAlias("ensuredAgain", out var temporaryObject, out _), Is.True);
-                var temporaryComponent = (CompOperationTestComponent)temporaryObject!;
+                Assert.That(context.TryGetTemporaryAliasState("ensuredAgain", out var temporaryAliasState), Is.True);
+                var temporaryComponent = (CompOperationTestComponent)temporaryAliasState.UnityObject!;
                 Assert.That(temporaryComponent.NestedList.Count, Is.EqualTo(2));
                 Assert.That(temporaryComponent.NestedList[1].Number, Is.EqualTo(30));
                 Assert.That(temporaryComponent.NestedList[1].Label, Is.EqualTo("second"));
@@ -909,8 +908,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 AssertSuccess(secondResult, applied: false, changed: true, scenePath);
                 AssertSuccess(thirdResult, applied: false, changed: true, scenePath);
                 AssertSuccess(fourthResult, applied: false, changed: true, scenePath);
-                Assert.That(context.TryGetTemporaryAlias("target", out var temporaryObject, out _), Is.True);
-                var temporaryComponent = (CompOperationTestComponent)temporaryObject!;
+                Assert.That(context.TryGetTemporaryAliasState("target", out var temporaryAliasState), Is.True);
+                var temporaryComponent = (CompOperationTestComponent)temporaryAliasState.UnityObject!;
                 Assert.That(temporaryComponent.IntegerValue, Is.EqualTo(5));
                 Assert.That(temporaryComponent.NestedList.Count, Is.EqualTo(2));
                 Assert.That(temporaryComponent.NestedList[1].Number, Is.EqualTo(30));

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/GoOperationTests.cs
@@ -133,7 +133,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [Test]
         [Category("Size.Small")]
-        public void Create_Plan_WhenAliasIsSpecified_DoesNotStoreAlias ()
+        public void Create_Plan_WhenAliasIsSpecified_StoresTemporaryAlias ()
         {
             var operation = new GoCreateOperation();
             var scenePath = CreateTemporaryScenePath();
@@ -155,7 +155,11 @@ namespace MackySoft.Ucli.Unity.Tests
                 var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
 
                 AssertSuccess(result, applied: false, changed: true);
+                Assert.That(context.TryGetTemporaryAliasState("created", out var temporaryAliasState), Is.True);
                 Assert.That(context.AliasStore.TryGet("created", out _), Is.False);
+                Assert.That(temporaryAliasState.Resource.Path, Is.EqualTo(scenePath));
+                Assert.That(temporaryAliasState.UnityObject, Is.TypeOf<GameObject>());
+                Assert.That(((GameObject)temporaryAliasState.UnityObject!).name, Is.EqualTo("CreatedRoot"));
             }
             finally
             {

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/PrefabOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/PrefabOperationTests.cs
@@ -1,0 +1,501 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.Requests;
+using MackySoft.Ucli.Unity.Index;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+#nullable enable
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class PrefabOperationTests
+    {
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Call_WhenSceneGameObjectIsValid_CreatesPrefabAndConnectsSourceObject ()
+        {
+            var operation = new PrefabCreateOperation();
+            var scenePath = CreateTemporaryScenePath();
+            var prefabPath = CreateTemporaryPrefabPath();
+            try
+            {
+                var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                var root = new GameObject("Root");
+                EditorSceneManager.SaveScene(scene, scenePath);
+                var context = new OperationExecutionContext();
+                var requestOperation = CreateOperation(
+                    opId: "op-prefab-create",
+                    opName: "ucli.prefab.create",
+                    args: new
+                    {
+                        target = new
+                        {
+                            scene = scenePath,
+                            hierarchyPath = "Root",
+                        },
+                        path = prefabPath,
+                    },
+                    alias: "created");
+
+                var result = operation.Call(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: true, changed: true);
+                AssertTouchSet(
+                    result,
+                    (OperationTouchKind.Scene, scenePath),
+                    (OperationTouchKind.Prefab, prefabPath));
+                Assert.That(AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath), Is.Not.Null);
+                Assert.That(PrefabUtility.IsPartOfPrefabInstance(root), Is.True);
+                Assert.That(PrefabUtility.GetCorrespondingObjectFromOriginalSource(root), Is.Not.Null);
+                Assert.That(context.AliasStore.TryGet("created", out var resolvedReference), Is.True);
+                Assert.That(resolvedReference!.GlobalObjectId, Is.EqualTo(UnityObjectReferenceResolver.CreateResolvedReference(root).GlobalObjectId));
+            }
+            finally
+            {
+                ClosePrefabStageIfOpen();
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(scenePath);
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Create_Validate_WhenTargetIsMissing_ReturnsInvalidArgument ()
+        {
+            var operation = new PrefabCreateOperation();
+            var requestOperation = CreateOperation(
+                opId: "op-prefab-create",
+                opName: "ucli.prefab.create",
+                args: new
+                {
+                    path = "Assets/MissingTarget.prefab",
+                });
+
+            var result = operation.Validate(requestOperation, new OperationExecutionContext(), CancellationToken.None).GetAwaiter().GetResult();
+
+            AssertInvalidArgument(result, "op-prefab-create");
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Open_Plan_WhenAliasIsSpecified_StoresTemporaryPrefabRootAlias ()
+        {
+            var operation = new PrefabOpenOperation();
+            var prefabPath = CreateTemporaryPrefabPath();
+            try
+            {
+                CreatePrefabAsset(prefabPath, "PrefabRoot");
+                var context = new OperationExecutionContext();
+                var requestOperation = CreateOperation(
+                    opId: "op-prefab-open",
+                    opName: "ucli.prefab.open",
+                    args: new
+                    {
+                        path = prefabPath,
+                    },
+                    alias: "root");
+
+                var result = operation.Plan(requestOperation, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(result, applied: false, changed: false);
+                AssertTouchSet(result, (OperationTouchKind.Prefab, prefabPath));
+                Assert.That(context.TryGetTemporaryAliasState("root", out var temporaryAliasState), Is.True);
+                Assert.That(temporaryAliasState.Resource.Kind, Is.EqualTo(OperationTouchKind.Prefab));
+                Assert.That(temporaryAliasState.Resource.Path, Is.EqualTo(prefabPath));
+                Assert.That(temporaryAliasState.UnityObject, Is.TypeOf<GameObject>());
+                Assert.That(
+                    ((GameObject)temporaryAliasState.UnityObject!).name,
+                    Is.EqualTo(Path.GetFileNameWithoutExtension(prefabPath)));
+            }
+            finally
+            {
+                ClosePrefabStageIfOpen();
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Open_Plan_WhenFollowedByGoCreateAndCompEnsureAndSet_AllowsTemporaryAliasChain ()
+        {
+            var openOperation = new PrefabOpenOperation();
+            var goCreateOperation = new GoCreateOperation();
+            var compEnsureOperation = new CompEnsureOperation();
+            var compSetOperation = new CompSetOperation();
+            var prefabPath = CreateTemporaryPrefabPath();
+            try
+            {
+                CreatePrefabAsset(prefabPath, "PrefabRoot");
+                var componentTypeId = IndexTypeIdFormatter.Format(typeof(CompOperationTestComponent));
+                var context = new OperationExecutionContext();
+                var openRequest = CreateOperation(
+                    opId: "op-prefab-open",
+                    opName: "ucli.prefab.open",
+                    args: new
+                    {
+                        path = prefabPath,
+                    },
+                    alias: "root");
+                var createRequest = CreateOperation(
+                    opId: "op-go-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "Child",
+                        parent = new
+                        {
+                            @var = "root",
+                        },
+                    },
+                    alias: "child");
+                var ensureRequest = CreateOperation(
+                    opId: "op-comp-ensure",
+                    opName: "ucli.comp.ensure",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "child",
+                        },
+                        type = componentTypeId,
+                    },
+                    alias: "childComp");
+                var setRequest = CreateOperation(
+                    opId: "op-comp-set",
+                    opName: "ucli.comp.set",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "childComp",
+                        },
+                        sets = new object[]
+                        {
+                            new
+                            {
+                                path = "integerValue",
+                                value = 11,
+                            },
+                        },
+                    });
+
+                var openResult = openOperation.Plan(openRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var createResult = goCreateOperation.Plan(createRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var ensureResult = compEnsureOperation.Plan(ensureRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var setResult = compSetOperation.Plan(setRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(openResult, applied: false, changed: false);
+                AssertSuccess(createResult, applied: false, changed: true);
+                AssertSuccess(ensureResult, applied: false, changed: true);
+                AssertSuccess(setResult, applied: false, changed: true);
+                Assert.That(context.TryGetTemporaryAliasState("childComp", out var temporaryAliasState), Is.True);
+                Assert.That(temporaryAliasState.Resource.Kind, Is.EqualTo(OperationTouchKind.Prefab));
+                Assert.That(temporaryAliasState.Resource.Path, Is.EqualTo(prefabPath));
+                Assert.That(temporaryAliasState.UnityObject, Is.TypeOf<CompOperationTestComponent>());
+                Assert.That(((CompOperationTestComponent)temporaryAliasState.UnityObject!).IntegerValue, Is.EqualTo(11));
+            }
+            finally
+            {
+                ClosePrefabStageIfOpen();
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Open_Call_ThenCompEnsureSet_ThenSave_Call_PersistsComponentChanges ()
+        {
+            var openOperation = new PrefabOpenOperation();
+            var ensureOperation = new CompEnsureOperation();
+            var setOperation = new CompSetOperation();
+            var saveOperation = new PrefabSaveOperation();
+            var prefabPath = CreateTemporaryPrefabPath();
+            GameObject? loadedPrefabContentsRoot = null;
+            try
+            {
+                CreatePrefabAsset(prefabPath, "PrefabRoot");
+                var context = new OperationExecutionContext();
+                var componentTypeId = IndexTypeIdFormatter.Format(typeof(CompOperationTestComponent));
+                var openRequest = CreateOperation(
+                    opId: "op-prefab-open",
+                    opName: "ucli.prefab.open",
+                    args: new
+                    {
+                        path = prefabPath,
+                    },
+                    alias: "root");
+                var ensureRequest = CreateOperation(
+                    opId: "op-comp-ensure",
+                    opName: "ucli.comp.ensure",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "root",
+                        },
+                        type = componentTypeId,
+                    },
+                    alias: "component");
+                var setRequest = CreateOperation(
+                    opId: "op-comp-set",
+                    opName: "ucli.comp.set",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "component",
+                        },
+                        sets = new object[]
+                        {
+                            new
+                            {
+                                path = "integerValue",
+                                value = 42,
+                            },
+                        },
+                    });
+                var saveRequest = CreateOperation(
+                    opId: "op-prefab-save",
+                    opName: "ucli.prefab.save",
+                    args: new
+                    {
+                        path = prefabPath,
+                    });
+
+                var openResult = openOperation.Call(openRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var ensureResult = ensureOperation.Call(ensureRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var setResult = setOperation.Call(setRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var saveResult = saveOperation.Call(saveRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(openResult, applied: true, changed: false);
+                AssertSuccess(ensureResult, applied: true, changed: true);
+                AssertSuccess(setResult, applied: true, changed: true);
+                AssertSuccess(saveResult, applied: true, changed: true);
+                AssertTouchSet(saveResult, (OperationTouchKind.Prefab, prefabPath));
+
+                ClosePrefabStageIfOpen();
+                loadedPrefabContentsRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+                var component = loadedPrefabContentsRoot.GetComponent<CompOperationTestComponent>();
+                Assert.That(component, Is.Not.Null);
+                Assert.That(component!.IntegerValue, Is.EqualTo(42));
+            }
+            finally
+            {
+                if (loadedPrefabContentsRoot != null)
+                {
+                    PrefabUtility.UnloadPrefabContents(loadedPrefabContentsRoot);
+                }
+
+                ClosePrefabStageIfOpen();
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void Open_Call_ThenGoCreateAndCompEnsureSet_ThenSave_Call_PersistsChildChanges ()
+        {
+            var openOperation = new PrefabOpenOperation();
+            var goCreateOperation = new GoCreateOperation();
+            var ensureOperation = new CompEnsureOperation();
+            var setOperation = new CompSetOperation();
+            var saveOperation = new PrefabSaveOperation();
+            var prefabPath = CreateTemporaryPrefabPath();
+            GameObject? loadedPrefabContentsRoot = null;
+            try
+            {
+                CreatePrefabAsset(prefabPath, "PrefabRoot");
+                var context = new OperationExecutionContext();
+                var componentTypeId = IndexTypeIdFormatter.Format(typeof(CompOperationTestComponent));
+                var openRequest = CreateOperation(
+                    opId: "op-prefab-open",
+                    opName: "ucli.prefab.open",
+                    args: new
+                    {
+                        path = prefabPath,
+                    },
+                    alias: "root");
+                var createRequest = CreateOperation(
+                    opId: "op-go-create",
+                    opName: "ucli.go.create",
+                    args: new
+                    {
+                        name = "Child",
+                        parent = new
+                        {
+                            @var = "root",
+                        },
+                    },
+                    alias: "child");
+                var ensureRequest = CreateOperation(
+                    opId: "op-comp-ensure",
+                    opName: "ucli.comp.ensure",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "child",
+                        },
+                        type = componentTypeId,
+                    },
+                    alias: "childComp");
+                var setRequest = CreateOperation(
+                    opId: "op-comp-set",
+                    opName: "ucli.comp.set",
+                    args: new
+                    {
+                        target = new
+                        {
+                            @var = "childComp",
+                        },
+                        sets = new object[]
+                        {
+                            new
+                            {
+                                path = "integerValue",
+                                value = 7,
+                            },
+                        },
+                    });
+                var saveRequest = CreateOperation(
+                    opId: "op-prefab-save",
+                    opName: "ucli.prefab.save",
+                    args: new
+                    {
+                        path = prefabPath,
+                    });
+
+                var openResult = openOperation.Call(openRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var createResult = goCreateOperation.Call(createRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var ensureResult = ensureOperation.Call(ensureRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var setResult = setOperation.Call(setRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+                var saveResult = saveOperation.Call(saveRequest, context, CancellationToken.None).GetAwaiter().GetResult();
+
+                AssertSuccess(openResult, applied: true, changed: false);
+                AssertSuccess(createResult, applied: true, changed: true);
+                AssertSuccess(ensureResult, applied: true, changed: true);
+                AssertSuccess(setResult, applied: true, changed: true);
+                AssertSuccess(saveResult, applied: true, changed: true);
+
+                ClosePrefabStageIfOpen();
+                loadedPrefabContentsRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+                var child = loadedPrefabContentsRoot.transform.Find("Child");
+                Assert.That(child, Is.Not.Null);
+                var component = child!.GetComponent<CompOperationTestComponent>();
+                Assert.That(component, Is.Not.Null);
+                Assert.That(component!.IntegerValue, Is.EqualTo(7));
+            }
+            finally
+            {
+                if (loadedPrefabContentsRoot != null)
+                {
+                    PrefabUtility.UnloadPrefabContents(loadedPrefabContentsRoot);
+                }
+
+                ClosePrefabStageIfOpen();
+                EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                AssetDatabase.DeleteAsset(prefabPath);
+            }
+        }
+
+        private static void CreatePrefabAsset (
+            string prefabPath,
+            string rootName)
+        {
+            var temporaryRoot = new GameObject(rootName);
+            try
+            {
+                Assert.That(PrefabUtility.SaveAsPrefabAsset(temporaryRoot, prefabPath), Is.Not.Null);
+                AssetDatabase.SaveAssets();
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(temporaryRoot);
+            }
+        }
+
+        private static void ClosePrefabStageIfOpen ()
+        {
+            if (PrefabStageUtility.GetCurrentPrefabStage() == null)
+            {
+                return;
+            }
+
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        }
+
+        private static string CreateTemporaryScenePath ()
+        {
+            return $"Assets/PrefabOperationTests_{Guid.NewGuid():N}.unity";
+        }
+
+        private static string CreateTemporaryPrefabPath ()
+        {
+            return $"Assets/PrefabOperationTests_{Guid.NewGuid():N}.prefab";
+        }
+
+        private static NormalizedOperation CreateOperation (
+            string opId,
+            string opName,
+            object args,
+            string? alias = null)
+        {
+            return new NormalizedOperation(
+                Id: opId,
+                Op: opName,
+                Args: JsonSerializer.SerializeToElement(args),
+                As: alias,
+                Expect: null);
+        }
+
+        private static void AssertInvalidArgument (
+            OperationPhaseStepResult result,
+            string expectedOperationId)
+        {
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Failure, Is.Not.Null);
+            Assert.That(result.Failure!.Code, Is.EqualTo(IpcErrorCodes.InvalidArgument));
+            Assert.That(result.Failure.OpId, Is.EqualTo(expectedOperationId));
+        }
+
+        private static void AssertSuccess (
+            OperationPhaseStepResult result,
+            bool applied,
+            bool changed)
+        {
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Applied, Is.EqualTo(applied));
+            Assert.That(result.Changed, Is.EqualTo(changed));
+            Assert.That(result.Failure, Is.Null);
+        }
+
+        private static void AssertTouchSet (
+            OperationPhaseStepResult result,
+            params (OperationTouchKind Kind, string Path)[] expectedTouches)
+        {
+            Assert.That(result.Touched.Count, Is.EqualTo(expectedTouches.Length));
+            for (var i = 0; i < expectedTouches.Length; i++)
+            {
+                var expectedTouch = expectedTouches[i];
+                Assert.That(
+                    result.Touched.Any(touch =>
+                        touch.Kind == expectedTouch.Kind
+                        && touch.Path == expectedTouch.Path),
+                    Is.True,
+                    $"Touched resource was not found. kind={expectedTouch.Kind}, path={expectedTouch.Path}");
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/PrefabOperationTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/PrefabOperationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 946dbd9094aca4102b47ab185bb6eb63

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UcliOperationDiscovererTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UcliOperationDiscovererTests.cs
@@ -79,6 +79,19 @@ namespace MackySoft.Ucli.Unity.Tests
             var compSetProperties = compSetSchemaDocument.RootElement.GetProperty("properties");
             Assert.That(compSetProperties.TryGetProperty("target", out _), Is.True);
             Assert.That(compSetProperties.GetProperty("sets").GetProperty("minItems").GetInt32(), Is.EqualTo(1));
+
+            var prefabCreateMetadata = FindMetadata(operations, "ucli.prefab.create");
+            using var prefabCreateSchemaDocument = JsonDocument.Parse(prefabCreateMetadata.ArgsSchemaJson);
+            var prefabCreateProperties = prefabCreateSchemaDocument.RootElement.GetProperty("properties");
+            Assert.That(prefabCreateProperties.TryGetProperty("target", out _), Is.True);
+            Assert.That(prefabCreateProperties.TryGetProperty("path", out _), Is.True);
+            Assert.That(prefabCreateSchemaDocument.RootElement.GetProperty("required").GetArrayLength(), Is.EqualTo(2));
+
+            var prefabOpenMetadata = FindMetadata(operations, "ucli.prefab.open");
+            using var prefabOpenSchemaDocument = JsonDocument.Parse(prefabOpenMetadata.ArgsSchemaJson);
+            var prefabOpenProperties = prefabOpenSchemaDocument.RootElement.GetProperty("properties");
+            Assert.That(prefabOpenProperties.TryGetProperty("path", out _), Is.True);
+            Assert.That(prefabOpenSchemaDocument.RootElement.GetProperty("required").GetArrayLength(), Is.EqualTo(1));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- `ucli.prefab.create` / `ucli.prefab.open` / `ucli.prefab.save` を追加し、Prefab を owner resource として扱う実行経路を実装しました。
- `prefab.open` 後も既存の `go` / `comp` 操作を適用できるように、実行コンテキストと参照解決を Scene 固定から resource 基準へ一般化しました。
- JSON 契約の更新、EditMode テスト追加、CLI からの op 表示確認まで含めて反映しています。

## Scope
- `src/Ucli.Unity` に Prefab operation、本体の argument codec / utility、owner resource 一般化、Prefab 対応の object reference 解決を追加しました。
- `src/Ucli.Unity/Assets/Tests` に `prefab.create/open/save` と既存 `go` / `comp` の prefab 編集コンテキスト回帰を追加しました。
- `docs/uCLI.md` と `docs/ops-catalog.md` を更新し、`prefab.create` の `target` 必須契約と空 Prefab 非対応を明記しました。

## Verification
- Gate level: Standard
- Diff budget: PASS (`Split waived` を Issue #25 に記載)
- Spec drift: Skipped (`docs/agents/feature_issue-25-prefab-domain/spec.md` が存在しないため)
- Format: PASS (`dotnet format src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj --verbosity minimal --verify-no-changes --no-restore`)
- Tests: PASS (Unity EditMode `214/214 passed`、`dotnet run --project src/Ucli -- ops list/describe --projectPath src/Ucli.Unity --mode oneshot --timeout 30000`)
- Coverage: N/A

## Risks / Rollback
- owner resource 一般化が scene / prefab 共通の実行経路に入っているため、レビューでは既存 scene 操作の回帰確認が重点になります。
- ロールバックする場合は `44d5d76`、`972d576`、`f3c7910` を順に revert してください。

## Checklist
- [ ] Unity Editor 上で `prefab.open -> go/comp -> prefab.save` の手動確認が必要なら追加で行う
- [ ] Issue #25 の受け入れ条件チェック更新はレビュー完了後に行う

Closes #25
