### PR TITLE
feat(unity): add NuGetForUnity package distribution

### DIFF
--- a/.github/actions/mirror-nuget-release/action.yaml
+++ b/.github/actions/mirror-nuget-release/action.yaml
@@ -1,0 +1,46 @@
+name: Mirror NuGet package to GitHub Release
+description: Mirror one NuGet package artifact to the matching GitHub Release.
+
+inputs:
+  github-token:
+    description: GitHub token used by gh to create or update the release.
+    required: true
+  package-id:
+    description: NuGet package ID.
+    required: true
+  package-version:
+    description: NuGet package version.
+    required: true
+  release-tag:
+    description: GitHub Release tag name.
+    required: true
+  release-title:
+    description: GitHub Release title.
+    required: true
+  release-notes:
+    description: GitHub Release notes.
+    required: true
+  repository:
+    description: GitHub repository in owner/name form.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Mirror package to GitHub Release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PACKAGE_ID: ${{ inputs.package-id }}
+        PACKAGE_VERSION: ${{ inputs.package-version }}
+        RELEASE_NOTES: ${{ inputs.release-notes }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+        RELEASE_TITLE: ${{ inputs.release-title }}
+        REPOSITORY: ${{ inputs.repository }}
+      run: >-
+        ./scripts/mirror-nuget-package-release.sh
+        --repository "${REPOSITORY}"
+        --tag-name "${RELEASE_TAG}"
+        --package-glob "artifacts/packages/${PACKAGE_ID}.${PACKAGE_VERSION}.nupkg"
+        --title "${RELEASE_TITLE}"
+        --notes "${RELEASE_NOTES}"

--- a/.github/actions/publish-nuget-package/action.yaml
+++ b/.github/actions/publish-nuget-package/action.yaml
@@ -1,0 +1,31 @@
+name: Publish NuGet package
+description: Publish one or more package artifacts to nuget.org with Trusted Publishing.
+
+inputs:
+  package-glob:
+    description: Glob or path passed to dotnet nuget push.
+    required: true
+  nuget-user:
+    description: nuget.org account name configured for Trusted Publishing.
+    required: true
+  source:
+    description: NuGet package source URL.
+    required: false
+    default: https://api.nuget.org/v3/index.json
+
+runs:
+  using: composite
+  steps:
+    - name: NuGet login
+      id: nuget_login
+      uses: NuGet/login@v1
+      with:
+        user: ${{ inputs.nuget-user }}
+
+    - name: Publish package
+      shell: bash
+      run: >-
+        dotnet nuget push "${{ inputs.package-glob }}"
+        --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}"
+        --source "${{ inputs.source }}"
+        --skip-duplicate

--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -161,10 +161,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          sync_branch="chore/cli-sync-${PACKAGE_VERSION}"
+          ./scripts/prepare-version-sync-branch.sh \
+            --default-branch "${DEFAULT_BRANCH}" \
+            --sync-branch "${sync_branch}"
+
+          ./scripts/sync-cli-package-version.sh \
+            --version "${PACKAGE_VERSION}"
+
           ./scripts/create-version-sync-pr.sh \
-            --package cli \
-            --version "${PACKAGE_VERSION}" \
-            --release-tag "${RELEASE_TAG}" \
             --repository "${REPOSITORY}" \
             --default-branch "${DEFAULT_BRANCH}" \
-            --verify-workflow verify.yaml
+            --sync-branch "${sync_branch}" \
+            --commit-message "chore(cli): sync package version to ${PACKAGE_VERSION}" \
+            --pr-title "chore(cli): sync package version to ${PACKAGE_VERSION}" \
+            --pr-body "Sync \`MackySoft.Ucli\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
+            --verify-workflow verify.yaml \
+            --changed-path "src/Ucli/Ucli.csproj"

--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -35,25 +35,7 @@ jobs:
         shell: bash
         env:
           DISPATCH_VERSION: ${{ github.event.inputs.package_version }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            package_version="${DISPATCH_VERSION}"
-          else
-            tag_name="${GITHUB_REF_NAME}"
-            package_version="${tag_name#cli/}"
-          fi
-
-          if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-            exit 1
-          fi
-
-          tag_name="cli/${package_version}"
-
-          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
-          echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
+        run: ./scripts/resolve-release-version.sh --tag-prefix cli --dispatch-version "${DISPATCH_VERSION}"
 
       - name: Create and push release tag
         if: github.event_name == 'workflow_dispatch'
@@ -61,19 +43,7 @@ jobs:
         env:
           TAG_NAME: ${{ steps.version.outputs.tag_name }}
           RELEASE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null; then
-            echo "Tag ${TAG_NAME} already exists." >&2
-            exit 1
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag "${TAG_NAME}" "${RELEASE_SHA}"
-          git push origin "refs/tags/${TAG_NAME}"
+        run: ./scripts/create-release-tag.sh --tag-name "${TAG_NAME}" --release-sha "${RELEASE_SHA}"
 
   publish:
     needs: prepare-release
@@ -116,18 +86,11 @@ jobs:
           PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
         run: ./scripts/verify-cli-package.sh artifacts/packages "${PACKAGE_VERSION}"
 
-      - name: NuGet login
-        id: nuget_login
-        uses: NuGet/login@v1
-        with:
-          user: ${{ vars.NUGET_USER }}
-
       - name: Publish to nuget.org
-        run: >-
-          dotnet nuget push "artifacts/packages/*.nupkg"
-          --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}"
-          --source "https://api.nuget.org/v3/index.json"
-          --skip-duplicate
+        uses: ./.github/actions/publish-nuget-package
+        with:
+          package-glob: artifacts/packages/*.nupkg
+          nuget-user: ${{ vars.NUGET_USER }}
 
       - name: Create or update GitHub Release
         shell: bash

--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -92,27 +92,16 @@ jobs:
           package-glob: artifacts/packages/*.nupkg
           nuget-user: ${{ vars.NUGET_USER }}
 
-      - name: Create or update GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
-          REPOSITORY: ${{ github.repository }}
-          TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
-        run: |
-          set -euo pipefail
-
-          package_path="$(find artifacts/packages -maxdepth 1 -type f -name 'MackySoft.Ucli.*.nupkg' | head -n 1)"
-          [[ -n "${package_path}" ]] || { echo "CLI package was not created." >&2; exit 1; }
-
-          if gh release view "${TAG_NAME}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
-            gh release upload "${TAG_NAME}" "${package_path}" --repo "${REPOSITORY}" --clobber
-          else
-            gh release create "${TAG_NAME}" "${package_path}" \
-              --repo "${REPOSITORY}" \
-              --title "uCLI ${PACKAGE_VERSION}" \
-              --notes "CLI global tool package for ${TAG_NAME}."
-          fi
+      - name: Mirror package to GitHub Release
+        uses: ./.github/actions/mirror-nuget-release
+        with:
+          github-token: ${{ github.token }}
+          package-id: MackySoft.Ucli
+          package-version: ${{ needs.prepare-release.outputs.package_version }}
+          release-tag: ${{ needs.prepare-release.outputs.tag_name }}
+          release-title: uCLI ${{ needs.prepare-release.outputs.package_version }}
+          release-notes: CLI global tool package for ${{ needs.prepare-release.outputs.tag_name }}.
+          repository: ${{ github.repository }}
 
       - name: Create CLI package version sync pull request
         env:

--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -14,7 +14,7 @@ on:
 permissions:
   actions: write
   contents: write
-  packages: write
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -35,23 +35,7 @@ jobs:
         shell: bash
         env:
           DISPATCH_VERSION: ${{ github.event.inputs.package_version }}
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            package_version="${DISPATCH_VERSION}"
-          else
-            tag_name="${GITHUB_REF_NAME}"
-            package_version="${tag_name#contracts/}"
-          fi
-
-          if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-            exit 1
-          fi
-
-          tag_name="contracts/${package_version}"
-
-          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
-          echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
+        run: ./scripts/resolve-release-version.sh --tag-prefix contracts --dispatch-version "${DISPATCH_VERSION}"
 
       - name: Create and push release tag
         if: github.event_name == 'workflow_dispatch'
@@ -59,17 +43,7 @@ jobs:
         env:
           TAG_NAME: ${{ steps.version.outputs.tag_name }}
           RELEASE_SHA: ${{ github.sha }}
-        run: |
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null; then
-            echo "Tag ${TAG_NAME} already exists." >&2
-            exit 1
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag "${TAG_NAME}" "${RELEASE_SHA}"
-          git push origin "refs/tags/${TAG_NAME}"
+        run: ./scripts/create-release-tag.sh --tag-name "${TAG_NAME}" --release-sha "${RELEASE_SHA}"
 
   publish:
     needs: prepare-release
@@ -94,12 +68,11 @@ jobs:
           -p:PackageVersion=${{ needs.prepare-release.outputs.package_version }}
           --output artifacts/packages
 
-      - name: Publish to GitHub Packages
-        run: >-
-          dotnet nuget push "artifacts/packages/*.nupkg"
-          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-          --api-key "${{ secrets.GITHUB_TOKEN }}"
-          --skip-duplicate
+      - name: Publish to nuget.org
+        uses: ./.github/actions/publish-nuget-package
+        with:
+          package-glob: artifacts/packages/*.nupkg
+          nuget-user: ${{ vars.NUGET_USER }}
 
       - name: Create contracts package version sync pull request
         env:

--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -109,78 +109,12 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag_name }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
 
-          git fetch origin "${DEFAULT_BRANCH}"
-          sync_branch="chore/contracts-sync-${PACKAGE_VERSION}"
-          git checkout -B "${sync_branch}" "origin/${DEFAULT_BRANCH}"
-
-          csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
-          unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
-
-          csproj_current_version="$(sed -n 's#.*<Version>\(.*\)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-          if [[ -z "${csproj_current_version}" ]]; then
-            echo "Failed to resolve contracts csproj version from ${csproj_path}." >&2
-            exit 1
-          fi
-
-          unity_current_version="$(sed -n 's#.*<package id="MackySoft.Ucli.Contracts" version="\([^"]\+\)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
-          if [[ -z "${unity_current_version}" ]]; then
-            echo "Failed to resolve Unity contracts package version from ${unity_packages_config_path}." >&2
-            exit 1
-          fi
-
-          if [[ "${csproj_current_version}" != "${PACKAGE_VERSION}" ]]; then
-            sed -i -E "0,/<Version>[^<]+<\/Version>/s//<Version>${PACKAGE_VERSION}<\/Version>/" "${csproj_path}"
-          fi
-
-          if [[ "${unity_current_version}" != "${PACKAGE_VERSION}" ]]; then
-            sed -i -E "s#(<package id=\"MackySoft.Ucli.Contracts\" version=\")[^\"]+(\".*)#\\1${PACKAGE_VERSION}\\2#" "${unity_packages_config_path}"
-          fi
-
-          if git diff --quiet -- "${csproj_path}" "${unity_packages_config_path}"; then
-            echo "No repository version sync required."
-            exit 0
-          fi
-
-          git add "${csproj_path}" "${unity_packages_config_path}"
-          git commit -m "chore(contracts): sync package version to ${PACKAGE_VERSION}"
-          if git ls-remote --exit-code --heads origin "${sync_branch}" >/dev/null; then
-            git fetch origin "${sync_branch}:refs/remotes/origin/${sync_branch}"
-            remote_sync_sha="$(git rev-parse "refs/remotes/origin/${sync_branch}")"
-            git push --force-with-lease="refs/heads/${sync_branch}:${remote_sync_sha}" origin "HEAD:${sync_branch}"
-          else
-            git push origin "HEAD:${sync_branch}"
-          fi
-
-          existing_pr_url="$(gh pr list \
-            --repo "${REPOSITORY}" \
-            --state open \
-            --head "${sync_branch}" \
-            --json url \
-            --jq '.[0].url // empty')"
-          if [[ -n "${existing_pr_url}" ]]; then
-            echo "Contracts version sync pull request already exists: ${existing_pr_url}"
-          else
-            pr_body="$(cat <<EOF
-          ## Summary
-          - Sync \`MackySoft.Ucli.Contracts\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish.
-          - Update \`${csproj_path}\` and \`${unity_packages_config_path}\`.
-
-          ## Verification
-          - \`contracts-package-publish\` packed and published \`${RELEASE_TAG}\` before creating this PR.
-          - \`verify\` workflow was dispatched for \`${sync_branch}\`.
-          EOF
-          )"
-            gh pr create \
-              --repo "${REPOSITORY}" \
-              --base "${DEFAULT_BRANCH}" \
-              --head "${sync_branch}" \
-              --title "chore(contracts): sync package version to ${PACKAGE_VERSION}" \
-              --body "${pr_body}"
-          fi
-
-          gh workflow run verify.yaml \
-            --repo "${REPOSITORY}" \
-            --ref "${sync_branch}"
+          ./scripts/create-version-sync-pr.sh \
+            --package contracts \
+            --version "${PACKAGE_VERSION}" \
+            --release-tag "${RELEASE_TAG}" \
+            --repository "${REPOSITORY}" \
+            --default-branch "${DEFAULT_BRANCH}" \
+            --verify-workflow verify.yaml

--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -74,6 +74,17 @@ jobs:
           package-glob: artifacts/packages/*.nupkg
           nuget-user: ${{ vars.NUGET_USER }}
 
+      - name: Mirror package to GitHub Release
+        uses: ./.github/actions/mirror-nuget-release
+        with:
+          github-token: ${{ github.token }}
+          package-id: MackySoft.Ucli.Contracts
+          package-version: ${{ needs.prepare-release.outputs.package_version }}
+          release-tag: ${{ needs.prepare-release.outputs.tag_name }}
+          release-title: uCLI Contracts ${{ needs.prepare-release.outputs.package_version }}
+          release-notes: Shared contracts package for ${{ needs.prepare-release.outputs.tag_name }}.
+          repository: ${{ github.repository }}
+
       - name: Create contracts package version sync pull request
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/contracts-package-publish.yaml
+++ b/.github/workflows/contracts-package-publish.yaml
@@ -111,10 +111,34 @@ jobs:
         run: |
           set -euo pipefail
 
+          sync_branch="chore/contracts-sync-${PACKAGE_VERSION}"
+          ./scripts/prepare-version-sync-branch.sh \
+            --default-branch "${DEFAULT_BRANCH}" \
+            --sync-branch "${sync_branch}"
+
+          ./scripts/sync-contracts-package-version.sh \
+            --version "${PACKAGE_VERSION}"
+
+          pr_body_file="$(mktemp)"
+          trap 'rm -f "${pr_body_file}"' EXIT
+          cat > "${pr_body_file}" <<EOF
+          ## Summary
+          - Sync \`MackySoft.Ucli.Contracts\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish.
+          - Update \`src/Ucli.Contracts/Ucli.Contracts.csproj\`, \`src/Ucli.Unity/Assets/packages.config\`, and \`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec\`.
+
+          ## Verification
+          - \`contracts-package-publish\` packed and published \`${RELEASE_TAG}\` before creating this PR.
+          - \`verify.yaml\` workflow was dispatched for \`${sync_branch}\`.
+          EOF
+
           ./scripts/create-version-sync-pr.sh \
-            --package contracts \
-            --version "${PACKAGE_VERSION}" \
-            --release-tag "${RELEASE_TAG}" \
             --repository "${REPOSITORY}" \
             --default-branch "${DEFAULT_BRANCH}" \
-            --verify-workflow verify.yaml
+            --sync-branch "${sync_branch}" \
+            --commit-message "chore(contracts): sync package version to ${PACKAGE_VERSION}" \
+            --pr-title "chore(contracts): sync package version to ${PACKAGE_VERSION}" \
+            --pr-body-file "${pr_body_file}" \
+            --verify-workflow verify.yaml \
+            --changed-path "src/Ucli.Contracts/Ucli.Contracts.csproj" \
+            --changed-path "src/Ucli.Unity/Assets/packages.config" \
+            --changed-path "src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"

--- a/.github/workflows/unity-package-publish.yaml
+++ b/.github/workflows/unity-package-publish.yaml
@@ -1,20 +1,20 @@
-name: cli-package-publish
+name: unity-package-publish
 
 on:
   push:
     tags:
-      - cli/*
+      - unity/*
   workflow_dispatch:
     inputs:
       package_version:
-        description: "SemVer CLI package version (e.g. 0.18.0)"
+        description: "SemVer Unity package version (e.g. 0.18.0)"
         required: true
         type: string
 
 permissions:
   actions: write
   contents: write
-  id-token: write
+  packages: write
   pull-requests: write
 
 jobs:
@@ -42,7 +42,7 @@ jobs:
             package_version="${DISPATCH_VERSION}"
           else
             tag_name="${GITHUB_REF_NAME}"
-            package_version="${tag_name#cli/}"
+            package_version="${tag_name#unity/}"
           fi
 
           if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
 
-          tag_name="cli/${package_version}"
+          tag_name="unity/${package_version}"
 
           echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
           echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
@@ -79,13 +79,15 @@ jobs:
     needs: prepare-release
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          # Pack from the resolved release tag so the nupkg, GitHub Release,
-          # and post-publish sync PR all refer to the same immutable source.
           ref: ${{ needs.prepare-release.outputs.tag_name }}
 
       - name: Setup .NET
@@ -93,65 +95,23 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('Ucli.slnx', '**/*.csproj') }}
+      - name: Setup NuGet CLI
+        run: ./scripts/setup-nuget-cli.sh
 
-      - name: Restore CLI
-        run: dotnet restore src/Ucli/Ucli.csproj
+      - name: Pack Unity plugin
+        run: ./scripts/pack-unity-plugin.sh --version "${{ needs.prepare-release.outputs.package_version }}" --output artifacts/packages
 
-      - name: Pack CLI tool
-        run: >-
-          dotnet pack src/Ucli/Ucli.csproj
-          --configuration Release
-          --no-restore
-          -p:Version=${{ needs.prepare-release.outputs.package_version }}
-          -p:PackageVersion=${{ needs.prepare-release.outputs.package_version }}
-          --output artifacts/packages
+      - name: Verify Unity plugin package
+        run: ./scripts/verify-unity-plugin-package.sh artifacts/packages "${{ needs.prepare-release.outputs.package_version }}"
 
-      - name: Smoke test CLI tool package
-        env:
-          PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
-        run: ./scripts/verify-cli-package.sh artifacts/packages "${PACKAGE_VERSION}"
-
-      - name: NuGet login
-        id: nuget_login
-        uses: NuGet/login@v1
-        with:
-          user: ${{ vars.NUGET_USER }}
-
-      - name: Publish to nuget.org
+      - name: Publish to GitHub Packages
         run: >-
           dotnet nuget push "artifacts/packages/*.nupkg"
-          --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}"
-          --source "https://api.nuget.org/v3/index.json"
+          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --api-key "${{ secrets.GITHUB_TOKEN }}"
           --skip-duplicate
 
-      - name: Create or update GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
-          REPOSITORY: ${{ github.repository }}
-          TAG_NAME: ${{ needs.prepare-release.outputs.tag_name }}
-        run: |
-          set -euo pipefail
-
-          package_path="$(find artifacts/packages -maxdepth 1 -type f -name 'MackySoft.Ucli.*.nupkg' | head -n 1)"
-          [[ -n "${package_path}" ]] || { echo "CLI package was not created." >&2; exit 1; }
-
-          if gh release view "${TAG_NAME}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
-            gh release upload "${TAG_NAME}" "${package_path}" --repo "${REPOSITORY}" --clobber
-          else
-            gh release create "${TAG_NAME}" "${package_path}" \
-              --repo "${REPOSITORY}" \
-              --title "uCLI ${PACKAGE_VERSION}" \
-              --notes "CLI global tool package for ${TAG_NAME}."
-          fi
-
-      - name: Create CLI package version sync pull request
+      - name: Create Unity package version sync pull request
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
@@ -162,7 +122,7 @@ jobs:
           set -euo pipefail
 
           ./scripts/create-version-sync-pr.sh \
-            --package cli \
+            --package unity \
             --version "${PACKAGE_VERSION}" \
             --release-tag "${RELEASE_TAG}" \
             --repository "${REPOSITORY}" \

--- a/.github/workflows/unity-package-publish.yaml
+++ b/.github/workflows/unity-package-publish.yaml
@@ -14,7 +14,7 @@ on:
 permissions:
   actions: write
   contents: write
-  packages: write
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -35,25 +35,7 @@ jobs:
         shell: bash
         env:
           DISPATCH_VERSION: ${{ github.event.inputs.package_version }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            package_version="${DISPATCH_VERSION}"
-          else
-            tag_name="${GITHUB_REF_NAME}"
-            package_version="${tag_name#unity/}"
-          fi
-
-          if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-            exit 1
-          fi
-
-          tag_name="unity/${package_version}"
-
-          echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
-          echo "tag_name=${tag_name}" >> "${GITHUB_OUTPUT}"
+        run: ./scripts/resolve-release-version.sh --tag-prefix unity --dispatch-version "${DISPATCH_VERSION}"
 
       - name: Create and push release tag
         if: github.event_name == 'workflow_dispatch'
@@ -61,19 +43,7 @@ jobs:
         env:
           TAG_NAME: ${{ steps.version.outputs.tag_name }}
           RELEASE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null; then
-            echo "Tag ${TAG_NAME} already exists." >&2
-            exit 1
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag "${TAG_NAME}" "${RELEASE_SHA}"
-          git push origin "refs/tags/${TAG_NAME}"
+        run: ./scripts/create-release-tag.sh --tag-name "${TAG_NAME}" --release-sha "${RELEASE_SHA}"
 
   publish:
     needs: prepare-release
@@ -104,12 +74,11 @@ jobs:
       - name: Verify Unity plugin package
         run: ./scripts/verify-unity-plugin-package.sh artifacts/packages "${{ needs.prepare-release.outputs.package_version }}"
 
-      - name: Publish to GitHub Packages
-        run: >-
-          dotnet nuget push "artifacts/packages/*.nupkg"
-          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-          --api-key "${{ secrets.GITHUB_TOKEN }}"
-          --skip-duplicate
+      - name: Publish to nuget.org
+        uses: ./.github/actions/publish-nuget-package
+        with:
+          package-glob: artifacts/packages/*.nupkg
+          nuget-user: ${{ vars.NUGET_USER }}
 
       - name: Create Unity package version sync pull request
         env:
@@ -135,6 +104,6 @@ jobs:
             --sync-branch "${sync_branch}" \
             --commit-message "chore(unity): sync package version to ${PACKAGE_VERSION}" \
             --pr-title "chore(unity): sync package version to ${PACKAGE_VERSION}" \
-            --pr-body "Sync \`MackySoft.Ucli.Unity\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`unity-package-publish\` workflow packed, verified, and published the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
+            --pr-body "Sync \`MackySoft.Ucli.Unity\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`unity-package-publish\` workflow packed, verified, published to nuget.org, and dispatched \`verify.yaml\` for \`${sync_branch}\`." \
             --verify-workflow verify.yaml \
             --changed-path "src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"

--- a/.github/workflows/unity-package-publish.yaml
+++ b/.github/workflows/unity-package-publish.yaml
@@ -121,10 +121,20 @@ jobs:
         run: |
           set -euo pipefail
 
+          sync_branch="chore/unity-sync-${PACKAGE_VERSION}"
+          ./scripts/prepare-version-sync-branch.sh \
+            --default-branch "${DEFAULT_BRANCH}" \
+            --sync-branch "${sync_branch}"
+
+          ./scripts/sync-unity-package-version.sh \
+            --version "${PACKAGE_VERSION}"
+
           ./scripts/create-version-sync-pr.sh \
-            --package unity \
-            --version "${PACKAGE_VERSION}" \
-            --release-tag "${RELEASE_TAG}" \
             --repository "${REPOSITORY}" \
             --default-branch "${DEFAULT_BRANCH}" \
-            --verify-workflow verify.yaml
+            --sync-branch "${sync_branch}" \
+            --commit-message "chore(unity): sync package version to ${PACKAGE_VERSION}" \
+            --pr-title "chore(unity): sync package version to ${PACKAGE_VERSION}" \
+            --pr-body "Sync \`MackySoft.Ucli.Unity\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`unity-package-publish\` workflow packed, verified, and published the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
+            --verify-workflow verify.yaml \
+            --changed-path "src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"

--- a/.github/workflows/unity-package-publish.yaml
+++ b/.github/workflows/unity-package-publish.yaml
@@ -80,6 +80,17 @@ jobs:
           package-glob: artifacts/packages/*.nupkg
           nuget-user: ${{ vars.NUGET_USER }}
 
+      - name: Mirror package to GitHub Release
+        uses: ./.github/actions/mirror-nuget-release
+        with:
+          github-token: ${{ github.token }}
+          package-id: MackySoft.Ucli.Unity
+          package-version: ${{ needs.prepare-release.outputs.package_version }}
+          release-tag: ${{ needs.prepare-release.outputs.tag_name }}
+          release-title: uCLI Unity ${{ needs.prepare-release.outputs.package_version }}
+          release-notes: NuGetForUnity plugin package for ${{ needs.prepare-release.outputs.tag_name }}.
+          repository: ${{ github.repository }}
+
       - name: Create Unity package version sync pull request
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,6 +24,7 @@ jobs:
       needs_unity: ${{ steps.detect.outputs.needs_unity }}
       needs_contracts_pack: ${{ steps.detect.outputs.needs_contracts_pack }}
       needs_cli_pack: ${{ steps.detect.outputs.needs_cli_pack }}
+      needs_unity_pack: ${{ steps.detect.outputs.needs_unity_pack }}
       dotnet_matrix_json: ${{ steps.detect.outputs.dotnet_matrix_json }}
       unity_matrix_json: ${{ steps.detect.outputs.unity_matrix_json }}
 
@@ -160,44 +161,9 @@ jobs:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('Ucli.slnx', '**/*.csproj') }}
 
-      - name: Setup Mono on Linux
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          set -euo pipefail
-          if command -v mono >/dev/null 2>&1; then
-            mono --version | head -n 1
-            exit 0
-          fi
-
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update
-          sudo apt-get install --yes mono-complete
-        shell: bash
-
-      - name: Setup Mono on macOS
-        if: ${{ runner.os == 'macOS' }}
-        run: |
-          set -euo pipefail
-          brew install mono
-        shell: bash
-
-      - name: Setup NuGet on Linux or macOS
+      - name: Setup NuGet CLI on Linux or macOS
         if: ${{ runner.os != 'Windows' }}
-        run: |
-          set -euo pipefail
-
-          nuget_dir="${RUNNER_TEMP}/nuget"
-          mkdir -p "${nuget_dir}"
-          curl --fail --location --silent --show-error \
-            "https://dist.nuget.org/win-x86-commandline/v7.3.0/nuget.exe" \
-            --output "${nuget_dir}/nuget.exe"
-          cat <<'EOF' > "${nuget_dir}/nuget"
-          #!/usr/bin/env bash
-          set -euo pipefail
-          mono "$(dirname "$0")/nuget.exe" "$@"
-          EOF
-          chmod +x "${nuget_dir}/nuget"
-          echo "${nuget_dir}" >> "${GITHUB_PATH}"
+        run: ./scripts/setup-nuget-cli.sh
         shell: bash
 
       - name: Setup NuGet on Windows
@@ -451,6 +417,37 @@ jobs:
           path: artifacts/packages
           if-no-files-found: warn
 
+  unity_pack:
+    name: unity-pack
+    needs: changes
+    if: ${{ needs.changes.outputs.needs_unity_pack == 'true' }}
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup NuGet CLI
+        run: ./scripts/setup-nuget-cli.sh
+
+      - name: Pack Unity plugin
+        run: ./scripts/pack-unity-plugin.sh --version 0.0.0-ci --output artifacts/packages
+
+      - name: Verify Unity plugin package
+        run: ./scripts/verify-unity-plugin-package.sh artifacts/packages 0.0.0-ci
+
+      - name: Upload Unity plugin package
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unity-package-artifacts
+          path: artifacts/packages
+          if-no-files-found: warn
+
   required:
     name: required
     if: ${{ always() }}
@@ -461,6 +458,7 @@ jobs:
       - unity
       - contracts_pack
       - cli_pack
+      - unity_pack
     runs-on: ubuntu-latest
 
     steps:
@@ -471,12 +469,14 @@ jobs:
           NEEDS_UNITY: ${{ needs.changes.outputs.needs_unity }}
           NEEDS_CONTRACTS_PACK: ${{ needs.changes.outputs.needs_contracts_pack }}
           NEEDS_CLI_PACK: ${{ needs.changes.outputs.needs_cli_pack }}
+          NEEDS_UNITY_PACK: ${{ needs.changes.outputs.needs_unity_pack }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           ACCESS_GUARD_RESULT: ${{ needs.access_guard.result }}
           DOTNET_RESULT: ${{ needs.dotnet.result }}
           UNITY_RESULT: ${{ needs.unity.result }}
           CONTRACTS_PACK_RESULT: ${{ needs.contracts_pack.result }}
           CLI_PACK_RESULT: ${{ needs.cli_pack.result }}
+          UNITY_PACK_RESULT: ${{ needs.unity_pack.result }}
         run: |
           set -euo pipefail
 
@@ -509,6 +509,11 @@ jobs:
 
           if [[ "${NEEDS_CLI_PACK}" == "true" && "${CLI_PACK_RESULT}" != "success" ]]; then
             echo "cli-pack job is required but finished with ${CLI_PACK_RESULT}." >&2
+            exit 1
+          fi
+
+          if [[ "${NEEDS_UNITY_PACK}" == "true" && "${UNITY_PACK_RESULT}" != "success" ]]; then
+            echo "unity-pack job is required but finished with ${UNITY_PACK_RESULT}." >&2
             exit 1
           fi
 

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -9,43 +9,28 @@
 ## Unity Dependency Restore
 - `src/Ucli.Unity/Assets/NuGet.config` で以下のソースを利用する。
   - `LocalNuGet`: `../Packages/nuget-local-source`
-  - `PrivateNuGet`: `https://nuget.pkg.github.com/mackysoft/index.json`
   - `nuget.org`: `https://api.nuget.org/v3/index.json`
 - NuGetForUnity の復元成果物は生成物として扱う。
   - `src/Ucli.Unity/Assets/Packages/`
   - `src/Ucli.Unity/.nuget-cache/`
   - `src/Ucli.Unity/.nuget-packages/`
+- `src/Ucli.Unity/Assets/NuGet.config` は package source mapping で `MackySoft.Ucli.Contracts` を `LocalNuGet` に固定し、開発中の共有契約が公開済み版で上書きされることを防ぐ。
 
-## GitHub Packages Authentication
-- 認証情報はリポジトリに含めない。
-- NuGetForUnity は `ApplicationData/NuGet/NuGet.Config` を参照する。
-  - macOS/Linux: `~/.config/NuGet/NuGet.Config`
-  - Windows: `%AppData%\NuGet\NuGet.Config`
-- `dotnet` CLI は通常 `~/.nuget/NuGet/NuGet.Config` を参照する。
-- Unity と CLI の設定を揃えるため、`~/.config/NuGet/NuGet.Config` と `~/.nuget/NuGet/NuGet.Config` は同一内容に維持する。
-- `packageSourceCredentials` のキー名は、`NuGet.config` の source key と一致させる（`PrivateNuGet`）。
-- GitHub Packages 読み取りには `read:packages` 権限が必要。private repository 配下のパッケージは `repo` も必要。
-
-```bash
-dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
-  --name "PrivateNuGet" \
-  --username "<github-user>" \
-  --password "<github-pat>" \
-  --store-password-in-clear-text \
-  --configfile "$HOME/.config/NuGet/NuGet.Config"
-```
-
-上記設定後に Unity を batchmode で開くと、NuGetForUnity が `packages.config` の依存を GitHub Packages から復元する。
+## NuGet Source Policy
+- 公開パッケージは `MackySoft.Ucli`、`MackySoft.Ucli.Contracts`、`MackySoft.Ucli.Unity` のいずれも nuget.org へ公開する。
+- 利用者側の Unity project は `nuget.org` source だけで `MackySoft.Ucli.Unity` と推移依存を復元できる。
+- 開発用 project は `MackySoft.Ucli.Contracts` を `LocalNuGet` から復元し、`Microsoft.*` / `System.*` の外部依存を `nuget.org` から復元する。
+- 認証付き feed は標準導入手順に含めない。
 
 ## Unity Plugin Distribution
-`MackySoft.Ucli.Unity` は NuGetForUnity 用の nupkg として GitHub Packages へ公開する。Unityプラグイン本体、`ucli-plugin.json`、README、LICENSE を package root に含め、復元後の配置は次の形になる。
+`MackySoft.Ucli.Unity` は NuGetForUnity 用の nupkg として nuget.org へ公開する。Unityプラグイン本体、`ucli-plugin.json`、README、LICENSE を package root に含め、復元後の配置は次の形になる。
 
 ```text
 Assets/Packages/MackySoft.Ucli.Unity.<version>/ucli-plugin.json
 Assets/Packages/MackySoft.Ucli.Unity.<version>/Editor/MackySoft.Ucli.Unity.Editor.asmdef
 ```
 
-利用者側は `Assets/NuGet.config` に `PrivateNuGet` と `nuget.org` を設定し、NuGetForUnity で `MackySoft.Ucli.Unity` を導入する。`MackySoft.Ucli.Unity` は `MackySoft.Ucli.Contracts`、`System.Text.Json`、`Microsoft.Extensions.DependencyInjection` などを NuGet 依存として定義する。
+利用者側は `Assets/NuGet.config` に `nuget.org` を設定し、NuGetForUnity で `MackySoft.Ucli.Unity` を導入する。`MackySoft.Ucli.Unity` は `MackySoft.Ucli.Contracts`、`System.Text.Json`、`Microsoft.Extensions.DependencyInjection` などを NuGet 依存として定義する。
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -86,7 +71,7 @@ dotnet pack "src/Ucli/Ucli.csproj" \
   -o "artifacts/packages"
 ```
 
-nuget.org への公開は GitHub Actions の Trusted Publishing を使用する。nuget.org 側で repository owner `mackysoft`、repository `ucli`、workflow file `cli-package-publish.yaml`、environment 未指定の policy を作成し、GitHub repository variable `NUGET_USER` に nuget.org profile name を設定する。
+nuget.org への公開は GitHub Actions の Trusted Publishing を使用する。nuget.org 側で repository owner `mackysoft`、repository `ucli`、workflow file `cli-package-publish.yaml` / `contracts-package-publish.yaml` / `unity-package-publish.yaml`、environment 未指定の policy を作成し、GitHub repository variable `NUGET_USER` に nuget.org profile name を設定する。
 
 ## NuGetForUnity パッケージ解決手順
 ### 標準フロー（Unity エディタ起動）
@@ -124,6 +109,7 @@ rm -rf src/Ucli.Unity/.nuget-packages
 nuget restore "src/Ucli.Unity/Assets/packages.config" \
   -PackagesDirectory "src/Ucli.Unity/Assets/Packages" \
   -ConfigFile "src/Ucli.Unity/Assets/NuGet.config" \
+  -NoCache \
   -NonInteractive
 ```
 3. `nuget restore` が生成した package 配下の簡易 `.meta` を削除し、次回 Unity 起動で importer 設定を再生成させる。
@@ -187,7 +173,7 @@ done
 - `contracts-package-publish` は公開後に `chore/contracts-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Contracts` バージョンを同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release 作成まで継続する。
 - `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`src/Ucli/Ucli.csproj` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
-- `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / GitHub Packages publish / repository version sync PR 作成まで継続する。
+- `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / nuget.org publish / repository version sync PR 作成まで継続する。
 - `unity-package-publish` は公開後に `chore/unity-sync-<version>` ブランチを作成し、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Unity` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`、`cli/x.y.z`、`unity/x.y.z`）。
 

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -23,7 +23,7 @@
 - 認証付き feed は標準導入手順に含めない。
 
 ## Unity Plugin Distribution
-`MackySoft.Ucli.Unity` は NuGetForUnity 用の nupkg として nuget.org へ公開する。Unityプラグイン本体、`ucli-plugin.json`、README、LICENSE を package root に含め、復元後の配置は次の形になる。
+`MackySoft.Ucli.Unity` は NuGetForUnity 用の nupkg として nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。Unityプラグイン本体、`ucli-plugin.json`、README、LICENSE を package root に含め、復元後の配置は次の形になる。
 
 ```text
 Assets/Packages/MackySoft.Ucli.Unity.<version>/ucli-plugin.json
@@ -48,6 +48,13 @@ NuGetForUnity のUIで導入した場合は依存パッケージも `packages.co
 ./scripts/verify-unity-plugin-package.sh "artifacts/packages" <version>
 ```
 
+## Release Artifact Mirror
+各 publish workflow は、nuget.org への公開が成功した後に同じ `.nupkg` を GitHub Releases へミラーする。配布の正は nuget.org とし、GitHub Releases はタグごとの公開成果物を確認する監査場所として扱う。
+
+- `cli/<version>`: `MackySoft.Ucli.<version>.nupkg`
+- `contracts/<version>`: `MackySoft.Ucli.Contracts.<version>.nupkg`
+- `unity/<version>`: `MackySoft.Ucli.Unity.<version>.nupkg`
+
 ## CLI Global Tool Distribution
 `MackySoft.Ucli` は nuget.org へ .NET global tool として公開する。利用者は追加 NuGet source を設定せず、次のコマンドで導入する。
 
@@ -61,7 +68,7 @@ dotnet tool install --global MackySoft.Ucli --version <version>
 dotnet tool update --global MackySoft.Ucli --version <version>
 ```
 
-CLI パッケージは `src/Ucli/Ucli.csproj` を正として `dotnet pack` で生成する。公開 workflow は release tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから publish する。
+CLI パッケージは `src/Ucli/Ucli.csproj` を正として `dotnet pack` で生成する。公開 workflow は release tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。
 
 ```bash
 dotnet pack "src/Ucli/Ucli.csproj" \
@@ -169,11 +176,11 @@ done
 - Unity 検証は `src/Ucli`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`scripts/update-local-contracts-package.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、`ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
 - CLI pack 検証は `src/Ucli`、`src/Ucli.Contracts`、`README.md`、`LICENSE`、`cli-package-publish`、`verify` 自体の変更時に動く。`dotnet pack` 後にローカル tool install、`ucli --version`、`ucli --help`、nupkg 内の `DotnetToolSettings.xml` / `README.md` / `LICENSE` を検証する。
 - Unity package pack 検証は `scripts/pack-unity-plugin.sh` で `MackySoft.Ucli.Unity` nupkg を作成し、`scripts/verify-unity-plugin-package.sh` で必須ファイル、依存定義、ローカル復元後の `ucli-plugin.json` 配置を検証する。
-- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で同じ publish / repository version sync PR 作成まで継続する。
+- `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `contracts-package-publish` は公開後に `chore/contracts-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Contracts` バージョンを同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
-- `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release 作成まで継続する。
+- `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release mirror まで継続する。
 - `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`src/Ucli/Ucli.csproj` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
-- `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / nuget.org publish / repository version sync PR 作成まで継続する。
+- `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `unity-package-publish` は公開後に `chore/unity-sync-<version>` ブランチを作成し、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Unity` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`、`cli/x.y.z`、`unity/x.y.z`）。
 

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -3,10 +3,12 @@
 ## Shared Contracts Ownership
 - 共通DTOは `src/Ucli.Contracts` で定義する。
 - CLI（`src/Ucli`）は `ProjectReference` で `Ucli.Contracts` を参照する。
-- Unityプラグイン（`src/Ucli.Unity`）は NuGetForUnity と `packages.config` で `MackySoft.Ucli.Contracts` を参照する。
+- Unity開発プロジェクト（`src/Ucli.Unity`）は NuGetForUnity と `packages.config` で `MackySoft.Ucli.Contracts` を参照する。
+- 配布用Unityプラグインは `MackySoft.Ucli.Unity` nupkg として生成し、NuGetForUnity で導入する。
 
 ## Unity Dependency Restore
 - `src/Ucli.Unity/Assets/NuGet.config` で以下のソースを利用する。
+  - `LocalNuGet`: `../Packages/nuget-local-source`
   - `PrivateNuGet`: `https://nuget.pkg.github.com/mackysoft/index.json`
   - `nuget.org`: `https://api.nuget.org/v3/index.json`
 - NuGetForUnity の復元成果物は生成物として扱う。
@@ -34,6 +36,32 @@ dotnet nuget add source "https://nuget.pkg.github.com/mackysoft/index.json" \
 ```
 
 上記設定後に Unity を batchmode で開くと、NuGetForUnity が `packages.config` の依存を GitHub Packages から復元する。
+
+## Unity Plugin Distribution
+`MackySoft.Ucli.Unity` は NuGetForUnity 用の nupkg として GitHub Packages へ公開する。Unityプラグイン本体、`ucli-plugin.json`、README、LICENSE を package root に含め、復元後の配置は次の形になる。
+
+```text
+Assets/Packages/MackySoft.Ucli.Unity.<version>/ucli-plugin.json
+Assets/Packages/MackySoft.Ucli.Unity.<version>/Editor/MackySoft.Ucli.Unity.Editor.asmdef
+```
+
+利用者側は `Assets/NuGet.config` に `PrivateNuGet` と `nuget.org` を設定し、NuGetForUnity で `MackySoft.Ucli.Unity` を導入する。`MackySoft.Ucli.Unity` は `MackySoft.Ucli.Contracts`、`System.Text.Json`、`Microsoft.Extensions.DependencyInjection` などを NuGet 依存として定義する。
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MackySoft.Ucli.Unity" version="<version>" manuallyInstalled="true" targetFramework="netstandard2.1" />
+</packages>
+```
+
+NuGetForUnity のUIで導入した場合は依存パッケージも `packages.config` に追加される。`nuget restore` をCIなどで直接使うプロジェクトでは、NuGetForUnity が生成した依存行を含む `packages.config` をコミットする。
+
+配布パッケージは次のコマンドで生成・検証する。
+
+```bash
+./scripts/pack-unity-plugin.sh --version <version> --output "artifacts/packages"
+./scripts/verify-unity-plugin-package.sh "artifacts/packages" <version>
+```
 
 ## CLI Global Tool Distribution
 `MackySoft.Ucli` は nuget.org へ .NET global tool として公開する。利用者は追加 NuGet source を設定せず、次のコマンドで導入する。
@@ -147,17 +175,21 @@ done
 - `verify`: PR、`master` push、`workflow_dispatch` で起動する統一検証 workflow。変更差分に応じて `.NET`、Unity、contracts pack、CLI pack を job 単位で分岐し、最終的な必須判定は `required` job で集約する。
 - `contracts-package-publish` の workflow 自体を変更した PR でも `verify` は `.NET` と contracts pack を起動し、公開フロー変更を無検証のまま通さない。
 - `cli-package-publish` の workflow 自体を変更した PR では `verify` は `.NET` と CLI pack を起動し、global tool packaging の回帰を検出する。
+- `unity-package-publish` の workflow、Unity package nuspec、pack/verify script、Unityプラグイン本体、`packages.config` を変更した PR では `verify` は Unity package pack を起動し、NuGetForUnity配布物の回帰を検出する。
 - `verify` は workflow-level `concurrency` で同一 PR または同一 branch の古い run を自動キャンセルする。`workflow_dispatch` のみ明示比較用途のため自動キャンセルしない。
 - `pull_request` では変更差分を merge base 起点で判定し、必要な job だけを `Linux`、`Windows`、`macOS` の 3 OS matrix で実行する。外部 contributor の PR では `access-guard` job が失敗し、Unity job は実行しない。
 - `push` to `master` では変更差分を判定しつつ、実行 OS は `Linux` のみに絞って post-merge 検証を軽量化する。
-- `workflow_dispatch` は差分判定を使わず、`.NET`、Unity、contracts pack、CLI pack をフル検証する。`.NET` と Unity は `Linux`、`Windows`、`macOS` の 3 OS で実行し、package 検証は `Linux` で実行する。
+- `workflow_dispatch` は差分判定を使わず、`.NET`、Unity、contracts pack、CLI pack、Unity package pack をフル検証する。`.NET` と Unity は `Linux`、`Windows`、`macOS` の 3 OS で実行し、package 検証は `Linux` で実行する。
 - Unity 検証は `src/Ucli`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`scripts/update-local-contracts-package.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、`ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
 - CLI pack 検証は `src/Ucli`、`src/Ucli.Contracts`、`README.md`、`LICENSE`、`cli-package-publish`、`verify` 自体の変更時に動く。`dotnet pack` 後にローカル tool install、`ucli --version`、`ucli --help`、nupkg 内の `DotnetToolSettings.xml` / `README.md` / `LICENSE` を検証する。
+- Unity package pack 検証は `scripts/pack-unity-plugin.sh` で `MackySoft.Ucli.Unity` nupkg を作成し、`scripts/verify-unity-plugin-package.sh` で必須ファイル、依存定義、ローカル復元後の `ucli-plugin.json` 配置を検証する。
 - `contracts-package-publish`: `contracts/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で同じ publish / repository version sync PR 作成まで継続する。
-- `contracts-package-publish` は公開後に `chore/contracts-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj` と `src/Ucli.Unity/Assets/packages.config` の `MackySoft.Ucli.Contracts` バージョンを同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
+- `contracts-package-publish` は公開後に `chore/contracts-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Contracts` バージョンを同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release 作成まで継続する。
 - `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`src/Ucli/Ucli.csproj` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
-- タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`、`cli/x.y.z`）。
+- `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / GitHub Packages publish / repository version sync PR 作成まで継続する。
+- `unity-package-publish` は公開後に `chore/unity-sync-<version>` ブランチを作成し、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Unity` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
+- タグは `v` プレフィックスを付けない（例: `contracts/x.y.z`、`cli/x.y.z`、`unity/x.y.z`）。
 
 ```bash
 git tag contracts/x.y.z
@@ -165,4 +197,7 @@ git push origin contracts/x.y.z
 
 git tag cli/x.y.z
 git push origin cli/x.y.z
+
+git tag unity/x.y.z
+git push origin unity/x.y.z
 ```

--- a/scripts/create-release-tag.sh
+++ b/scripts/create-release-tag.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/create-release-tag.sh --tag-name <tag> --release-sha <sha> [--remote <remote>]
+
+Creates and pushes one lightweight release tag for workflow_dispatch package publishes.
+EOF
+}
+
+tag_name=""
+release_sha=""
+remote_name="origin"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag-name)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      tag_name="$2"
+      shift 2
+      ;;
+    --release-sha)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      release_sha="$2"
+      shift 2
+      ;;
+    --remote)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      remote_name="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${tag_name}" || -z "${release_sha}" || -z "${remote_name}" ]]; then
+  usage
+  exit 2
+fi
+
+if git ls-remote --exit-code --tags "${remote_name}" "refs/tags/${tag_name}" >/dev/null; then
+  echo "Tag ${tag_name} already exists." >&2
+  exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git tag "${tag_name}" "${release_sha}"
+git push "${remote_name}" "refs/tags/${tag_name}"

--- a/scripts/create-version-sync-pr.sh
+++ b/scripts/create-version-sync-pr.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/create-version-sync-pr.sh --package <cli|contracts|unity> --version <version> --release-tag <tag> --repository <owner/repo> --default-branch <branch> [--verify-workflow <workflow>]
+
+Creates or updates the post-publish version sync pull request and dispatches verification.
+EOF
+}
+
+package_name=""
+package_version=""
+release_tag=""
+repository=""
+default_branch=""
+verify_workflow="verify.yaml"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --package)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_name="$2"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    --release-tag)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      release_tag="$2"
+      shift 2
+      ;;
+    --repository)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      repository="$2"
+      shift 2
+      ;;
+    --default-branch)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      default_branch="$2"
+      shift 2
+      ;;
+    --verify-workflow)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      verify_workflow="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${package_name}" || -z "${package_version}" || -z "${release_tag}" || -z "${repository}" || -z "${default_branch}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+  exit 1
+fi
+
+changed_paths=()
+sync_branch=""
+commit_message=""
+pr_title=""
+pr_body=""
+
+replace_first_xml_element() {
+  local path="$1"
+  local element_name="$2"
+
+  PACKAGE_VERSION="${package_version}" ELEMENT_NAME="${element_name}" perl -0pi -e '
+    my $element = $ENV{"ELEMENT_NAME"};
+    my $version = $ENV{"PACKAGE_VERSION"};
+    s{<\Q$element\E>[^<]+</\Q$element\E>}{<$element>$version</$element>};
+  ' "${path}"
+}
+
+replace_xml_attribute_version() {
+  local path="$1"
+  local id="$2"
+
+  PACKAGE_VERSION="${package_version}" PACKAGE_ID="${id}" perl -0pi -e '
+    my $id = quotemeta($ENV{"PACKAGE_ID"});
+    my $version = $ENV{"PACKAGE_VERSION"};
+    s{(<(?:package|dependency) id="$id" version=")[^"]+(")}{$1$version$2};
+  ' "${path}"
+}
+
+require_value() {
+  local value="$1"
+  local message="$2"
+
+  if [[ -z "${value}" ]]; then
+    echo "${message}" >&2
+    exit 1
+  fi
+}
+
+sync_cli_version() {
+  local csproj_path="src/Ucli/Ucli.csproj"
+  local current_version
+  current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+  require_value "${current_version}" "Failed to resolve CLI csproj version from ${csproj_path}."
+
+  if [[ "${current_version}" != "${package_version}" ]]; then
+    replace_first_xml_element "${csproj_path}" "Version"
+  fi
+
+  changed_paths=("${csproj_path}")
+  sync_branch="chore/cli-sync-${package_version}"
+  commit_message="chore(cli): sync package version to ${package_version}"
+  pr_title="chore(cli): sync package version to ${package_version}"
+  pr_body="Sync \`MackySoft.Ucli\` package version to \`${package_version}\` after \`${release_tag}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`${verify_workflow}\` for \`${sync_branch}\`."
+}
+
+sync_contracts_version() {
+  local csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
+  local unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
+  local unity_package_nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
+  local csproj_current_version
+  local unity_current_version
+  local unity_package_dependency_version
+
+  csproj_current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+  require_value "${csproj_current_version}" "Failed to resolve contracts csproj version from ${csproj_path}."
+
+  unity_current_version="$(sed -nE 's#.*<package id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
+  require_value "${unity_current_version}" "Failed to resolve Unity contracts package version from ${unity_packages_config_path}."
+
+  unity_package_dependency_version="$(sed -nE 's#.*<dependency id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_package_nuspec_path}" | head -n 1)"
+  require_value "${unity_package_dependency_version}" "Failed to resolve Unity package contracts dependency version from ${unity_package_nuspec_path}."
+
+  if [[ "${csproj_current_version}" != "${package_version}" ]]; then
+    replace_first_xml_element "${csproj_path}" "Version"
+  fi
+
+  if [[ "${unity_current_version}" != "${package_version}" ]]; then
+    replace_xml_attribute_version "${unity_packages_config_path}" "MackySoft.Ucli.Contracts"
+  fi
+
+  if [[ "${unity_package_dependency_version}" != "${package_version}" ]]; then
+    replace_xml_attribute_version "${unity_package_nuspec_path}" "MackySoft.Ucli.Contracts"
+  fi
+
+  changed_paths=("${csproj_path}" "${unity_packages_config_path}" "${unity_package_nuspec_path}")
+  sync_branch="chore/contracts-sync-${package_version}"
+  commit_message="chore(contracts): sync package version to ${package_version}"
+  pr_title="chore(contracts): sync package version to ${package_version}"
+  pr_body="$(cat <<EOF
+## Summary
+- Sync \`MackySoft.Ucli.Contracts\` package version to \`${package_version}\` after \`${release_tag}\` publish.
+- Update \`${csproj_path}\`, \`${unity_packages_config_path}\`, and \`${unity_package_nuspec_path}\`.
+
+## Verification
+- \`contracts-package-publish\` packed and published \`${release_tag}\` before creating this PR.
+- \`${verify_workflow}\` workflow was dispatched for \`${sync_branch}\`.
+EOF
+)"
+}
+
+sync_unity_version() {
+  local nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
+  local current_version
+  current_version="$(sed -nE 's#.*<version>([^<]+)</version>.*#\1#p' "${nuspec_path}" | head -n 1)"
+  require_value "${current_version}" "Failed to resolve Unity package version from ${nuspec_path}."
+
+  if [[ "${current_version}" != "${package_version}" ]]; then
+    replace_first_xml_element "${nuspec_path}" "version"
+  fi
+
+  changed_paths=("${nuspec_path}")
+  sync_branch="chore/unity-sync-${package_version}"
+  commit_message="chore(unity): sync package version to ${package_version}"
+  pr_title="chore(unity): sync package version to ${package_version}"
+  pr_body="Sync \`MackySoft.Ucli.Unity\` package version to \`${package_version}\` after \`${release_tag}\` publish. The \`unity-package-publish\` workflow packed, verified, and published the package before creating this PR, then dispatched \`${verify_workflow}\` for \`${sync_branch}\`."
+}
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git fetch origin "${default_branch}"
+
+case "${package_name}" in
+  cli)
+    sync_branch="chore/cli-sync-${package_version}"
+    ;;
+  contracts)
+    sync_branch="chore/contracts-sync-${package_version}"
+    ;;
+  unity)
+    sync_branch="chore/unity-sync-${package_version}"
+    ;;
+  *)
+    echo "Unsupported package sync target: ${package_name}" >&2
+    exit 2
+    ;;
+esac
+
+git checkout -B "${sync_branch}" "origin/${default_branch}"
+
+case "${package_name}" in
+  cli)
+    sync_cli_version
+    ;;
+  contracts)
+    sync_contracts_version
+    ;;
+  unity)
+    sync_unity_version
+    ;;
+esac
+
+if git diff --quiet -- "${changed_paths[@]}"; then
+  echo "No repository version sync required."
+  exit 0
+fi
+
+git add "${changed_paths[@]}"
+git commit -m "${commit_message}"
+
+if git ls-remote --exit-code --heads origin "${sync_branch}" >/dev/null; then
+  git fetch origin "${sync_branch}:refs/remotes/origin/${sync_branch}"
+  remote_sync_sha="$(git rev-parse "refs/remotes/origin/${sync_branch}")"
+  git push --force-with-lease="refs/heads/${sync_branch}:${remote_sync_sha}" origin "HEAD:${sync_branch}"
+else
+  git push origin "HEAD:${sync_branch}"
+fi
+
+existing_pr_url="$(gh pr list \
+  --repo "${repository}" \
+  --state open \
+  --head "${sync_branch}" \
+  --json url \
+  --jq '.[0].url // empty')"
+if [[ -n "${existing_pr_url}" ]]; then
+  echo "Version sync pull request already exists: ${existing_pr_url}"
+else
+  gh pr create \
+    --repo "${repository}" \
+    --base "${default_branch}" \
+    --head "${sync_branch}" \
+    --title "${pr_title}" \
+    --body "${pr_body}"
+fi
+
+gh workflow run "${verify_workflow}" \
+  --repo "${repository}" \
+  --ref "${sync_branch}"

--- a/scripts/create-version-sync-pr.sh
+++ b/scripts/create-version-sync-pr.sh
@@ -3,36 +3,24 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/create-version-sync-pr.sh --package <cli|contracts|unity> --version <version> --release-tag <tag> --repository <owner/repo> --default-branch <branch> [--verify-workflow <workflow>]
+Usage: scripts/create-version-sync-pr.sh --repository <owner/repo> --default-branch <branch> --sync-branch <branch> --commit-message <message> --pr-title <title> (--pr-body <body> | --pr-body-file <path>) --changed-path <path>... [--verify-workflow <workflow>]
 
-Creates or updates the post-publish version sync pull request and dispatches verification.
+Commits prepared version sync changes, pushes the sync branch, creates or reuses the pull request, and dispatches verification.
 EOF
 }
 
-package_name=""
-package_version=""
-release_tag=""
 repository=""
 default_branch=""
+sync_branch=""
+commit_message=""
+pr_title=""
+pr_body=""
+pr_body_file=""
 verify_workflow="verify.yaml"
+changed_paths=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --package)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      package_name="$2"
-      shift 2
-      ;;
-    --version)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      package_version="$2"
-      shift 2
-      ;;
-    --release-tag)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      release_tag="$2"
-      shift 2
-      ;;
     --repository)
       [[ $# -ge 2 ]] || { usage; exit 2; }
       repository="$2"
@@ -43,9 +31,39 @@ while [[ $# -gt 0 ]]; do
       default_branch="$2"
       shift 2
       ;;
+    --sync-branch)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      sync_branch="$2"
+      shift 2
+      ;;
+    --commit-message)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      commit_message="$2"
+      shift 2
+      ;;
+    --pr-title)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      pr_title="$2"
+      shift 2
+      ;;
+    --pr-body)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      pr_body="$2"
+      shift 2
+      ;;
+    --pr-body-file)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      pr_body_file="$2"
+      shift 2
+      ;;
     --verify-workflow)
       [[ $# -ge 2 ]] || { usage; exit 2; }
       verify_workflow="$2"
+      shift 2
+      ;;
+    --changed-path)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      changed_paths+=("$2")
       shift 2
       ;;
     -h|--help)
@@ -59,167 +77,32 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${package_name}" || -z "${package_version}" || -z "${release_tag}" || -z "${repository}" || -z "${default_branch}" ]]; then
+if [[ -z "${repository}" || -z "${default_branch}" || -z "${sync_branch}" || -z "${commit_message}" || -z "${pr_title}" || ${#changed_paths[@]} -eq 0 ]]; then
   usage
   exit 2
 fi
 
-if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-  exit 1
+if [[ -n "${pr_body}" && -n "${pr_body_file}" ]]; then
+  echo "--pr-body and --pr-body-file are mutually exclusive." >&2
+  exit 2
 fi
 
-changed_paths=()
-sync_branch=""
-commit_message=""
-pr_title=""
-pr_body=""
-
-replace_first_xml_element() {
-  local path="$1"
-  local element_name="$2"
-
-  PACKAGE_VERSION="${package_version}" ELEMENT_NAME="${element_name}" perl -0pi -e '
-    my $element = $ENV{"ELEMENT_NAME"};
-    my $version = $ENV{"PACKAGE_VERSION"};
-    s{<\Q$element\E>[^<]+</\Q$element\E>}{<$element>$version</$element>};
-  ' "${path}"
-}
-
-replace_xml_attribute_version() {
-  local path="$1"
-  local id="$2"
-
-  PACKAGE_VERSION="${package_version}" PACKAGE_ID="${id}" perl -0pi -e '
-    my $id = quotemeta($ENV{"PACKAGE_ID"});
-    my $version = $ENV{"PACKAGE_VERSION"};
-    s{(<(?:package|dependency) id="$id" version=")[^"]+(")}{$1$version$2};
-  ' "${path}"
-}
-
-require_value() {
-  local value="$1"
-  local message="$2"
-
-  if [[ -z "${value}" ]]; then
-    echo "${message}" >&2
+if [[ -n "${pr_body_file}" ]]; then
+  if [[ ! -f "${pr_body_file}" ]]; then
+    echo "Pull request body file does not exist: ${pr_body_file}" >&2
     exit 1
   fi
-}
 
-sync_cli_version() {
-  local csproj_path="src/Ucli/Ucli.csproj"
-  local current_version
-  current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-  require_value "${current_version}" "Failed to resolve CLI csproj version from ${csproj_path}."
+  pr_body="$(cat "${pr_body_file}")"
+fi
 
-  if [[ "${current_version}" != "${package_version}" ]]; then
-    replace_first_xml_element "${csproj_path}" "Version"
-  fi
-
-  changed_paths=("${csproj_path}")
-  sync_branch="chore/cli-sync-${package_version}"
-  commit_message="chore(cli): sync package version to ${package_version}"
-  pr_title="chore(cli): sync package version to ${package_version}"
-  pr_body="Sync \`MackySoft.Ucli\` package version to \`${package_version}\` after \`${release_tag}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`${verify_workflow}\` for \`${sync_branch}\`."
-}
-
-sync_contracts_version() {
-  local csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
-  local unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
-  local unity_package_nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
-  local csproj_current_version
-  local unity_current_version
-  local unity_package_dependency_version
-
-  csproj_current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-  require_value "${csproj_current_version}" "Failed to resolve contracts csproj version from ${csproj_path}."
-
-  unity_current_version="$(sed -nE 's#.*<package id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
-  require_value "${unity_current_version}" "Failed to resolve Unity contracts package version from ${unity_packages_config_path}."
-
-  unity_package_dependency_version="$(sed -nE 's#.*<dependency id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_package_nuspec_path}" | head -n 1)"
-  require_value "${unity_package_dependency_version}" "Failed to resolve Unity package contracts dependency version from ${unity_package_nuspec_path}."
-
-  if [[ "${csproj_current_version}" != "${package_version}" ]]; then
-    replace_first_xml_element "${csproj_path}" "Version"
-  fi
-
-  if [[ "${unity_current_version}" != "${package_version}" ]]; then
-    replace_xml_attribute_version "${unity_packages_config_path}" "MackySoft.Ucli.Contracts"
-  fi
-
-  if [[ "${unity_package_dependency_version}" != "${package_version}" ]]; then
-    replace_xml_attribute_version "${unity_package_nuspec_path}" "MackySoft.Ucli.Contracts"
-  fi
-
-  changed_paths=("${csproj_path}" "${unity_packages_config_path}" "${unity_package_nuspec_path}")
-  sync_branch="chore/contracts-sync-${package_version}"
-  commit_message="chore(contracts): sync package version to ${package_version}"
-  pr_title="chore(contracts): sync package version to ${package_version}"
-  pr_body="$(cat <<EOF
-## Summary
-- Sync \`MackySoft.Ucli.Contracts\` package version to \`${package_version}\` after \`${release_tag}\` publish.
-- Update \`${csproj_path}\`, \`${unity_packages_config_path}\`, and \`${unity_package_nuspec_path}\`.
-
-## Verification
-- \`contracts-package-publish\` packed and published \`${release_tag}\` before creating this PR.
-- \`${verify_workflow}\` workflow was dispatched for \`${sync_branch}\`.
-EOF
-)"
-}
-
-sync_unity_version() {
-  local nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
-  local current_version
-  current_version="$(sed -nE 's#.*<version>([^<]+)</version>.*#\1#p' "${nuspec_path}" | head -n 1)"
-  require_value "${current_version}" "Failed to resolve Unity package version from ${nuspec_path}."
-
-  if [[ "${current_version}" != "${package_version}" ]]; then
-    replace_first_xml_element "${nuspec_path}" "version"
-  fi
-
-  changed_paths=("${nuspec_path}")
-  sync_branch="chore/unity-sync-${package_version}"
-  commit_message="chore(unity): sync package version to ${package_version}"
-  pr_title="chore(unity): sync package version to ${package_version}"
-  pr_body="Sync \`MackySoft.Ucli.Unity\` package version to \`${package_version}\` after \`${release_tag}\` publish. The \`unity-package-publish\` workflow packed, verified, and published the package before creating this PR, then dispatched \`${verify_workflow}\` for \`${sync_branch}\`."
-}
+if [[ -z "${pr_body}" ]]; then
+  echo "Pull request body is required." >&2
+  exit 2
+fi
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-git fetch origin "${default_branch}"
-
-case "${package_name}" in
-  cli)
-    sync_branch="chore/cli-sync-${package_version}"
-    ;;
-  contracts)
-    sync_branch="chore/contracts-sync-${package_version}"
-    ;;
-  unity)
-    sync_branch="chore/unity-sync-${package_version}"
-    ;;
-  *)
-    echo "Unsupported package sync target: ${package_name}" >&2
-    exit 2
-    ;;
-esac
-
-git checkout -B "${sync_branch}" "origin/${default_branch}"
-
-case "${package_name}" in
-  cli)
-    sync_cli_version
-    ;;
-  contracts)
-    sync_contracts_version
-    ;;
-  unity)
-    sync_unity_version
-    ;;
-esac
 
 if git diff --quiet -- "${changed_paths[@]}"; then
   echo "No repository version sync required."

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -111,11 +111,28 @@ is_unity_input() {
   esac
 }
 
-is_contracts_pack_input() {
+is_package_publish_shared_input() {
   local file="$1"
 
   case "${file}" in
-    .github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/sync-contracts-package-version.sh)
+    .github/actions/mirror-nuget-release/action.yaml|.github/actions/publish-nuget-package/action.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/mirror-nuget-package-release.sh|scripts/package-version-sync-common.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_contracts_pack_input() {
+  local file="$1"
+
+  if is_package_publish_shared_input "${file}"; then
+    return 0
+  fi
+
+  case "${file}" in
+    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-contracts-package-version.sh)
       return 0
       ;;
   esac
@@ -137,8 +154,12 @@ is_contracts_pack_input() {
 is_cli_pack_input() {
   local file="$1"
 
+  if is_package_publish_shared_input "${file}"; then
+    return 0
+  fi
+
   case "${file}" in
-    README.md|LICENSE|.github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
+    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
       return 0
       ;;
     *)
@@ -150,8 +171,12 @@ is_cli_pack_input() {
 is_unity_pack_input() {
   local file="$1"
 
+  if is_package_publish_shared_input "${file}"; then
+    return 0
+  fi
+
   case "${file}" in
-    README.md|LICENSE|docs/package-operations.md|.github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/setup-nuget-cli.sh|scripts/sync-unity-package-version.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
+    README.md|LICENSE|docs/package-operations.md|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/setup-nuget-cli.sh|scripts/sync-unity-package-version.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
       return 0
       ;;
     *)

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -115,7 +115,7 @@ is_contracts_pack_input() {
   local file="$1"
 
   case "${file}" in
-    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/sync-contracts-package-version.sh)
+    .github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/sync-contracts-package-version.sh)
       return 0
       ;;
   esac
@@ -138,7 +138,7 @@ is_cli_pack_input() {
   local file="$1"
 
   case "${file}" in
-    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
+    README.md|LICENSE|.github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
       return 0
       ;;
     *)
@@ -151,7 +151,7 @@ is_unity_pack_input() {
   local file="$1"
 
   case "${file}" in
-    README.md|LICENSE|docs/package-operations.md|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/prepare-version-sync-branch.sh|scripts/setup-nuget-cli.sh|scripts/sync-unity-package-version.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
+    README.md|LICENSE|docs/package-operations.md|.github/actions/publish-nuget-package/action.yaml|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-release-tag.sh|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/prepare-version-sync-branch.sh|scripts/resolve-release-version.sh|scripts/setup-nuget-cli.sh|scripts/sync-unity-package-version.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
       return 0
       ;;
     *)

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -115,7 +115,7 @@ is_contracts_pack_input() {
   local file="$1"
 
   case "${file}" in
-    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh)
+    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/sync-contracts-package-version.sh)
       return 0
       ;;
   esac
@@ -138,7 +138,7 @@ is_cli_pack_input() {
   local file="$1"
 
   case "${file}" in
-    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
+    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/prepare-version-sync-branch.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
       return 0
       ;;
     *)
@@ -151,7 +151,7 @@ is_unity_pack_input() {
   local file="$1"
 
   case "${file}" in
-    README.md|LICENSE|docs/package-operations.md|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/setup-nuget-cli.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
+    README.md|LICENSE|docs/package-operations.md|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/prepare-version-sync-branch.sh|scripts/setup-nuget-cli.sh|scripts/sync-unity-package-version.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
       return 0
       ;;
     *)

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -12,6 +12,7 @@ needs_dotnet=false
 needs_unity=false
 needs_contracts_pack=false
 needs_cli_pack=false
+needs_unity_pack=false
 
 event_name="${EVENT_NAME:-}"
 current_sha="${CURRENT_SHA:-}"
@@ -33,6 +34,7 @@ emit_outputs() {
   emit_output needs_unity "${needs_unity}"
   emit_output needs_contracts_pack "${needs_contracts_pack}"
   emit_output needs_cli_pack "${needs_cli_pack}"
+  emit_output needs_unity_pack "${needs_unity_pack}"
   emit_output dotnet_matrix_json "${dotnet_matrix_json}"
   emit_output unity_matrix_json "${unity_matrix_json}"
 }
@@ -43,6 +45,7 @@ emit_full_verification() {
   needs_unity=true
   needs_contracts_pack=true
   needs_cli_pack=true
+  needs_unity_pack=true
   dotnet_matrix_json="${dotnet_matrix_pr}"
   unity_matrix_json="${unity_matrix_pr}"
   emit_outputs
@@ -89,7 +92,7 @@ is_unity_input() {
   local file="$1"
 
   case "${file}" in
-    .github/workflows/verify.yaml|scripts/detect-verify-scopes.sh|scripts/update-local-contracts-package.sh|src/Ucli.Unity/Ucli.Unity.slnx|src/Ucli.Unity/*.csproj|src/Ucli.Unity/Assets/*|src/Ucli.Unity/Packages/*|src/Ucli.Unity/ProjectSettings/*)
+    .github/workflows/verify.yaml|scripts/detect-verify-scopes.sh|scripts/setup-nuget-cli.sh|scripts/update-local-contracts-package.sh|src/Ucli.Unity/Ucli.Unity.slnx|src/Ucli.Unity/*.csproj|src/Ucli.Unity/Assets/*|src/Ucli.Unity/Packages/*|src/Ucli.Unity/ProjectSettings/*)
       return 0
       ;;
   esac
@@ -112,7 +115,7 @@ is_contracts_pack_input() {
   local file="$1"
 
   case "${file}" in
-    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/detect-verify-scopes.sh)
+    .github/workflows/verify.yaml|.github/workflows/contracts-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh)
       return 0
       ;;
   esac
@@ -135,7 +138,20 @@ is_cli_pack_input() {
   local file="$1"
 
   case "${file}" in
-    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
+    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Contracts/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_unity_pack_input() {
+  local file="$1"
+
+  case "${file}" in
+    README.md|LICENSE|docs/package-operations.md|.github/workflows/verify.yaml|.github/workflows/unity-package-publish.yaml|scripts/create-version-sync-pr.sh|scripts/detect-verify-scopes.sh|scripts/pack-unity-plugin.sh|scripts/setup-nuget-cli.sh|scripts/verify-unity-plugin-package.sh|src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec|src/Ucli.Unity/Assets/packages.config|src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/*)
       return 0
       ;;
     *)
@@ -215,6 +231,10 @@ while IFS= read -r file; do
 
   if is_cli_pack_input "${file}"; then
     needs_cli_pack=true
+  fi
+
+  if is_unity_pack_input "${file}"; then
+    needs_unity_pack=true
   fi
 done <<< "${changed_files}"
 

--- a/scripts/mirror-nuget-package-release.sh
+++ b/scripts/mirror-nuget-package-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/mirror-nuget-package-release.sh --repository <owner/repo> --tag-name <tag> --package-glob <glob> --title <title> --notes <notes>
+
+Creates or updates the GitHub Release for a package tag and uploads matched nupkg artifacts.
+EOF
+}
+
+repository=""
+tag_name=""
+package_glob=""
+release_title=""
+release_notes=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repository)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      repository="$2"
+      shift 2
+      ;;
+    --tag-name)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      tag_name="$2"
+      shift 2
+      ;;
+    --package-glob)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_glob="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      release_title="$2"
+      shift 2
+      ;;
+    --notes)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      release_notes="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${repository}" || -z "${tag_name}" || -z "${package_glob}" || -z "${release_title}" || -z "${release_notes}" ]]; then
+  usage
+  exit 2
+fi
+
+package_paths=()
+while IFS= read -r package_path; do
+  package_paths+=("${package_path}")
+done < <(compgen -G "${package_glob}" | sort)
+if [[ ${#package_paths[@]} -eq 0 ]]; then
+  echo "No NuGet package artifacts matched: ${package_glob}" >&2
+  exit 1
+fi
+
+if gh release view "${tag_name}" --repo "${repository}" >/dev/null 2>&1; then
+  gh release upload "${tag_name}" "${package_paths[@]}" --repo "${repository}" --clobber
+else
+  gh release create "${tag_name}" "${package_paths[@]}" \
+    --repo "${repository}" \
+    --title "${release_title}" \
+    --notes "${release_notes}"
+fi

--- a/scripts/pack-unity-plugin.sh
+++ b/scripts/pack-unity-plugin.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/pack-unity-plugin.sh [--repo-root <path>] [--version <version>] [--output <dir>]
+
+Creates MackySoft.Ucli.Unity.<version>.nupkg for NuGetForUnity.
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_dir}/.." && pwd)"
+package_version=""
+output_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      repository_root="$(cd "$2" && pwd)"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+nuspec_path="${repository_root}/src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
+if [[ ! -f "${nuspec_path}" ]]; then
+  echo "Unity package nuspec does not exist: ${nuspec_path}" >&2
+  exit 1
+fi
+
+if [[ -z "${package_version}" ]]; then
+  package_version="$(
+    sed -nE 's#.*<version>([^<]+)</version>.*#\1#p' "${nuspec_path}" | head -n 1
+  )"
+fi
+
+if [[ -z "${package_version}" ]]; then
+  echo "Failed to resolve MackySoft.Ucli.Unity package version from ${nuspec_path}." >&2
+  exit 1
+fi
+
+if [[ -z "${output_dir}" ]]; then
+  output_dir="${repository_root}/artifacts/packages"
+fi
+
+mkdir -p "${output_dir}"
+echo "Packing MackySoft.Ucli.Unity ${package_version}"
+nuget pack "${nuspec_path}" \
+  -Version "${package_version}" \
+  -OutputDirectory "${output_dir}" \
+  -NoDefaultExcludes \
+  -NonInteractive

--- a/scripts/package-version-sync-common.sh
+++ b/scripts/package-version-sync-common.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+parse_package_version_arg() {
+  local usage_function="$1"
+  shift
+
+  local package_version=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --version)
+        [[ $# -ge 2 ]] || { "${usage_function}"; exit 2; }
+        package_version="$2"
+        shift 2
+        ;;
+      -h|--help)
+        "${usage_function}"
+        exit 0
+        ;;
+      *)
+        "${usage_function}"
+        exit 2
+        ;;
+    esac
+  done
+
+  if [[ -z "${package_version}" ]]; then
+    "${usage_function}"
+    exit 2
+  fi
+
+  require_semver_package_version "${package_version}"
+  printf '%s\n' "${package_version}"
+}
+
+require_semver_package_version() {
+  local package_version="$1"
+
+  if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+    exit 1
+  fi
+}
+
+read_required_xml_element_value() {
+  local file_path="$1"
+  local element_name="$2"
+  local description="$3"
+
+  local current_value
+  current_value="$(
+    ELEMENT_NAME="${element_name}" perl -ne '
+      my $element = $ENV{"ELEMENT_NAME"};
+      if (/<\Q$element\E>([^<]+)<\/\Q$element\E>/) {
+        print $1;
+        exit;
+      }
+    ' "${file_path}"
+  )"
+
+  if [[ -z "${current_value}" ]]; then
+    echo "Failed to resolve ${description} from ${file_path}." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${current_value}"
+}
+
+read_required_xml_attribute_value() {
+  local file_path="$1"
+  local attribute_prefix="$2"
+  local description="$3"
+
+  local current_value
+  current_value="$(
+    ATTRIBUTE_PREFIX="${attribute_prefix}" perl -ne '
+      my $prefix = $ENV{"ATTRIBUTE_PREFIX"};
+      if (/\Q$prefix\E([^"]+)"/) {
+        print $1;
+        exit;
+      }
+    ' "${file_path}"
+  )"
+
+  if [[ -z "${current_value}" ]]; then
+    echo "Failed to resolve ${description} from ${file_path}." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${current_value}"
+}
+
+update_xml_element_value() {
+  local file_path="$1"
+  local element_name="$2"
+  local package_version="$3"
+  local description="$4"
+
+  local current_value
+  current_value="$(read_required_xml_element_value "${file_path}" "${element_name}" "${description}")"
+  if [[ "${current_value}" == "${package_version}" ]]; then
+    return 0
+  fi
+
+  ELEMENT_NAME="${element_name}" PACKAGE_VERSION="${package_version}" perl -0pi -e '
+    my $element = $ENV{"ELEMENT_NAME"};
+    my $version = $ENV{"PACKAGE_VERSION"};
+    s{(<\Q$element\E>)[^<]+(</\Q$element\E>)}{$1$version$2};
+  ' "${file_path}"
+}
+
+update_xml_attribute_value() {
+  local file_path="$1"
+  local attribute_prefix="$2"
+  local package_version="$3"
+  local description="$4"
+
+  local current_value
+  current_value="$(read_required_xml_attribute_value "${file_path}" "${attribute_prefix}" "${description}")"
+  if [[ "${current_value}" == "${package_version}" ]]; then
+    return 0
+  fi
+
+  ATTRIBUTE_PREFIX="${attribute_prefix}" PACKAGE_VERSION="${package_version}" perl -0pi -e '
+    my $prefix = $ENV{"ATTRIBUTE_PREFIX"};
+    my $version = $ENV{"PACKAGE_VERSION"};
+    s{(\Q$prefix\E)[^"]+(")}{$1$version$2};
+  ' "${file_path}"
+}

--- a/scripts/prepare-version-sync-branch.sh
+++ b/scripts/prepare-version-sync-branch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/prepare-version-sync-branch.sh --default-branch <branch> --sync-branch <branch>
+
+Checks out a version sync branch from the latest origin default branch.
+EOF
+}
+
+default_branch=""
+sync_branch=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --default-branch)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      default_branch="$2"
+      shift 2
+      ;;
+    --sync-branch)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      sync_branch="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${default_branch}" || -z "${sync_branch}" ]]; then
+  usage
+  exit 2
+fi
+
+git fetch origin "${default_branch}"
+git checkout -B "${sync_branch}" "origin/${default_branch}"

--- a/scripts/resolve-release-version.sh
+++ b/scripts/resolve-release-version.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/resolve-release-version.sh --tag-prefix <prefix> [--dispatch-version <version>] [--event-name <event>] [--ref-name <ref>]
+
+Resolves a SemVer package version and release tag name for package publish workflows.
+EOF
+}
+
+tag_prefix=""
+dispatch_version="${DISPATCH_VERSION:-}"
+event_name="${GITHUB_EVENT_NAME:-}"
+ref_name="${GITHUB_REF_NAME:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag-prefix)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      tag_prefix="$2"
+      shift 2
+      ;;
+    --dispatch-version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      dispatch_version="$2"
+      shift 2
+      ;;
+    --event-name)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      event_name="$2"
+      shift 2
+      ;;
+    --ref-name)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      ref_name="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${tag_prefix}" || -z "${event_name}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! "${tag_prefix}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "Tag prefix must not contain path separators or shell pattern characters. Actual: ${tag_prefix}" >&2
+  exit 2
+fi
+
+if [[ "${event_name}" == "workflow_dispatch" ]]; then
+  package_version="${dispatch_version}"
+else
+  expected_prefix="${tag_prefix}/"
+  if [[ -z "${ref_name}" || "${ref_name}" != "${expected_prefix}"* ]]; then
+    echo "Release ref must start with ${expected_prefix}. Actual: ${ref_name}" >&2
+    exit 1
+  fi
+
+  package_version="${ref_name#${expected_prefix}}"
+fi
+
+if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+  exit 1
+fi
+
+tag_name="${tag_prefix}/${package_version}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "package_version=${package_version}"
+    echo "tag_name=${tag_name}"
+  } >> "${GITHUB_OUTPUT}"
+else
+  echo "package_version=${package_version}"
+  echo "tag_name=${tag_name}"
+fi

--- a/scripts/setup-nuget-cli.sh
+++ b/scripts/setup-nuget-cli.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/setup-nuget-cli.sh [--version <nuget-version>]
+
+Installs a NuGet CLI wrapper for Linux and macOS GitHub Actions runners.
+EOF
+}
+
+nuget_version="${NUGET_CLI_VERSION:-7.3.0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      nuget_version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+runner_os="${RUNNER_OS:-$(uname -s)}"
+case "${runner_os}" in
+  Linux)
+    if ! command -v mono >/dev/null 2>&1; then
+      export DEBIAN_FRONTEND=noninteractive
+      sudo apt-get update
+      sudo apt-get install --yes mono-complete
+    fi
+    ;;
+  macOS|Darwin)
+    if ! command -v mono >/dev/null 2>&1; then
+      if ! command -v brew >/dev/null 2>&1; then
+        echo "Homebrew is required to install Mono on macOS runners." >&2
+        exit 1
+      fi
+
+      brew install mono
+    fi
+    ;;
+  *)
+    echo "setup-nuget-cli.sh supports Linux and macOS runners only. Actual: ${runner_os}" >&2
+    exit 2
+    ;;
+esac
+
+mono --version | head -n 1
+
+runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+nuget_dir="${runner_temp}/nuget"
+mkdir -p "${nuget_dir}"
+
+curl --fail --location --silent --show-error \
+  "https://dist.nuget.org/win-x86-commandline/v${nuget_version}/nuget.exe" \
+  --output "${nuget_dir}/nuget.exe"
+
+cat > "${nuget_dir}/nuget" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mono "$(dirname "$0")/nuget.exe" "$@"
+EOF
+chmod +x "${nuget_dir}/nuget"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${nuget_dir}" >> "${GITHUB_PATH}"
+else
+  echo "NuGet CLI wrapper created at ${nuget_dir}/nuget"
+fi

--- a/scripts/sync-cli-package-version.sh
+++ b/scripts/sync-cli-package-version.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/package-version-sync-common.sh"
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/sync-cli-package-version.sh --version <version>
@@ -9,48 +12,7 @@ Updates the CLI package version tracked in the repository.
 EOF
 }
 
-package_version=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --version)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      package_version="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      usage
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "${package_version}" ]]; then
-  usage
-  exit 2
-fi
-
-if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-  exit 1
-fi
-
+package_version="$(parse_package_version_arg usage "$@")"
 csproj_path="src/Ucli/Ucli.csproj"
-current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-if [[ -z "${current_version}" ]]; then
-  echo "Failed to resolve CLI csproj version from ${csproj_path}." >&2
-  exit 1
-fi
 
-if [[ "${current_version}" == "${package_version}" ]]; then
-  exit 0
-fi
-
-PACKAGE_VERSION="${package_version}" perl -0pi -e '
-  my $version = $ENV{"PACKAGE_VERSION"};
-  s{<Version>[^<]+</Version>}{<Version>$version</Version>};
-' "${csproj_path}"
+update_xml_element_value "${csproj_path}" "Version" "${package_version}" "CLI csproj version"

--- a/scripts/sync-cli-package-version.sh
+++ b/scripts/sync-cli-package-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/sync-cli-package-version.sh --version <version>
+
+Updates the CLI package version tracked in the repository.
+EOF
+}
+
+package_version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${package_version}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+  exit 1
+fi
+
+csproj_path="src/Ucli/Ucli.csproj"
+current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+if [[ -z "${current_version}" ]]; then
+  echo "Failed to resolve CLI csproj version from ${csproj_path}." >&2
+  exit 1
+fi
+
+if [[ "${current_version}" == "${package_version}" ]]; then
+  exit 0
+fi
+
+PACKAGE_VERSION="${package_version}" perl -0pi -e '
+  my $version = $ENV{"PACKAGE_VERSION"};
+  s{<Version>[^<]+</Version>}{<Version>$version</Version>};
+' "${csproj_path}"

--- a/scripts/sync-contracts-package-version.sh
+++ b/scripts/sync-contracts-package-version.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/package-version-sync-common.sh"
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/sync-contracts-package-version.sh --version <version>
@@ -9,69 +12,11 @@ Updates repository files that track the MackySoft.Ucli.Contracts package version
 EOF
 }
 
-package_version=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --version)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      package_version="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      usage
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "${package_version}" ]]; then
-  usage
-  exit 2
-fi
-
-if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-  exit 1
-fi
-
+package_version="$(parse_package_version_arg usage "$@")"
 csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
 unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
 unity_package_nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
 
-csproj_current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
-if [[ -z "${csproj_current_version}" ]]; then
-  echo "Failed to resolve contracts csproj version from ${csproj_path}." >&2
-  exit 1
-fi
-
-unity_current_version="$(sed -nE 's#.*<package id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
-if [[ -z "${unity_current_version}" ]]; then
-  echo "Failed to resolve Unity contracts package version from ${unity_packages_config_path}." >&2
-  exit 1
-fi
-
-unity_package_dependency_version="$(sed -nE 's#.*<dependency id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_package_nuspec_path}" | head -n 1)"
-if [[ -z "${unity_package_dependency_version}" ]]; then
-  echo "Failed to resolve Unity package contracts dependency version from ${unity_package_nuspec_path}." >&2
-  exit 1
-fi
-
-PACKAGE_VERSION="${package_version}" perl -0pi -e '
-  my $version = $ENV{"PACKAGE_VERSION"};
-  s{<Version>[^<]+</Version>}{<Version>$version</Version>};
-' "${csproj_path}"
-
-PACKAGE_VERSION="${package_version}" perl -0pi -e '
-  my $version = $ENV{"PACKAGE_VERSION"};
-  s{(<package id="MackySoft.Ucli.Contracts" version=")[^"]+(")}{$1$version$2};
-' "${unity_packages_config_path}"
-
-PACKAGE_VERSION="${package_version}" perl -0pi -e '
-  my $version = $ENV{"PACKAGE_VERSION"};
-  s{(<dependency id="MackySoft.Ucli.Contracts" version=")[^"]+(")}{$1$version$2};
-' "${unity_package_nuspec_path}"
+update_xml_element_value "${csproj_path}" "Version" "${package_version}" "contracts csproj version"
+update_xml_attribute_value "${unity_packages_config_path}" '<package id="MackySoft.Ucli.Contracts" version="' "${package_version}" "Unity contracts package version"
+update_xml_attribute_value "${unity_package_nuspec_path}" '<dependency id="MackySoft.Ucli.Contracts" version="' "${package_version}" "Unity package contracts dependency version"

--- a/scripts/sync-contracts-package-version.sh
+++ b/scripts/sync-contracts-package-version.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/sync-contracts-package-version.sh --version <version>
+
+Updates repository files that track the MackySoft.Ucli.Contracts package version.
+EOF
+}
+
+package_version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${package_version}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+  exit 1
+fi
+
+csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
+unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
+unity_package_nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
+
+csproj_current_version="$(sed -nE 's#.*<Version>([^<]+)</Version>.*#\1#p' "${csproj_path}" | head -n 1)"
+if [[ -z "${csproj_current_version}" ]]; then
+  echo "Failed to resolve contracts csproj version from ${csproj_path}." >&2
+  exit 1
+fi
+
+unity_current_version="$(sed -nE 's#.*<package id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_packages_config_path}" | head -n 1)"
+if [[ -z "${unity_current_version}" ]]; then
+  echo "Failed to resolve Unity contracts package version from ${unity_packages_config_path}." >&2
+  exit 1
+fi
+
+unity_package_dependency_version="$(sed -nE 's#.*<dependency id="MackySoft.Ucli.Contracts" version="([^"]+)".*#\1#p' "${unity_package_nuspec_path}" | head -n 1)"
+if [[ -z "${unity_package_dependency_version}" ]]; then
+  echo "Failed to resolve Unity package contracts dependency version from ${unity_package_nuspec_path}." >&2
+  exit 1
+fi
+
+PACKAGE_VERSION="${package_version}" perl -0pi -e '
+  my $version = $ENV{"PACKAGE_VERSION"};
+  s{<Version>[^<]+</Version>}{<Version>$version</Version>};
+' "${csproj_path}"
+
+PACKAGE_VERSION="${package_version}" perl -0pi -e '
+  my $version = $ENV{"PACKAGE_VERSION"};
+  s{(<package id="MackySoft.Ucli.Contracts" version=")[^"]+(")}{$1$version$2};
+' "${unity_packages_config_path}"
+
+PACKAGE_VERSION="${package_version}" perl -0pi -e '
+  my $version = $ENV{"PACKAGE_VERSION"};
+  s{(<dependency id="MackySoft.Ucli.Contracts" version=")[^"]+(")}{$1$version$2};
+' "${unity_package_nuspec_path}"

--- a/scripts/sync-unity-package-version.sh
+++ b/scripts/sync-unity-package-version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/sync-unity-package-version.sh --version <version>
+
+Updates the MackySoft.Ucli.Unity package version tracked in the repository.
+EOF
+}
+
+package_version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${package_version}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+  exit 1
+fi
+
+nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
+current_version="$(sed -nE 's#.*<version>([^<]+)</version>.*#\1#p' "${nuspec_path}" | head -n 1)"
+if [[ -z "${current_version}" ]]; then
+  echo "Failed to resolve Unity package version from ${nuspec_path}." >&2
+  exit 1
+fi
+
+if [[ "${current_version}" == "${package_version}" ]]; then
+  exit 0
+fi
+
+PACKAGE_VERSION="${package_version}" perl -0pi -e '
+  my $version = $ENV{"PACKAGE_VERSION"};
+  s{<version>[^<]+</version>}{<version>$version</version>};
+' "${nuspec_path}"

--- a/scripts/sync-unity-package-version.sh
+++ b/scripts/sync-unity-package-version.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/package-version-sync-common.sh"
+
 usage() {
   cat >&2 <<'EOF'
 Usage: scripts/sync-unity-package-version.sh --version <version>
@@ -9,48 +12,7 @@ Updates the MackySoft.Ucli.Unity package version tracked in the repository.
 EOF
 }
 
-package_version=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --version)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      package_version="$2"
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      usage
-      exit 2
-      ;;
-  esac
-done
-
-if [[ -z "${package_version}" ]]; then
-  usage
-  exit 2
-fi
-
-if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
-  exit 1
-fi
-
+package_version="$(parse_package_version_arg usage "$@")"
 nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
-current_version="$(sed -nE 's#.*<version>([^<]+)</version>.*#\1#p' "${nuspec_path}" | head -n 1)"
-if [[ -z "${current_version}" ]]; then
-  echo "Failed to resolve Unity package version from ${nuspec_path}." >&2
-  exit 1
-fi
 
-if [[ "${current_version}" == "${package_version}" ]]; then
-  exit 0
-fi
-
-PACKAGE_VERSION="${package_version}" perl -0pi -e '
-  my $version = $ENV{"PACKAGE_VERSION"};
-  s{<version>[^<]+</version>}{<version>$version</version>};
-' "${nuspec_path}"
+update_xml_element_value "${nuspec_path}" "version" "${package_version}" "Unity package version"

--- a/scripts/update-local-contracts-package.sh
+++ b/scripts/update-local-contracts-package.sh
@@ -116,6 +116,7 @@ echo "[4/7] Restore Unity packages.config from local/source feeds"
 nuget restore "${unity_packages_config}" \
   -PackagesDirectory "${unity_packages_dir}" \
   -ConfigFile "${unity_nuget_config}" \
+  -NoCache \
   -NonInteractive
 
 echo "[5/7] Remove NuGet placeholder .meta files from restored Unity packages"

--- a/scripts/verify-unity-plugin-package.sh
+++ b/scripts/verify-unity-plugin-package.sh
@@ -103,6 +103,7 @@ EOF
 nuget restore "${temp_dir}/packages.config" \
   -PackagesDirectory "${restore_root}/Assets/Packages" \
   -Source "${package_dir}" \
+  -NoCache \
   -NonInteractive >/dev/null
 
 restored_marker_path="${restore_root}/Assets/Packages/${package_id}.${expected_version}/ucli-plugin.json"

--- a/scripts/verify-unity-plugin-package.sh
+++ b/scripts/verify-unity-plugin-package.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <package-dir> <expected-version>" >&2
+  exit 2
+fi
+
+package_dir="$1"
+expected_version="$2"
+
+if [[ ! -d "${package_dir}" ]]; then
+  echo "Unity package directory does not exist: ${package_dir}" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "${script_dir}/.." && pwd)"
+package_dir="$(cd "${package_dir}" && pwd)"
+package_id="MackySoft.Ucli.Unity"
+package_path="${package_dir}/${package_id}.${expected_version}.nupkg"
+nuspec_entry="${package_id}.nuspec"
+unity_packages_config="${repository_root}/src/Ucli.Unity/Assets/packages.config"
+
+if [[ ! -f "${package_path}" ]]; then
+  echo "Unity package was not created: ${package_path}" >&2
+  exit 1
+fi
+
+for required_tool in unzip nuget; do
+  if ! command -v "${required_tool}" >/dev/null 2>&1; then
+    echo "Required tool is missing: ${required_tool}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${unity_packages_config}" ]]; then
+  echo "Unity packages.config does not exist: ${unity_packages_config}" >&2
+  exit 1
+fi
+
+package_entries="$(unzip -Z1 "${package_path}")"
+required_entries=(
+  "${nuspec_entry}"
+  "ucli-plugin.json"
+  "Editor/MackySoft.Ucli.Unity.Editor.asmdef"
+  "Editor/AssemblyInfo.cs"
+  "Editor/Ipc/Bootstrap/UnityDaemonBootstrap.cs"
+  "Editor/Execution/UnityExecutionServiceCollectionExtensions.cs"
+  "README.md"
+  "LICENSE"
+)
+
+for entry in "${required_entries[@]}"; do
+  if ! grep -Fx "${entry}" <<< "${package_entries}" >/dev/null; then
+    echo "Unity package is missing required entry: ${entry}" >&2
+    exit 1
+  fi
+done
+
+for forbidden_pattern in '^Assets/' '^Tests/' '^ProjectSettings/' '^Packages/' '^.*\.unitypackage$' '^package\.json$'; do
+  if grep -E "${forbidden_pattern}" <<< "${package_entries}" >/dev/null; then
+    echo "Unity package contains forbidden entry matching ${forbidden_pattern}." >&2
+    grep -E "${forbidden_pattern}" <<< "${package_entries}" >&2
+    exit 1
+  fi
+done
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+nuspec_path="${temp_dir}/${nuspec_entry}"
+unzip -p "${package_path}" "${nuspec_entry}" > "${nuspec_path}"
+
+if ! grep -F "<id>${package_id}</id>" "${nuspec_path}" >/dev/null; then
+  echo "Unity package nuspec has an unexpected package id." >&2
+  exit 1
+fi
+
+if ! grep -F "<version>${expected_version}</version>" "${nuspec_path}" >/dev/null; then
+  echo "Unity package nuspec has an unexpected version." >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r dependency_id dependency_version; do
+  [[ -n "${dependency_id}" ]] || continue
+  if ! grep -F "<dependency id=\"${dependency_id}\" version=\"${dependency_version}\" />" "${nuspec_path}" >/dev/null; then
+    echo "Unity package nuspec is missing dependency ${dependency_id} ${dependency_version}." >&2
+    exit 1
+  fi
+done < <(
+  sed -nE 's#.*<package id="([^"]+)" version="([^"]+)".*#\1\t\2#p' "${unity_packages_config}"
+)
+
+restore_root="${temp_dir}/UnityProject"
+mkdir -p "${restore_root}/Assets"
+cat > "${temp_dir}/packages.config" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="${package_id}" version="${expected_version}" targetFramework="netstandard2.1" />
+</packages>
+EOF
+
+nuget restore "${temp_dir}/packages.config" \
+  -PackagesDirectory "${restore_root}/Assets/Packages" \
+  -Source "${package_dir}" \
+  -NonInteractive >/dev/null
+
+restored_marker_path="${restore_root}/Assets/Packages/${package_id}.${expected_version}/ucli-plugin.json"
+if [[ ! -f "${restored_marker_path}" ]]; then
+  echo "Restored Unity package marker was not found: ${restored_marker_path}" >&2
+  exit 1
+fi
+
+echo "Unity package verification passed: ${package_path}"

--- a/src/Ucli.Unity/Assets/NuGet.config
+++ b/src/Ucli.Unity/Assets/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <add key="LocalNuGet" value="../Packages/nuget-local-source" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" enableCredentialProvider="false" />
-    <add key="PrivateNuGet" value="https://nuget.pkg.github.com/mackysoft/index.json" enableCredentialProvider="false" supportsPackageIdSearchFilter="false" />
   </packageSources>
 
   <disabledPackageSources />
@@ -12,6 +11,16 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+
+  <packageSourceMapping>
+    <packageSource key="LocalNuGet">
+      <package pattern="MackySoft.Ucli.Contracts" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="Microsoft.*" />
+      <package pattern="System.*" />
+    </packageSource>
+  </packageSourceMapping>
 
   <config>
     <add key="packageInstallLocation" value="CustomWithinAssets" />

--- a/src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec
+++ b/src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>MackySoft.Ucli.Unity</id>
+    <version>0.18.0</version>
+    <title>uCLI Unity Plugin</title>
+    <authors>Hiroya Aramaki</authors>
+    <owners>MackySoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="file">LICENSE</license>
+    <readme>README.md</readme>
+    <projectUrl>https://github.com/mackysoft/ucli</projectUrl>
+    <repository type="git" url="https://github.com/mackysoft/ucli" />
+    <description>Unity Editor plugin for uCLI IPC and automation.</description>
+    <tags>ucli unity editor automation ipc nugetforunity</tags>
+    <dependencies>
+      <dependency id="MackySoft.Ucli.Contracts" version="0.18.0" />
+      <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
+      <dependency id="Microsoft.Extensions.DependencyInjection" version="6.0.0" />
+      <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" />
+      <dependency id="System.Buffers" version="4.5.1" />
+      <dependency id="System.Memory" version="4.5.5" />
+      <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" />
+      <dependency id="System.Text.Encodings.Web" version="8.0.0" />
+      <dependency id="System.Text.Json" version="8.0.5" />
+      <dependency id="System.Threading.Tasks.Extensions" version="4.5.4" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Assets/MackySoft/MackySoft.Ucli.Unity/**" target="" />
+    <file src="../../README.md" target="README.md" />
+    <file src="../../LICENSE" target="LICENSE" />
+  </files>
+</package>

--- a/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
@@ -3,6 +3,7 @@ namespace MackySoft.Ucli.Tests;
 using System.Xml.Linq;
 using MackySoft.Tests;
 using MackySoft.Ucli.UnityIntegration.Project.Plugin;
+using MackySoft.Ucli.UnityIntegration.Project.Plugin.Cache;
 
 public sealed class UnityPluginPackageSpecTests
 {
@@ -41,7 +42,7 @@ public sealed class UnityPluginPackageSpecTests
               "protocolVersion": 1
             }
             """);
-        var locator = new UnityUcliPluginLocator();
+        var locator = new UnityUcliPluginLocator(CreateNoOpCacheStore());
 
         var result = await locator.Locate(unityProjectPath, CancellationToken.None);
 
@@ -85,6 +86,14 @@ public sealed class UnityPluginPackageSpecTests
             .Descendants(ns + "version")
             .Select(element => element.Value)
             .First();
+    }
+
+    private static UnityUcliPluginMarkerCacheStore CreateNoOpCacheStore ()
+    {
+        return new UnityUcliPluginMarkerCacheStore(
+            static (_, _) => ValueTask.FromResult<string?>(null),
+            static (_, _, _) => ValueTask.CompletedTask,
+            static _ => { });
     }
 
     private static string ResolveRepositoryRoot ()

--- a/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
@@ -1,0 +1,105 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Xml.Linq;
+using MackySoft.Tests;
+using MackySoft.Ucli.UnityIntegration.Project.Plugin;
+
+public sealed class UnityPluginPackageSpecTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Nuspec_DeclaresSameDependenciesAsUnityPackagesConfig ()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var nuspecPath = Path.Combine(repositoryRoot, "src", "Ucli.Unity", "MackySoft.Ucli.Unity.nuspec");
+        var packagesConfigPath = Path.Combine(repositoryRoot, "src", "Ucli.Unity", "Assets", "packages.config");
+
+        var nuspecDependencies = ReadNuspecDependencies(nuspecPath);
+        var packagesConfigDependencies = ReadPackagesConfigDependencies(packagesConfigPath);
+
+        Assert.Equal(packagesConfigDependencies, nuspecDependencies);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Locate_WhenNuGetForUnityRestoredUnityPackageContainsMarker_ReturnsFound ()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var packageVersion = ReadUnityPackageVersion(Path.Combine(
+            repositoryRoot,
+            "src",
+            "Ucli.Unity",
+            "MackySoft.Ucli.Unity.nuspec"));
+        using var scope = TestDirectories.CreateTempScope("unity-ucli-plugin-package", "nugetforunity-restore");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+        var packageRoot = Path.Combine("UnityProject", "Assets", "Packages", $"MackySoft.Ucli.Unity.{packageVersion}");
+        scope.WriteFile(
+            Path.Combine(packageRoot, UnityUcliPluginLocator.MarkerFileName),
+            """
+            {
+              "pluginId": "com.mackysoft.ucli.unity",
+              "protocolVersion": 1
+            }
+            """);
+        var locator = new UnityUcliPluginLocator();
+
+        var result = await locator.Locate(unityProjectPath, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(UnityUcliPluginLocateStatus.Found, result.Status);
+        Assert.NotNull(result.MarkerPath);
+        Assert.EndsWith(
+            Path.Combine("Assets", "Packages", $"MackySoft.Ucli.Unity.{packageVersion}", UnityUcliPluginLocator.MarkerFileName),
+            result.MarkerPath,
+            StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadNuspecDependencies (string nuspecPath)
+    {
+        var document = XDocument.Load(nuspecPath);
+        var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+        return document
+            .Descendants(ns + "dependency")
+            .ToDictionary(
+                dependency => dependency.Attribute("id")?.Value ?? string.Empty,
+                dependency => dependency.Attribute("version")?.Value ?? string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadPackagesConfigDependencies (string packagesConfigPath)
+    {
+        var document = XDocument.Load(packagesConfigPath);
+        return document
+            .Descendants("package")
+            .ToDictionary(
+                package => package.Attribute("id")?.Value ?? string.Empty,
+                package => package.Attribute("version")?.Value ?? string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string ReadUnityPackageVersion (string nuspecPath)
+    {
+        var document = XDocument.Load(nuspecPath);
+        var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+        return document
+            .Descendants(ns + "version")
+            .Select(element => element.Value)
+            .First();
+    }
+
+    private static string ResolveRepositoryRoot ()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Ucli.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved from the test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MackySoft.Ucli.Unity` as the official NuGetForUnity distribution package.
- Add pack and verification scripts that validate package contents, dependency parity, and restored marker placement.
- Add Unity package publish CI and wire `verify` to run Unity package pack validation.
- Consolidate NuGet CLI setup and release version sync PR creation so package workflows stay focused on their release flow.

## Scope
- `src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec`: defines package metadata, Unity plugin content, README/LICENSE, and NuGet dependencies.
- `scripts/pack-unity-plugin.sh` / `scripts/verify-unity-plugin-package.sh`: create and validate the NuGetForUnity nupkg.
- `.github/workflows/unity-package-publish.yaml` / `.github/workflows/verify.yaml`: publish `unity/<version>` releases and require pack verification for relevant changes.
- `scripts/setup-nuget-cli.sh` / `scripts/create-version-sync-pr.sh`: centralize shared CI setup and post-publish sync PR mechanics.
- `docs/package-operations.md` and `UnityPluginPackageSpecTests`: document the NuGetForUnity operation and cover package dependency/locator behavior.

## Verification
- Gate level: Standard
- Diff budget: PASS with `Split waived` recorded in #46
- Spec drift: Skipped (`docs/agents/ci_issue-46-unity-nugetforunity/spec.md` does not exist)
- Format: PASS (`dotnet format tests/Ucli.Tests/Ucli.Tests.csproj --include tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs --verbosity minimal --verify-no-changes --no-restore`)
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter FullyQualifiedName~UnityPluginPackageSpecTests --no-restore --verbosity minimal`)
- Package verification: PASS (`./scripts/pack-unity-plugin.sh --version 0.0.0-ci --output artifacts/packages && ./scripts/verify-unity-plugin-package.sh artifacts/packages 0.0.0-ci`)
- CI config checks: PASS (`bash -n` for related scripts, workflow YAML parse, `EVENT_NAME=workflow_dispatch ./scripts/detect-verify-scopes.sh`, `git diff --check`)
- Version sync script smoke: PASS with temporary Git repository and fake `gh`
- Coverage: N/A

## Risks / Rollback
- The publish workflow depends on GitHub Packages permissions and NuGet CLI availability on hosted runners; failures should be isolated to `unity-package-publish` or `unity-pack` jobs.
- Rollback is to revert this PR, which removes the Unity package workflow, nuspec, scripts, docs, and tests without changing runtime Unity plugin source behavior.

## Checklist
- [x] `MackySoft.Ucli.Unity` nupkg can be packed for NuGetForUnity.
- [x] Package verification checks marker, asmdef, Editor source, README, LICENSE, dependencies, and local restore output.
- [x] `verify` runs Unity package pack validation when package inputs change.
- [x] Unity package release path uses `unity/<major>.<minor>.<patch>` without a `v` prefix.

Closes #46
