### PR TITLE
ci(contracts): create release sync pull request

### DIFF
--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -12,8 +12,10 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
   prepare-release:
@@ -99,16 +101,20 @@ jobs:
           --api-key "${{ secrets.GITHUB_TOKEN }}"
           --skip-duplicate
 
-      - name: Sync contracts package versions in repository
+      - name: Create contracts package version sync pull request
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
           PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin "${DEFAULT_BRANCH}"
-          git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
+          sync_branch="chore/contracts-sync-${PACKAGE_VERSION}"
+          git checkout -B "${sync_branch}" "origin/${DEFAULT_BRANCH}"
 
           csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
           unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
@@ -140,4 +146,41 @@ jobs:
 
           git add "${csproj_path}" "${unity_packages_config_path}"
           git commit -m "chore(contracts): sync package version to ${PACKAGE_VERSION}"
-          git push origin "HEAD:${DEFAULT_BRANCH}"
+          if git ls-remote --exit-code --heads origin "${sync_branch}" >/dev/null; then
+            git fetch origin "${sync_branch}:refs/remotes/origin/${sync_branch}"
+            remote_sync_sha="$(git rev-parse "refs/remotes/origin/${sync_branch}")"
+            git push --force-with-lease="refs/heads/${sync_branch}:${remote_sync_sha}" origin "HEAD:${sync_branch}"
+          else
+            git push origin "HEAD:${sync_branch}"
+          fi
+
+          existing_pr_url="$(gh pr list \
+            --repo "${REPOSITORY}" \
+            --state open \
+            --head "${sync_branch}" \
+            --json url \
+            --jq '.[0].url // empty')"
+          if [[ -n "${existing_pr_url}" ]]; then
+            echo "Contracts version sync pull request already exists: ${existing_pr_url}"
+          else
+            pr_body="$(cat <<EOF
+          ## Summary
+          - Sync \`MackySoft.Ucli.Contracts\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish.
+          - Update \`${csproj_path}\` and \`${unity_packages_config_path}\`.
+
+          ## Verification
+          - \`contracts-package-publish\` packed and published \`${RELEASE_TAG}\` before creating this PR.
+          - \`verify\` workflow was dispatched for \`${sync_branch}\`.
+          EOF
+          )"
+            gh pr create \
+              --repo "${REPOSITORY}" \
+              --base "${DEFAULT_BRANCH}" \
+              --head "${sync_branch}" \
+              --title "chore(contracts): sync package version to ${PACKAGE_VERSION}" \
+              --body "${pr_body}"
+          fi
+
+          gh workflow run verify.yaml \
+            --repo "${REPOSITORY}" \
+            --ref "${sync_branch}"

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -126,8 +126,8 @@ done
 - `push` to `master` では変更差分を判定しつつ、実行 OS は `Linux` のみに絞って post-merge 検証を軽量化する。
 - `workflow_dispatch` は差分判定を使わず、`.NET`、Unity、contracts pack を常に `Linux`、`Windows`、`macOS` の 3 OS でフル検証する。
 - Unity 検証は `src/Ucli`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`scripts/update-local-contracts-package.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、`ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
-- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で同じ publish / repository version sync 処理まで継続する。
-- `contracts-package-publish` は公開後に `src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の `MackySoft.Ucli.Contracts` バージョンを同一値へ自動同期する。
+- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で同じ publish / repository version sync PR 作成まで継続する。
+- `contracts-package-publish` は公開後に `chore/contracts-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の `MackySoft.Ucli.Contracts` バージョンを同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`）。
 
 ```bash


### PR DESCRIPTION
## Summary
- Change `contracts-package-publish` so package version repository sync is done through a generated pull request instead of direct push to `master`.
- Grant the workflow `actions: write` and `pull-requests: write`, then explicitly dispatch `verify.yaml` for the generated sync branch.
- Update package operations documentation to describe the PR-based sync flow.

## Verification
- `git diff --check origin/master...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/contracts-package-publish.yaml"); puts "yaml ok"'`
- `ruby -e 'require "yaml"; steps=YAML.load_file(".github/workflows/contracts-package-publish.yaml")["jobs"]["publish"]["steps"]; print steps.find{|s| s["name"] == "Create contracts package version sync pull request"}["run"]' | bash -n`
- `dotnet restore src/Ucli.Contracts/Ucli.Contracts.csproj`

Issueなし運用。