### PR TITLE
refactor(ucli): share read-index helpers across execution layers

### DIFF
--- a/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
+++ b/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
@@ -9,7 +9,6 @@ using MackySoft.Ucli.Shared.Execution.Process;
 using MackySoft.Ucli.Shared.Execution.Timeout;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
-using MackySoft.Ucli.UnityIntegration.Indexing.Core;
 using MackySoft.Ucli.UnityIntegration.Ipc.Transport;
 
 namespace MackySoft.Ucli.Features.OperationCatalog.Catalog.Source;

--- a/src/Ucli/Features/OperationCatalog/UseCases/Ops/Preflight/OpsPreflightService.cs
+++ b/src/Ucli/Features/OperationCatalog/UseCases/Ops/Preflight/OpsPreflightService.cs
@@ -12,7 +12,6 @@ using MackySoft.Ucli.Shared.Execution.Timeout;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 namespace MackySoft.Ucli.Features.OperationCatalog.UseCases.Ops.Preflight;
 

--- a/src/Ucli/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolver.cs
+++ b/src/Ucli/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolver.cs
@@ -2,7 +2,6 @@ using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Features.OperationCatalog.Catalog.Source;
-using MackySoft.Ucli.UnityIntegration.Indexing.Core;
 
 namespace MackySoft.Ucli.Features.Requests.Shared.OperationMetadata;
 

--- a/src/Ucli/Features/Requests/Shared/Preparation/RequestStaticValidationPreflightService.cs
+++ b/src/Ucli/Features/Requests/Shared/Preparation/RequestStaticValidationPreflightService.cs
@@ -4,7 +4,6 @@ using MackySoft.Ucli.Features.Requests.Shared.OperationMetadata;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 namespace MackySoft.Ucli.Features.Requests.Shared.Preparation;
 

--- a/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessEvaluationResult.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessEvaluationResult.cs
@@ -1,6 +1,6 @@
 using MackySoft.Ucli.Contracts.Index;
 
-namespace MackySoft.Ucli.UnityIntegration.Indexing.Core;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Represents one index freshness evaluation result. </summary>
 /// <param name="Freshness"> The evaluated freshness value. </param>

--- a/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessPolicy.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessPolicy.cs
@@ -2,7 +2,7 @@ using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Ipc;
 
-namespace MackySoft.Ucli.UnityIntegration.Indexing.Core;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Provides read-index freshness policy evaluation and mode constraints. </summary>
 internal static class IndexFreshnessPolicy

--- a/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessTarget.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexFreshnessTarget.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.UnityIntegration.Indexing.Core;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Identifies one read-index artifact whose freshness is evaluated against current project inputs. </summary>
 internal enum IndexFreshnessTarget

--- a/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexServiceError.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Freshness/IndexServiceError.cs
@@ -1,4 +1,4 @@
-namespace MackySoft.Ucli.UnityIntegration.Indexing.Core;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Represents one machine-readable index service error. </summary>
 /// <param name="Code"> The error code. </param>

--- a/src/Ucli/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolutionResult.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolutionResult.cs
@@ -1,7 +1,7 @@
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Represents one read-index mode resolution result. </summary>
 /// <param name="Mode"> The resolved mode on success; otherwise <see langword="null" />. </param>

--- a/src/Ucli/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolver.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolver.cs
@@ -2,7 +2,7 @@ using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Foundation;
 
-namespace MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Resolves effective read-index mode from command options and config defaults. </summary>
 internal static class ReadIndexModeResolver

--- a/src/Ucli/Shared/Execution/ReadIndex/Validation/IndexCatalogContractValidator.cs
+++ b/src/Ucli/Shared/Execution/ReadIndex/Validation/IndexCatalogContractValidator.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Index;
 
-namespace MackySoft.Ucli.UnityIntegration.Indexing.Core;
+namespace MackySoft.Ucli.Shared.Execution.ReadIndex;
 
 /// <summary> Validates read-index catalog contracts loaded from persistent storage. </summary>
 internal static class IndexCatalogContractValidator

--- a/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogReaderTests.cs
+++ b/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogReaderTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using MackySoft.Ucli.Contracts;
+using MackySoft.Ucli.Contracts.Configuration;
+using MackySoft.Ucli.Contracts.Index;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Features.OperationCatalog.Catalog.Source;
+using MackySoft.Ucli.Shared.Configuration;
+using MackySoft.Ucli.Shared.Context.Project;
+using MackySoft.Ucli.Shared.Execution.UnityRequest;
+using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
+
+namespace MackySoft.Ucli.Tests.Ops.Source;
+
+public sealed class OpsCatalogReaderTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenResponseIsSuccessful_ReturnsCatalogPayload ()
+    {
+        var executor = new StubUnityRequestExecutor
+        {
+            Result = UnityRequestExecutionResult.Success(CreateResponse(
+                IpcProtocol.StatusOk,
+                Array.Empty<IpcError>(),
+                new IpcOpsReadResponse(
+                    DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+                    [
+                        new IndexOpEntryJsonContract(
+                            Name: UcliPrimitiveOperationNames.GoDescribe,
+                            Kind: "query",
+                            Policy: "safe",
+                            ArgsSchemaJson: """{"type":"object"}"""),
+                    ]))),
+        };
+        var reader = new OpsCatalogReader(executor);
+
+        var result = await reader.Read(
+            CreateProjectContext(),
+            UcliConfig.CreateDefault(),
+            UnityExecutionMode.Daemon,
+            TimeSpan.FromMilliseconds(1200),
+            failFast: true,
+            requireReadinessGate: false,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Response);
+        Assert.Single(result.Response.Operations!);
+        Assert.Equal(UcliPrimitiveOperationNames.GoDescribe, result.Response.Operations![0].Name);
+        Assert.Equal(UcliCommandIds.Ops, executor.Command.Name);
+        Assert.Equal(IpcMethodNames.OpsRead, executor.Method);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenResponseContainsIpcFailure_ReturnsFailure ()
+    {
+        var executor = new StubUnityRequestExecutor
+        {
+            Result = UnityRequestExecutionResult.Success(CreateResponse(
+                IpcProtocol.StatusError,
+                [
+                    new IpcError(
+                        IpcErrorCodes.InvalidArgument,
+                        "invalid request",
+                        null),
+                ],
+                new { })),
+        };
+        var reader = new OpsCatalogReader(executor);
+
+        var result = await reader.Read(
+            CreateProjectContext(),
+            UcliConfig.CreateDefault(),
+            UnityExecutionMode.Auto,
+            TimeSpan.FromMilliseconds(1200),
+            failFast: false,
+            requireReadinessGate: true,
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(IpcErrorCodes.InvalidArgument, result.ErrorCode);
+        Assert.Equal("invalid request", result.Message);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenPayloadIsMalformed_ReturnsFailure ()
+    {
+        var executor = new StubUnityRequestExecutor
+        {
+            Result = UnityRequestExecutionResult.Success(CreateResponse(
+                IpcProtocol.StatusOk,
+                Array.Empty<IpcError>(),
+                new
+                {
+                    generatedAtUtc = "2026-03-07T00:00:00+00:00",
+                })),
+        };
+        var reader = new OpsCatalogReader(executor);
+
+        var result = await reader.Read(
+            CreateProjectContext(),
+            UcliConfig.CreateDefault(),
+            UnityExecutionMode.Auto,
+            TimeSpan.FromMilliseconds(1200),
+            failFast: false,
+            requireReadinessGate: false,
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(IpcErrorCodes.InternalError, result.ErrorCode);
+        Assert.Contains("payload is invalid", result.Message, StringComparison.Ordinal);
+    }
+
+    private static ResolvedUnityProjectContext CreateProjectContext ()
+    {
+        return new ResolvedUnityProjectContext(
+            UnityProjectRoot: "/repo/UnityProject",
+            RepositoryRoot: "/repo",
+            ProjectFingerprint: "project-fingerprint",
+            PathSource: UnityProjectPathSource.CommandOption);
+    }
+
+    private static IpcResponse CreateResponse (
+        string status,
+        IReadOnlyList<IpcError> errors,
+        object payload)
+    {
+        return new IpcResponse(
+            IpcProtocol.CurrentVersion,
+            "req-ops-1",
+            status,
+            IpcPayloadCodec.SerializeToElement(payload),
+            errors);
+    }
+
+    private sealed class StubUnityRequestExecutor : IUnityRequestExecutor
+    {
+        public UnityRequestExecutionResult Result { get; set; } = null!;
+
+        public UcliCommand Command { get; private set; } = new("pending");
+
+        public string Method { get; private set; } = string.Empty;
+
+        public ValueTask<UnityRequestExecutionResult> Execute (
+            UcliCommand command,
+            UnityExecutionMode mode,
+            TimeSpan timeout,
+            UcliConfig config,
+            ResolvedUnityProjectContext unityProject,
+            string method,
+            JsonElement payload,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Command = command;
+            Method = method;
+            return ValueTask.FromResult(Result);
+        }
+    }
+}

--- a/tests/Ucli.Tests/Features/OperationCatalog/UseCases/Ops/Preflight/OpsPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Features/OperationCatalog/UseCases/Ops/Preflight/OpsPreflightServiceTests.cs
@@ -9,10 +9,10 @@ using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Context;
 using MackySoft.Ucli.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Shared.Execution.Process;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Execution.Timeout;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 using MackySoft.Ucli.Shared.Context.Project;
 using static MackySoft.Ucli.Tests.Helpers.Cli.CommandOptionNormalizationTestHelper;
 

--- a/tests/Ucli.Tests/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolverTests.cs
+++ b/tests/Ucli.Tests/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolverTests.cs
@@ -3,8 +3,9 @@ using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Features.OperationCatalog.Catalog.Source;
 using MackySoft.Ucli.Features.Requests.Shared.OperationMetadata;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Context.Project;
+using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 namespace MackySoft.Ucli.Tests;
 

--- a/tests/Ucli.Tests/Features/Requests/Shared/Preparation/RequestStaticValidationPreflightServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Requests/Shared/Preparation/RequestStaticValidationPreflightServiceTests.cs
@@ -7,8 +7,8 @@ using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Requests.Input;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Context;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 using MackySoft.Ucli.Shared.Context.Project;
 
 namespace MackySoft.Ucli.Tests;

--- a/tests/Ucli.Tests/Hosting/Cli/PlanCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/PlanCommandTests.cs
@@ -9,8 +9,8 @@ using MackySoft.Ucli.Features.Requests.Shared.OperationMetadata;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Requests;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 namespace MackySoft.Ucli.Tests;
 

--- a/tests/Ucli.Tests/ProjectContextResolverTests.cs
+++ b/tests/Ucli.Tests/ProjectContextResolverTests.cs
@@ -6,7 +6,7 @@ using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Context;
 using MackySoft.Ucli.Shared.EnvironmentVariables;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Context.Project;
 using MackySoft.Ucli.UnityIntegration.Project.Resolution;
 

--- a/tests/Ucli.Tests/Shared/Execution/ReadIndex/Freshness/IndexFreshnessPolicyTests.cs
+++ b/tests/Ucli.Tests/Shared/Execution/ReadIndex/Freshness/IndexFreshnessPolicyTests.cs
@@ -1,9 +1,8 @@
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Ipc;
-using MackySoft.Ucli.UnityIntegration.Indexing.Core;
 
-namespace MackySoft.Ucli.Tests.Index;
+namespace MackySoft.Ucli.Tests.Execution.ReadIndex;
 
 public sealed class IndexFreshnessPolicyTests
 {

--- a/tests/Ucli.Tests/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolverTests.cs
+++ b/tests/Ucli.Tests/Shared/Execution/ReadIndex/Mode/ReadIndexModeResolverTests.cs
@@ -1,9 +1,8 @@
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
-namespace MackySoft.Ucli.Tests.ReadIndex;
+namespace MackySoft.Ucli.Tests.Execution.ReadIndex;
 
 public sealed class ReadIndexModeResolverTests
 {

--- a/tests/Ucli.Tests/Shared/Execution/ReadIndex/Validation/IndexCatalogContractValidatorTests.cs
+++ b/tests/Ucli.Tests/Shared/Execution/ReadIndex/Validation/IndexCatalogContractValidatorTests.cs
@@ -1,7 +1,6 @@
 using MackySoft.Ucli.Contracts.Index;
-using MackySoft.Ucli.UnityIntegration.Indexing.Core;
 
-namespace MackySoft.Ucli.Tests.Index;
+namespace MackySoft.Ucli.Tests.Execution.ReadIndex;
 
 public sealed class IndexCatalogContractValidatorTests
 {

--- a/tests/Ucli.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
+++ b/tests/Ucli.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
@@ -6,11 +6,11 @@ using MackySoft.Ucli.Features.Requests.Shared.Validation.Parsing;
 using MackySoft.Ucli.Shared.Configuration;
 using MackySoft.Ucli.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Shared.Execution.Process;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Execution.Timeout;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 namespace MackySoft.Ucli.Tests.Execution.Timeout;
 

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -4,8 +4,8 @@ using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Shared.Configuration;
+using MackySoft.Ucli.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Shared.Foundation;
-using MackySoft.Ucli.UnityIntegration.Indexing.ReadIndex;
 
 public sealed class UcliConfigStoreTests
 {


### PR DESCRIPTION
## Summary
- Share read-index mode, freshness, and contract-validation helpers under `Shared.Execution.ReadIndex` instead of keeping them under `UnityIntegration.Indexing`.
- Remove direct `UnityIntegration.Indexing` dependencies from `Features/Requests` and `Features/OperationCatalog`.
- Add focused unit coverage for `OpsCatalogReader` and move existing helper tests to the shared owner.

## Scope
- Move read-index helper types into `src/Ucli/Shared/Execution/ReadIndex/{Mode,Freshness,Validation}` and update feature consumers to use the shared owner.
- Keep UnityIntegration implementations in place, but retarget their internal consumers to the shared helper namespace.
- Update affected tests and add `tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogReaderTests.cs` for success, IPC failure, and malformed payload handling.

## Verification
- Gate level: Standard
- Diff budget: PASS (22 files, but the change is a single owner-move refactor with test relocation)
- Spec drift: Skipped (`docs/agents/refactor_read-index-shared-helpers/spec.md` not found)
- Format: PASS (`dotnet format src/Ucli/Ucli.csproj --verbosity minimal --no-restore`; `dotnet format src/Ucli/Ucli.csproj --verbosity minimal --verify-no-changes --no-restore`)
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --no-restore`)
- Coverage: N/A

## Risks / Rollback
- Main risk is namespace drift in remaining read-index consumers, mitigated by the full `Ucli.Tests` run and the new `OpsCatalogReader` coverage.
- Rollback is a straight revert of commit `8363709`.

## Checklist
- [x] read-index helper / policy owner is fixed under `Shared.Execution.ReadIndex`
- [x] `Features/Requests` and `Features/OperationCatalog` no longer reference `UnityIntegration.Indexing`
- [x] affected unit tests and new `OpsCatalogReader` tests pass

Issue: none (ad-hoc task)
