### PR TITLE
refactor(test-run): align internal boundaries around use case pipeline

### DIFF
--- a/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunErrorCodes.cs
+++ b/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunErrorCodes.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Defines machine-readable error codes used by test-run service results. </summary>
 internal static class TestRunErrorCodes

--- a/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunErrorKind.cs
+++ b/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunErrorKind.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Represents normalized test-run error kinds. </summary>
 internal enum TestRunErrorKind

--- a/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunExitCode.cs
+++ b/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunExitCode.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Defines process exit codes for test-run execution results. </summary>
 internal enum TestRunExitCode

--- a/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunResultKind.cs
+++ b/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunResultKind.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Represents normalized test-run result kinds. </summary>
 internal enum TestRunResultKind

--- a/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
+++ b/src/Ucli/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Represents normalized output returned from test-run core service. </summary>
 /// <param name="Result"> The pass/fail result when execution reaches test result evaluation; otherwise <see langword="null" />. </param>

--- a/src/Ucli/Features/Testing/Run/Configuration/ITestRunConfigurationResolver.cs
+++ b/src/Ucli/Features/Testing/Run/Configuration/ITestRunConfigurationResolver.cs
@@ -8,6 +8,6 @@ internal interface ITestRunConfigurationResolver
     /// <param name="cancellationToken"> A cancellation token propagated by caller. </param>
     /// <returns> A task that resolves to the configuration resolution result. </returns>
     ValueTask<TestRunConfigurationResolutionResult> Resolve (
-        TestRunCommandInput input,
+        TestRunConfigurationRequest input,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationMerger.cs
+++ b/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationMerger.cs
@@ -14,7 +14,7 @@ internal static class TestRunConfigurationMerger
     /// <param name="projectPath"> The resolved project path candidate selected before merge. </param>
     /// <returns> The merged normalized configuration. </returns>
     public static MergedTestRunConfiguration Merge (
-        TestRunCommandInput cli,
+        TestRunConfigurationRequest cli,
         TestRunProfile? profile,
         string projectPath)
     {
@@ -52,7 +52,7 @@ internal static class TestRunConfigurationMerger
     }
 
     private static UnityExecutionMode ResolveMode (
-        TestRunCommandInput cli)
+        TestRunConfigurationRequest cli)
     {
         ArgumentNullException.ThrowIfNull(cli);
 
@@ -65,7 +65,7 @@ internal static class TestRunConfigurationMerger
     }
 
     private static (string RawValue, TestRunPlatform? ParsedValue) ResolveTestPlatform (
-        TestRunCommandInput cli,
+        TestRunConfigurationRequest cli,
         TestRunProfile? profile)
     {
         ArgumentNullException.ThrowIfNull(cli);

--- a/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationRequest.cs
+++ b/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationRequest.cs
@@ -1,9 +1,9 @@
 using MackySoft.Ucli.Contracts.Testing;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 
-namespace MackySoft.Ucli.Features.Testing.Run;
+namespace MackySoft.Ucli.Features.Testing.Run.Configuration;
 
-/// <summary> Represents normalized CLI input values for test-run execution. </summary>
+/// <summary> Represents configuration-resolution input values for one test-run request. </summary>
 /// <param name="ProjectPath"> Optional Unity project root path. </param>
 /// <param name="ProfilePath"> Optional profile configuration path. </param>
 /// <param name="Mode"> Optional Unity execution-mode value. </param>
@@ -15,8 +15,7 @@ namespace MackySoft.Ucli.Features.Testing.Run;
 /// <param name="AssemblyName"> Optional assembly names parsed from the CLI option. </param>
 /// <param name="TestSettingsPath"> Optional path to <c>TestSettings.json</c>. </param>
 /// <param name="TimeoutMilliseconds"> Optional timeout in milliseconds. </param>
-/// <param name="FailFast"> Whether daemon-backed execution should fail immediately instead of waiting for lifecycle readiness. </param>
-internal sealed record TestRunCommandInput (
+internal sealed record TestRunConfigurationRequest (
     string? ProjectPath,
     string? ProfilePath,
     UnityExecutionMode? Mode,
@@ -27,5 +26,4 @@ internal sealed record TestRunCommandInput (
     string[]? TestCategory,
     string[]? AssemblyName,
     string? TestSettingsPath,
-    int? TimeoutMilliseconds,
-    bool FailFast = false);
+    int? TimeoutMilliseconds);

--- a/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationResolver.cs
+++ b/src/Ucli/Features/Testing/Run/Configuration/TestRunConfigurationResolver.cs
@@ -46,7 +46,7 @@ internal sealed class TestRunConfigurationResolver : ITestRunConfigurationResolv
     /// <param name="cancellationToken"> A cancellation token propagated by caller. </param>
     /// <returns> A task that resolves to the configuration resolution result. </returns>
     public async ValueTask<TestRunConfigurationResolutionResult> Resolve (
-        TestRunCommandInput input,
+        TestRunConfigurationRequest input,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -130,7 +130,7 @@ internal sealed class TestRunConfigurationResolver : ITestRunConfigurationResolv
     /// <param name="profile"> The optional loaded profile values. </param>
     /// <returns> The resolved project-path candidate. </returns>
     private string ResolveProjectPath (
-        TestRunCommandInput input,
+        TestRunConfigurationRequest input,
         TestRunProfile? profile)
     {
         ArgumentNullException.ThrowIfNull(input);

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/ITestRunService.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/ITestRunService.cs
@@ -1,10 +1,12 @@
-namespace MackySoft.Ucli.Features.Testing.Run.Service;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
 
 /// <summary> Executes core test-run flow and returns normalized result payload values. </summary>
 internal interface ITestRunService
 {
     /// <summary> Executes one test-run operation. </summary>
-    /// <param name="input"> The raw test-run command input. </param>
+    /// <param name="input"> The interpreted test-run command input. </param>
     /// <param name="cancellationToken"> A cancellation token propagated by command execution. </param>
     /// <returns> A task that resolves to the test-run service result. </returns>
     ValueTask<TestRunServiceResult> Execute (

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/ITestRunExecutionPipeline.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/ITestRunExecutionPipeline.cs
@@ -1,6 +1,6 @@
-using MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
 
 /// <summary> Executes the test-run artifacts, Unity execution, and conversion pipeline. </summary>
 internal interface ITestRunExecutionPipeline

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
@@ -6,7 +6,7 @@ using MackySoft.Ucli.Features.Testing.Run.Artifacts;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 using MackySoft.Ucli.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Results;
-using MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 using MackySoft.Ucli.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Shared.Execution.Process;
 using MackySoft.Ucli.Shared.Execution.Timeout;
@@ -14,7 +14,7 @@ using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
 
 /// <summary> Implements one test-run execution pipeline from artifacts preparation to conversion completion. </summary>
 internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipelineResult.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipelineResult.cs
@@ -3,7 +3,7 @@ using MackySoft.Ucli.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Results;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
 
 /// <summary> Represents one execution pipeline outcome. </summary>
 /// <param name="Session"> The run artifacts session when prepared; otherwise <see langword="null" />. </param>

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/ITestRunPreflightService.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/ITestRunPreflightService.cs
@@ -1,6 +1,8 @@
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
+
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 
 /// <summary> Resolves command input and execution mode prerequisites before test-run pipeline execution. </summary>
 internal interface ITestRunPreflightService

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunExecutionContext.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunExecutionContext.cs
@@ -1,7 +1,7 @@
 using MackySoft.Ucli.Contracts.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 
 /// <summary> Represents preflight-resolved execution context for test-run pipeline. </summary>
 /// <param name="Configuration"> The resolved test-run configuration. </param>

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightResult.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightResult.cs
@@ -1,4 +1,6 @@
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 
 /// <summary> Represents one preflight outcome for test-run execution. </summary>
 /// <param name="Context"> The resolved execution context when preflight succeeds; otherwise <see langword="null" />. </param>

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightService.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightService.cs
@@ -2,8 +2,9 @@ using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Features.Requests.Shared.Execution;
 using MackySoft.Ucli.Features.Requests.Shared.Preparation;
 using MackySoft.Ucli.Features.Requests.Shared.Validation.Parsing;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
-using MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Shared.Execution.Process;
@@ -12,7 +13,7 @@ using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
 
 /// <summary> Implements preflight flow for configuration resolution and execution-mode decision. </summary>
 internal sealed class TestRunPreflightService : ITestRunPreflightService
@@ -48,7 +49,9 @@ internal sealed class TestRunPreflightService : ITestRunPreflightService
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(input);
 
-        var configurationResolutionResult = await ResolveConfigurationSafely(input, cancellationToken).ConfigureAwait(false);
+        var configurationResolutionResult = await ResolveConfigurationSafely(
+            CreateConfigurationRequest(input),
+            cancellationToken).ConfigureAwait(false);
         if (!configurationResolutionResult.IsSuccess)
         {
             return TestRunPreflightResult.FailureResult(
@@ -107,7 +110,7 @@ internal sealed class TestRunPreflightService : ITestRunPreflightService
     /// <returns> A task that resolves to the configuration resolution result. </returns>
     /// <exception cref="OperationCanceledException"> Thrown when <paramref name="cancellationToken" /> is canceled during resolution. </exception>
     private async ValueTask<TestRunConfigurationResolutionResult> ResolveConfigurationSafely (
-        TestRunCommandInput input,
+        TestRunConfigurationRequest input,
         CancellationToken cancellationToken)
     {
         try
@@ -126,6 +129,24 @@ internal sealed class TestRunPreflightService : ITestRunPreflightService
                 ExecutionError.InternalError($"Unexpected error while resolving run configuration: {exception.Message}"),
             ]);
         }
+    }
+
+    private static TestRunConfigurationRequest CreateConfigurationRequest (TestRunCommandInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        return new TestRunConfigurationRequest(
+            ProjectPath: input.ProjectPath,
+            ProfilePath: input.ProfilePath,
+            Mode: input.Mode,
+            UnityVersion: input.UnityVersion,
+            UnityEditorPath: input.UnityEditorPath,
+            TestPlatform: input.TestPlatform,
+            TestFilter: input.TestFilter,
+            TestCategory: input.TestCategory,
+            AssemblyName: input.AssemblyName,
+            TestSettingsPath: input.TestSettingsPath,
+            TimeoutMilliseconds: input.TimeoutMilliseconds);
     }
 
 }

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/ITestRunResultMapper.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/ITestRunResultMapper.cs
@@ -1,6 +1,7 @@
-using MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 
 /// <summary> Maps pipeline outcomes into command-facing test-run service results. </summary>
 internal interface ITestRunResultMapper

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
@@ -1,11 +1,11 @@
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Features.Testing.Run.Artifacts;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Results;
-using MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
-using MackySoft.Ucli.Hosting.Cli;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 
 /// <summary> Implements mapping from pipeline outcomes to command-facing test-run results. </summary>
 internal sealed class TestRunResultMapper : ITestRunResultMapper

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/TestRunServiceErrorMapper.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/Projection/TestRunServiceErrorMapper.cs
@@ -1,9 +1,9 @@
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Features.Testing.Run.Artifacts;
-using MackySoft.Ucli.Hosting.Cli;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 
 /// <summary> Maps shared execution error contracts into command-facing test-run service results. </summary>
 internal static class TestRunServiceErrorMapper

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/TestRunCommandInput.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/TestRunCommandInput.cs
@@ -1,0 +1,31 @@
+using MackySoft.Ucli.Contracts.Testing;
+using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
+
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
+
+/// <summary> Represents normalized CLI input values for test-run execution. </summary>
+/// <param name="ProjectPath"> Optional Unity project root path. </param>
+/// <param name="ProfilePath"> Optional profile configuration path. </param>
+/// <param name="Mode"> Optional Unity execution-mode value. </param>
+/// <param name="UnityVersion"> Optional Unity version override. </param>
+/// <param name="UnityEditorPath"> Optional Unity editor executable path override. </param>
+/// <param name="TestPlatform"> Optional test-platform value. </param>
+/// <param name="TestFilter"> Optional Unity test filter pattern. </param>
+/// <param name="TestCategory"> Optional test categories parsed from the CLI option. </param>
+/// <param name="AssemblyName"> Optional assembly names parsed from the CLI option. </param>
+/// <param name="TestSettingsPath"> Optional path to <c>TestSettings.json</c>. </param>
+/// <param name="TimeoutMilliseconds"> Optional timeout in milliseconds. </param>
+/// <param name="FailFast"> Whether daemon-backed execution should fail immediately instead of waiting for lifecycle readiness. </param>
+internal sealed record TestRunCommandInput (
+    string? ProjectPath,
+    string? ProfilePath,
+    UnityExecutionMode? Mode,
+    string? UnityVersion,
+    string? UnityEditorPath,
+    TestRunPlatform? TestPlatform,
+    string? TestFilter,
+    string[]? TestCategory,
+    string[]? AssemblyName,
+    string? TestSettingsPath,
+    int? TimeoutMilliseconds,
+    bool FailFast = false);

--- a/src/Ucli/Features/Testing/Run/UseCases/TestRun/TestRunService.cs
+++ b/src/Ucli/Features/Testing/Run/UseCases/TestRun/TestRunService.cs
@@ -1,8 +1,9 @@
-using MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
-using MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
-using MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 
-namespace MackySoft.Ucli.Features.Testing.Run.Service;
+namespace MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
 
 /// <summary> Implements the core test-run orchestration flow. </summary>
 internal sealed class TestRunService : ITestRunService

--- a/src/Ucli/Hosting/Cli/TestRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/TestRunCommand.cs
@@ -1,7 +1,7 @@
 using ConsoleAppFramework;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Features.Testing.Run;
-using MackySoft.Ucli.Features.Testing.Run.Service;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
 using MackySoft.Ucli.Hosting.Cli.Options;
 
 namespace MackySoft.Ucli.Hosting.Cli;

--- a/src/Ucli/Hosting/Cli/TestRunCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/TestRunCommandResultFactory.cs
@@ -1,5 +1,5 @@
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Features.Testing.Run;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 
 namespace MackySoft.Ucli.Hosting.Cli;
 

--- a/src/Ucli/Hosting/Composition/TestingServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/TestingServiceCollectionExtensions.cs
@@ -3,10 +3,10 @@ using MackySoft.Ucli.Features.Testing.Run.Artifacts;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 using MackySoft.Ucli.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Results;
-using MackySoft.Ucli.Features.Testing.Run.Service;
-using MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
-using MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
-using MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MackySoft.Ucli.Hosting.Composition;

--- a/tests/Ucli.Tests/Features/Testing/Run/Configuration/TestRunConfigurationResolverTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/Configuration/TestRunConfigurationResolverTests.cs
@@ -1,6 +1,5 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Testing;
-using MackySoft.Ucli.Features.Testing.Run;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 using MackySoft.Ucli.Shared.EnvironmentVariables;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
@@ -47,7 +46,7 @@ public sealed class TestRunConfigurationResolverTests
             unityVersionResolver,
             unityEditorPathResolver);
 
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: unityProject.UnityProjectRoot,
             ProfilePath: scope.GetPath("test.profile.json"),
             Mode: NormalizeMode("oneshot"),
@@ -105,7 +104,7 @@ public sealed class TestRunConfigurationResolverTests
             new StubUnityVersionResolver(UnityVersionResolutionResult.Success("6000.1.4f1")),
             new StubUnityEditorPathResolver(UnityEditorPathResolutionResult.Success(scope.GetPath("Editors/6000.1.4f1/Editor/Unity"))));
 
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: null,
             ProfilePath: scope.GetPath("test.profile.json"),
             Mode: NormalizeMode("auto"),
@@ -155,7 +154,7 @@ public sealed class TestRunConfigurationResolverTests
             new StubUnityVersionResolver(UnityVersionResolutionResult.Success("6000.1.4f1")),
             new StubUnityEditorPathResolver(UnityEditorPathResolutionResult.Success(scope.GetPath("Editors/6000.1.4f1/Editor/Unity"))));
 
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: commandProjectPath,
             ProfilePath: scope.GetPath("test.profile.json"),
             Mode: NormalizeMode("auto"),
@@ -181,7 +180,7 @@ public sealed class TestRunConfigurationResolverTests
         using var scope = TestDirectories.CreateTempScope("test-run-config-resolver", "player-target");
 
         var resolver = CreateResolverWithSuccessfulDependencies(scope);
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: scope.GetPath("Unity"),
             ProfilePath: null,
             Mode: NormalizeMode("auto"),
@@ -209,7 +208,7 @@ public sealed class TestRunConfigurationResolverTests
         using var scope = TestDirectories.CreateTempScope("test-run-config-resolver", $"timeout-{timeoutMilliseconds}");
 
         var resolver = CreateResolverWithSuccessfulDependencies(scope);
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: scope.GetPath("Unity"),
             ProfilePath: null,
             Mode: NormalizeMode("auto"),
@@ -237,7 +236,7 @@ public sealed class TestRunConfigurationResolverTests
         using var scope = TestDirectories.CreateTempScope("test-run-config-resolver", "missing-test-settings");
 
         var resolver = CreateResolverWithSuccessfulDependencies(scope);
-        var input = new TestRunCommandInput(
+        var input = new TestRunConfigurationRequest(
             ProjectPath: scope.GetPath("Unity"),
             ProfilePath: null,
             Mode: NormalizeMode("auto"),

--- a/tests/Ucli.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
@@ -1,0 +1,83 @@
+using MackySoft.Ucli.Features.Testing.Run.Artifacts;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+using MackySoft.Ucli.Features.Testing.Run.Execution;
+using MackySoft.Ucli.Features.Testing.Run.Results;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
+using MackySoft.Ucli.Shared.Foundation;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class TestRunResultMapperTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Map_WithIpcTimeoutExecutionFailure_ReturnsToolErrorWithArtifactsContext ()
+    {
+        var session = CreateSession();
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Success(
+            session,
+            UnityTestExecutionResult.Failure(
+                UnityTestExecutionFailureKind.IpcTimedOut,
+                "Unity daemon test run request timed out."),
+            UnityResultsConversionResult.Success(false)));
+
+        Assert.Null(result.Result);
+        Assert.Equal(TestRunErrorKind.ToolError, result.ErrorKind);
+        Assert.Equal((int)TestRunExitCode.ToolError, result.ExitCode);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, result.ErrorCode);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Map_WithCompletionErrorAfterFailedTests_PrefersFailedTestsOutcome ()
+    {
+        var session = CreateSession();
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Failure(
+            ExecutionError.InternalError("Failed to finalize artifacts."),
+            session,
+            UnityTestExecutionResult.Success(0),
+            UnityResultsConversionResult.Success(true)));
+
+        Assert.Equal(TestRunResultKind.Fail, result.Result);
+        Assert.Null(result.ErrorKind);
+        Assert.Equal((int)TestRunExitCode.Fail, result.ExitCode);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Map_WithPipelineErrorAndSession_PreservesArtifactsContext ()
+    {
+        var session = CreateSession();
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Failure(
+            ExecutionError.InternalError("Unexpected execution pipeline state."),
+            session));
+
+        Assert.Null(result.Result);
+        Assert.Equal(TestRunErrorKind.InfraError, result.ErrorKind);
+        Assert.Equal((int)TestRunExitCode.InfraError, result.ExitCode);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
+    private static ArtifactsSession CreateSession ()
+    {
+        return new ArtifactsSession(
+            "run-id",
+            new ArtifactPaths("/tmp/ucli-tests/run-id"),
+            DateTimeOffset.Parse("2026-04-21T00:00:00Z"));
+    }
+}

--- a/tests/Ucli.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
@@ -5,15 +5,15 @@ using MackySoft.Ucli.Contracts.Testing;
 using MackySoft.Ucli.Features.Requests.Shared.Execution;
 using MackySoft.Ucli.Features.Requests.Shared.Preparation;
 using MackySoft.Ucli.Features.Requests.Shared.Validation.Parsing;
-using MackySoft.Ucli.Features.Testing.Run;
 using MackySoft.Ucli.Features.Testing.Run.Artifacts;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Features.Testing.Run.Configuration;
 using MackySoft.Ucli.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Features.Testing.Run.Results;
-using MackySoft.Ucli.Features.Testing.Run.Service;
-using MackySoft.Ucli.Features.Testing.Run.Service.Mapping;
-using MackySoft.Ucli.Features.Testing.Run.Service.Pipeline;
-using MackySoft.Ucli.Features.Testing.Run.Service.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Pipeline;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Preflight;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun.Projection;
 using MackySoft.Ucli.Hosting.Cli;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Execution.Lifecycle;
@@ -678,7 +678,7 @@ public sealed class TestRunServiceTests
         }
 
         public ValueTask<TestRunConfigurationResolutionResult> Resolve (
-            TestRunCommandInput input,
+            TestRunConfigurationRequest input,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.Features.Testing.Run;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli;
 
 namespace MackySoft.Ucli.Tests;

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
@@ -1,8 +1,8 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Testing;
-using MackySoft.Ucli.Features.Testing.Run;
-using MackySoft.Ucli.Features.Testing.Run.Service;
+using MackySoft.Ucli.Features.Testing.Run.Common.Contracts;
+using MackySoft.Ucli.Features.Testing.Run.UseCases.TestRun;
 using MackySoft.Ucli.Hosting.Cli;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 


### PR DESCRIPTION
## Summary
- `Features/Testing/Run` の内部責務を整理し、共有契約を `Common/Contracts` へ、orchestration / preflight / pipeline / projection を `UseCases/TestRun` へ再配置しました。
- `Configuration` が `UseCases` を直接参照しないように `TestRunConfigurationRequest` を導入し、境界方向を固定しました。
- `TestRunResultMapper` の直接テストを追加し、artifact 文脈保持と result 優先順位の契約を固定しました。

## Scope
- `src/Ucli/Features/Testing/Run/Common/Contracts`: test run の共有契約型を集約
- `src/Ucli/Features/Testing/Run/UseCases/TestRun`: service / preflight / pipeline / projection の owner を集約
- `src/Ucli/Features/Testing/Run/Configuration`: `TestRunConfigurationRequest` 導入と依存方向の整理
- `src/Ucli/Hosting/Cli/TestRunCommand.cs`, `src/Ucli/Hosting/Composition/TestingServiceCollectionExtensions.cs`: 新 owner への追随
- `tests/Ucli.Tests/Features/Testing/Run/UseCases/TestRun`: 構造追随と `TestRunResultMapperTests` の追加

## Verification
- `dotnet restore Ucli.slnx`
- `dotnet format Ucli.slnx --verbosity minimal --no-restore`
- `dotnet format Ucli.slnx --verbosity minimal --verify-no-changes --no-restore`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --verbosity minimal`  (`1018` passed)
- `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --verbosity minimal`  (`448` passed)

## Risks / Rollback
- 外部契約は変更していないため、リスクは `Testing/Run` 内部の namespace / DI 配線追随漏れに限られます。
- 問題があればこの PR を revert すれば元の owner に戻せます。

## Checklist
- [x] `TestRunService` を orchestration owner に限定
- [x] `Configuration` から `UseCases` 依存を除去
- [x] `TestRunResultMapper` の直接テストを追加
- [x] format / tests を通過

Issue: none (ad-hoc task)
