### PR TITLE
test: isolate current directory init tests

### DIFF
--- a/tests/Ucli.Tests/CurrentDirectoryTestCollection.cs
+++ b/tests/Ucli.Tests/CurrentDirectoryTestCollection.cs
@@ -1,0 +1,7 @@
+namespace MackySoft.Ucli.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class CurrentDirectoryTestCollection
+{
+    public const string Name = "CurrentDirectory";
+}

--- a/tests/Ucli.Tests/Features/Init/UseCases/Init/InitServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Init/UseCases/Init/InitServiceTests.cs
@@ -7,6 +7,7 @@ using MackySoft.Ucli.Shared.Foundation;
 
 namespace MackySoft.Ucli.Tests;
 
+[Collection(CurrentDirectoryTestCollection.Name)]
 public sealed class InitServiceTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- isolate InitServiceTests that mutate Environment.CurrentDirectory into a non-parallel xUnit collection
- unblock the RC gate Windows .NET test failure caught by verify workflow_dispatch

## Verification
- dotnet restore Ucli.slnx
- dotnet format Ucli.slnx --verbosity minimal --verify-no-changes --no-restore
- dotnet build Ucli.slnx --configuration Release --no-restore
- dotnet test Ucli.slnx --configuration Release --no-build
- dotnet pack src/Ucli/Ucli.csproj --configuration Release --no-build
- scripts/verify-cli-package.sh <temp package dir> 0.18.0
- scripts/pack-unity-plugin.sh --version 0.18.0 --output <temp package dir>
- scripts/verify-unity-plugin-package.sh <temp package dir> 0.18.0
- dotnet src/Ucli/bin/Release/net8.0/MackySoft.Ucli.dll test run --projectPath src/Ucli.Unity --mode oneshot --unityEditorPath /Applications/Unity/Hub/Editor/2023.2.22f1/Unity.app/Contents/MacOS/Unity --testPlatform editmode --assemblyName MackySoft.Ucli.Unity.Tests.Editor --timeout 1800000