### PR TITLE
Fix release command verification blockers

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -338,6 +338,12 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('Ucli.slnx', '**/*.csproj') }}
+
       - name: Setup Mono on Linux
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -402,12 +408,6 @@ jobs:
           license: personal
           username: ${{ secrets.UNITY_EMAIL }}
           password: ${{ secrets.UNITY_PASSWORD }}
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('Ucli.slnx', '**/*.csproj') }}
 
       - name: Restore uCLI
         run: dotnet restore src/Ucli/Ucli.csproj

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/ComponentSchemaExtractor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/ComponentSchemaExtractor.cs
@@ -94,11 +94,7 @@ namespace MackySoft.Ucli.Unity.Index
                 {
                     hideFlags = HideFlags.HideAndDontSave,
                 };
-                var component = host.AddComponent(componentType);
-                if (component == null)
-                {
-                    throw new InvalidOperationException($"Failed to create component instance. type={componentType.FullName}");
-                }
+                var component = CreateComponentInstance(host, componentType);
 
                 var serializedObject = new SerializedObject(component);
                 propertyResult = schemaPropertyCollector.Collect(componentType, serializedObject);
@@ -122,6 +118,24 @@ namespace MackySoft.Ucli.Unity.Index
         {
             var typeId = IndexTypeIdFormatter.Format(componentType);
             return $"{IndexSchemaKindValues.Comp}:{typeId}";
+        }
+
+        private static Component CreateComponentInstance (
+            GameObject host,
+            Type componentType)
+        {
+            if (componentType == typeof(Transform))
+            {
+                return host.transform;
+            }
+
+            var component = host.AddComponent(componentType);
+            if (component == null)
+            {
+                throw new InvalidOperationException($"Failed to create component instance. type={componentType.FullName}");
+            }
+
+            return component;
         }
 
         private static bool IsValidComponentType (Type componentType)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CompOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CompOperationTests.cs
@@ -1075,6 +1075,33 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(schema.GetProperty("properties").ToString(), Does.Contain("\"path\":\"integerValue\""));
         });
 
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Schema_Plan_WhenTypeIsTransform_ReturnsSchemaResult () => UniTask.ToCoroutine(async () =>
+        {
+            var operation = new CompSchemaOperation();
+            var typeId = IndexTypeIdFormatter.Format(typeof(Transform));
+            var requestOperation = CreateOperation(
+                opId: "op-schema",
+                opName: UcliPrimitiveOperationNames.CompSchema,
+                args: new
+                {
+                    type = typeId,
+                });
+
+            using var executionContext = new OperationExecutionContext();
+            var result = await operation.Plan(requestOperation, executionContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True, result.Failure?.Message);
+            Assert.That(result.Result.HasValue, Is.True);
+            var schema = result.Result!.Value;
+            Assert.That(schema.GetProperty("schemaKey").GetString(), Is.EqualTo($"comp:{typeId}"));
+            Assert.That(schema.GetProperty("kind").GetString(), Is.EqualTo("comp"));
+            Assert.That(schema.GetProperty("typeId").GetString(), Is.EqualTo(typeId));
+            Assert.That(schema.GetProperty("displayName").GetString(), Is.EqualTo(nameof(Transform)));
+            Assert.That(schema.GetProperty("properties").ValueKind, Is.EqualTo(JsonValueKind.Array));
+        });
+
         private static NormalizedOperation CreateOperation (
             string opId,
             string opName,

--- a/src/Ucli/Hosting/Cli/Requests/Input/RequestInputReader.cs
+++ b/src/Ucli/Hosting/Cli/Requests/Input/RequestInputReader.cs
@@ -49,14 +49,23 @@ internal sealed class RequestInputReader : IRequestInputReader
         var hasRequestPath = !string.IsNullOrWhiteSpace(requestPath);
         var hasRedirectedStandardInput = isStandardInputRedirected();
 
-        if (hasRequestPath && hasRedirectedStandardInput)
-        {
-            return RequestInputReadResult.Failure(ExecutionError.InvalidArgument(
-                "Request input source is ambiguous. Specify either --requestPath or redirected standard input."));
-        }
-
         if (hasRequestPath)
         {
+            if (hasRedirectedStandardInput)
+            {
+                var standardInputResult = await ReadStandardInputForSourceSelectionAsync(cancellationToken);
+                if (!standardInputResult.IsSuccess)
+                {
+                    return RequestInputReadResult.Failure(standardInputResult.Error!);
+                }
+
+                if (!string.IsNullOrWhiteSpace(standardInputResult.Json))
+                {
+                    return RequestInputReadResult.Failure(ExecutionError.InvalidArgument(
+                        "Request input source is ambiguous. Specify either --requestPath or redirected standard input."));
+                }
+            }
+
             return await ReadFromRequestPathAsync(requestPath!, cancellationToken);
         }
 
@@ -86,6 +95,24 @@ internal sealed class RequestInputReader : IRequestInputReader
         }
 
         return ValidateJson(json, RequestInputSource.StandardInput, "standard input");
+    }
+
+    /// <summary> Reads redirected standard input only to decide whether it carries request content. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result used for source selection. </returns>
+    private async ValueTask<(bool IsSuccess, string? Json, ExecutionError? Error)> ReadStandardInputForSourceSelectionAsync (
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = await readStandardInputAsync(cancellationToken);
+            return (true, json, null);
+        }
+        catch (IOException exception)
+        {
+            return (false, null, ExecutionError.InternalError(
+                $"Failed to read request JSON from standard input. {exception.Message}"));
+        }
     }
 
     /// <summary> Reads and validates request JSON from a request file path. </summary>

--- a/tests/Ucli.Tests/Hosting/Cli/Requests/RequestInputReaderTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/Requests/RequestInputReaderTests.cs
@@ -34,6 +34,24 @@ public sealed class RequestInputReaderTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task ReadAsync_ReadsRequestPath_WhenRedirectedStandardInputIsEmpty ()
+    {
+        const string expectedJson = """{"source":"file"}""";
+        var reader = new RequestInputReader(
+            isStandardInputRedirected: static () => true,
+            readStandardInputAsync: static _ => Task.FromResult(" \r\n\t"),
+            readRequestFileAsync: static (_, _) => Task.FromResult(expectedJson));
+
+        var result = await reader.ReadAsync("request.json");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedJson, result.Json);
+        Assert.Equal(RequestInputSource.RequestPath, result.Source);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task ReadAsync_ReadsRequestPath_WhenOnlyRequestPathIsSpecified ()
     {
         const string expectedJson = """{"source":"file"}""";


### PR DESCRIPTION
## Summary
- Treat empty redirected standard input as absent when `--requestPath` is specified, while preserving the ambiguity error when stdin contains request JSON.
- Reuse the host `Transform` when extracting component schema for `UnityEngine.Transform`.
- Add regression coverage for both release verification failures.

## Verification
- `dotnet restore Ucli.slnx`
- `dotnet restore src/Ucli.Unity/Ucli.Unity.slnx`
- `./scripts/update-local-contracts-package.sh --prune`
- `dotnet format Ucli.slnx --verbosity minimal --include src/Ucli/Hosting/Cli/Requests/Input/RequestInputReader.cs tests/Ucli.Tests/Hosting/Cli/Requests/RequestInputReaderTests.cs --no-restore`
- `dotnet format Ucli.slnx --verbosity minimal --verify-no-changes --include src/Ucli/Hosting/Cli/Requests/Input/RequestInputReader.cs tests/Ucli.Tests/Hosting/Cli/Requests/RequestInputReaderTests.cs --no-restore`
- `dotnet format src/Ucli.Unity/Ucli.Unity.slnx --verbosity minimal --include src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/ComponentSchemaExtractor.cs src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CompOperationTests.cs --no-restore`
- `dotnet format src/Ucli.Unity/Ucli.Unity.slnx --verbosity minimal --verify-no-changes --include src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/ComponentSchemaExtractor.cs src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CompOperationTests.cs --no-restore`
- `dotnet build Ucli.slnx --configuration Release --no-restore`
- `dotnet test Ucli.slnx --configuration Release --no-build` (48 / 454 / 1074 passed)
- `dotnet src/Ucli/bin/Release/net8.0/MackySoft.Ucli.dll test run --projectPath src/Ucli.Unity --mode oneshot --unityEditorPath /Applications/Unity/Hub/Editor/2023.2.22f1/Unity.app/Contents/MacOS/Unity --testPlatform editmode --assemblyName MackySoft.Ucli.Unity.Tests.Editor --testFilter MackySoft.Ucli.Unity.Tests.CompOperationTests.Schema_Plan_WhenTypeIsTransform_ReturnsSchemaResult --timeout 1800000`
- `dotnet src/Ucli/bin/Release/net8.0/MackySoft.Ucli.dll query comp schema --projectPath src/Ucli.Unity --mode oneshot --timeout 180000 --readIndexMode disabled --type "UnityEngine.Transform, UnityEngine.CoreModule"`
- `dotnet src/Ucli/bin/Release/net8.0/MackySoft.Ucli.dll validate --requestPath <tmp-request> --projectPath src/Ucli.Unity --readIndexMode allowStale`
- `dotnet src/Ucli/bin/Release/net8.0/MackySoft.Ucli.dll test run --projectPath src/Ucli.Unity --mode oneshot --unityEditorPath /Applications/Unity/Hub/Editor/2023.2.22f1/Unity.app/Contents/MacOS/Unity --testPlatform editmode --assemblyName MackySoft.Ucli.Unity.Tests.Editor --timeout 1800000` (430 passed)

Issueなし運用です。
