### PR TITLE
fix(contracts): publish dispatch release in same run

### DIFF
--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -17,8 +17,10 @@ permissions:
 
 jobs:
   prepare-release:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+      tag_name: ${{ steps.version.outputs.tag_name }}
 
     steps:
       - name: Checkout
@@ -32,17 +34,28 @@ jobs:
         env:
           DISPATCH_VERSION: ${{ github.event.inputs.package_version }}
         run: |
-          package_version="${DISPATCH_VERSION}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            package_version="${DISPATCH_VERSION}"
+          else
+            tag_name="${GITHUB_REF_NAME}"
+            package_version="${tag_name#contracts/}"
+          fi
 
           if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
             exit 1
           fi
 
+          tag_name="contracts/${package_version}"
+
+          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
+          echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
+
       - name: Create and push release tag
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         env:
-          TAG_NAME: contracts/${{ github.event.inputs.package_version }}
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}
           RELEASE_SHA: ${{ github.sha }}
         run: |
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null; then
@@ -57,7 +70,7 @@ jobs:
           git push origin "refs/tags/${TAG_NAME}"
 
   publish:
-    if: github.event_name == 'push'
+    needs: prepare-release
     runs-on: ubuntu-latest
 
     steps:
@@ -65,31 +78,18 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.tag_name }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
-      - name: Resolve package version
-        id: version
-        shell: bash
-        run: |
-          tag_name="${GITHUB_REF_NAME}"
-          package_version="${tag_name#contracts/}"
-
-          if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-            exit 1
-          fi
-
-          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
-
       - name: Pack contracts
         run: >-
           dotnet pack src/Ucli.Contracts/Ucli.Contracts.csproj
           --configuration Release
-          -p:PackageVersion=${{ steps.version.outputs.package_version }}
+          -p:PackageVersion=${{ needs.prepare-release.outputs.package_version }}
           --output artifacts/packages
 
       - name: Publish to GitHub Packages
@@ -102,7 +102,7 @@ jobs:
       - name: Sync contracts package versions in repository
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
+          PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -126,7 +126,7 @@ done
 - `push` to `master` では変更差分を判定しつつ、実行 OS は `Linux` のみに絞って post-merge 検証を軽量化する。
 - `workflow_dispatch` は差分判定を使わず、`.NET`、Unity、contracts pack を常に `Linux`、`Windows`、`macOS` の 3 OS でフル検証する。
 - Unity 検証は `src/Ucli`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`scripts/update-local-contracts-package.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、`ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
-- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを作成して push するだけで、実際の publish と repository version sync は tag push で起動した同じ workflow 経路が担う。
+- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で同じ publish / repository version sync 処理まで継続する。
 - `contracts-package-publish` は公開後に `src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の `MackySoft.Ucli.Contracts` バージョンを同一値へ自動同期する。
 - タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`）。
 


### PR DESCRIPTION
## Summary
- workflow_dispatch でも contracts/<version> tag を作成した後、その同じ run の中で publish まで続行するようにした
- publish job は push tag と workflow_dispatch の両方で同じ経路を使うように統一した
- package-operations.md を新しい release 運用に合わせて更新した

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/contracts-package-publish.yaml")'
- git diff --check

Issueなし運用。