### PR TITLE
[v1.0][D4] 同一ユーザー IPC 認可境界を実装する

### DIFF
--- a/src/Ucli.Contracts/Ipc/Common/IpcTransportConstraints.cs
+++ b/src/Ucli.Contracts/Ipc/Common/IpcTransportConstraints.cs
@@ -1,8 +1,8 @@
-namespace MackySoft.Ucli.Ipc;
+namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Defines transport-level constraints shared by IPC endpoint resolution and tests. </summary>
-internal static class IpcTransportConstraints
+public static class IpcTransportConstraints
 {
     /// <summary> Gets the maximum usable UTF-8 byte length for Unix domain socket paths on macOS. </summary>
-    internal const int UnixDomainSocketPathMaxBytes = 103;
+    public const int UnixDomainSocketPathMaxBytes = 103;
 }

--- a/src/Ucli.Contracts/Ipc/Common/UcliIpcEndpointNames.cs
+++ b/src/Ucli.Contracts/Ipc/Common/UcliIpcEndpointNames.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Defines canonical endpoint naming literals shared by uCLI IPC transports. </summary>
+public static class UcliIpcEndpointNames
+{
+    /// <summary> Gets the daemon endpoint prefix used for named pipes and unix fallback directories. </summary>
+    public const string DaemonAddressPrefix = "ucli-";
+
+    /// <summary> Gets the supervisor endpoint prefix used for named pipes and unix fallback directories. </summary>
+    public const string SupervisorAddressPrefix = "ucli-supervisor-";
+
+    /// <summary> Gets the fixed unix-domain-socket file name used by uCLI listeners. </summary>
+    public const string UnixSocketFileName = "ipc.sock";
+}

--- a/src/Ucli.Contracts/Ipc/Common/UcliIpcEndpointNames.cs
+++ b/src/Ucli.Contracts/Ipc/Common/UcliIpcEndpointNames.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 public static class UcliIpcEndpointNames
 {
     /// <summary> Gets the daemon endpoint prefix used for named pipes and unix fallback directories. </summary>
-    public const string DaemonAddressPrefix = "ucli-";
+    public const string DaemonAddressPrefix = "ucli-daemon-";
 
     /// <summary> Gets the supervisor endpoint prefix used for named pipes and unix fallback directories. </summary>
     public const string SupervisorAddressPrefix = "ucli-supervisor-";

--- a/src/Ucli.Contracts/Ipc/Common/UnixSocketPathUtilities.cs
+++ b/src/Ucli.Contracts/Ipc/Common/UnixSocketPathUtilities.cs
@@ -1,11 +1,11 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using MackySoft.Ucli.Contracts.Cryptography;
-using MackySoft.Ucli.Contracts.Ipc;
 
-namespace MackySoft.Ucli.Ipc;
+namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Provides deterministic unix-domain-socket fallback path utilities. </summary>
-internal static class UnixSocketPathUtilities
+public static class UnixSocketPathUtilities
 {
     /// <summary> Builds one deterministic fallback unix-domain-socket path under the current temp root. </summary>
     /// <param name="directoryPrefix"> The dedicated fallback directory prefix. </param>
@@ -15,8 +15,15 @@ internal static class UnixSocketPathUtilities
         string directoryPrefix,
         string identitySource)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPrefix);
-        ArgumentException.ThrowIfNullOrWhiteSpace(identitySource);
+        if (string.IsNullOrWhiteSpace(directoryPrefix))
+        {
+            throw new ArgumentException("Directory prefix must not be empty.", nameof(directoryPrefix));
+        }
+
+        if (string.IsNullOrWhiteSpace(identitySource))
+        {
+            throw new ArgumentException("Identity source must not be empty.", nameof(identitySource));
+        }
 
         var normalizedTempRoot = NormalizeDirectoryPath(Path.GetTempPath());
         var hashHex = Sha256LowerHex.Compute(Encoding.UTF8.GetBytes(identitySource));
@@ -40,8 +47,15 @@ internal static class UnixSocketPathUtilities
         string socketPath,
         string directoryPrefix)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
-        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPrefix);
+        if (string.IsNullOrWhiteSpace(socketPath))
+        {
+            throw new ArgumentException("Socket path must not be empty.", nameof(socketPath));
+        }
+
+        if (string.IsNullOrWhiteSpace(directoryPrefix))
+        {
+            throw new ArgumentException("Directory prefix must not be empty.", nameof(directoryPrefix));
+        }
 
         if (!TryResolveFallbackDirectoryPath(socketPath, directoryPrefix, out var directoryPath))
         {
@@ -53,7 +67,8 @@ internal static class UnixSocketPathUtilities
             return;
         }
 
-        if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
+        using var enumerator = Directory.EnumerateFileSystemEntries(directoryPath).GetEnumerator();
+        if (enumerator.MoveNext())
         {
             return;
         }
@@ -88,13 +103,10 @@ internal static class UnixSocketPathUtilities
             return false;
         }
 
-        var pathComparison = OperatingSystem.IsWindows()
-            ? StringComparison.OrdinalIgnoreCase
-            : StringComparison.Ordinal;
         if (!string.Equals(
                 NormalizeDirectoryPath(parentOfDirectoryPath),
                 normalizedTempRoot,
-                pathComparison))
+                GetPathComparison()))
         {
             return false;
         }
@@ -113,5 +125,12 @@ internal static class UnixSocketPathUtilities
     {
         var normalizedDirectoryPath = Path.GetFullPath(directoryPath);
         return normalizedDirectoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static StringComparison GetPathComparison ()
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/DaemonDiagnosisPersistence.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/DaemonDiagnosisPersistence.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/NamedPipeUnityIpcTransportListener.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/NamedPipeUnityIpcTransportListener.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -58,12 +61,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                using var serverStream = new NamedPipeServerStream(
-                    address,
-                    PipeDirection.InOut,
-                    NamedPipeServerStream.MaxAllowedServerInstances,
-                    PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous);
+                using var serverStream = PipeServerStreamFactory.Create(address);
 
                 lock (syncRoot)
                 {
@@ -122,6 +120,52 @@ namespace MackySoft.Ucli.Unity.Ipc
                     activeServerStream.Dispose();
                     activeServerStream = null;
                 }
+            }
+        }
+
+        private static class PipeServerStreamFactory
+        {
+            public static NamedPipeServerStream Create (string address)
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return new NamedPipeServerStream(
+                        address,
+                        PipeDirection.InOut,
+                        NamedPipeServerStream.MaxAllowedServerInstances,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous);
+                }
+
+                var pipeSecurity = CreateCurrentUserOnlySecurity();
+                return new NamedPipeServerStream(
+                    address,
+                    PipeDirection.InOut,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous,
+                    0,
+                    0,
+                    pipeSecurity);
+            }
+
+            private static PipeSecurity CreateCurrentUserOnlySecurity ()
+            {
+                var pipeSecurity = new PipeSecurity();
+                pipeSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+                pipeSecurity.AddAccessRule(new PipeAccessRule(
+                    GetCurrentUserSid(),
+                    PipeAccessRights.FullControl,
+                    AccessControlType.Allow));
+                return pipeSecurity;
+            }
+
+            private static SecurityIdentifier GetCurrentUserSid ()
+            {
+                using var identity = WindowsIdentity.GetCurrent();
+                return identity.User
+                    ?? identity.Owner
+                    ?? throw new InvalidOperationException("Current Windows user SID could not be resolved for named pipe access boundary.");
             }
         }
     }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixDomainSocketUnityIpcTransportListener.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixDomainSocketUnityIpcTransportListener.cs
@@ -11,7 +11,7 @@ namespace MackySoft.Ucli.Unity.Ipc
     internal sealed class UnixDomainSocketUnityIpcTransportListener : IUnityIpcTransportListener
     {
         private readonly object syncRoot = new object();
-	
+
         private readonly IDaemonLogger daemonLogger;
 
         private Socket activeListenerSocket;
@@ -61,7 +61,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             listener.Bind(endPoint);
             accessBoundary.HardenBoundSocket();
             listener.Listen(8);
-	
+
             lock (syncRoot)
             {
                 activeListenerSocket = listener;
@@ -85,6 +85,11 @@ namespace MackySoft.Ucli.Unity.Ipc
                     {
                         throw;
                     }
+                    catch (Exception exception) when (cancellationToken.IsCancellationRequested && exception is ObjectDisposedException or SocketException)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return;
+                    }
                     catch (Exception exception) when (!cancellationToken.IsCancellationRequested && (exception is IOException or InvalidDataException or SocketException))
                     {
                         daemonLogger.Warning(
@@ -106,7 +111,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 accessBoundary.Cleanup();
             }
         }
-	
+
         /// <summary> Releases active transport handles to unblock accept loops. </summary>
         public void Release ()
         {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixDomainSocketUnityIpcTransportListener.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixDomainSocketUnityIpcTransportListener.cs
@@ -4,7 +4,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Contracts.Storage;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -12,7 +11,7 @@ namespace MackySoft.Ucli.Unity.Ipc
     internal sealed class UnixDomainSocketUnityIpcTransportListener : IUnityIpcTransportListener
     {
         private readonly object syncRoot = new object();
-
+	
         private readonly IDaemonLogger daemonLogger;
 
         private Socket activeListenerSocket;
@@ -54,23 +53,15 @@ namespace MackySoft.Ucli.Unity.Ipc
                 throw new ArgumentNullException(nameof(onStarted));
             }
 
-            var socketDirectoryPath = Path.GetDirectoryName(address);
-            if (!string.IsNullOrWhiteSpace(socketDirectoryPath))
-            {
-                UcliLocalStorageBootstrapper.EnsureInitialized(socketDirectoryPath);
-                Directory.CreateDirectory(socketDirectoryPath);
-            }
-
-            if (File.Exists(address))
-            {
-                File.Delete(address);
-            }
+            var accessBoundary = new UnixSocketAccessBoundary(address);
+            accessBoundary.PrepareForBind();
 
             using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             var endPoint = new UnixDomainSocketEndPoint(address);
             listener.Bind(endPoint);
+            accessBoundary.HardenBoundSocket();
             listener.Listen(8);
-
+	
             lock (syncRoot)
             {
                 activeListenerSocket = listener;
@@ -112,13 +103,10 @@ namespace MackySoft.Ucli.Unity.Ipc
                     }
                 }
 
-                if (File.Exists(address))
-                {
-                    File.Delete(address);
-                }
+                accessBoundary.Cleanup();
             }
         }
-
+	
         /// <summary> Releases active transport handles to unblock accept loops. </summary>
         public void Release ()
         {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs
@@ -1,0 +1,176 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Storage;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Applies same-user filesystem boundary rules for one unix-domain-socket listener path. </summary>
+    internal sealed class UnixSocketAccessBoundary
+    {
+        private const int OwnerOnlyDirectoryMode = 0x1C0;
+
+        private const int OwnerOnlyFileMode = 0x180;
+
+        private readonly string socketPath;
+
+        /// <summary> Initializes a new instance of the <see cref="UnixSocketAccessBoundary" /> class. </summary>
+        /// <param name="socketPath"> The target unix-domain-socket path. </param>
+        public UnixSocketAccessBoundary (string socketPath)
+        {
+            this.socketPath = socketPath ?? throw new ArgumentNullException(nameof(socketPath));
+        }
+
+        /// <summary> Ensures the socket directory is secure and removes stale socket residue before bind. </summary>
+        public void PrepareForBind ()
+        {
+            var socketDirectoryPath = Path.GetDirectoryName(socketPath);
+            if (!string.IsNullOrWhiteSpace(socketDirectoryPath))
+            {
+                UcliLocalStorageBootstrapper.EnsureInitialized(socketDirectoryPath);
+                EnsureSecureDirectory(socketDirectoryPath);
+            }
+
+            FileUtilities.DeleteIfExists(socketPath);
+        }
+
+        /// <summary> Applies owner-only mode to the bound socket node. </summary>
+        public void HardenBoundSocket ()
+        {
+            ApplyOwnerOnlyFileMode(socketPath);
+        }
+
+        /// <summary> Removes stale socket residue and cleans up empty fallback directory when applicable. </summary>
+        public void Cleanup ()
+        {
+            FileUtilities.DeleteIfExists(socketPath);
+            DeleteEmptyFallbackDirectoryIfPresent(socketPath);
+        }
+
+        private static void EnsureSecureDirectory (string directoryPath)
+        {
+            var normalizedDirectoryPath = Path.GetFullPath(directoryPath);
+            if (TryResolveLocalDirectoryRoot(normalizedDirectoryPath, out var localDirectoryRoot))
+            {
+                var pendingDirectories = new System.Collections.Generic.Stack<string>();
+                var currentDirectoryPath = normalizedDirectoryPath;
+                while (true)
+                {
+                    pendingDirectories.Push(currentDirectoryPath);
+                    if (string.Equals(currentDirectoryPath, localDirectoryRoot, StringComparison.Ordinal))
+                    {
+                        break;
+                    }
+
+                    currentDirectoryPath = Path.GetDirectoryName(currentDirectoryPath)
+                        ?? throw new InvalidOperationException($"Parent directory path could not be resolved: {currentDirectoryPath}");
+                }
+
+                while (pendingDirectories.Count > 0)
+                {
+                    var currentPath = pendingDirectories.Pop();
+                    Directory.CreateDirectory(currentPath);
+                    ApplyOwnerOnlyDirectoryMode(currentPath);
+                }
+
+                return;
+            }
+
+            Directory.CreateDirectory(normalizedDirectoryPath);
+            ApplyOwnerOnlyDirectoryMode(normalizedDirectoryPath);
+        }
+
+        private static bool TryResolveLocalDirectoryRoot (
+            string directoryPath,
+            out string localDirectoryRoot)
+        {
+            var currentDirectory = new DirectoryInfo(directoryPath);
+            while (currentDirectory != null)
+            {
+                var parentDirectory = currentDirectory.Parent;
+                if (string.Equals(currentDirectory.Name, UcliStoragePathNames.LocalDirectoryName, StringComparison.Ordinal)
+                    && parentDirectory != null
+                    && string.Equals(parentDirectory.Name, UcliStoragePathNames.UcliDirectoryName, StringComparison.Ordinal))
+                {
+                    localDirectoryRoot = currentDirectory.FullName;
+                    return true;
+                }
+
+                currentDirectory = parentDirectory;
+            }
+
+            localDirectoryRoot = string.Empty;
+            return false;
+        }
+
+        private static void DeleteEmptyFallbackDirectoryIfPresent (string socketPath)
+        {
+            if (!string.Equals(Path.GetFileName(socketPath), UcliIpcEndpointNames.UnixSocketFileName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var normalizedSocketPath = Path.GetFullPath(socketPath);
+            var directoryPath = Path.GetDirectoryName(normalizedSocketPath);
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return;
+            }
+
+            var normalizedDirectoryPath = directoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var tempRootPath = Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var parentDirectoryPath = Path.GetDirectoryName(normalizedDirectoryPath);
+            if (!string.Equals(parentDirectoryPath, tempRootPath, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var directoryName = Path.GetFileName(normalizedDirectoryPath);
+            if (!directoryName.StartsWith(UcliIpcEndpointNames.DaemonAddressPrefix, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (Directory.Exists(normalizedDirectoryPath) && IsEmptyDirectory(normalizedDirectoryPath))
+            {
+                Directory.Delete(normalizedDirectoryPath);
+            }
+        }
+
+        private static bool IsEmptyDirectory (string directoryPath)
+        {
+            using var enumerator = Directory.EnumerateFileSystemEntries(directoryPath).GetEnumerator();
+            return !enumerator.MoveNext();
+        }
+
+        private static void ApplyOwnerOnlyDirectoryMode (string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            if (Chmod(path, OwnerOnlyDirectoryMode) != 0)
+            {
+                throw new IOException($"chmod failed for directory '{path}'. errno={Marshal.GetLastWin32Error()}");
+            }
+        }
+
+        private static void ApplyOwnerOnlyFileMode (string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            if (Chmod(path, OwnerOnlyFileMode) != 0)
+            {
+                throw new IOException($"chmod failed for socket '{path}'. errno={Marshal.GetLastWin32Error()}");
+            }
+        }
+
+        [DllImport("libc", SetLastError = true, EntryPoint = "chmod")]
+        private static extern int Chmod (string pathname, int mode);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs
@@ -45,7 +45,9 @@ namespace MackySoft.Ucli.Unity.Ipc
         public void Cleanup ()
         {
             FileUtilities.DeleteIfExists(socketPath);
-            DeleteEmptyFallbackDirectoryIfPresent(socketPath);
+            UnixSocketPathUtilities.DeleteEmptyFallbackDirectoryIfPresent(
+                socketPath,
+                UcliIpcEndpointNames.DaemonAddressPrefix);
         }
 
         private static void EnsureSecureDirectory (string directoryPath)
@@ -102,46 +104,6 @@ namespace MackySoft.Ucli.Unity.Ipc
 
             localDirectoryRoot = string.Empty;
             return false;
-        }
-
-        private static void DeleteEmptyFallbackDirectoryIfPresent (string socketPath)
-        {
-            if (!string.Equals(Path.GetFileName(socketPath), UcliIpcEndpointNames.UnixSocketFileName, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            var normalizedSocketPath = Path.GetFullPath(socketPath);
-            var directoryPath = Path.GetDirectoryName(normalizedSocketPath);
-            if (string.IsNullOrWhiteSpace(directoryPath))
-            {
-                return;
-            }
-
-            var normalizedDirectoryPath = directoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var tempRootPath = Path.GetFullPath(Path.GetTempPath()).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var parentDirectoryPath = Path.GetDirectoryName(normalizedDirectoryPath);
-            if (!string.Equals(parentDirectoryPath, tempRootPath, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            var directoryName = Path.GetFileName(normalizedDirectoryPath);
-            if (!directoryName.StartsWith(UcliIpcEndpointNames.DaemonAddressPrefix, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            if (Directory.Exists(normalizedDirectoryPath) && IsEmptyDirectory(normalizedDirectoryPath))
-            {
-                Directory.Delete(normalizedDirectoryPath);
-            }
-        }
-
-        private static bool IsEmptyDirectory (string directoryPath)
-        {
-            using var enumerator = Directory.EnumerateFileSystemEntries(directoryPath).GetEnumerator();
-            return !enumerator.MoveNext();
         }
 
         private static void ApplyOwnerOnlyDirectoryMode (string path)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport/UnixSocketAccessBoundary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a88cb8e2285854f0f9f52770236c0b79

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -108,6 +109,54 @@ namespace MackySoft.Ucli.Unity.Tests
 
             await server.Stop().AsUniTask();
             Assert.That(server.IsRunning, Is.False);
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator UnixDomainSocketListener_Run_WhenUsingFallbackEndpoint_AppliesOwnerOnlyBoundaryAndCleansUp () => UniTask.ToCoroutine(async () =>
+        {
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                return;
+            }
+
+            var socketDirectoryPath = Path.Combine(Path.GetTempPath(), UcliIpcEndpointNames.DaemonAddressPrefix + Guid.NewGuid().ToString("N"));
+            var address = Path.Combine(socketDirectoryPath, UcliIpcEndpointNames.UnixSocketFileName);
+            var listener = new UnixDomainSocketUnityIpcTransportListener();
+            var startedTaskSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var runTask = listener.Run(
+                address,
+                new StubConnectionHandler(),
+                () => startedTaskSource.TrySetResult(true),
+                cancellationTokenSource.Token);
+
+            try
+            {
+                await WaitForTask(startedTaskSource.Task, TimeSpan.FromSeconds(5));
+
+                Assert.That(Directory.Exists(socketDirectoryPath), Is.True);
+                Assert.That(File.Exists(address), Is.True);
+                Assert.That(ReadUnixFileMode(socketDirectoryPath), Is.EqualTo("700"));
+                Assert.That(ReadUnixFileMode(address), Is.EqualTo("600"));
+            }
+            finally
+            {
+                cancellationTokenSource.Cancel();
+                listener.Release();
+
+                try
+                {
+                    await runTask;
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+
+            Assert.That(File.Exists(address), Is.False);
+            Assert.That(Directory.Exists(socketDirectoryPath), Is.False);
         });
 
         [UnityTest]
@@ -631,6 +680,35 @@ namespace MackySoft.Ucli.Unity.Tests
             return new UnityIpcServer(requestProcessor, connectionHandler, transportListeners);
         }
 
+        private static async Task WaitForTask (
+            Task task,
+            TimeSpan timeout)
+        {
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout));
+            Assert.That(completedTask, Is.SameAs(task));
+            await task;
+        }
+
+        private static string ReadUnixFileMode (string path)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/stat",
+                Arguments = string.Concat("-f %Mp%Lp \"", path.Replace("\"", "\\\""), "\""),
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var process = Process.Start(startInfo);
+            Assert.That(process, Is.Not.Null);
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.That(process.ExitCode, Is.EqualTo(0), error);
+            return output.Trim();
+        }
+
         private sealed class StubDaemonShutdownSignal : IDaemonShutdownSignal
         {
             public int SignalCount { get; private set; }
@@ -644,6 +722,17 @@ namespace MackySoft.Ucli.Unity.Tests
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 return Task.CompletedTask;
+            }
+        }
+
+        private sealed class StubConnectionHandler : IUnityIpcConnectionHandler
+        {
+            public Task<UnityIpcConnectionHandleResult> Handle (
+                Stream stream,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(default(UnityIpcConnectionHandleResult));
             }
         }
 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
@@ -138,8 +138,8 @@ namespace MackySoft.Ucli.Unity.Tests
 
                 Assert.That(Directory.Exists(socketDirectoryPath), Is.True);
                 Assert.That(File.Exists(address), Is.True);
-                Assert.That(ReadUnixFileMode(socketDirectoryPath), Is.EqualTo("700"));
-                Assert.That(ReadUnixFileMode(address), Is.EqualTo("600"));
+                Assert.That(ReadUnixFileMode(socketDirectoryPath), Is.EqualTo("0700"));
+                Assert.That(ReadUnixFileMode(address), Is.EqualTo("0600"));
             }
             finally
             {

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/UnityIpcServerTests.cs
@@ -103,7 +103,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator Start_ThenStop_TransitionsRunningState () => UniTask.ToCoroutine(async () =>
         {
             var server = CreateServerForLifecycle();
-            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test");
+            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test");
             await server.Start(endpoint).AsUniTask();
             Assert.That(server.IsRunning, Is.True);
 
@@ -186,7 +186,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     new ThrowingTransportListener(IpcTransportKind.NamedPipe, "listener failed"),
                 });
-            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-failure");
+            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test-failure");
 
             await AsyncExceptionCapture.CaptureAsync<InvalidOperationException>(async () =>
             {
@@ -212,7 +212,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         "listener failed after delay",
                         TimeSpan.FromMilliseconds(50)),
                 });
-            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-delayed-failure");
+            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test-delayed-failure");
 
             await AsyncExceptionCapture.CaptureAsync<InvalidOperationException>(async () =>
             {
@@ -236,7 +236,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     blockingListener,
                 });
-            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-start-cancel");
+            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test-start-cancel");
             using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
 
             await AsyncExceptionCapture.CaptureAsync<OperationCanceledException>(async () =>
@@ -267,7 +267,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         "listener failed after startup",
                         TimeSpan.FromMilliseconds(50)),
                 });
-            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-fault-after-startup");
+            var endpoint = new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test-fault-after-startup");
 
             await server.Start(endpoint).AsUniTask();
             await AsyncExceptionCapture.CaptureAsync<InvalidOperationException>(async () =>

--- a/src/Ucli/Daemon/DaemonArtifactCleaner.cs
+++ b/src/Ucli/Daemon/DaemonArtifactCleaner.cs
@@ -52,10 +52,13 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
             var endpoint = endpointResolver.Resolve(
                 unityProject.RepositoryRoot,
                 unityProject.ProjectFingerprint);
-            if (endpoint.TransportKind == IpcTransportKind.UnixDomainSocket
-                && File.Exists(endpoint.Address))
+            if (endpoint.TransportKind == IpcTransportKind.UnixDomainSocket)
             {
                 FileUtilities.DeleteIfExists(endpoint.Address);
+
+                UnixSocketPathUtilities.DeleteEmptyFallbackDirectoryIfPresent(
+                    endpoint.Address,
+                    UcliIpcEndpointNames.DaemonAddressPrefix);
             }
 
             return DaemonSessionStoreOperationResult.Success();

--- a/src/Ucli/Daemon/DaemonDiagnosisStore.cs
+++ b/src/Ucli/Daemon/DaemonDiagnosisStore.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Contracts.Text;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Daemon;
 
@@ -142,8 +143,7 @@ internal sealed class DaemonDiagnosisStore : IDaemonDiagnosisStore
         {
             var diagnosisDirectoryPath = Path.GetDirectoryName(diagnosisPath)
                 ?? throw new InvalidOperationException($"Daemon diagnosis directory path could not be resolved: {diagnosisPath}");
-            UcliLocalStorageBootstrapper.EnsureInitialized(diagnosisDirectoryPath);
-            Directory.CreateDirectory(diagnosisDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(diagnosisDirectoryPath);
             await FileUtilities.WriteAllTextAtomically(diagnosisPath, json, cancellationToken).ConfigureAwait(false);
             return DaemonDiagnosisStoreOperationResult.Success();
         }

--- a/src/Ucli/Daemon/DaemonSessionStore.cs
+++ b/src/Ucli/Daemon/DaemonSessionStore.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Daemon;
 
@@ -166,9 +167,9 @@ internal sealed class DaemonSessionStore : IDaemonSessionStore
         {
             var sessionDirectoryPath = Path.GetDirectoryName(sessionPath)
                 ?? throw new InvalidOperationException($"Daemon session directory path could not be resolved: {sessionPath}");
-            UcliLocalStorageBootstrapper.EnsureInitialized(sessionDirectoryPath);
-            Directory.CreateDirectory(sessionDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(sessionDirectoryPath);
             await FileUtilities.WriteAllTextAtomically(sessionPath, json, cancellationToken).ConfigureAwait(false);
+            FileSystemAccessBoundary.EnsureSecureFile(sessionPath);
             return DaemonSessionStoreOperationResult.Success();
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))

--- a/src/Ucli/Execution/Lifecycle/FileSystemProjectLifecycleLockProvider.cs
+++ b/src/Ucli/Execution/Lifecycle/FileSystemProjectLifecycleLockProvider.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Execution;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Execution;
 
@@ -38,8 +39,7 @@ internal sealed class FileSystemProjectLifecycleLockProvider : IProjectLifecycle
         var lockDirectoryPath = Path.GetDirectoryName(lockFilePath);
         if (!string.IsNullOrWhiteSpace(lockDirectoryPath))
         {
-            UcliLocalStorageBootstrapper.EnsureInitialized(lockDirectoryPath);
-            Directory.CreateDirectory(lockDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(lockDirectoryPath);
         }
 
         var deadline = ExecutionDeadline.Start(timeout);

--- a/src/Ucli/Ipc/IpcEndpointResolver.cs
+++ b/src/Ucli/Ipc/IpcEndpointResolver.cs
@@ -9,16 +9,6 @@ namespace MackySoft.Ucli.Ipc;
 /// <summary> Resolves daemon IPC endpoints from project identity values. </summary>
 internal sealed class IpcEndpointResolver : IIpcEndpointResolver
 {
-    private const string SocketFileName = "ipc.sock";
-
-    private const string PipeNamePrefix = "ucli-";
-
-    private const string UnixSocketFallbackDirectoryPath = "/tmp";
-
-    private const string UnixSocketFallbackFilePrefix = "ucli-";
-
-    private const string UnixSocketFallbackFileExtension = ".sock";
-
     /// <summary> Resolves the transport endpoint for the given project identity. </summary>
     /// <param name="storageRoot"> The storage-root path. Must not be <see langword="null" />, empty, or whitespace. </param>
     /// <param name="projectFingerprint"> The project fingerprint value. Must not be <see langword="null" />, empty, or whitespace. </param>
@@ -42,13 +32,13 @@ internal sealed class IpcEndpointResolver : IIpcEndpointResolver
 
         if (OperatingSystem.IsWindows())
         {
-            var pipeName = PipeNamePrefix + normalizedProjectFingerprint;
+            var pipeName = UcliIpcEndpointNames.DaemonAddressPrefix + normalizedProjectFingerprint;
             return new IpcEndpoint(IpcTransportKind.NamedPipe, pipeName);
         }
 
         var preferredSocketPath = Path.Combine(
             UcliStoragePathResolver.ResolveFingerprintDirectory(normalizedStorageRoot, normalizedProjectFingerprint),
-            SocketFileName);
+            UcliIpcEndpointNames.UnixSocketFileName);
 
         if (Encoding.UTF8.GetByteCount(preferredSocketPath) <= IpcTransportConstraints.UnixDomainSocketPathMaxBytes)
         {
@@ -69,10 +59,8 @@ internal sealed class IpcEndpointResolver : IIpcEndpointResolver
         string normalizedProjectFingerprint)
     {
         var hashSource = $"{normalizedStorageRoot}\n{normalizedProjectFingerprint}";
-        var hashHex = Sha256LowerHex.Compute(Encoding.UTF8.GetBytes(hashSource));
-        var shortHash = hashHex[..32];
-        return Path.Combine(
-            UnixSocketFallbackDirectoryPath,
-            UnixSocketFallbackFilePrefix + shortHash + UnixSocketFallbackFileExtension);
+        return UnixSocketPathUtilities.BuildFallbackSocketPath(
+            UcliIpcEndpointNames.DaemonAddressPrefix,
+            hashSource);
     }
 }

--- a/src/Ucli/Ipc/UnityBatchmodeProcessLauncher.cs
+++ b/src/Ucli/Ipc/UnityBatchmodeProcessLauncher.cs
@@ -4,6 +4,7 @@ using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Daemon;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 using MackySoft.Ucli.UnityProject;
 using MackySoft.Ucli.UnityProject.Resolution;
 
@@ -133,8 +134,7 @@ internal sealed class UnityBatchmodeProcessLauncher : IUnityDaemonProcessLaunche
             var unityLogDirectoryPath = Path.GetDirectoryName(unityLogPath);
             if (!string.IsNullOrWhiteSpace(unityLogDirectoryPath))
             {
-                UcliLocalStorageBootstrapper.EnsureInitialized(unityLogDirectoryPath);
-                Directory.CreateDirectory(unityLogDirectoryPath);
+                FileSystemAccessBoundary.EnsureSecureDirectory(unityLogDirectoryPath);
             }
 
             var processStartInfo = new ProcessStartInfo

--- a/src/Ucli/Ipc/UnityOneshotIpcClient.cs
+++ b/src/Ucli/Ipc/UnityOneshotIpcClient.cs
@@ -4,6 +4,7 @@ using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Execution;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 using MackySoft.Ucli.UnityProject;
 
 namespace MackySoft.Ucli.Ipc;
@@ -81,8 +82,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
             var unityLogDirectoryPath = Path.GetDirectoryName(unityLogPath);
             if (!string.IsNullOrWhiteSpace(unityLogDirectoryPath))
             {
-                UcliLocalStorageBootstrapper.EnsureInitialized(unityLogDirectoryPath);
-                Directory.CreateDirectory(unityLogDirectoryPath);
+                FileSystemAccessBoundary.EnsureSecureDirectory(unityLogDirectoryPath);
             }
 
             if (!deadline.TryGetRemainingTimeout(out _))

--- a/src/Ucli/Ipc/UnixSocketPathUtilities.cs
+++ b/src/Ucli/Ipc/UnixSocketPathUtilities.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using MackySoft.Ucli.Contracts.Cryptography;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Ipc;
+
+/// <summary> Provides deterministic unix-domain-socket fallback path utilities. </summary>
+internal static class UnixSocketPathUtilities
+{
+    /// <summary> Builds one deterministic fallback unix-domain-socket path under the current temp root. </summary>
+    /// <param name="directoryPrefix"> The dedicated fallback directory prefix. </param>
+    /// <param name="identitySource"> The stable identity source used for hashing. </param>
+    /// <returns> The deterministic fallback socket path. </returns>
+    public static string BuildFallbackSocketPath (
+        string directoryPrefix,
+        string identitySource)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPrefix);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identitySource);
+
+        var normalizedTempRoot = NormalizeDirectoryPath(Path.GetTempPath());
+        var hashHex = Sha256LowerHex.Compute(Encoding.UTF8.GetBytes(identitySource));
+        var basePath = Path.Combine(normalizedTempRoot, directoryPrefix, UcliIpcEndpointNames.UnixSocketFileName);
+        var availableHashLength = IpcTransportConstraints.UnixDomainSocketPathMaxBytes - Encoding.UTF8.GetByteCount(basePath);
+        if (availableHashLength <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Unix socket fallback path exceeds platform limit before hash is added. TempRoot={normalizedTempRoot}, Prefix={directoryPrefix}.");
+        }
+
+        var hashLength = Math.Min(hashHex.Length, availableHashLength);
+        var directoryName = directoryPrefix + hashHex[..hashLength];
+        return Path.Combine(normalizedTempRoot, directoryName, UcliIpcEndpointNames.UnixSocketFileName);
+    }
+
+    /// <summary> Deletes one empty fallback directory when the socket path uses the dedicated temp-root pattern. </summary>
+    /// <param name="socketPath"> The socket path to inspect. </param>
+    /// <param name="directoryPrefix"> The dedicated fallback directory prefix. </param>
+    public static void DeleteEmptyFallbackDirectoryIfPresent (
+        string socketPath,
+        string directoryPrefix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPrefix);
+
+        if (!TryResolveFallbackDirectoryPath(socketPath, directoryPrefix, out var directoryPath))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(directoryPath))
+        {
+            return;
+        }
+
+        if (Directory.EnumerateFileSystemEntries(directoryPath).Any())
+        {
+            return;
+        }
+
+        Directory.Delete(directoryPath);
+    }
+
+    private static bool TryResolveFallbackDirectoryPath (
+        string socketPath,
+        string directoryPrefix,
+        out string directoryPath)
+    {
+        directoryPath = string.Empty;
+
+        if (!string.Equals(Path.GetFileName(socketPath), UcliIpcEndpointNames.UnixSocketFileName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var normalizedSocketPath = Path.GetFullPath(socketPath);
+        var parentDirectoryPath = Path.GetDirectoryName(normalizedSocketPath);
+        if (string.IsNullOrWhiteSpace(parentDirectoryPath))
+        {
+            return false;
+        }
+
+        var normalizedParentDirectoryPath = NormalizeDirectoryPath(parentDirectoryPath);
+        var normalizedTempRoot = NormalizeDirectoryPath(Path.GetTempPath());
+        var parentOfDirectoryPath = Path.GetDirectoryName(normalizedParentDirectoryPath.TrimEnd(Path.DirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(parentOfDirectoryPath))
+        {
+            return false;
+        }
+
+        var pathComparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!string.Equals(
+                NormalizeDirectoryPath(parentOfDirectoryPath),
+                normalizedTempRoot,
+                pathComparison))
+        {
+            return false;
+        }
+
+        var directoryName = Path.GetFileName(normalizedParentDirectoryPath.TrimEnd(Path.DirectorySeparatorChar));
+        if (!directoryName.StartsWith(directoryPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        directoryPath = normalizedParentDirectoryPath;
+        return true;
+    }
+
+    private static string NormalizeDirectoryPath (string directoryPath)
+    {
+        var normalizedDirectoryPath = Path.GetFullPath(directoryPath);
+        return normalizedDirectoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+}

--- a/src/Ucli/Ops/FileOpsCatalogStore.cs
+++ b/src/Ucli/Ops/FileOpsCatalogStore.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Ops;
 
@@ -29,10 +30,8 @@ internal sealed class FileOpsCatalogStore : IOpsCatalogStore
             ?? throw new InvalidOperationException($"ops.catalog.json directory path could not be resolved: {opsCatalogPath}");
         var inputsManifestDirectoryPath = Path.GetDirectoryName(inputsManifestPath)
             ?? throw new InvalidOperationException($"inputs manifest directory path could not be resolved: {inputsManifestPath}");
-        UcliLocalStorageBootstrapper.EnsureInitialized(opsCatalogDirectoryPath);
-        Directory.CreateDirectory(opsCatalogDirectoryPath);
-        UcliLocalStorageBootstrapper.EnsureInitialized(inputsManifestDirectoryPath);
-        Directory.CreateDirectory(inputsManifestDirectoryPath);
+        FileSystemAccessBoundary.EnsureSecureDirectory(opsCatalogDirectoryPath);
+        FileSystemAccessBoundary.EnsureSecureDirectory(inputsManifestDirectoryPath);
 
         var opsCatalog = new IndexOpsCatalogJsonContract(
             SchemaVersion: SchemaVersion,

--- a/src/Ucli/Storage/FileSystemAccessBoundary.cs
+++ b/src/Ucli/Storage/FileSystemAccessBoundary.cs
@@ -1,0 +1,209 @@
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using MackySoft.Ucli.Contracts.Storage;
+
+namespace MackySoft.Ucli.Storage;
+
+/// <summary> Applies same-user filesystem boundaries to local runtime storage. </summary>
+internal static class FileSystemAccessBoundary
+{
+    private const UnixFileMode OwnerOnlyDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    private const UnixFileMode OwnerOnlyFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    /// <summary> Ensures the target directory exists and is limited to the current user. </summary>
+    /// <param name="directoryPath"> The directory path to secure. </param>
+    public static void EnsureSecureDirectory (string directoryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath);
+
+        var normalizedDirectoryPath = Path.GetFullPath(directoryPath);
+        if (TryResolveLocalDirectoryRoot(normalizedDirectoryPath, out var localDirectoryRoot))
+        {
+            UcliLocalStorageBootstrapper.EnsureInitialized(normalizedDirectoryPath);
+            EnsureSecureDirectoryChain(localDirectoryRoot!, normalizedDirectoryPath);
+            return;
+        }
+
+        Directory.CreateDirectory(normalizedDirectoryPath);
+        ApplySecureDirectoryMode(normalizedDirectoryPath);
+    }
+
+    /// <summary> Ensures the target file is limited to the current user. </summary>
+    /// <param name="filePath"> The file path to secure. </param>
+    public static void EnsureSecureFile (string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+        var normalizedFilePath = Path.GetFullPath(filePath);
+        if (!File.Exists(normalizedFilePath))
+        {
+            throw new FileNotFoundException($"Secure file target was not found: {normalizedFilePath}", normalizedFilePath);
+        }
+
+        ApplySecureFileMode(normalizedFilePath);
+    }
+
+    /// <summary> Ensures the target unix-domain-socket node is limited to the current user. </summary>
+    /// <param name="socketPath"> The socket path to secure. </param>
+    public static void EnsureSecureUnixSocket (string socketPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+
+        var normalizedSocketPath = Path.GetFullPath(socketPath);
+        if (!File.Exists(normalizedSocketPath))
+        {
+            throw new FileNotFoundException($"Secure socket target was not found: {normalizedSocketPath}", normalizedSocketPath);
+        }
+
+        ApplySecureFileMode(normalizedSocketPath);
+    }
+
+    private static void EnsureSecureDirectoryChain (
+        string boundaryRootPath,
+        string directoryPath)
+    {
+        var normalizedBoundaryRootPath = NormalizeDirectoryPath(boundaryRootPath);
+        var normalizedDirectoryPath = NormalizeDirectoryPath(directoryPath);
+        if (!IsPathUnderOrEqual(normalizedDirectoryPath, normalizedBoundaryRootPath))
+        {
+            throw new InvalidOperationException(
+                $"Secure directory target must remain under the local storage root. Root={normalizedBoundaryRootPath}, Target={normalizedDirectoryPath}");
+        }
+
+        var pendingDirectories = new Stack<string>();
+        var currentDirectoryPath = normalizedDirectoryPath;
+        while (true)
+        {
+            pendingDirectories.Push(currentDirectoryPath);
+            if (string.Equals(currentDirectoryPath, normalizedBoundaryRootPath, GetPathComparison()))
+            {
+                break;
+            }
+
+            currentDirectoryPath = Path.GetDirectoryName(currentDirectoryPath)
+                ?? throw new InvalidOperationException($"Parent directory path could not be resolved: {currentDirectoryPath}");
+        }
+
+        while (pendingDirectories.Count > 0)
+        {
+            var currentPath = pendingDirectories.Pop();
+            Directory.CreateDirectory(currentPath);
+            ApplySecureDirectoryMode(currentPath);
+        }
+    }
+
+    private static void ApplySecureDirectoryMode (string directoryPath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            ApplyCurrentUserDirectoryAcl(directoryPath);
+            return;
+        }
+
+        File.SetUnixFileMode(directoryPath, OwnerOnlyDirectoryMode);
+    }
+
+    private static void ApplySecureFileMode (string filePath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            ApplyCurrentUserFileAcl(filePath);
+            return;
+        }
+
+        File.SetUnixFileMode(filePath, OwnerOnlyFileMode);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void ApplyCurrentUserDirectoryAcl (string directoryPath)
+    {
+        var directorySecurity = new DirectorySecurity();
+        directorySecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        directorySecurity.AddAccessRule(new FileSystemAccessRule(
+            GetCurrentUserSid(),
+            FileSystemRights.FullControl,
+            InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+            PropagationFlags.None,
+            AccessControlType.Allow));
+        new DirectoryInfo(directoryPath).SetAccessControl(directorySecurity);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void ApplyCurrentUserFileAcl (string filePath)
+    {
+        var fileSecurity = new FileSecurity();
+        fileSecurity.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+        fileSecurity.AddAccessRule(new FileSystemAccessRule(
+            GetCurrentUserSid(),
+            FileSystemRights.FullControl,
+            AccessControlType.Allow));
+        new FileInfo(filePath).SetAccessControl(fileSecurity);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static SecurityIdentifier GetCurrentUserSid ()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return identity.User
+            ?? throw new InvalidOperationException("Current Windows user SID could not be resolved for filesystem access boundary.");
+    }
+
+    private static bool TryResolveLocalDirectoryRoot (
+        string directoryPath,
+        out string? localDirectoryRoot)
+    {
+        var currentDirectory = new DirectoryInfo(Path.GetFullPath(directoryPath));
+        while (currentDirectory != null)
+        {
+            var parentDirectory = currentDirectory.Parent;
+            if (string.Equals(currentDirectory.Name, UcliStoragePathNames.LocalDirectoryName, GetPathComparison())
+                && parentDirectory != null
+                && string.Equals(parentDirectory.Name, UcliStoragePathNames.UcliDirectoryName, GetPathComparison()))
+            {
+                localDirectoryRoot = currentDirectory.FullName;
+                return true;
+            }
+
+            currentDirectory = parentDirectory;
+        }
+
+        localDirectoryRoot = null;
+        return false;
+    }
+
+    private static bool IsPathUnderOrEqual (
+        string path,
+        string rootPath)
+    {
+        if (string.Equals(path, rootPath, GetPathComparison()))
+        {
+            return true;
+        }
+
+        var normalizedRootPath = EnsureTrailingDirectorySeparator(rootPath);
+        return EnsureTrailingDirectorySeparator(path).StartsWith(normalizedRootPath, GetPathComparison());
+    }
+
+    private static string NormalizeDirectoryPath (string directoryPath)
+    {
+        return Path.GetFullPath(directoryPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static string EnsureTrailingDirectorySeparator (string directoryPath)
+    {
+        return directoryPath.EndsWith(Path.DirectorySeparatorChar)
+            ? directoryPath
+            : directoryPath + Path.DirectorySeparatorChar;
+    }
+
+    private static StringComparison GetPathComparison ()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+    }
+}

--- a/src/Ucli/Supervisor/LaunchdSupervisorProcessLauncher.cs
+++ b/src/Ucli/Supervisor/LaunchdSupervisorProcessLauncher.cs
@@ -3,6 +3,7 @@ using System.Text;
 using MackySoft.Ucli.Contracts.Cryptography;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -47,8 +48,7 @@ internal sealed class LaunchdSupervisorProcessLauncher
             var plistDirectoryPath = Path.GetDirectoryName(plistPath);
             if (!string.IsNullOrWhiteSpace(plistDirectoryPath))
             {
-                UcliLocalStorageBootstrapper.EnsureInitialized(plistDirectoryPath);
-                Directory.CreateDirectory(plistDirectoryPath);
+                FileSystemAccessBoundary.EnsureSecureDirectory(plistDirectoryPath);
             }
 
             var plistContents = BuildLaunchAgentPlist(label, launchCommand, normalizedStorageRoot, logPath);

--- a/src/Ucli/Supervisor/SupervisorBootstrapLockProvider.cs
+++ b/src/Ucli/Supervisor/SupervisorBootstrapLockProvider.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Execution;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -29,8 +30,7 @@ internal sealed class SupervisorBootstrapLockProvider
         var lockDirectoryPath = Path.GetDirectoryName(lockFilePath);
         if (!string.IsNullOrWhiteSpace(lockDirectoryPath))
         {
-            UcliLocalStorageBootstrapper.EnsureInitialized(lockDirectoryPath);
-            Directory.CreateDirectory(lockDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(lockDirectoryPath);
         }
 
         var deadline = ExecutionDeadline.Start(timeout);

--- a/src/Ucli/Supervisor/SupervisorBootstrapper.cs
+++ b/src/Ucli/Supervisor/SupervisorBootstrapper.cs
@@ -4,6 +4,7 @@ using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Execution;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Ipc;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -271,10 +272,13 @@ internal sealed class SupervisorBootstrapper
             var endpoint = manifest != null && IpcTransportKindCodec.TryParse(manifest.EndpointTransportKind, out var transportKind)
                 ? new IpcEndpoint(transportKind, manifest.EndpointAddress)
                 : endpointResolver.Resolve(storageRoot);
-            if (endpoint.TransportKind == IpcTransportKind.UnixDomainSocket
-                && File.Exists(endpoint.Address))
+            if (endpoint.TransportKind == IpcTransportKind.UnixDomainSocket)
             {
                 FileUtilities.DeleteIfExists(endpoint.Address);
+
+                UnixSocketPathUtilities.DeleteEmptyFallbackDirectoryIfPresent(
+                    endpoint.Address,
+                    UcliIpcEndpointNames.SupervisorAddressPrefix);
             }
         }
         catch (Exception)

--- a/src/Ucli/Supervisor/SupervisorEndpointResolver.cs
+++ b/src/Ucli/Supervisor/SupervisorEndpointResolver.cs
@@ -9,16 +9,6 @@ namespace MackySoft.Ucli.Supervisor;
 /// <summary> Resolves transport endpoints for the worktree-local supervisor runtime. </summary>
 internal sealed class SupervisorEndpointResolver
 {
-    private const string SocketFileName = "ipc.sock";
-
-    private const string PipeNamePrefix = "ucli-supervisor-";
-
-    private const string UnixSocketFallbackDirectoryPath = "/tmp";
-
-    private const string UnixSocketFallbackFilePrefix = "ucli-supervisor-";
-
-    private const string UnixSocketFallbackFileExtension = ".sock";
-
     /// <summary> Resolves one transport endpoint for the specified storage root. </summary>
     /// <param name="storageRoot"> The storage-root path. </param>
     /// <returns> The resolved transport endpoint. </returns>
@@ -35,23 +25,22 @@ internal sealed class SupervisorEndpointResolver
         {
             return new IpcEndpoint(
                 IpcTransportKind.NamedPipe,
-                PipeNamePrefix + ComputeIdentityHash(normalizedStorageRoot)[..24]);
+                UcliIpcEndpointNames.SupervisorAddressPrefix + ComputeIdentityHash(normalizedStorageRoot)[..24]);
         }
 
         var preferredSocketPath = Path.Combine(
             UcliStoragePathResolver.ResolveSupervisorDirectoryPath(normalizedStorageRoot),
-            SocketFileName);
+            UcliIpcEndpointNames.UnixSocketFileName);
         if (Encoding.UTF8.GetByteCount(preferredSocketPath) <= IpcTransportConstraints.UnixDomainSocketPathMaxBytes)
         {
             return new IpcEndpoint(IpcTransportKind.UnixDomainSocket, preferredSocketPath);
         }
 
-        var shortHash = ComputeIdentityHash(normalizedStorageRoot)[..32];
         return new IpcEndpoint(
             IpcTransportKind.UnixDomainSocket,
-            Path.Combine(
-                UnixSocketFallbackDirectoryPath,
-                UnixSocketFallbackFilePrefix + shortHash + UnixSocketFallbackFileExtension));
+            UnixSocketPathUtilities.BuildFallbackSocketPath(
+                UcliIpcEndpointNames.SupervisorAddressPrefix,
+                normalizedStorageRoot));
     }
 
     private static string ComputeIdentityHash (string normalizedStorageRoot)

--- a/src/Ucli/Supervisor/SupervisorManifestStore.cs
+++ b/src/Ucli/Supervisor/SupervisorManifestStore.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Contracts.Text;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -114,9 +115,9 @@ internal sealed class SupervisorManifestStore
         var json = JsonSerializer.Serialize(manifest, SerializerOptions) + Environment.NewLine;
         var manifestDirectoryPath = Path.GetDirectoryName(manifestPath)
             ?? throw new InvalidOperationException($"Supervisor manifest directory path could not be resolved: {manifestPath}");
-        UcliLocalStorageBootstrapper.EnsureInitialized(manifestDirectoryPath);
-        Directory.CreateDirectory(manifestDirectoryPath);
+        FileSystemAccessBoundary.EnsureSecureDirectory(manifestDirectoryPath);
         await writeAllTextAtomically(manifestPath, json, cancellationToken).ConfigureAwait(false);
+        FileSystemAccessBoundary.EnsureSecureFile(manifestPath);
     }
 
     /// <summary> Deletes the persisted supervisor manifest when it exists. </summary>

--- a/src/Ucli/Supervisor/SupervisorRuntimeLogger.cs
+++ b/src/Ucli/Supervisor/SupervisorRuntimeLogger.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -24,8 +25,7 @@ internal sealed class SupervisorRuntimeLogger
         var logDirectoryPath = Path.GetDirectoryName(logPath);
         if (!string.IsNullOrWhiteSpace(logDirectoryPath))
         {
-            UcliLocalStorageBootstrapper.EnsureInitialized(logDirectoryPath);
-            Directory.CreateDirectory(logDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(logDirectoryPath);
         }
 
         await writeGate.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Ucli/Supervisor/SupervisorTransportServer.cs
+++ b/src/Ucli/Supervisor/SupervisorTransportServer.cs
@@ -3,7 +3,8 @@ using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Ipc;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.Supervisor;
 
@@ -99,7 +100,7 @@ internal sealed class SupervisorTransportServer
                     PipeDirection.InOut,
                     NamedPipeServerStream.MaxAllowedServerInstances,
                     PipeTransmissionMode.Byte,
-                    PipeOptions.Asynchronous);
+                    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
 
                 lock (syncRoot)
                 {
@@ -155,8 +156,7 @@ internal sealed class SupervisorTransportServer
         var socketDirectoryPath = Path.GetDirectoryName(address);
         if (!string.IsNullOrWhiteSpace(socketDirectoryPath))
         {
-            UcliLocalStorageBootstrapper.EnsureInitialized(socketDirectoryPath);
-            Directory.CreateDirectory(socketDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(socketDirectoryPath);
         }
 
         if (File.Exists(address))
@@ -166,6 +166,7 @@ internal sealed class SupervisorTransportServer
 
         using var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
         listener.Bind(new UnixDomainSocketEndPoint(address));
+        FileSystemAccessBoundary.EnsureSecureUnixSocket(address);
         listener.Listen(8);
 
         lock (syncRoot)
@@ -218,6 +219,10 @@ internal sealed class SupervisorTransportServer
             {
                 File.Delete(address);
             }
+
+            UnixSocketPathUtilities.DeleteEmptyFallbackDirectoryIfPresent(
+                address,
+                UcliIpcEndpointNames.SupervisorAddressPrefix);
         }
     }
 

--- a/src/Ucli/TestRun/Artifacts/TestRunArtifactsService.cs
+++ b/src/Ucli/TestRun/Artifacts/TestRunArtifactsService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 using MackySoft.Ucli.TestRun.Configuration;
 using MackySoft.Ucli.UnityProject;
 
@@ -73,8 +74,7 @@ internal sealed class TestRunArtifactsService : ITestRunArtifactsService
 
             try
             {
-                UcliLocalStorageBootstrapper.EnsureInitialized(artifactsDir);
-                Directory.CreateDirectory(artifactsDir);
+                FileSystemAccessBoundary.EnsureSecureDirectory(artifactsDir);
             }
             catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
             {

--- a/src/Ucli/Unity/Project/UnityUcliPluginMarkerCacheStore.cs
+++ b/src/Ucli/Unity/Project/UnityUcliPluginMarkerCacheStore.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MackySoft.Ucli.Contracts.Paths;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Storage;
 
 namespace MackySoft.Ucli.UnityProject;
 
@@ -146,8 +147,7 @@ internal sealed class UnityUcliPluginMarkerCacheStore
             var json = JsonSerializer.Serialize(cache, SerializerOptions) + Environment.NewLine;
             var cacheDirectoryPath = Path.GetDirectoryName(cachePath)
                 ?? throw new InvalidOperationException($"uCLI Unity plugin marker cache directory path could not be resolved: {cachePath}");
-            UcliLocalStorageBootstrapper.EnsureInitialized(cacheDirectoryPath);
-            Directory.CreateDirectory(cacheDirectoryPath);
+            FileSystemAccessBoundary.EnsureSecureDirectory(cacheDirectoryPath);
             await writeAllTextAtomically(cachePath, json, cancellationToken).ConfigureAwait(false);
             return UnityUcliPluginMarkerCacheStoreOperationResult.Success();
         }

--- a/tests/Ucli.Contracts.Tests/Storage/DaemonSessionJsonContractSerializerTests.cs
+++ b/tests/Ucli.Contracts.Tests/Storage/DaemonSessionJsonContractSerializerTests.cs
@@ -20,7 +20,7 @@ public sealed class DaemonSessionJsonContractSerializerTests
               "ownerKind": "supervisor",
               "canShutdownProcess": true,
               "endpointTransportKind": "namedPipe",
-              "endpointAddress": "ucli-endpoint",
+              "endpointAddress": "ucli-daemon-endpoint",
               "processId": 1234,
               "ownerProcessId": 5678
             }
@@ -37,7 +37,7 @@ public sealed class DaemonSessionJsonContractSerializerTests
         Assert.Equal("supervisor", contract.OwnerKind);
         Assert.True(contract.CanShutdownProcess);
         Assert.Equal("namedPipe", contract.EndpointTransportKind);
-        Assert.Equal("ucli-endpoint", contract.EndpointAddress);
+        Assert.Equal("ucli-daemon-endpoint", contract.EndpointAddress);
         Assert.Equal(1234, contract.ProcessId);
         Assert.Equal(5678, contract.OwnerProcessId);
     }
@@ -74,7 +74,7 @@ public sealed class DaemonSessionJsonContractSerializerTests
             OwnerKind: "supervisor",
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: 1234,
             OwnerProcessId: 5678);
 

--- a/tests/Ucli.Tests/Daemon/DaemonArtifactCleanerTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonArtifactCleanerTests.cs
@@ -1,0 +1,85 @@
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Daemon;
+using MackySoft.Ucli.Foundation;
+using MackySoft.Ucli.Ipc;
+using MackySoft.Ucli.UnityProject;
+
+namespace MackySoft.Ucli.Tests.Daemon;
+
+public sealed class DaemonArtifactCleanerTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Cleanup_WhenUnixFallbackSocketDirectoryBecomesEmpty_DeletesFallbackDirectory ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var socketPath = UnixSocketPathUtilities.BuildFallbackSocketPath(UcliIpcEndpointNames.DaemonAddressPrefix, Guid.NewGuid().ToString("N"));
+        var socketDirectoryPath = Path.GetDirectoryName(socketPath)!;
+        Directory.CreateDirectory(socketDirectoryPath);
+        await File.WriteAllTextAsync(socketPath, string.Empty, CancellationToken.None);
+
+        var cleaner = new DaemonArtifactCleaner(
+            new StubDaemonSessionStore(),
+            new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.UnixDomainSocket, socketPath)));
+
+        var result = await cleaner.Cleanup(
+            new ResolvedUnityProjectContext(
+                UnityProjectRoot: "/tmp/unity-project",
+                RepositoryRoot: "/tmp/repo-root",
+                ProjectFingerprint: "fingerprint-cleanup",
+                PathSource: UnityProjectPathSource.CommandOption),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(File.Exists(socketPath));
+        Assert.False(Directory.Exists(socketDirectoryPath));
+    }
+
+    private sealed class StubDaemonSessionStore : IDaemonSessionStore
+    {
+        public ValueTask<DaemonSessionReadResult> Read (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonSessionStoreOperationResult> Write (
+            string storageRoot,
+            DaemonSession session,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonSessionStoreOperationResult> Delete (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(DaemonSessionStoreOperationResult.Success());
+        }
+    }
+
+    private sealed class StubEndpointResolver : IIpcEndpointResolver
+    {
+        private readonly IpcEndpoint endpoint;
+
+        public StubEndpointResolver (IpcEndpoint endpoint)
+        {
+            this.endpoint = endpoint;
+        }
+
+        public IpcEndpoint Resolve (
+            string storageRoot,
+            string projectFingerprint)
+        {
+            return endpoint;
+        }
+    }
+}

--- a/tests/Ucli.Tests/Daemon/DaemonCleanupOperationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonCleanupOperationTests.cs
@@ -26,7 +26,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-none"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -47,7 +47,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new DaemonPingResponseException("token invalid", IpcErrorCodes.SessionTokenInvalid))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-none-live"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -70,7 +70,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(static () => ValueTask.CompletedTask),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-running"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -93,7 +93,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new DaemonPingResponseException("token invalid", IpcErrorCodes.SessionTokenInvalid))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-token-invalid"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -116,7 +116,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new DaemonPingResponseException("token required", IpcErrorCodes.SessionTokenRequired))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-token-required"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -142,7 +142,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-stale"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -164,7 +164,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.AccessDenied))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-access-denied"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -289,7 +289,7 @@ public sealed class DaemonCleanupOperationTests
             {
                 RequiresUnsafeSkipResult = false,
             },
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(context, TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -316,7 +316,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(context, TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -374,7 +374,7 @@ public sealed class DaemonCleanupOperationTests
             {
                 RequiresUnsafeSkipResult = true,
             },
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(context, TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -419,7 +419,7 @@ public sealed class DaemonCleanupOperationTests
             },
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new TimeoutException("probe timeout"))),
             artifactCleaner: artifactCleaner,
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-timeout"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -438,7 +438,7 @@ public sealed class DaemonCleanupOperationTests
             {
                 ThrowTimeoutOnAcquire = true,
             },
-            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test")));
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
 
         var result = await operation.Cleanup(CreateContext("fingerprint-cleanup-lock-timeout"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
 
@@ -492,7 +492,7 @@ public sealed class DaemonCleanupOperationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: processId,
             OwnerProcessId: 9876);
     }

--- a/tests/Ucli.Tests/Daemon/DaemonCommandServiceTestContext.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonCommandServiceTestContext.cs
@@ -41,7 +41,7 @@ internal static class DaemonCommandServiceTestContext
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: 1234,
             OwnerProcessId: 9876);
     }

--- a/tests/Ucli.Tests/Daemon/DaemonExistingSessionGateServiceTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonExistingSessionGateServiceTests.cs
@@ -198,7 +198,7 @@ public sealed class DaemonExistingSessionGateServiceTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonInvalidSessionCleanupSafetyEvaluatorTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonInvalidSessionCleanupSafetyEvaluatorTests.cs
@@ -210,7 +210,7 @@ public sealed class DaemonInvalidSessionCleanupSafetyEvaluatorTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: 2468,
             OwnerProcessId: 1357);
     }

--- a/tests/Ucli.Tests/Daemon/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonLaunchServiceTests.cs
@@ -542,7 +542,7 @@ public sealed class DaemonLaunchServiceTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonLaunchSessionServiceTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonLaunchSessionServiceTests.cs
@@ -139,7 +139,7 @@ public sealed class DaemonLaunchSessionServiceTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
 
             OwnerProcessId: 9876);
@@ -151,7 +151,7 @@ public sealed class DaemonLaunchSessionServiceTests
             string storageRoot,
             string projectFingerprint)
         {
-            return new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-endpoint");
+            return new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-daemon-endpoint");
         }
     }
 

--- a/tests/Ucli.Tests/Daemon/DaemonSessionCleanupServiceTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionCleanupServiceTests.cs
@@ -54,7 +54,7 @@ public sealed class DaemonSessionCleanupServiceTests
                 OwnerKind: DaemonSession.OwnerKindSupervisor,
                 CanShutdownProcess: true,
                 EndpointTransportKind: "namedPipe",
-                EndpointAddress: "ucli-test-endpoint",
+                EndpointAddress: "ucli-daemon-test-endpoint",
                 ProcessId: 7171,
                 OwnerProcessId: 9876));
         var processTerminationService = new StubDaemonProcessTerminationService
@@ -190,7 +190,7 @@ public sealed class DaemonSessionCleanupServiceTests
             OwnerKind: ownerKind,
             CanShutdownProcess: canShutdownProcess,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
             OwnerProcessId: ownerProcessId);
     }

--- a/tests/Ucli.Tests/Daemon/DaemonSessionIssuedAtValidationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionIssuedAtValidationTests.cs
@@ -26,7 +26,7 @@ public sealed class DaemonSessionIssuedAtValidationTests
               "ownerKind": "cli",
               "canShutdownProcess": true,
               "endpointTransportKind": "namedPipe",
-              "endpointAddress": "ucli-test",
+              "endpointAddress": "ucli-daemon-test",
               "processId": 1234
             }
             """,
@@ -56,7 +56,7 @@ public sealed class DaemonSessionIssuedAtValidationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test",
+            EndpointAddress: "ucli-daemon-test",
             ProcessId: 1234,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonSessionProcessIdValidationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionProcessIdValidationTests.cs
@@ -28,7 +28,7 @@ public sealed class DaemonSessionProcessIdValidationTests
               "ownerKind": "cli",
               "canShutdownProcess": true,
               "endpointTransportKind": "namedPipe",
-              "endpointAddress": "ucli-test",
+              "endpointAddress": "ucli-daemon-test",
               "processId": 0
             }
             """,
@@ -61,7 +61,7 @@ public sealed class DaemonSessionProcessIdValidationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test",
+            EndpointAddress: "ucli-daemon-test",
             ProcessId: processId,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonSessionShutdownCapabilityValidationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionShutdownCapabilityValidationTests.cs
@@ -27,7 +27,7 @@ public sealed class DaemonSessionShutdownCapabilityValidationTests
               "runtimeKind": "batchmode",
               "ownerKind": "supervisor",
               "endpointTransportKind": "namedPipe",
-              "endpointAddress": "ucli-test",
+              "endpointAddress": "ucli-daemon-test",
               "processId": 1234,
               "ownerProcessId": 9876
             }
@@ -59,7 +59,7 @@ public sealed class DaemonSessionShutdownCapabilityValidationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: false,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test",
+            EndpointAddress: "ucli-daemon-test",
             ProcessId: 1234,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
@@ -302,7 +302,7 @@ public sealed class DaemonSessionStoreTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test",
+            EndpointAddress: "ucli-daemon-test",
             ProcessId: 1234,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
@@ -127,6 +127,30 @@ public sealed class DaemonSessionStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Write_WhenSessionDirectoryCannotBeSecured_ReturnsInternalError ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-session-store", "blocked-session-directory");
+        var blockedPath = Path.Combine(
+            scope.FullPath,
+            UcliStoragePathNames.UcliDirectoryName,
+            UcliStoragePathNames.LocalDirectoryName,
+            UcliStoragePathNames.FingerprintsDirectoryName);
+        Directory.CreateDirectory(Path.GetDirectoryName(blockedPath)!);
+        await File.WriteAllTextAsync(blockedPath, "blocked", CancellationToken.None);
+
+        var store = new DaemonSessionStore();
+        var session = CreateSession(projectFingerprint: "fingerprint-blocked", sessionToken: "token-1");
+
+        var writeResult = await store.Write(scope.FullPath, session, CancellationToken.None);
+
+        Assert.False(writeResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(writeResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Contains("Failed to write daemon session file", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Read_WhenSessionJsonIsMalformed_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "malformed-json");

--- a/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionStoreTests.cs
@@ -1,10 +1,12 @@
 namespace MackySoft.Ucli.Tests.Daemon;
 
+using System.Runtime.Versioning;
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Daemon;
 using MackySoft.Ucli.Foundation;
 using MackySoft.Ucli.Tests;
+using MackySoft.Ucli.Tests.Helpers;
 
 public sealed class DaemonSessionStoreTests
 {
@@ -66,6 +68,61 @@ public sealed class DaemonSessionStoreTests
 
         Assert.True(writeResult.IsSuccess);
         Assert.Equal("legacy/" + Environment.NewLine, File.ReadAllText(gitIgnorePath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public async Task Write_OnUnix_SavesSessionJsonUnderOwnerOnlyBoundary ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-session-store", "owner-only");
+        var store = new DaemonSessionStore();
+        var session = CreateSession(projectFingerprint: "fingerprint-owner-only", sessionToken: "token-1");
+
+        var writeResult = await store.Write(scope.FullPath, session, CancellationToken.None);
+
+        Assert.True(writeResult.IsSuccess);
+
+        var localDirectoryPath = UcliStoragePathResolver.ResolveLocalDirectoryPath(scope.FullPath);
+        var fingerprintDirectoryPath = UcliStoragePathResolver.ResolveFingerprintDirectory(scope.FullPath, session.ProjectFingerprint);
+        var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, session.ProjectFingerprint);
+
+        PosixAccessBoundaryAssert.DirectoryIsOwnerOnly(localDirectoryPath);
+        PosixAccessBoundaryAssert.DirectoryIsOwnerOnly(fingerprintDirectoryPath);
+        PosixAccessBoundaryAssert.FileIsOwnerOnly(sessionPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("windows")]
+    public async Task Write_OnWindows_SavesSessionJsonUnderCurrentUserOnlyBoundary ()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-session-store", "current-user-only");
+        var store = new DaemonSessionStore();
+        var session = CreateSession(projectFingerprint: "fingerprint-current-user-only", sessionToken: "token-1");
+
+        var writeResult = await store.Write(scope.FullPath, session, CancellationToken.None);
+
+        Assert.True(writeResult.IsSuccess);
+
+        var localDirectoryPath = UcliStoragePathResolver.ResolveLocalDirectoryPath(scope.FullPath);
+        var fingerprintDirectoryPath = UcliStoragePathResolver.ResolveFingerprintDirectory(scope.FullPath, session.ProjectFingerprint);
+        var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, session.ProjectFingerprint);
+
+        WindowsAccessBoundaryAssert.DirectoryIsCurrentUserOnly(localDirectoryPath);
+        WindowsAccessBoundaryAssert.DirectoryIsCurrentUserOnly(fingerprintDirectoryPath);
+        WindowsAccessBoundaryAssert.FileIsCurrentUserOnly(sessionPath);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Daemon/DaemonSessionTokenProviderTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonSessionTokenProviderTests.cs
@@ -69,7 +69,7 @@ public sealed class DaemonSessionTokenProviderTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test",
+            EndpointAddress: "ucli-daemon-test",
             ProcessId: 123,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonShutdownClientTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonShutdownClientTests.cs
@@ -66,7 +66,7 @@ public sealed class DaemonShutdownClientTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: 1234,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonStartOperationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonStartOperationTests.cs
@@ -447,7 +447,7 @@ public sealed class DaemonStartOperationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
             OwnerProcessId: ownerProcessId);
     }

--- a/tests/Ucli.Tests/Daemon/DaemonStatusOperationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonStatusOperationTests.cs
@@ -241,7 +241,7 @@ public sealed class DaemonStatusOperationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Daemon/DaemonStopOperationTests.cs
+++ b/tests/Ucli.Tests/Daemon/DaemonStopOperationTests.cs
@@ -170,7 +170,7 @@ public sealed class DaemonStopOperationTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-test-endpoint",
+            EndpointAddress: "ucli-daemon-test-endpoint",
             ProcessId: processId,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Execution/UnityExecutionMode/Probe/IpcDaemonReachabilityProbeTests.cs
+++ b/tests/Ucli.Tests/Execution/UnityExecutionMode/Probe/IpcDaemonReachabilityProbeTests.cs
@@ -38,7 +38,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenPingSucceeds_ReturnsRunning ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => ValueTask.CompletedTask);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -62,7 +62,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenPingTimesOut_ReturnsTimeoutFailure ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-timeout"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-timeout"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw new TimeoutException("timeout"));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
         var probeTimeout = TimeSpan.FromMilliseconds(150);
@@ -82,7 +82,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenConnectTimeoutOccurs_ReturnsTimeoutFailure ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-connect-timeout"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-connect-timeout"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw new IpcConnectTimeoutException("connect timeout"));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
         var probeTimeout = TimeSpan.FromMilliseconds(150);
@@ -102,7 +102,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenConnectTimeoutOccursBeforeDeadlineAndSubsequentPingSucceeds_ReturnsRunning ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-connect-timeout-retry-success"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-connect-timeout-retry-success"));
         var pingAttemptCount = 0;
         var daemonPingClient = new StubDaemonPingClient((_, _) =>
         {
@@ -130,7 +130,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenTimeoutOccursBeforeDeadlineAndSubsequentPingSucceeds_ReturnsRunning ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-retry-success"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-retry-success"));
         var pingAttemptCount = 0;
         var daemonPingClient = new StubDaemonPingClient((_, _) =>
         {
@@ -159,7 +159,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenConnectivityExceptionOccurs_ReturnsNotRunning (Exception exception)
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-connectivity"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-connectivity"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw exception);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -189,7 +189,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenUnexpectedExceptionOccurs_ReturnsInternalError ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-failure"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-failure"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw new InvalidOperationException("boom"));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -208,7 +208,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenIoFailureOccurs_ReturnsInternalError (Exception exception)
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-io-failure"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-io-failure"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw exception);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -226,7 +226,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenPingResponseIsRejected_ReturnsInternalError ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-ping-response-error"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-ping-response-error"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw new DaemonPingResponseException("status=error", IpcErrorCodes.InternalError));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -244,7 +244,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenUnauthorizedAccessOccurs_ReturnsInternalError ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-unauthorized"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-unauthorized"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => throw new UnauthorizedAccessException("unauthorized"));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
 
@@ -262,7 +262,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenCanceled_ThrowsOperationCanceledException ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-canceled"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-canceled"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => ValueTask.CompletedTask);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
         using var cancellationTokenSource = new CancellationTokenSource();
@@ -280,7 +280,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WhenCanceledDuringPing_ThrowsOperationCanceledException ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-canceled-during-ping"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-canceled-during-ping"));
         var daemonPingClient = new StubDaemonPingClient((_, cancellationToken) =>
             new ValueTask(Task.Delay(System.Threading.Timeout.Infinite, cancellationToken)));
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
@@ -301,7 +301,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WithNestedUnityProject_UsesRepositoryRootForEndpointResolution ()
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-nested-project"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-nested-project"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => ValueTask.CompletedTask);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
         var repositoryRoot = Path.GetFullPath(Path.Combine(".", "sandbox", "Repo"));
@@ -321,7 +321,7 @@ public sealed class IpcDaemonReachabilityProbeTests
     public async Task Probe_WithNonPositiveTimeout_ThrowsArgumentOutOfRangeException (int timeoutMilliseconds)
     {
         var endpointResolver = new StubEndpointResolver(
-            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-invalid-timeout"));
+            new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-invalid-timeout"));
         var daemonPingClient = new StubDaemonPingClient((_, _) => ValueTask.CompletedTask);
         var probe = new IpcDaemonReachabilityProbe(endpointResolver, daemonPingClient);
         var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);

--- a/tests/Ucli.Tests/Helpers/PosixAccessBoundaryAssert.cs
+++ b/tests/Ucli.Tests/Helpers/PosixAccessBoundaryAssert.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Versioning;
+
+namespace MackySoft.Ucli.Tests.Helpers;
+
+internal static class PosixAccessBoundaryAssert
+{
+    private const UnixFileMode OwnerOnlyDirectoryMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    private const UnixFileMode OwnerOnlyFileMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public static void DirectoryIsOwnerOnly (string path)
+    {
+        Assert.Equal(OwnerOnlyDirectoryMode, File.GetUnixFileMode(path));
+    }
+
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public static void FileIsOwnerOnly (string path)
+    {
+        Assert.Equal(OwnerOnlyFileMode, File.GetUnixFileMode(path));
+    }
+}

--- a/tests/Ucli.Tests/Helpers/WindowsAccessBoundaryAssert.cs
+++ b/tests/Ucli.Tests/Helpers/WindowsAccessBoundaryAssert.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace MackySoft.Ucli.Tests.Helpers;
+
+[SupportedOSPlatform("windows")]
+internal static class WindowsAccessBoundaryAssert
+{
+    public static void DirectoryIsCurrentUserOnly (string path)
+    {
+        AssertCurrentUserOnly(new DirectoryInfo(path).GetAccessControl());
+    }
+
+    public static void FileIsCurrentUserOnly (string path)
+    {
+        AssertCurrentUserOnly(new FileInfo(path).GetAccessControl());
+    }
+
+    private static void AssertCurrentUserOnly (FileSystemSecurity security)
+    {
+        Assert.True(security.AreAccessRulesProtected);
+
+        var currentUserSid = GetCurrentUserSid();
+        var rules = security.GetAccessRules(true, true, typeof(SecurityIdentifier))
+            .Cast<FileSystemAccessRule>()
+            .ToArray();
+
+        Assert.NotEmpty(rules);
+        Assert.All(
+            rules,
+            rule =>
+            {
+                Assert.False(rule.IsInherited);
+                Assert.Equal(AccessControlType.Allow, rule.AccessControlType);
+                Assert.Equal(currentUserSid, rule.IdentityReference);
+            });
+    }
+
+    private static SecurityIdentifier GetCurrentUserSid ()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return identity.User
+            ?? throw new InvalidOperationException("Current Windows user SID could not be resolved for ACL assertions.");
+    }
+}

--- a/tests/Ucli.Tests/Ipc/IpcEndpointResolverTests.cs
+++ b/tests/Ucli.Tests/Ipc/IpcEndpointResolverTests.cs
@@ -36,7 +36,7 @@ public sealed class IpcEndpointResolverTests
         if (OperatingSystem.IsWindows())
         {
             Assert.Equal(IpcTransportKind.NamedPipe, endpoint.TransportKind);
-            Assert.Equal("ucli-abc123", endpoint.Address);
+            Assert.Equal("ucli-daemon-abc123", endpoint.Address);
             return;
         }
 

--- a/tests/Ucli.Tests/Status/StatusServiceTests.cs
+++ b/tests/Ucli.Tests/Status/StatusServiceTests.cs
@@ -304,7 +304,7 @@ public sealed class StatusServiceTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-status",
+            EndpointAddress: "ucli-daemon-status",
             ProcessId: 1234,
 
             OwnerProcessId: 9876);

--- a/tests/Ucli.Tests/Supervisor/SupervisorBootstrapperTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorBootstrapperTests.cs
@@ -90,6 +90,37 @@ public sealed class SupervisorBootstrapperTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task EnsureReady_WhenManifestReadFailsWithUnauthorizedAccess_ReturnsInternalError ()
+    {
+        using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "manifest-read-unauthorized");
+        var transportClient = new MackySoft.Ucli.Tests.Daemon.DaemonCommandServiceTestContext.StubIpcTransportClient
+        {
+            SendHandler = static (_, _, _, _) => throw new InvalidOperationException("Supervisor transport should not be called when manifest read fails."),
+        };
+        var manifestStore = new SupervisorManifestStore(
+            readAllTextOrNull: static (_, _) => throw new UnauthorizedAccessException("manifest denied"),
+            writeAllTextAtomically: static (_, _, _) => ValueTask.CompletedTask,
+            deleteIfExists: static _ => { });
+        var bootstrapper = new SupervisorBootstrapper(
+            manifestStore,
+            new SupervisorClient(transportClient),
+            new StubSupervisorProcessLauncher(),
+            new SupervisorBootstrapLockProvider(),
+            new SupervisorEndpointResolver());
+
+        var result = await bootstrapper.EnsureReady(
+            scope.FullPath,
+            TimeSpan.FromMilliseconds(150),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, result.Error.Kind);
+        Assert.Contains("Failed to read supervisor manifest", result.Error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task EnsureReady_WhenInitialLaunchDoesNotPublishManifest_RelaunchesAndSucceeds ()
     {
         using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "relaunch-success");

--- a/tests/Ucli.Tests/Supervisor/SupervisorEndpointResolverTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorEndpointResolverTests.cs
@@ -1,46 +1,38 @@
 using System.Text;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Ipc;
+using MackySoft.Ucli.Supervisor;
 
-namespace MackySoft.Ucli.Tests.Ipc;
+namespace MackySoft.Ucli.Tests.Supervisor;
 
-public sealed class IpcEndpointResolverTests
+public sealed class SupervisorEndpointResolverTests
 {
     [Fact]
     [Trait("Size", "Small")]
     public void Resolve_WithEmptyStorageRoot_ThrowsArgumentException ()
     {
-        var resolver = new IpcEndpointResolver();
+        var resolver = new SupervisorEndpointResolver();
 
-        Assert.Throws<ArgumentException>(() => resolver.Resolve("", "fingerprint"));
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public void Resolve_WithEmptyProjectFingerprint_ThrowsArgumentException ()
-    {
-        var resolver = new IpcEndpointResolver();
-
-        Assert.Throws<ArgumentException>(() => resolver.Resolve(".", " "));
+        Assert.Throws<ArgumentException>(() => resolver.Resolve(""));
     }
 
     [Fact]
     [Trait("Size", "Small")]
     public void Resolve_WithValidInputs_ReturnsPlatformSpecificEndpoint ()
     {
-        var resolver = new IpcEndpointResolver();
-        var storageRoot = Path.GetFullPath(Path.Combine(".", "sandbox", "Unity"));
+        var resolver = new SupervisorEndpointResolver();
+        var storageRoot = Path.GetFullPath(Path.Combine(".", "sandbox", "Supervisor"));
 
-        var endpoint = resolver.Resolve(storageRoot, "abc123");
+        var endpoint = resolver.Resolve(storageRoot);
 
         if (OperatingSystem.IsWindows())
         {
             Assert.Equal(IpcTransportKind.NamedPipe, endpoint.TransportKind);
-            Assert.Equal("ucli-abc123", endpoint.Address);
+            Assert.StartsWith(UcliIpcEndpointNames.SupervisorAddressPrefix, endpoint.Address, StringComparison.Ordinal);
             return;
         }
 
-        var preferredPath = Path.Combine(storageRoot, ".ucli", "local", "fingerprints", "abc123", "ipc.sock");
+        var preferredPath = Path.Combine(storageRoot, ".ucli", "local", "supervisor", "ipc.sock");
 
         Assert.Equal(IpcTransportKind.UnixDomainSocket, endpoint.TransportKind);
         Assert.True(Encoding.UTF8.GetByteCount(endpoint.Address) <= IpcTransportConstraints.UnixDomainSocketPathMaxBytes);
@@ -51,7 +43,7 @@ public sealed class IpcEndpointResolverTests
             return;
         }
 
-        AssertFallbackPath(endpoint.Address, UcliIpcEndpointNames.DaemonAddressPrefix);
+        AssertFallbackPath(endpoint.Address, UcliIpcEndpointNames.SupervisorAddressPrefix);
     }
 
     [Fact]
@@ -63,19 +55,19 @@ public sealed class IpcEndpointResolverTests
             return;
         }
 
-        var resolver = new IpcEndpointResolver();
+        var resolver = new SupervisorEndpointResolver();
         var storageRoot = Path.GetFullPath(Path.Combine(
             Path.GetTempPath(),
             "ucli-tests",
             new string('a', 140)));
 
-        var endpoint1 = resolver.Resolve(storageRoot, "abc123");
-        var endpoint2 = resolver.Resolve(storageRoot, "abc123");
+        var endpoint1 = resolver.Resolve(storageRoot);
+        var endpoint2 = resolver.Resolve(storageRoot);
 
         Assert.Equal(IpcTransportKind.UnixDomainSocket, endpoint1.TransportKind);
         Assert.Equal(endpoint1.Address, endpoint2.Address);
         Assert.True(Encoding.UTF8.GetByteCount(endpoint1.Address) <= IpcTransportConstraints.UnixDomainSocketPathMaxBytes);
-        AssertFallbackPath(endpoint1.Address, UcliIpcEndpointNames.DaemonAddressPrefix);
+        AssertFallbackPath(endpoint1.Address, UcliIpcEndpointNames.SupervisorAddressPrefix);
     }
 
     private static void AssertFallbackPath (

--- a/tests/Ucli.Tests/Supervisor/SupervisorManifestStoreTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorManifestStoreTests.cs
@@ -1,0 +1,96 @@
+using System.Runtime.Versioning;
+using MackySoft.Tests;
+using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Supervisor;
+using MackySoft.Ucli.Tests.Helpers;
+
+namespace MackySoft.Ucli.Tests.Supervisor;
+
+public sealed class SupervisorManifestStoreTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteReadDelete_RoundTripsManifestJson ()
+    {
+        using var scope = TestDirectories.CreateTempScope("supervisor-manifest-store", "roundtrip");
+        var store = new SupervisorManifestStore();
+        var manifest = CreateManifest();
+
+        await store.Write(scope.FullPath, manifest, CancellationToken.None);
+
+        var loadedManifest = await store.ReadOrNull(scope.FullPath, CancellationToken.None);
+
+        Assert.NotNull(loadedManifest);
+        Assert.Equal(manifest.ProcessId, loadedManifest.ProcessId);
+        Assert.Equal(manifest.SessionToken, loadedManifest.SessionToken);
+        Assert.Equal(manifest.EndpointTransportKind, loadedManifest.EndpointTransportKind);
+        Assert.Equal(manifest.EndpointAddress, loadedManifest.EndpointAddress);
+        Assert.Equal(manifest.IssuedAtUtc, loadedManifest.IssuedAtUtc);
+
+        store.DeleteIfExists(scope.FullPath);
+
+        var readAfterDelete = await store.ReadOrNull(scope.FullPath, CancellationToken.None);
+        Assert.Null(readAfterDelete);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public async Task Write_OnUnix_SavesManifestJsonUnderOwnerOnlyBoundary ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("supervisor-manifest-store", "owner-only");
+        var store = new SupervisorManifestStore();
+        var manifest = CreateManifest();
+
+        await store.Write(scope.FullPath, manifest, CancellationToken.None);
+
+        var localDirectoryPath = UcliStoragePathResolver.ResolveLocalDirectoryPath(scope.FullPath);
+        var supervisorDirectoryPath = UcliStoragePathResolver.ResolveSupervisorDirectoryPath(scope.FullPath);
+        var manifestPath = UcliStoragePathResolver.ResolveSupervisorManifestPath(scope.FullPath);
+
+        PosixAccessBoundaryAssert.DirectoryIsOwnerOnly(localDirectoryPath);
+        PosixAccessBoundaryAssert.DirectoryIsOwnerOnly(supervisorDirectoryPath);
+        PosixAccessBoundaryAssert.FileIsOwnerOnly(manifestPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("windows")]
+    public async Task Write_OnWindows_SavesManifestJsonUnderCurrentUserOnlyBoundary ()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("supervisor-manifest-store", "current-user-only");
+        var store = new SupervisorManifestStore();
+        var manifest = CreateManifest();
+
+        await store.Write(scope.FullPath, manifest, CancellationToken.None);
+
+        var localDirectoryPath = UcliStoragePathResolver.ResolveLocalDirectoryPath(scope.FullPath);
+        var supervisorDirectoryPath = UcliStoragePathResolver.ResolveSupervisorDirectoryPath(scope.FullPath);
+        var manifestPath = UcliStoragePathResolver.ResolveSupervisorManifestPath(scope.FullPath);
+
+        WindowsAccessBoundaryAssert.DirectoryIsCurrentUserOnly(localDirectoryPath);
+        WindowsAccessBoundaryAssert.DirectoryIsCurrentUserOnly(supervisorDirectoryPath);
+        WindowsAccessBoundaryAssert.FileIsCurrentUserOnly(manifestPath);
+    }
+
+    private static SupervisorInstanceManifest CreateManifest ()
+    {
+        return new SupervisorInstanceManifest(
+            ProcessId: 2468,
+            SessionToken: "supervisor-session-token",
+            EndpointTransportKind: "unixDomainSocket",
+            EndpointAddress: "/tmp/ucli-supervisor-test/ipc.sock",
+            IssuedAtUtc: new DateTimeOffset(2026, 03, 14, 0, 0, 0, TimeSpan.Zero));
+    }
+}

--- a/tests/Ucli.Tests/Supervisor/SupervisorProjectCoordinatorTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorProjectCoordinatorTests.cs
@@ -469,7 +469,7 @@ public sealed class SupervisorProjectCoordinatorTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: processId,
             OwnerProcessId: 9876);
     }

--- a/tests/Ucli.Tests/Supervisor/SupervisorRequestDispatcherTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorRequestDispatcherTests.cs
@@ -12,6 +12,52 @@ public sealed class SupervisorRequestDispatcherTests
 {
     [Fact]
     [Trait("Size", "Small")]
+    public async Task HandleConnection_WhenSessionTokenIsMissing_ReturnsSessionTokenRequired ()
+    {
+        var dispatcher = CreateDispatcher();
+        var runtimeContext = CreateRuntimeContext();
+
+        var response = await SendRequest(
+            dispatcher,
+            runtimeContext,
+            new IpcRequest(
+                ProtocolVersion: IpcProtocol.CurrentVersion,
+                RequestId: "request-missing-token",
+                SessionToken: string.Empty,
+                Method: SupervisorIpcContracts.PingMethod,
+                Payload: IpcPayloadCodec.SerializeToElement(
+                    new SupervisorIpcContracts.PingRequest(SupervisorConstants.PingClientVersion))));
+
+        Assert.Equal(IpcProtocol.StatusError, response.Status);
+        var error = Assert.Single(response.Errors);
+        Assert.Equal(IpcErrorCodes.SessionTokenRequired, error.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task HandleConnection_WhenSessionTokenIsInvalid_ReturnsSessionTokenInvalid ()
+    {
+        var dispatcher = CreateDispatcher();
+        var runtimeContext = CreateRuntimeContext();
+
+        var response = await SendRequest(
+            dispatcher,
+            runtimeContext,
+            new IpcRequest(
+                ProtocolVersion: IpcProtocol.CurrentVersion,
+                RequestId: "request-invalid-token",
+                SessionToken: "invalid-token",
+                Method: SupervisorIpcContracts.PingMethod,
+                Payload: IpcPayloadCodec.SerializeToElement(
+                    new SupervisorIpcContracts.PingRequest(SupervisorConstants.PingClientVersion))));
+
+        Assert.Equal(IpcProtocol.StatusError, response.Status);
+        var error = Assert.Single(response.Errors);
+        Assert.Equal(IpcErrorCodes.SessionTokenInvalid, error.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task HandleConnection_WhenUnityProjectRootIsInvalid_ReturnsInvalidArgumentWithoutBreakingSubsequentRequests ()
     {
         var dispatcher = CreateDispatcher();

--- a/tests/Ucli.Tests/Supervisor/SupervisorStabilityVerifierTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorStabilityVerifierTests.cs
@@ -120,7 +120,7 @@ public sealed class SupervisorStabilityVerifierTests
             OwnerKind: DaemonSession.OwnerKindSupervisor,
             CanShutdownProcess: true,
             EndpointTransportKind: "namedPipe",
-            EndpointAddress: "ucli-endpoint",
+            EndpointAddress: "ucli-daemon-endpoint",
             ProcessId: 1234,
             OwnerProcessId: 9876);
     }

--- a/tests/Ucli.Tests/Supervisor/SupervisorTransportServerTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorTransportServerTests.cs
@@ -114,6 +114,33 @@ public sealed class SupervisorTransportServerTests
     [Trait("Size", "Small")]
     [SupportedOSPlatform("macos")]
     [SupportedOSPlatform("linux")]
+    public async Task Run_OnUnix_WhenSocketDirectoryCannotBeSecured_ThrowsIOException ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("supervisor-transport-server", "blocked-socket-directory");
+        var blockedDirectoryPath = scope.WriteFile("blocked", "directory path is blocked");
+        var endpoint = new IpcEndpoint(
+            IpcTransportKind.UnixDomainSocket,
+            Path.Combine(blockedDirectoryPath, UcliIpcEndpointNames.UnixSocketFileName));
+        var server = new SupervisorTransportServer();
+
+        var exception = await Assert.ThrowsAsync<IOException>(() => server.Run(
+            endpoint,
+            static (_, _) => Task.CompletedTask,
+            static _ => Task.CompletedTask,
+            CancellationToken.None));
+
+        Assert.Contains(blockedDirectoryPath, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
     public async Task Run_OnUnix_AppliesOwnerOnlyPermissionsToSocketAndParentDirectory ()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/Ucli.Tests/Supervisor/SupervisorTransportServerTests.cs
+++ b/tests/Ucli.Tests/Supervisor/SupervisorTransportServerTests.cs
@@ -1,7 +1,9 @@
+using System.Runtime.Versioning;
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Ipc;
 using MackySoft.Ucli.Supervisor;
+using MackySoft.Ucli.Tests.Helpers;
 
 namespace MackySoft.Ucli.Tests.Supervisor;
 
@@ -108,18 +110,121 @@ public sealed class SupervisorTransportServerTests
         }
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public async Task Run_OnUnix_AppliesOwnerOnlyPermissionsToSocketAndParentDirectory ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var endpoint = new IpcEndpoint(
+            IpcTransportKind.UnixDomainSocket,
+            UnixSocketPathUtilities.BuildFallbackSocketPath("ucli-supervisor-", Guid.NewGuid().ToString("N")));
+        var server = new SupervisorTransportServer();
+        var startedTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var serverTask = server.Run(
+            endpoint,
+            static (_, _) => Task.CompletedTask,
+            cancellationToken =>
+            {
+                startedTaskSource.TrySetResult();
+                return Task.CompletedTask;
+            },
+            cancellationTokenSource.Token);
+
+        try
+        {
+            await startedTaskSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            PosixAccessBoundaryAssert.DirectoryIsOwnerOnly(Path.GetDirectoryName(endpoint.Address)!);
+            PosixAccessBoundaryAssert.FileIsOwnerOnly(endpoint.Address);
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            server.Release();
+            try
+            {
+                await serverTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("linux")]
+    public async Task Run_OnUnix_WhenUsingFallbackEndpoint_DeletesEmptyFallbackDirectoryOnShutdown ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var endpoint = new IpcEndpoint(
+            IpcTransportKind.UnixDomainSocket,
+            UnixSocketPathUtilities.BuildFallbackSocketPath("ucli-supervisor-", Guid.NewGuid().ToString("N")));
+        var socketDirectoryPath = Path.GetDirectoryName(endpoint.Address)!;
+        var server = new SupervisorTransportServer();
+        var startedTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var serverTask = server.Run(
+            endpoint,
+            static (_, _) => Task.CompletedTask,
+            cancellationToken =>
+            {
+                startedTaskSource.TrySetResult();
+                return Task.CompletedTask;
+            },
+            cancellationTokenSource.Token);
+
+        try
+        {
+            await startedTaskSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(Directory.Exists(socketDirectoryPath));
+            Assert.True(File.Exists(endpoint.Address));
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            server.Release();
+            try
+            {
+                await serverTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        Assert.False(File.Exists(endpoint.Address));
+        Assert.False(Directory.Exists(socketDirectoryPath));
+    }
+
     private static IpcEndpoint CreateEndpoint (string storageRoot)
     {
         if (OperatingSystem.IsWindows())
         {
             return new IpcEndpoint(
                 IpcTransportKind.NamedPipe,
-                $"ucli-supervisor-transport-{Guid.NewGuid():N}");
+                $"{UcliIpcEndpointNames.SupervisorAddressPrefix}transport-{Guid.NewGuid():N}");
         }
 
         return new IpcEndpoint(
             IpcTransportKind.UnixDomainSocket,
-            $"/tmp/ucli-supervisor-transport-{Guid.NewGuid():N}.sock");
+            UnixSocketPathUtilities.BuildFallbackSocketPath(
+                UcliIpcEndpointNames.SupervisorAddressPrefix + "transport-",
+                storageRoot));
     }
 
     private static IpcRequest CreateRequest (string method)


### PR DESCRIPTION
## Summary
- daemon と supervisor の IPC に、OS レベルの同一ユーザー制限と sessionToken 照合の二段防御を実装しました。
- Unix の長経路 fallback は temp root 配下の専用 directory + `ipc.sock` に統一し、endpoint naming も共通化しました。
- Unity listener は Windows named pipe security と Unix socket access boundary に対応し、責務分離も進めました。

## Scope
- `src/Ucli/Storage` / `src/Ucli/Ipc` / `src/Ucli/Supervisor`: filesystem boundary helper、endpoint naming、fallback path、transport hardening、cleanup を更新。
- `src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Transport`: current-user named pipe security、Unix socket access boundary、fallback cleanup を実装。
- `tests/Ucli.Tests` / `src/Ucli.Unity/Assets/Tests`: endpoint、metadata ACL/permissions、supervisor sessionToken 拒否、transport cleanup の契約テストを追加。

## Verification
- `dotnet format src/Ucli.Contracts/Ucli.Contracts.csproj --verbosity minimal --verify-no-changes --no-restore`
- `dotnet format src/Ucli/Ucli.csproj --verbosity minimal --verify-no-changes --no-restore`
- `dotnet format tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal --verify-no-changes --no-restore`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore --filter "FullyQualifiedName~MackySoft.Ucli.Tests.Ipc.IpcEndpointResolverTests|FullyQualifiedName~MackySoft.Ucli.Tests.Supervisor.SupervisorEndpointResolverTests|FullyQualifiedName~MackySoft.Ucli.Tests.Daemon.DaemonSessionStoreTests|FullyQualifiedName~MackySoft.Ucli.Tests.Supervisor.SupervisorManifestStoreTests|FullyQualifiedName~MackySoft.Ucli.Tests.Supervisor.SupervisorTransportServerTests|FullyQualifiedName~MackySoft.Ucli.Tests.Daemon.DaemonArtifactCleanerTests|FullyQualifiedName~MackySoft.Ucli.Tests.Supervisor.SupervisorRequestDispatcherTests"`
  - 28 passed
- `Unity 2023.2.22f1 -batchmode -nographics -projectPath src/Ucli.Unity -logFile /tmp/ucli-meta-update.log`
  - `UnixSocketAccessBoundary.cs.meta` を正規生成
  - Unity の test run は既存 compile error（`OperationPolicy` / `JsonElement` 解決失敗）で未実施

## Risks / Rollback
- Windows named pipe の実接続境界は、この macOS 環境では実機確認していません。metadata ACL の契約テストは追加済みです。
- 問題が出た場合は `fc7bb7b` と `850486e` をまとめて戻すのが最短です。

## Checklist
- [x] daemon / supervisor の same-user IPC boundary を実装
- [x] endpoint naming と Unix fallback path を一元化
- [x] metadata と Unix socket の contract test を追加
- [ ] Windows runner で named pipe / ACL を実機確認
- [ ] Unity project 側の既存 compile error 解消後に EditMode tests を再実行

Closes #122
