### PR TITLE
docs(readme): fix markdown table and credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![verify](https://github.com/mackysoft/ucli/actions/workflows/verify.yaml/badge.svg)](https://github.com/mackysoft/ucli/actions/workflows/verify.yaml) [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli?label=MackySoft.Ucli)](https://www.nuget.org/packages/MackySoft.Ucli) [![NuGet Unity](https://img.shields.io/nuget/v/MackySoft.Ucli.Unity?label=MackySoft.Ucli.Unity)](https://www.nuget.org/packages/MackySoft.Ucli.Unity) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-uCLI lets you inspect, plan, apply, and verify Unity Editor automation from a terminal, script, continuous integration job, or agent workflow. It is built for Unity project changes that should go through Unity Editor APIs instead of direct YAML editing.
+**Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
 
-Created by Hiroya Aramaki ([Makihiro](https://github.com/mackysoft), [mackysoft.net](https://mackysoft.net/)). Development is supported through [GitHub Sponsors](https://github.com/sponsors/mackysoft).
+uCLI lets you inspect, plan, apply, and verify Unity Editor automation from a terminal, script, continuous integration job, or agent workflow. It is built for Unity project changes that should go through Unity Editor APIs instead of direct YAML editing.
 
 ## What You Can Do
 
@@ -550,9 +550,9 @@ Common options:
 | Option | Applies to | Meaning |
 | --- | --- | --- |
 | `--projectPath <path>` | Unity-backed commands | Target Unity project path. |
-| `--mode auto|daemon|oneshot` | Unity-backed commands | Choose daemon reuse or one-shot batchmode. |
+| `--mode auto\|daemon\|oneshot` | Unity-backed commands | Choose daemon reuse or one-shot batchmode. |
 | `--timeout <milliseconds>` | Unity-backed commands | Override the command timeout. |
-| `--readIndexMode disabled|allowStale|requireFresh` | Query-like commands | Control read-index use. |
+| `--readIndexMode disabled\|allowStale\|requireFresh` | Query-like commands | Control read-index use. |
 | `--failFast` | Unity-backed commands | Fail when the Unity editor lifecycle is not ready instead of waiting. |
 | `--withPlan` | `ucli call` | Run a plan pass inside `call` and include it in the result. |
 | `--planToken <token>` | `ucli call` | Apply a request using a token returned by `ucli plan`. |

--- a/src/Ucli.Contracts/README.md
+++ b/src/Ucli.Contracts/README.md
@@ -2,11 +2,11 @@
 
 [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Contracts?label=MackySoft.Ucli.Contracts)](https://www.nuget.org/packages/MackySoft.Ucli.Contracts) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mackysoft/ucli/blob/master/LICENSE)
 
+**Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
+
 `MackySoft.Ucli.Contracts` contains the shared IPC protocol and data contract types used by uCLI runtime components.
 
 This is an advanced integration package for uCLI runtime, Unity plugin integration, and tooling that needs to exchange uCLI protocol messages directly. Users who only run the `ucli` command or install `MackySoft.Ucli.Unity` usually do not need to reference this package directly.
-
-Created by Hiroya Aramaki ([Makihiro](https://github.com/mackysoft), [mackysoft.net](https://mackysoft.net/)).
 
 ## Installation
 

--- a/src/Ucli.Infrastructure/README.md
+++ b/src/Ucli.Infrastructure/README.md
@@ -2,11 +2,11 @@
 
 [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Infrastructure?label=MackySoft.Ucli.Infrastructure)](https://www.nuget.org/packages/MackySoft.Ucli.Infrastructure) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mackysoft/ucli/blob/master/LICENSE)
 
+**Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
+
 `MackySoft.Ucli.Infrastructure` contains shared infrastructure services used by uCLI runtime components.
 
 This is an advanced integration package, not the protocol contract layer. It builds on `MackySoft.Ucli.Contracts` and provides boundary services for runtime code that needs filesystem, process, fingerprint, and transport helpers. Users who only run the `ucli` command or install `MackySoft.Ucli.Unity` usually do not need to reference this package directly.
-
-Created by Hiroya Aramaki ([Makihiro](https://github.com/mackysoft), [mackysoft.net](https://mackysoft.net/)).
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Fix the Common options table so option values containing alternatives do not introduce extra Markdown columns.
- Keep the allowed values in the Option column and escape the pipe characters used between alternatives.
- Move the `Created by` line back to the MackySoft README credit position and remove extra sponsor/site links from that line.

## Verification
- `git diff --check`
- checked README table rows for unexpected unescaped pipe separators
- `dotnet pack src/Ucli/Ucli.csproj --configuration Release --no-restore --output /tmp/ucli-readme-createdby-final-pack-check`
- `dotnet pack src/Ucli.Contracts/Ucli.Contracts.csproj --configuration Release --no-restore --output /tmp/ucli-contracts-createdby-final-pack-check`
- `dotnet pack src/Ucli.Infrastructure/Ucli.Infrastructure.csproj --configuration Release --no-restore --output /tmp/ucli-infrastructure-createdby-final-pack-check`
- confirmed README.md and LICENSE are included in each generated package

Issueなし運用です。