### PR TITLE
chore(contracts): sync package version to 0.18.0

### DIFF
--- a/src/Ucli.Contracts/Ucli.Contracts.csproj
+++ b/src/Ucli.Contracts/Ucli.Contracts.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Contracts</PackageId>
-    <Version>0.17.0</Version>
+    <Version>0.18.0</Version>
     <Description>Shared contract types for uCLI IPC protocol.</Description>
     <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;ipc</PackageTags>

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.17.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.18.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.Extensions.DependencyInjection" version="6.0.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" targetFramework="netstandard2.0" />


### PR DESCRIPTION
## Summary
- Sync MackySoft.Ucli.Contracts package version to 0.18.0 in the contracts project and Unity packages.config.
- Follow up for contracts-package-publish run 25014102050, where publish succeeded but direct master version sync was blocked by repository rules.

## Verification
- dotnet restore src/Ucli.Contracts/Ucli.Contracts.csproj
- dotnet pack src/Ucli.Contracts/Ucli.Contracts.csproj --configuration Release --no-restore -p:PackageVersion=0.18.0 --output /tmp/ucli-contracts-pack-0.18.0
- git diff --check