### PR TITLE
ci(contracts): upgrade workflow actions to v5

### DIFF
--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/contracts-package-verify.yaml
+++ b/.github/workflows/contracts-package-verify.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
## Summary
- contracts package workflows using Node 20 based GitHub Actions references are updated to `actions/checkout@v5` and `actions/setup-dotnet@v5`.
- release and verify runs should stop emitting the Node 20 deprecation warning caused by the old action versions.

## Scope
- `.github/workflows/contracts-package-verify.yaml`: update checkout and setup-dotnet action versions.
- `.github/workflows/contracts-package-publish.yaml`: update checkout and setup-dotnet action versions.

## Verification
- Gate level: Standard
- Diff budget: PASS (`2 files changed, 4 insertions(+), 4 deletions(-)`)
- Spec drift: Skipped (`docs/agents/ci_contracts-actions-v5/spec.md` is absent)
- Format: Skipped (workflow YAML only; no repository formatter target for this change)
- Tests: Skipped (product runtime code is unchanged)
- Coverage: N/A
- Supplemental check: `git diff --check HEAD -- .github/workflows/contracts-package-verify.yaml .github/workflows/contracts-package-publish.yaml`
- Supplemental check: `rg -n "actions/(checkout|setup-dotnet)@v4|actions/(checkout|setup-dotnet)@v5" .github/workflows`

## Risks / Rollback
- Risk is limited to GitHub Actions workflow execution because product code and package contents are unchanged.
- Rollback is a single commit revert if the upgraded action versions cause unexpected workflow behavior.

## Checklist
- [ ] Confirm the next contracts workflow run no longer reports the Node 20 deprecation warning.

Issue: none (ad-hoc task)
