### PR TITLE
docs(readme): highlight uCLI automation philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,6 @@ Set the target Unity project once for your shell session:
 export UCLI_PROJECT_PATH=./UnityProject
 ```
 
-uCLI resolves the target project in this order:
-
-1. `--projectPath`
-2. `UCLI_PROJECT_PATH`
-3. command default, usually the current working directory
-
 If your shell is already in the Unity project root, you can omit both `UCLI_PROJECT_PATH` and `--projectPath` for most commands.
 
 Then confirm that uCLI can resolve the project:
@@ -689,6 +683,8 @@ Common options:
 | `--withPlan` | `ucli call` | Run a plan pass inside `call` and include it in the result. |
 | `--planToken <token>` | `ucli call` | Apply a request using a token returned by `ucli plan`. |
 | `--allowDangerous` | `ucli call` | Allow operations marked dangerous by the operation catalog. |
+
+> **NOTE:** Project path resolution uses `--projectPath`, then `UCLI_PROJECT_PATH`, then the command default. The default is usually the current working directory.
 
 ## 📦 Packages
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ uCLI is built around the review boundary: an automated Unity change should be in
 | Editor readiness | Whether Unity can accept the request now. | Lifecycle states are surfaced; execution waits or fails with structured errors. |
 | Reviewed plan drift | Whether Unity state still matches the reviewed plan. | `planToken` validates request and state before `call`. |
 | Project and worktree identity | Which project owns local state, indexes, artifacts, and writer exclusion. | Local state is scoped by `projectFingerprint`. |
-| Timeout recovery | Whether a retry is safe after timeout or disconnect. | `opResults`, touched units, and logs remain part of the result contract. |
+| Timeout recovery | Whether a retry is safe after timeout or disconnect. | Timeout is not proof of no-op; inspect returned results when available and logs before retrying. |
 | Persistence | Whether a mutation also saved project data. | `commit` makes save boundaries explicit. |
 | Evidence | What changed, what was touched, and where diagnostics live. | JSON envelopes, logs, and test artifacts are first-class outputs. |
-| Operation discovery | Which operation contract is installed for this project. | `ops describe` exposes the live operation kind, policy, and argument schema for the installed plugin. |
-| Read freshness | Whether indexed read data is advisory or authoritative. | readIndex accelerates reads, while `call` re-resolves against live Unity state. |
+| Operation discovery | Which operation contract is installed for this project. | `ops describe` exposes the installed operation's kind, policy, argument schema, and static constraints. |
+| Read freshness | Whether cached read data is fresh, stale, or advisory. | readIndex accelerates reads, while `call` re-resolves against live Unity state. |
 | Guarded execution | Which requests cross the normal edit boundary. | Dangerous operations are isolated and require explicit opt-in. |
 
-## 🧠 Design Guarantees
+## 🧠 Design Contracts
 
 uCLI is designed around assurance, not convenience-first automation.
 
-| Guarantee | uCLI contract |
+| Contract | What uCLI does |
 | --- | --- |
 | Unity remains the source of truth | Mutations go through Unity Editor APIs. |
 | Edits have context | Every edit declares a scene, prefab, asset, or project context. |
@@ -70,7 +70,7 @@ Use uCLI when you need to automate Unity from scripts, CI, or agents without los
 Agents should not hard-code operation arguments or guess Unity state from memory.
 
 - Discover available operations with `ucli ops list` and `ucli ops describe`.
-- Treat `ucli ops describe <operation>` as the runtime contract for operation kind, policy, and argument schema.
+- Treat `ucli ops describe <operation>` as the runtime contract for that operation's kind, policy, argument schema, and static constraints.
 - Inspect assets, scene trees, components, and serialized schemas before editing.
 - Build JSON requests with primitive `op` steps and higher-level `edit` steps.
 - Use `validate`, `plan`, and `call` to keep review and execution separate.
@@ -80,6 +80,7 @@ Agents should not hard-code operation arguments or guess Unity state from memory
 - Run Unity in one-shot headless batchmode for isolated jobs.
 - Execute Unity Test Framework tests and collect normalized artifacts.
 - Parse one JSON result envelope from standard output for automation decisions.
+- Avoid log scraping by using structured result envelopes, exit codes, and test summaries.
 
 ### 🧰 For Local Tool Workflows
 
@@ -138,6 +139,14 @@ export UCLI_PROJECT_PATH=./UnityProject
 ```
 
 If your shell is already in the Unity project root, you can omit both `UCLI_PROJECT_PATH` and `--projectPath` for most commands.
+
+Create repository defaults when you want project-local configuration:
+
+```bash
+ucli init
+```
+
+This step is optional; the commands below can run with `UCLI_PROJECT_PATH` or current-directory resolution.
 
 Then confirm that uCLI can resolve the project:
 
@@ -592,10 +601,9 @@ ucli ops describe ucli.comp.set
 
 Use `ops describe` as the source of truth for:
 
-- operation kind
-- operation policy
-- argument schema
-- `readIndex` metadata
+- operation kind and policy
+- argument schema and static constraints
+- `readIndex` source and freshness metadata
 
 README examples show common operations only. The installed Unity plugin's operation catalog is the runtime contract.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Unity automation usually fails in the control plane, not only in the edit API. S
 
 In short:
 
-- MCP-style tools make Unity callable.
-- uCLI makes Unity changes reviewable.
+- Unity is callable.
+- Unity changes should be reviewable.
 - The normal workflow is `read -> validate -> plan -> call -> verify`.
 
 uCLI focuses on those guarantees:
@@ -31,21 +31,21 @@ uCLI focuses on those guarantees:
 - **Worktree-safe sessions:** daemon state, indexes, artifacts, and writer exclusion are scoped by project identity.
 - **Dangerous operations are opt-in:** unsafe paths are isolated behind operation policy and `--allowDangerous`.
 
-## 🧭 What Makes uCLI Different?
+## 🧭 What uCLI Makes Explicit
 
-Many Unity automation tools focus on exposing editor actions to an agent or remote client. uCLI does not compete on tool count; it competes on whether an automated Unity change can be reviewed, gated, applied, and diagnosed as a contract.
+uCLI is built around the review boundary: an automated Unity change should be inspectable before mutation, attributable after execution, and diagnosable when the runtime state is uncertain.
 
-| Problem | Typical shortcut | uCLI contract |
+| Concern | What must be knowable | uCLI contract |
 | --- | --- | --- |
-| Editor readiness | Guess with `sleep` after compile or reload. | Lifecycle states are surfaced; execution waits or fails with structured errors. |
-| Reviewed plan drift | Apply after Unity changed. | `planToken` validates request and state before `call`. |
-| Wrong project or worktree | Reuse global editor state or path guesses. | Local state is scoped by `projectFingerprint`. |
-| Retry after timeout | Treat timeout as "not applied". | `opResults`, touched units, and logs remain part of the result contract. |
-| Hidden persistence | Mutate and save implicitly. | `commit` makes save boundaries explicit. |
-| Lost evidence | Scrape editor logs or console text. | JSON envelopes, logs, and test artifacts are first-class outputs. |
-| Tool discovery | Guess operation arguments from memory or stale instructions. | `ops describe` exposes the live operation kind, policy, and argument schema for the installed plugin. |
-| Read freshness | Treat cached project state as mutation truth. | readIndex accelerates reads, while `call` re-resolves against live Unity state. |
-| Unsafe escape hatches | Make arbitrary code execution the happy path. | Dangerous operations are isolated and require explicit opt-in. |
+| Editor readiness | Whether Unity can accept the request now. | Lifecycle states are surfaced; execution waits or fails with structured errors. |
+| Reviewed plan drift | Whether Unity state still matches the reviewed plan. | `planToken` validates request and state before `call`. |
+| Project and worktree identity | Which project owns local state, indexes, artifacts, and writer exclusion. | Local state is scoped by `projectFingerprint`. |
+| Timeout recovery | Whether a retry is safe after timeout or disconnect. | `opResults`, touched units, and logs remain part of the result contract. |
+| Persistence | Whether a mutation also saved project data. | `commit` makes save boundaries explicit. |
+| Evidence | What changed, what was touched, and where diagnostics live. | JSON envelopes, logs, and test artifacts are first-class outputs. |
+| Operation discovery | Which operation contract is installed for this project. | `ops describe` exposes the live operation kind, policy, and argument schema for the installed plugin. |
+| Read freshness | Whether indexed read data is advisory or authoritative. | readIndex accelerates reads, while `call` re-resolves against live Unity state. |
+| Guarded execution | Which requests cross the normal edit boundary. | Dangerous operations are isolated and require explicit opt-in. |
 
 ## 🧠 Design Guarantees
 
@@ -585,7 +585,7 @@ Custom operations are not hidden shortcuts. Once they are in the catalog, they p
 
 > **WARNING:** `ucli call` blocks operations marked `dangerous` unless every guard allows them: project policy, operation allowlist, and the explicit `--allowDangerous` flag. Prefer the normal `edit` flow and non-dangerous primitive operations.
 
-Dynamic or arbitrary execution paths are useful escape hatches, but uCLI keeps the normal edit path declarative, typed, planned, and reviewable.
+uCLI keeps the normal edit path declarative, typed, planned, and reviewable.
 
 ## 🧪 Verifying Changes
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Use uCLI when you need to automate Unity from scripts, CI, or agents without los
 ### 🤖 For Agents
 
 - Discover available operations with `ucli ops list` and `ucli ops describe`.
+- Treat `ucli ops describe <operation>` as the runtime contract for arguments, constraints, results, and assurance metadata instead of guessing from memory.
 - Inspect assets, scene trees, components, and serialized schemas before editing.
 - Build JSON requests with primitive `op` steps and higher-level `edit` steps.
 - Use `validate`, `plan`, and `call` to keep review and execution separate.
@@ -278,6 +279,8 @@ printf '%s' "$REQUEST_JSON" | ucli call --projectPath ./UnityProject --planToken
 ```
 
 `validate` checks request shape and static constraints. `plan` checks the request against current Unity state and returns a `planToken` without applying persistent changes. `call` applies the same request when the token still matches the request and project state.
+
+> **IMPORTANT:** A timeout or disconnect does not prove that nothing was applied. Inspect the JSON result, `opResults`, touched units, Unity logs, and daemon logs before retrying.
 
 > **TIP:** Use `--requestPath` only when a file path is the natural interface for your tool. Standard input is the primary request path for scripts and agents.
 
@@ -535,6 +538,8 @@ Raw `set` operations use `sets`, while edit steps use the shorter `values` form:
 ## 📚 Operation Catalog Summary
 
 Use `edit` for common edits. Use `op` when you need an explicit primitive operation from the catalog. The live catalog for the installed Unity plugin is available through `ucli ops list` and `ucli ops describe`.
+
+> **TIP:** Agents should use `ucli ops describe <operation>` as the runtime contract before constructing primitive `op` steps. Do not hard-code operation arguments from memory.
 
 ### 📖 Read Operations
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@
 
 **Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
 
-uCLI turns Unity edits into reviewable, repeatable, machine-readable workflows for terminals, scripts, continuous integration jobs, and agent systems.
+uCLI turns Unity Editor changes into reviewable, repeatable, machine-readable workflows for scripts, CI, and AI agents.
 
-It reads current Unity state, declares the intended change, validates and plans it, applies it through Unity Editor APIs instead of direct YAML editing, chooses the save boundary, and returns evidence about what happened.
+It reads Unity state, declares the intended change, validates and plans it, applies it through Unity Editor APIs, chooses the save boundary, and returns structured evidence.
 
 uCLI is not a remote-control wrapper around the Unity Editor. It is an execution protocol for workflows where automation must be inspected, replayed, gated, and trusted.
 
 ## ❓ Why uCLI?
 
 Unity automation usually fails in the control plane, not only in the edit API. Scripts and agents need to know which Unity project they are talking to, whether the Editor is compiling or reloading, whether a request was applied before a timeout, what contexts were touched, and whether a reviewed plan is still valid when applied.
+
+In short:
+
+- MCP-style tools make Unity callable.
+- uCLI makes Unity changes reviewable.
+- The normal workflow is `read -> validate -> plan -> call -> verify`.
 
 uCLI focuses on those guarantees:
 
@@ -27,32 +33,33 @@ uCLI focuses on those guarantees:
 
 ## 🧭 What Makes uCLI Different?
 
-Many Unity automation tools focus on exposing editor actions to an agent or remote client. uCLI focuses on making those actions reviewable and operationally safe.
+Many Unity automation tools focus on exposing editor actions to an agent or remote client. uCLI does not compete on tool count; it competes on whether an automated Unity change can be reviewed, gated, applied, and diagnosed as a contract.
 
-| Area | Common failure mode | uCLI approach |
+| Problem | Typical shortcut | uCLI contract |
 | --- | --- | --- |
-| Editor lifecycle | Scripts guess with `sleep` after compile or reload. | Lifecycle states are surfaced, and execution waits or fails with structured errors. |
-| State drift | A plan is reviewed, then Unity changes before apply. | `planToken` validates request and state before `call`. |
-| Target identity | Multiple Unity instances, projects, or worktrees get confused. | Local state is scoped by `projectFingerprint`. |
-| Timeout handling | Timeout is treated as proof that nothing happened. | Partial `opResults` and logs remain part of the result contract. |
-| Persistence | Tools mutate and save implicitly. | `commit` makes save boundaries explicit. |
-| Observability | Errors disappear into editor logs. | JSON envelopes, Unity logs, daemon logs, and test artifacts are first-class outputs. |
-| Risk control | Arbitrary code execution becomes the normal path. | Dangerous operations are isolated and require explicit opt-in. |
+| Editor readiness | Guess with `sleep` after compile or reload. | Lifecycle states are surfaced; execution waits or fails with structured errors. |
+| Reviewed plan drift | Apply after Unity changed. | `planToken` validates request and state before `call`. |
+| Wrong project or worktree | Reuse global editor state or path guesses. | Local state is scoped by `projectFingerprint`. |
+| Retry after timeout | Treat timeout as "not applied". | `opResults`, touched units, and logs remain part of the result contract. |
+| Hidden persistence | Mutate and save implicitly. | `commit` makes save boundaries explicit. |
+| Lost evidence | Scrape editor logs or console text. | JSON envelopes, logs, and test artifacts are first-class outputs. |
+| Tool discovery | Guess operation arguments from memory or stale instructions. | `ops describe` exposes the live operation kind, policy, and argument schema for the installed plugin. |
+| Read freshness | Treat cached project state as mutation truth. | readIndex accelerates reads, while `call` re-resolves against live Unity state. |
+| Unsafe escape hatches | Make arbitrary code execution the happy path. | Dangerous operations are isolated and require explicit opt-in. |
 
-## 🧠 Design Philosophy
+## 🧠 Design Guarantees
 
 uCLI is designed around assurance, not convenience-first automation.
 
-| Principle | What it means in uCLI |
+| Guarantee | uCLI contract |
 | --- | --- |
-| Preserve Unity semantics | Mutations go through Unity Editor APIs instead of direct YAML editing. |
-| Context-first editing | Edits are scoped to scene, prefab, asset, or project boundaries. |
-| Plan before mutation | `ucli plan` produces a `planToken`; `ucli call` can verify request and state drift before applying. |
-| Modify is not persist | Edits declare `commit: "none"`, `"context"`, or `"project"`. |
-| Evidence over success text | JSON responses expose `opResults`, `applied`, `changed`, `touched`, errors, artifacts, and logs. |
-| Lifecycle is part of the protocol | Compile, domain reload, busy, play mode, shutdown, and blocked states are exposed as lifecycle state or structured errors. |
-| Runtime choice is operational | `daemon`, `auto`, and `oneshot` change execution mode, not request meaning. |
-| Unsafe paths are explicit | Dangerous operations require catalog policy and `--allowDangerous`. |
+| Unity remains the source of truth | Mutations go through Unity Editor APIs. |
+| Edits have context | Every edit declares a scene, prefab, asset, or project context. |
+| Plans are checked before write | `ucli plan` produces a `planToken`; `ucli call` can verify request and state drift before applying. |
+| Saves are explicit | `commit` controls persistence with `"none"`, `"context"`, or `"project"`. |
+| Results are evidence | JSON exposes `opResults`, `applied`, `changed`, `touched`, errors, logs, and artifacts. |
+| Runtime is operational | `daemon`, `auto`, and `oneshot` do not change request meaning. |
+| Unsafe paths are isolated | Dangerous operations require catalog policy and `--allowDangerous`. |
 
 ## ✨ What You Can Do
 
@@ -60,8 +67,10 @@ Use uCLI when you need to automate Unity from scripts, CI, or agents without los
 
 ### 🤖 For Agents
 
+Agents should not hard-code operation arguments or guess Unity state from memory.
+
 - Discover available operations with `ucli ops list` and `ucli ops describe`.
-- Treat `ucli ops describe <operation>` as the runtime contract for arguments, constraints, results, and assurance metadata instead of guessing from memory.
+- Treat `ucli ops describe <operation>` as the runtime contract for operation kind, policy, and argument schema.
 - Inspect assets, scene trees, components, and serialized schemas before editing.
 - Build JSON requests with primitive `op` steps and higher-level `edit` steps.
 - Use `validate`, `plan`, and `call` to keep review and execution separate.
@@ -176,6 +185,8 @@ The request protocol does not change between these modes. Runtime choice is oper
 
 > **TIP:** Read before you write. These commands emit machine-readable JSON.
 
+Use `ucli refresh` when Unity project state may be stale. It may trigger refresh or import work; query commands remain the read-only inspection path.
+
 ```bash
 ucli refresh --projectPath ./UnityProject
 
@@ -225,6 +236,8 @@ ucli ops describe ucli.scene.open --projectPath ./UnityProject
 
 > **IMPORTANT:** Request commands read JSON from standard input by default. Keep the request in your runner and pipe it to uCLI.
 
+Use `call --withPlan` for compact local automation where the same runner plans and applies immediately.
+
 ```bash
 REQUEST_JSON='{
   "protocolVersion": 1,
@@ -268,7 +281,7 @@ printf '%s' "$REQUEST_JSON" | ucli call --projectPath ./UnityProject --withPlan
 
 This example opens `Assets/Scenes/Main.unity`, selects `Root/Enemies/Spawner`, edits the `Game.EnemySpawner` component, and saves the scene through `commit: "context"`.
 
-When a human review step or quality gate must inspect the plan before applying changes, split execution into `validate`, `plan`, and `call`:
+Use `validate -> plan -> call --planToken` when a human review step, CI gate, or agent supervisor must inspect the plan before mutation:
 
 ```bash
 printf '%s' "$REQUEST_JSON" | ucli validate --projectPath ./UnityProject
@@ -535,51 +548,44 @@ Raw `set` operations use `sets`, while edit steps use the shorter `values` form:
 }
 ```
 
-## 📚 Operation Catalog Summary
+## 📚 Operation Catalog
 
-Use `edit` for common edits. Use `op` when you need an explicit primitive operation from the catalog. The live catalog for the installed Unity plugin is available through `ucli ops list` and `ucli ops describe`.
+The installed Unity plugin exposes its primitive operation catalog at runtime.
 
-> **TIP:** Agents should use `ucli ops describe <operation>` as the runtime contract before constructing primitive `op` steps. Do not hard-code operation arguments from memory.
+```bash
+ucli ops list --projectPath ./UnityProject
+ucli ops describe ucli.comp.set --projectPath ./UnityProject
+```
 
-### 📖 Read Operations
+Use `ops describe` as the source of truth for:
 
-| Operation | Type | Args | Use it for |
-| --- | --- | --- | --- |
-| `ucli.assets.find` | query | `{ type?, pathPrefix?, nameContains? }` | Find main assets under `Assets/`. At least one filter is required. |
-| `ucli.asset.schema` | query | `{ type }` or `{ target }` | Read writable serialized fields for an asset type or existing asset. |
-| `ucli.comp.schema` | query | `{ type }` | Read writable serialized fields for a component type. |
-| `ucli.go.describe` | query | `{ target, depth? }` | Inspect one GameObject and its components. |
-| `ucli.resolve` | query | selector object | Resolve a selector to a Unity object identifier. |
-| `ucli.scene.query` | query | `{ scene, pathPrefix?, componentType? }` | Find scene GameObjects or components for selection. |
-| `ucli.scene.tree` | query | `{ path, depth? }` | Read a scene hierarchy. |
+- operation kind
+- operation policy
+- argument schema
+- `readIndex` metadata
 
-### 🗂️ Context And Save Operations
+README examples show common operations only. The installed Unity plugin's operation catalog is the runtime contract.
 
-| Operation | Type | Args | Use it for |
-| --- | --- | --- | --- |
-| `ucli.scene.open` | query | `{ path }` | Ensure a scene is loaded. |
-| `ucli.scene.save` | mutation | `{ path }` | Save a loaded scene. |
-| `ucli.prefab.open` | query | `{ path }` | Open a prefab editing context. |
-| `ucli.prefab.save` | mutation | `{ path }` | Save the opened prefab context. |
-| `ucli.project.refresh` | mutation | `{}` | Refresh the Unity project and AssetDatabase. |
-| `ucli.project.save` | mutation | `{}` | Save project assets, project settings, and tracked open contexts. |
+Common operation groups include:
 
-### 🔧 Mutation Operations
+- `ucli.scene.*` - open, inspect, and save scenes.
+- `ucli.prefab.*` - open, edit, save, and create prefabs.
+- `ucli.assets.*` / `ucli.asset.*` - find assets, inspect schemas, and update asset values.
+- `ucli.go.*` - create, describe, delete, and reparent GameObjects.
+- `ucli.comp.*` - inspect, ensure, and set components.
+- `ucli.project.*` - refresh and save project-scoped state.
 
-| Operation | Type | Args | Use it for |
-| --- | --- | --- | --- |
-| `ucli.asset.create` | mutation | `{ type, path }` | Create a ScriptableObject main asset under `Assets/`. |
-| `ucli.asset.set` | mutation | `{ target, sets[] }` | Set serialized properties on an asset or project-scoped asset. |
-| `ucli.comp.ensure` | mutation | `{ target, type }` | Ensure a component exists on a GameObject. |
-| `ucli.comp.set` | mutation | `{ target, sets[] }` | Set serialized properties on a component. |
-| `ucli.go.create` | mutation | `{ name, scene }` or `{ name, parent }` | Create a GameObject at a scene root or under a parent. |
-| `ucli.go.delete` | mutation | `{ target }` | Delete a GameObject. |
-| `ucli.go.reparent` | mutation | `{ target, parent }` | Move a GameObject under a new parent. |
-| `ucli.prefab.create` | mutation | `{ target, path }` | Create a prefab asset from a GameObject. |
+## 🧱 Extensible by Contract
 
-### ⚠️ Dangerous Operations
+Extensions can expose operations under names such as `myorg.navmesh.bake`.
 
-> **WARNING:** `ucli call` blocks operations marked `dangerous` unless the command includes `--allowDangerous`. Prefer the normal `edit` flow and non-dangerous primitive operations. Use dangerous operations only when the catalog marks the required operation that way and the request has been reviewed.
+Custom operations are not hidden shortcuts. Once they are in the catalog, they participate in the same policy, schema, and JSON result envelope contracts as built-in operations, so agents and CI can discover them with `ucli ops list` and inspect them with `ucli ops describe`.
+
+## ⚠️ Dangerous Operations
+
+> **WARNING:** `ucli call` blocks operations marked `dangerous` unless every guard allows them: project policy, operation allowlist, and the explicit `--allowDangerous` flag. Prefer the normal `edit` flow and non-dangerous primitive operations.
+
+Dynamic or arbitrary execution paths are useful escape hatches, but uCLI keeps the normal edit path declarative, typed, planned, and reviewable.
 
 ## 🧪 Verifying Changes
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,24 @@ uCLI is an execution protocol for Unity automation from a terminal, script, cont
 
 ## 🧠 Design Philosophy
 
-uCLI is built for Unity automation you can trust after it runs. The goal is not to make every edit as short as possible; it is to make each edit explainable, reviewable, repeatable, and recoverable in local shells, CI, and agent workflows.
+uCLI is for Unity teams, tool authors, CI maintainers, and agent workflows that need automation they can inspect instead of blindly accept. Its design favors trustworthy edits over the shortest possible command.
 
-- Unity-native edits: changes go through Unity Editor APIs, not direct YAML patches, so Scene, Prefab, Asset, and Project semantics stay intact.
-- Bounded intent: requests name the context they are allowed to touch, which keeps edits scoped and reviewable.
-- Plan before write: `validate`, `plan`, and `call --withPlan` let runners inspect intent and current Unity state before persistence.
-- Explicit saving: `commit` makes the save boundary visible instead of silently persisting every modification.
-- Evidence for automation: JSON envelopes, logs, test artifacts, and touched contexts give humans and agents something concrete to verify.
-- Same contract everywhere: daemon, headless one-shot batchmode, CI, and parallel Git worktrees use the same request and output model.
-- Risk stays visible: dangerous operations require explicit opt-in and stay outside the normal guarded edit path.
+- Preserve Unity semantics: Unity remains the source of truth for scenes, prefabs, assets, project settings, and serialization.
+- Make intent reviewable: automation declares what it is allowed to touch before it mutates Unity state.
+- Separate change from persistence: a modification and the decision to save it are different responsibilities.
+- Return evidence, not just success: results should explain what was inspected, planned, touched, saved, tested, or logged.
+- Keep runtime choice operational: local shells, CI, headless execution, daemons, and worktrees should not change the meaning of a request.
+- Keep risk explicit: unsafe operations are visible opt-ins, not hidden shortcuts in the normal workflow.
 
 ## ✨ What You Can Do
 
-- Query assets, scenes, GameObjects, components, schemas, and operation metadata.
-- Send context-bound JSON requests that combine primitive Unity operations and higher-level edit steps.
-- Validate, plan, and apply changes through `validate`, `plan`, `call`, or `call --withPlan`, with explicit `commit` behavior.
-- Run headless Unity automation with one-shot batchmode for isolated jobs, or a daemon for repeated Unity-backed commands.
-- Run multiple Git worktrees side by side with project-scoped daemon sessions, indexes, and artifacts.
+Use uCLI when you need to automate Unity from scripts, CI, or agents without losing visibility into project state and saved changes.
+
+- Inspect assets, scenes, GameObjects, components, schemas, and operation metadata.
+- Build JSON requests from primitive Unity operations and higher-level edit steps.
+- Run `validate`, `plan`, `call`, or `call --withPlan` with explicit `commit` behavior.
+- Choose one-shot headless batchmode for isolated jobs or a daemon for repeated Unity-backed commands.
+- Work across multiple Git worktrees with project-scoped daemon sessions, indexes, and artifacts.
 - Run Unity Test Framework tests and collect normalized artifacts.
 - Read Unity and daemon logs when automation fails.
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,86 @@
-# uCLI - CLI workflow for Unity automation
+# uCLI - Contract-first Unity automation for agents, CI, and tools
 
 [![verify](https://github.com/mackysoft/ucli/actions/workflows/verify.yaml/badge.svg)](https://github.com/mackysoft/ucli/actions/workflows/verify.yaml) [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli?label=MackySoft.Ucli)](https://www.nuget.org/packages/MackySoft.Ucli) [![NuGet Unity](https://img.shields.io/nuget/v/MackySoft.Ucli.Unity?label=MackySoft.Ucli.Unity)](https://www.nuget.org/packages/MackySoft.Ucli.Unity) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 **Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
 
-uCLI is an execution protocol for Unity automation from a terminal, script, continuous integration job, or agent workflow. It treats Unity changes as context-bound work: read the current state, describe the intended edit, validate and plan it, apply it through Unity Editor APIs instead of direct YAML editing, choose the save boundary, and return machine-readable evidence.
+uCLI turns Unity edits into reviewable, repeatable, machine-readable workflows for terminals, scripts, continuous integration jobs, and agent systems.
+
+It reads current Unity state, declares the intended change, validates and plans it, applies it through Unity Editor APIs instead of direct YAML editing, chooses the save boundary, and returns evidence about what happened.
+
+uCLI is not a remote-control wrapper around the Unity Editor. It is an execution protocol for workflows where automation must be inspected, replayed, gated, and trusted.
+
+## ❓ Why uCLI?
+
+Unity automation usually fails in the control plane, not only in the edit API. Scripts and agents need to know which Unity project they are talking to, whether the Editor is compiling or reloading, whether a request was applied before a timeout, what contexts were touched, and whether a reviewed plan is still valid when applied.
+
+uCLI focuses on those guarantees:
+
+- **Plan before call:** preview a request, receive a `planToken`, and apply only when the request and project state still match.
+- **Live Unity source of truth:** mutations go through Unity Editor APIs and are re-resolved against live Unity state.
+- **Context-bound edits:** every edit belongs to a scene, prefab, asset, or project boundary.
+- **Explicit persistence:** changing an object and saving a context are separate decisions.
+- **Machine-readable evidence:** automation receives structured JSON with `opResults`, `applied`, `changed`, `touched`, errors, logs, and artifacts.
+- **Lifecycle-aware execution:** compile, domain reload, busy, play mode, shutdown, and blocked states are surfaced as protocol states or structured errors.
+- **Worktree-safe sessions:** daemon state, indexes, artifacts, and writer exclusion are scoped by project identity.
+- **Dangerous operations are opt-in:** unsafe paths are isolated behind operation policy and `--allowDangerous`.
+
+## 🧭 What Makes uCLI Different?
+
+Many Unity automation tools focus on exposing editor actions to an agent or remote client. uCLI focuses on making those actions reviewable and operationally safe.
+
+| Area | Common failure mode | uCLI approach |
+| --- | --- | --- |
+| Editor lifecycle | Scripts guess with `sleep` after compile or reload. | Lifecycle states are surfaced, and execution waits or fails with structured errors. |
+| State drift | A plan is reviewed, then Unity changes before apply. | `planToken` validates request and state before `call`. |
+| Target identity | Multiple Unity instances, projects, or worktrees get confused. | Local state is scoped by `projectFingerprint`. |
+| Timeout handling | Timeout is treated as proof that nothing happened. | Partial `opResults` and logs remain part of the result contract. |
+| Persistence | Tools mutate and save implicitly. | `commit` makes save boundaries explicit. |
+| Observability | Errors disappear into editor logs. | JSON envelopes, Unity logs, daemon logs, and test artifacts are first-class outputs. |
+| Risk control | Arbitrary code execution becomes the normal path. | Dangerous operations are isolated and require explicit opt-in. |
 
 ## 🧠 Design Philosophy
 
-uCLI is for Unity teams, tool authors, CI maintainers, and agent workflows that need automation they can inspect instead of blindly accept. Its design favors trustworthy edits over the shortest possible command.
+uCLI is designed around assurance, not convenience-first automation.
 
-- Preserve Unity semantics: Unity remains the source of truth for scenes, prefabs, assets, project settings, and serialization.
-- Make intent reviewable: automation declares what it is allowed to touch before it mutates Unity state.
-- Separate change from persistence: a modification and the decision to save it are different responsibilities.
-- Return evidence, not just success: results should explain what was inspected, planned, touched, saved, tested, or logged.
-- Keep runtime choice operational: local shells, CI, headless execution, daemons, and worktrees should not change the meaning of a request.
-- Keep risk explicit: unsafe operations are visible opt-ins, not hidden shortcuts in the normal workflow.
+| Principle | What it means in uCLI |
+| --- | --- |
+| Preserve Unity semantics | Mutations go through Unity Editor APIs instead of direct YAML editing. |
+| Context-first editing | Edits are scoped to scene, prefab, asset, or project boundaries. |
+| Plan before mutation | `ucli plan` produces a `planToken`; `ucli call` can verify request and state drift before applying. |
+| Modify is not persist | Edits declare `commit: "none"`, `"context"`, or `"project"`. |
+| Evidence over success text | JSON responses expose `opResults`, `applied`, `changed`, `touched`, errors, artifacts, and logs. |
+| Lifecycle is part of the protocol | Compile, domain reload, busy, play mode, shutdown, and blocked states are exposed as lifecycle state or structured errors. |
+| Runtime choice is operational | `daemon`, `auto`, and `oneshot` change execution mode, not request meaning. |
+| Unsafe paths are explicit | Dangerous operations require catalog policy and `--allowDangerous`. |
 
 ## ✨ What You Can Do
 
 Use uCLI when you need to automate Unity from scripts, CI, or agents without losing visibility into project state and saved changes.
 
-- Inspect assets, scenes, GameObjects, components, schemas, and operation metadata.
-- Build JSON requests from primitive Unity operations and higher-level edit steps.
-- Run `validate`, `plan`, `call`, or `call --withPlan` with explicit `commit` behavior.
-- Choose one-shot headless batchmode for isolated jobs or a daemon for repeated Unity-backed commands.
-- Work across multiple Git worktrees with project-scoped daemon sessions, indexes, and artifacts.
-- Run Unity Test Framework tests and collect normalized artifacts.
-- Read Unity and daemon logs when automation fails.
+### 🤖 For Agents
+
+- Discover available operations with `ucli ops list` and `ucli ops describe`.
+- Inspect assets, scene trees, components, and serialized schemas before editing.
+- Build JSON requests with primitive `op` steps and higher-level `edit` steps.
+- Use `validate`, `plan`, and `call` to keep review and execution separate.
+
+### 🧪 For CI
+
+- Run Unity in one-shot headless batchmode for isolated jobs.
+- Execute Unity Test Framework tests and collect normalized artifacts.
+- Parse one JSON result envelope from standard output for automation decisions.
+
+### 🧰 For Local Tool Workflows
+
+- Start a daemon for repeated Unity-backed commands.
+- Reuse read indexes for operation metadata, schemas, asset search, and scene inspection.
+- Read Unity and daemon logs from the same CLI.
+
+### 🌿 For Multi-Worktree Development
+
+- Scope sessions, indexes, artifacts, and writer exclusion by project identity.
+- Keep daemon state separate across Git worktrees.
 
 ## 📦 Installation
 
@@ -98,6 +151,18 @@ ucli daemon start --projectPath ./UnityProject
 
 > **NOTE:** For one-off local commands and CI jobs, you can skip the daemon. The default `--mode auto` uses a running daemon when one is available and falls back to one-shot batchmode when it is not.
 
+### 🧭 One Contract, Multiple Runtimes
+
+uCLI can run Unity-backed commands through three execution modes:
+
+| Mode | Use it for |
+| --- | --- |
+| `oneshot` | Start Unity in batchmode for isolated commands and CI jobs. |
+| `daemon` | Require an existing Unity-backed daemon for repeated local or agent requests. |
+| `auto` | Reuse a running daemon when available; otherwise fall back to one-shot batchmode. |
+
+The request protocol does not change between these modes. Runtime choice is operational, not semantic.
+
 ## 📤 Automation Output Contract
 
 > **IMPORTANT:** Except for `ucli logs`, the automation commands listed below write one JSON result envelope to standard output. Help and version output are human-readable command-line output. Progress messages and diagnostics that are not part of the JSON result contract are written to standard error.
@@ -133,6 +198,12 @@ ucli resolve \
   --hierarchyPath Root/Enemies/Spawner \
   --componentType "Game.EnemySpawner, Assembly-CSharp"
 ```
+
+### 🗃️ Read Index for Agent Loops
+
+uCLI includes a read index for read-heavy automation. It lets agents and scripts inspect operation metadata, schemas, asset search data, GUID/path mappings, and lightweight scene structure without reconnecting to Unity for every reasoning step.
+
+Mutations still re-resolve against live Unity state. The read index improves planning and validation, but it is never the source of truth for `call`.
 
 For read-heavy workflows, `--readIndexMode` controls whether query-like commands may use stored index data:
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,49 @@ If you manage `Assets/packages.config` directly, add:
 
 > **IMPORTANT:** Use a pinned `<version>` for both the CLI and Unity plugin in released automation.
 
+## 🚀 Quick Start
+
+Set the target Unity project once for your shell session:
+
+```bash
+export UCLI_PROJECT_PATH=./UnityProject
+```
+
+uCLI resolves the target project in this order:
+
+1. `--projectPath`
+2. `UCLI_PROJECT_PATH`
+3. command default, usually the current working directory
+
+If your shell is already in the Unity project root, you can omit both `UCLI_PROJECT_PATH` and `--projectPath` for most commands.
+
+Then confirm that uCLI can resolve the project:
+
+```bash
+ucli status
+```
+
+Inspect the installed operation catalog:
+
+```bash
+ucli ops list
+ucli ops describe ucli.scene.open
+```
+
+Read project state:
+
+```bash
+ucli query assets find --pathPrefix Assets --limit 10
+```
+
+For repeated local automation, start a daemon:
+
+```bash
+ucli daemon start
+```
+
+Use `--projectPath <path>` when a single command needs to override the environment value.
+
 ## 🧭 Compatibility and Stability
 
 - Pin `MackySoft.Ucli` and `MackySoft.Ucli.Unity` to compatible released versions and update them together.
@@ -150,13 +193,13 @@ ucli init
 Confirm that uCLI can resolve the target Unity project:
 
 ```bash
-ucli status --projectPath ./UnityProject
+ucli status
 ```
 
 Start a daemon when an interactive session or local automation will run several Unity-backed commands:
 
 ```bash
-ucli daemon start --projectPath ./UnityProject
+ucli daemon start
 ```
 
 > **NOTE:** For one-off local commands and CI jobs, you can skip the daemon. The default `--mode auto` uses a running daemon when one is available and falls back to one-shot batchmode when it is not.
@@ -188,24 +231,20 @@ The request protocol does not change between these modes. Runtime choice is oper
 Use `ucli refresh` when Unity project state may be stale. It may trigger refresh or import work; query commands remain the read-only inspection path.
 
 ```bash
-ucli refresh --projectPath ./UnityProject
+ucli refresh
 
 ucli query assets find \
-  --projectPath ./UnityProject \
   --type "UnityEngine.Material, UnityEngine.CoreModule" \
   --limit 100
 
 ucli query scene tree \
-  --projectPath ./UnityProject \
   --path Assets/Scenes/Main.unity \
   --depth 1
 
 ucli query comp schema \
-  --projectPath ./UnityProject \
   --type "Game.EnemySpawner, Assembly-CSharp"
 
 ucli resolve \
-  --projectPath ./UnityProject \
   --scene Assets/Scenes/Main.unity \
   --hierarchyPath Root/Enemies/Spawner \
   --componentType "Game.EnemySpawner, Assembly-CSharp"
@@ -228,8 +267,8 @@ For read-heavy workflows, `--readIndexMode` controls whether query-like commands
 The operation catalog is also available from the CLI:
 
 ```bash
-ucli ops list --projectPath ./UnityProject
-ucli ops describe ucli.scene.open --projectPath ./UnityProject
+ucli ops list
+ucli ops describe ucli.scene.open
 ```
 
 ## 🛠️ Applying Changes
@@ -276,7 +315,7 @@ REQUEST_JSON='{
   ]
 }'
 
-printf '%s' "$REQUEST_JSON" | ucli call --projectPath ./UnityProject --withPlan
+printf '%s' "$REQUEST_JSON" | ucli call --withPlan
 ```
 
 This example opens `Assets/Scenes/Main.unity`, selects `Root/Enemies/Spawner`, edits the `Game.EnemySpawner` component, and saves the scene through `commit: "context"`.
@@ -284,11 +323,11 @@ This example opens `Assets/Scenes/Main.unity`, selects `Root/Enemies/Spawner`, e
 Use `validate -> plan -> call --planToken` when a human review step, CI gate, or agent supervisor must inspect the plan before mutation:
 
 ```bash
-printf '%s' "$REQUEST_JSON" | ucli validate --projectPath ./UnityProject
-PLAN_JSON="$(printf '%s' "$REQUEST_JSON" | ucli plan --projectPath ./UnityProject)"
+printf '%s' "$REQUEST_JSON" | ucli validate
+PLAN_JSON="$(printf '%s' "$REQUEST_JSON" | ucli plan)"
 
 PLAN_TOKEN="$(printf '%s' "$PLAN_JSON" | jq -r '.payload.planToken')"
-printf '%s' "$REQUEST_JSON" | ucli call --projectPath ./UnityProject --planToken "$PLAN_TOKEN"
+printf '%s' "$REQUEST_JSON" | ucli call --planToken "$PLAN_TOKEN"
 ```
 
 `validate` checks request shape and static constraints. `plan` checks the request against current Unity state and returns a `planToken` without applying persistent changes. `call` applies the same request when the token still matches the request and project state.
@@ -553,8 +592,8 @@ Raw `set` operations use `sets`, while edit steps use the shorter `values` form:
 The installed Unity plugin exposes its primitive operation catalog at runtime.
 
 ```bash
-ucli ops list --projectPath ./UnityProject
-ucli ops describe ucli.comp.set --projectPath ./UnityProject
+ucli ops list
+ucli ops describe ucli.comp.set
 ```
 
 Use `ops describe` as the source of truth for:
@@ -593,7 +632,6 @@ Run Unity tests after applying edits:
 
 ```bash
 ucli test run \
-  --projectPath ./UnityProject \
   --testPlatform editmode \
   --assemblyName MyGame.Tests.EditMode
 ```
@@ -612,14 +650,14 @@ Test artifacts are written under `.ucli/local/fingerprints/<projectFingerprint>/
 > **TIP:** When a command or test fails, read Unity and daemon logs before retrying:
 
 ```bash
-ucli logs unity --projectPath ./UnityProject --tail 200 --level error
-ucli logs daemon --projectPath ./UnityProject --tail 200
+ucli logs unity --tail 200 --level error
+ucli logs daemon --tail 200
 ```
 
 Stop the daemon at the end of an interactive automation session:
 
 ```bash
-ucli daemon stop --projectPath ./UnityProject
+ucli daemon stop
 ```
 
 ## 🧰 Command Guide
@@ -643,7 +681,7 @@ Common options:
 
 | Option | Applies to | Meaning |
 | --- | --- | --- |
-| `--projectPath <path>` | Unity-backed commands | Target Unity project path. |
+| `--projectPath <path>` | Unity-backed commands | Target Unity project path. Overrides `UCLI_PROJECT_PATH` and current-directory resolution. |
 | `--mode auto\|daemon\|oneshot` | Unity-backed commands | Choose daemon reuse or one-shot batchmode. |
 | `--timeout <milliseconds>` | Unity-backed commands | Override the command timeout. |
 | `--readIndexMode disabled\|allowStale\|requireFresh` | Query-like commands | Control read-index use. |

--- a/README.md
+++ b/README.md
@@ -4,27 +4,38 @@
 
 **Created by Hiroya Aramaki ([Makihiro](https://twitter.com/makihiro_dev))**
 
-uCLI lets you inspect, plan, apply, and verify Unity Editor automation from a terminal, script, continuous integration job, or agent workflow. It is built for Unity project changes that should go through Unity Editor APIs instead of direct YAML editing.
+uCLI is an execution protocol for Unity automation from a terminal, script, continuous integration job, or agent workflow. It treats Unity changes as context-bound work: read the current state, describe the intended edit, validate and plan it, apply it through Unity Editor APIs instead of direct YAML editing, choose the save boundary, and return machine-readable evidence.
 
-## What You Can Do
+## 🧠 Design Philosophy
+
+uCLI is built for Unity automation you can trust after it runs. The goal is not to make every edit as short as possible; it is to make each edit explainable, reviewable, repeatable, and recoverable in local shells, CI, and agent workflows.
+
+- Unity-native edits: changes go through Unity Editor APIs, not direct YAML patches, so Scene, Prefab, Asset, and Project semantics stay intact.
+- Bounded intent: requests name the context they are allowed to touch, which keeps edits scoped and reviewable.
+- Plan before write: `validate`, `plan`, and `call --withPlan` let runners inspect intent and current Unity state before persistence.
+- Explicit saving: `commit` makes the save boundary visible instead of silently persisting every modification.
+- Evidence for automation: JSON envelopes, logs, test artifacts, and touched contexts give humans and agents something concrete to verify.
+- Same contract everywhere: daemon, headless one-shot batchmode, CI, and parallel Git worktrees use the same request and output model.
+- Risk stays visible: dangerous operations require explicit opt-in and stay outside the normal guarded edit path.
+
+## ✨ What You Can Do
 
 - Query assets, scenes, GameObjects, components, schemas, and operation metadata.
-- Send JSON requests that combine primitive Unity operations and higher-level edit steps.
-- Validate and plan requests before applying them.
-- Apply changes through Unity Editor APIs with `call`.
-- Use `call --withPlan` for a compact plan-and-apply flow.
-- Use a daemon for repeated Unity-backed commands, or one-shot batchmode for isolated jobs.
+- Send context-bound JSON requests that combine primitive Unity operations and higher-level edit steps.
+- Validate, plan, and apply changes through `validate`, `plan`, `call`, or `call --withPlan`, with explicit `commit` behavior.
+- Run headless Unity automation with one-shot batchmode for isolated jobs, or a daemon for repeated Unity-backed commands.
+- Run multiple Git worktrees side by side with project-scoped daemon sessions, indexes, and artifacts.
 - Run Unity Test Framework tests and collect normalized artifacts.
 - Read Unity and daemon logs when automation fails.
 
-## Installation
+## 📦 Installation
 
-### Requirements
+### ✅ Requirements
 
 - .NET 8 or later.
 - A Unity project with NuGetForUnity when installing the Unity plugin.
 
-### CLI
+### 💻 CLI
 
 ```bash
 dotnet tool install --global MackySoft.Ucli --version <version>
@@ -42,7 +53,7 @@ Confirm the command is available:
 ucli --version
 ```
 
-### Unity Plugin
+### 🎮 Unity Plugin
 
 Install `MackySoft.Ucli.Unity` into the Unity project with NuGetForUnity. The Unity project must be able to restore packages from nuget.org.
 
@@ -52,9 +63,9 @@ If you manage `Assets/packages.config` directly, add:
 <package id="MackySoft.Ucli.Unity" version="<version>" manuallyInstalled="true" targetFramework="netstandard2.1" />
 ```
 
-Use a pinned `<version>` for both the CLI and Unity plugin in released automation.
+> **IMPORTANT:** Use a pinned `<version>` for both the CLI and Unity plugin in released automation.
 
-## Compatibility and Stability
+## 🧭 Compatibility and Stability
 
 - Pin `MackySoft.Ucli` and `MackySoft.Ucli.Unity` to compatible released versions and update them together.
 - `protocolVersion: 1` is the current request protocol for automation workflows.
@@ -62,7 +73,7 @@ Use a pinned `<version>` for both the CLI and Unity plugin in released automatio
 - `MackySoft.Ucli.Infrastructure` is an advanced integration package for runtime support code.
 - Operations marked `dangerous` are outside the normal guarded edit path and require an explicit `ucli call --allowDangerous`.
 
-## Typical Workflow
+## 🔄 Typical Workflow
 
 uCLI is normally driven by a runner: a local shell script, a continuous integration job, or an agent. The runner reads Unity state, builds one JSON request, sends that request to uCLI, and decides whether to accept the result.
 
@@ -84,19 +95,19 @@ Start a daemon when an interactive session or local automation will run several 
 ucli daemon start --projectPath ./UnityProject
 ```
 
-For one-off local commands and CI jobs, you can skip the daemon. The default `--mode auto` uses a running daemon when one is available and falls back to one-shot batchmode when it is not.
+> **NOTE:** For one-off local commands and CI jobs, you can skip the daemon. The default `--mode auto` uses a running daemon when one is available and falls back to one-shot batchmode when it is not.
 
-## Automation Output Contract
+## 📤 Automation Output Contract
 
-Except for `ucli logs`, the automation commands listed below write one JSON result envelope to standard output. Help and version output are human-readable command-line output. Progress messages and diagnostics that are not part of the JSON result contract are written to standard error.
+> **IMPORTANT:** Except for `ucli logs`, the automation commands listed below write one JSON result envelope to standard output. Help and version output are human-readable command-line output. Progress messages and diagnostics that are not part of the JSON result contract are written to standard error.
 
 `ucli logs unity` and `ucli logs daemon` write log entries to standard output. Use `--format json` when a runner needs newline-delimited JSON log events.
 
-Automation should parse standard output and treat standard error as diagnostic text.
+> **IMPORTANT:** Automation should parse standard output and treat standard error as diagnostic text.
 
-## Reading Project State
+## 🔍 Reading Project State
 
-Read before you write. These commands emit machine-readable JSON.
+> **TIP:** Read before you write. These commands emit machine-readable JSON.
 
 ```bash
 ucli refresh --projectPath ./UnityProject
@@ -137,9 +148,9 @@ ucli ops list --projectPath ./UnityProject
 ucli ops describe ucli.scene.open --projectPath ./UnityProject
 ```
 
-## Applying Changes
+## 🛠️ Applying Changes
 
-Request commands read JSON from standard input by default. Keep the request in your runner and pipe it to uCLI.
+> **IMPORTANT:** Request commands read JSON from standard input by default. Keep the request in your runner and pipe it to uCLI.
 
 ```bash
 REQUEST_JSON='{
@@ -196,9 +207,9 @@ printf '%s' "$REQUEST_JSON" | ucli call --projectPath ./UnityProject --planToken
 
 `validate` checks request shape and static constraints. `plan` checks the request against current Unity state and returns a `planToken` without applying persistent changes. `call` applies the same request when the token still matches the request and project state.
 
-Use `--requestPath` only when a file path is the natural interface for your tool. Standard input is the primary request path for scripts and agents.
+> **TIP:** Use `--requestPath` only when a file path is the natural interface for your tool. Standard input is the primary request path for scripts and agents.
 
-## Request DSL Core
+## 🧩 Request DSL Core
 
 This section covers the core request shape used by common automation. Operation-specific arguments and policies come from the operation catalog exposed by `ucli ops list` and `ucli ops describe`.
 
@@ -220,7 +231,7 @@ A request is one ordered unit of work:
 
 Each step is either `kind: "op"` or `kind: "edit"`.
 
-### Primitive Operation Step
+### ⚙️ Primitive Operation Step
 
 Use `op` when the operation you need is already in the operation catalog.
 
@@ -241,7 +252,7 @@ Use `op` when the operation you need is already in the operation catalog.
 | `op` | Operation name, such as `ucli.scene.open`. |
 | `args` | Operation-specific argument object. |
 
-### Edit Step
+### ✏️ Edit Step
 
 Use `edit` for common Unity edits where you want to name a context, select targets, apply actions, and choose the save boundary.
 
@@ -277,9 +288,9 @@ Use `edit` for common Unity edits where you want to name a context, select targe
 | `actions` | One or more edits to apply to the selected target. |
 | `commit` | Save behavior. Use `none`, `context`, or `project`. |
 
-`scene` and `prefab` edits that mutate or use `commit: "context"` need that context open. Put `ucli.scene.open` or `ucli.prefab.open` before the edit step when the runner has not opened it already.
+> **IMPORTANT:** `scene` and `prefab` edits that mutate or use `commit: "context"` need that context open. Put `ucli.scene.open` or `ucli.prefab.open` before the edit step when the runner has not opened it already.
 
-### Edit Contexts
+### 📍 Edit Contexts
 
 | Context | JSON | Use it for |
 | --- | --- | --- |
@@ -288,7 +299,7 @@ Use `edit` for common Unity edits where you want to name a context, select targe
 | Asset | `{ "asset": "Assets/Data/GameBalance.asset" }` | A main asset such as a ScriptableObject. |
 | Project | `{ "project": true }` | Project-scoped assets such as `ProjectSettings/TagManager.asset`. |
 
-### Selectors
+### 🎯 Selectors
 
 For scene and prefab contexts, select a GameObject by hierarchy path. Add `component` when the action should target a component on that GameObject.
 
@@ -344,11 +355,11 @@ For a scene context, select a set produced by `ucli.scene.query`:
 | `all` | Apply the same action to every matched target. |
 | `atMostOne` | Allow zero or one target. |
 
-`all` runs the same action list for every selected target in deterministic order. Actions that create a new global resource, such as `createAsset` and `createPrefab`, require the selection to resolve to at most one target.
+> **IMPORTANT:** `all` runs the same action list for every selected target in deterministic order. Actions that create a new global resource, such as `createAsset` and `createPrefab`, require the selection to resolve to at most one target.
 
-### Actions
+### ▶️ Actions
 
-If `target` is omitted, the action uses the current selected target. `createPrefab` is the exception: it always requires an explicit `target` and `path`. An action that creates or ensures an object can expose it with `as`, and later actions in the same step can refer to it with `"$name"`.
+> **NOTE:** If `target` is omitted, the action uses the current selected target. `createPrefab` is the exception: it always requires an explicit `target` and `path`. An action that creates or ensures an object can expose it with `as`, and later actions in the same step can refer to it with `"$name"`.
 
 ```json
 {
@@ -402,7 +413,7 @@ If `target` is omitted, the action uses the current selected target. `createPref
 }
 ```
 
-### Commit
+### 💾 Commit
 
 | Value | Behavior |
 | --- | --- |
@@ -410,9 +421,9 @@ If `target` is omitted, the action uses the current selected target. `createPref
 | `context` | Save the current scene, prefab, asset, or project context. |
 | `project` | Save project-scoped changes and request-attributed open scene or prefab contexts. |
 
-uCLI does not implicitly save an edit step. Choose `commit` intentionally.
+> **IMPORTANT:** uCLI does not implicitly save an edit step. Choose `commit` intentionally.
 
-### Primitive Target Selectors
+### 🧷 Primitive Target Selectors
 
 Primitive operations that take a `target` use one of these selector shapes:
 
@@ -449,11 +460,11 @@ Raw `set` operations use `sets`, while edit steps use the shorter `values` form:
 }
 ```
 
-## Operation Catalog Summary
+## 📚 Operation Catalog Summary
 
 Use `edit` for common edits. Use `op` when you need an explicit primitive operation from the catalog. The live catalog for the installed Unity plugin is available through `ucli ops list` and `ucli ops describe`.
 
-### Read Operations
+### 📖 Read Operations
 
 | Operation | Type | Args | Use it for |
 | --- | --- | --- | --- |
@@ -465,7 +476,7 @@ Use `edit` for common edits. Use `op` when you need an explicit primitive operat
 | `ucli.scene.query` | query | `{ scene, pathPrefix?, componentType? }` | Find scene GameObjects or components for selection. |
 | `ucli.scene.tree` | query | `{ path, depth? }` | Read a scene hierarchy. |
 
-### Context And Save Operations
+### 🗂️ Context And Save Operations
 
 | Operation | Type | Args | Use it for |
 | --- | --- | --- | --- |
@@ -476,7 +487,7 @@ Use `edit` for common edits. Use `op` when you need an explicit primitive operat
 | `ucli.project.refresh` | mutation | `{}` | Refresh the Unity project and AssetDatabase. |
 | `ucli.project.save` | mutation | `{}` | Save project assets, project settings, and tracked open contexts. |
 
-### Mutation Operations
+### 🔧 Mutation Operations
 
 | Operation | Type | Args | Use it for |
 | --- | --- | --- | --- |
@@ -489,11 +500,11 @@ Use `edit` for common edits. Use `op` when you need an explicit primitive operat
 | `ucli.go.reparent` | mutation | `{ target, parent }` | Move a GameObject under a new parent. |
 | `ucli.prefab.create` | mutation | `{ target, path }` | Create a prefab asset from a GameObject. |
 
-### Dangerous Operations
+### ⚠️ Dangerous Operations
 
-`ucli call` blocks operations marked `dangerous` unless the command includes `--allowDangerous`. Prefer the normal `edit` flow and non-dangerous primitive operations. Use dangerous operations only when the catalog marks the required operation that way and the request has been reviewed.
+> **WARNING:** `ucli call` blocks operations marked `dangerous` unless the command includes `--allowDangerous`. Prefer the normal `edit` flow and non-dangerous primitive operations. Use dangerous operations only when the catalog marks the required operation that way and the request has been reviewed.
 
-## Verifying Changes
+## 🧪 Verifying Changes
 
 Run Unity tests after applying edits:
 
@@ -515,7 +526,7 @@ Test artifacts are written under `.ucli/local/fingerprints/<projectFingerprint>/
 | `editor.log` | Unity Editor diagnostics for setup failures, compiler errors, and runtime exceptions. |
 | `meta.json` | The resolved test run configuration and timestamps. |
 
-When a command or test fails, read Unity and daemon logs before retrying:
+> **TIP:** When a command or test fails, read Unity and daemon logs before retrying:
 
 ```bash
 ucli logs unity --projectPath ./UnityProject --tail 200 --level error
@@ -528,7 +539,7 @@ Stop the daemon at the end of an interactive automation session:
 ucli daemon stop --projectPath ./UnityProject
 ```
 
-## Command Guide
+## 🧰 Command Guide
 
 | Command | Use it when you need to |
 | --- | --- |
@@ -558,7 +569,7 @@ Common options:
 | `--planToken <token>` | `ucli call` | Apply a request using a token returned by `ucli plan`. |
 | `--allowDangerous` | `ucli call` | Allow operations marked dangerous by the operation catalog. |
 
-## Packages
+## 📦 Packages
 
 | Package | Install when |
 | --- | --- |
@@ -567,7 +578,7 @@ Common options:
 | `MackySoft.Ucli.Contracts` | You build advanced tooling that exchanges uCLI IPC contracts directly. |
 | `MackySoft.Ucli.Infrastructure` | You build advanced uCLI runtime integrations that need shared infrastructure helpers. |
 
-## Support
+## 💬 Support
 
 Use [GitHub Issues](https://github.com/mackysoft/ucli/issues) for bugs, feature requests, usage questions, and README problems.
 
@@ -582,13 +593,13 @@ For bug reports, include:
 
 Use [Pull Requests](https://github.com/mackysoft/ucli/pulls) for focused fixes and README improvements.
 
-## Sponsor
+## 💖 Sponsor
 
 If uCLI helps your Unity automation workflow, please support MackySoft through GitHub Sponsors:
 
 <https://github.com/sponsors/mackysoft>
 
-## Author
+## 👤 Author
 
 Hiroya Aramaki is an indie game developer in Japan.
 
@@ -596,6 +607,6 @@ Hiroya Aramaki is an indie game developer in Japan.
 - GitHub: <https://github.com/mackysoft>
 - Sponsors: <https://github.com/sponsors/mackysoft>
 
-## License
+## 📄 License
 
 uCLI is under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- Repositions the README around uCLI as contract-first Unity automation for agents, CI, and tools.
- Adds `Why uCLI?`, `What uCLI Makes Explicit`, and `Design Contracts` sections focused on reviewable Unity changes.
- Highlights control-plane contracts: `planToken`, live Unity re-resolution, context-bound edits, explicit persistence, lifecycle-aware execution, worktree-safe state, machine-readable evidence, and dangerous-operation isolation.
- Adds a Quick Start path that sets `UCLI_PROJECT_PATH` once and keeps examples focused on the command being demonstrated.
- Documents project path precedence as supplemental Command Guide guidance instead of making it part of the first-run flow.
- Replaces the hand-written operation table with runtime operation-catalog guidance centered on `ucli ops list` and `ucli ops describe`.
- Clarifies agent guidance, `ucli refresh` behavior, `call --withPlan` versus `validate -> plan -> call --planToken`, and timeout/disconnect handling.
- Adds contract-based extensibility guidance for custom operations.

## Scope
- `README.md`: title, introduction, positioning sections, design contracts, capability layout, installation and quick-start flow, runtime-mode explanation, read-index explanation, operation-catalog guidance, dangerous-operation guidance, timeout guidance, headings, and selected guidance callouts.

## Verification
- Gate level: Standard
- Format: PASS (`git diff --check origin/master..HEAD`)
- Tests: Skipped; README-only documentation change.
- Coverage: N/A

## Risks / Rollback
- Risk is limited to README wording and presentation.
- Rollback can revert the README commits on this branch if the messaging does not fit the project direction.

## Checklist
- [x] README communicates uCLI as contract-first Unity automation.
- [x] README gives first-time users a concrete install-to-first-command path.
- [x] README documents `UCLI_PROJECT_PATH` and avoids repeating `--projectPath` in every example.
- [x] README keeps project path precedence as supplemental guidance.
- [x] README explains the review, persistence, lifecycle, and evidence contracts without relying on competitor comparison.
- [x] README keeps design contracts separate from concrete capabilities.
- [x] README mentions headless automation, runtime modes, read index, and parallel Git worktree workflows.
- [x] README calls out `ops describe` as the agent-facing runtime contract within the current payload: kind, policy, argument schema, static constraints, and `readIndex` metadata.
- [x] README avoids hand-maintained operation tables that can drift from the installed plugin catalog.
- [x] README warns that timeout/disconnect is not proof of non-application.
- [x] Callout labels use uppercase symbols.

Issue: none (ad-hoc task)
