### PR TITLE
fix(testing): make Unity output drain best effort

### DIFF
--- a/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
+++ b/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
@@ -54,7 +54,8 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
                 new ProcessRunRequest(
                     FileName: configuration.UnityEditorPath,
                     Arguments: arguments,
-                    Timeout: timeout),
+                    Timeout: timeout,
+                    OutputDrainMode: ProcessOutputDrainMode.BestEffort),
                 cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Ucli/Shared/Execution/Process/ProcessOutputDrainMode.cs
+++ b/src/Ucli/Shared/Execution/Process/ProcessOutputDrainMode.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Shared.Execution.Process;
+
+/// <summary> Defines how redirected process output streams are drained after process exit. </summary>
+internal enum ProcessOutputDrainMode
+{
+    /// <summary> Waits for redirected output streams to reach end-of-stream before returning. </summary>
+    WaitForCompletion = 0,
+
+    /// <summary> Does not require redirected output streams to reach end-of-stream after the parent process exits. </summary>
+    BestEffort = 1,
+}

--- a/src/Ucli/Shared/Execution/Process/ProcessRunRequest.cs
+++ b/src/Ucli/Shared/Execution/Process/ProcessRunRequest.cs
@@ -5,8 +5,10 @@ namespace MackySoft.Ucli.Shared.Execution.Process;
 /// <param name="Arguments"> The command-line arguments. </param>
 /// <param name="Timeout"> The timeout budget. </param>
 /// <param name="CaptureStandardOutput"> Whether full standard-output text must be preserved for machine parsing. </param>
+/// <param name="OutputDrainMode"> How redirected output streams are drained after the process exits. </param>
 internal sealed record ProcessRunRequest (
     string FileName,
     IReadOnlyList<string> Arguments,
     TimeSpan Timeout,
-    bool CaptureStandardOutput = false);
+    bool CaptureStandardOutput = false,
+    ProcessOutputDrainMode OutputDrainMode = ProcessOutputDrainMode.WaitForCompletion);

--- a/src/Ucli/Shared/Execution/Process/ProcessRunner.cs
+++ b/src/Ucli/Shared/Execution/Process/ProcessRunner.cs
@@ -10,8 +10,6 @@ internal sealed class ProcessRunner : IProcessRunner
 {
     private const int MaxCapturedOutputChars = 4096;
 
-    private static readonly TimeSpan OutputDrainTimeout = TimeSpan.FromSeconds(2);
-
     private static readonly TimeSpan ProcessKillWaitTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary> Runs one process request. </summary>
@@ -23,6 +21,7 @@ internal sealed class ProcessRunner : IProcessRunner
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ValidateOutputDrainMode(request.OutputDrainMode);
 
         using var process = new DiagnosticsProcess();
         var startInfo = process.StartInfo;
@@ -69,11 +68,16 @@ internal sealed class ProcessRunner : IProcessRunner
         try
         {
             await WaitForProcessExitOnlyAsync(process, linkedCancellationTokenSource.Token).ConfigureAwait(false);
+            await DrainOutputAsync(
+                standardOutputCompleted.Task,
+                standardErrorCompleted.Task,
+                request.OutputDrainMode,
+                linkedCancellationTokenSource.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             await TryKillProcessAsync(process).ConfigureAwait(false);
-            await TryDrainOutputAsync(standardOutputCompleted.Task, standardErrorCompleted.Task).ConfigureAwait(false);
+            await TryDrainOutputBestEffortAsync(standardOutputCompleted.Task, standardErrorCompleted.Task).ConfigureAwait(false);
             return ProcessRunResult.Canceled(
                 $"Process execution was canceled.{BuildOutputSnippet(standardError, standardOutput)}",
                 standardOutput: standardOutput.Length > 0 ? standardOutput.ToString() : null);
@@ -82,13 +86,11 @@ internal sealed class ProcessRunner : IProcessRunner
                                                  && !cancellationToken.IsCancellationRequested)
         {
             await TryKillProcessAsync(process).ConfigureAwait(false);
-            await TryDrainOutputAsync(standardOutputCompleted.Task, standardErrorCompleted.Task).ConfigureAwait(false);
+            await TryDrainOutputBestEffortAsync(standardOutputCompleted.Task, standardErrorCompleted.Task).ConfigureAwait(false);
             return ProcessRunResult.TimedOut(
                 $"Process timed out after {request.Timeout.TotalMilliseconds:0} milliseconds.{BuildOutputSnippet(standardError, standardOutput)}",
                 standardOutput: standardOutput.Length > 0 ? standardOutput.ToString() : null);
         }
-
-        await TryDrainOutputAsync(standardOutputCompleted.Task, standardErrorCompleted.Task).ConfigureAwait(false);
 
         if (process.ExitCode == 0)
         {
@@ -101,6 +103,18 @@ internal sealed class ProcessRunner : IProcessRunner
             process.ExitCode,
             $"Process exited with code {process.ExitCode}.{BuildOutputSnippet(standardError, standardOutput)}",
             standardOutput: GetCapturedStandardOutput(standardOutput, fullStandardOutput));
+    }
+
+    /// <summary> Validates one output drain mode value before process execution starts. </summary>
+    /// <param name="outputDrainMode"> The output drain mode to validate. </param>
+    private static void ValidateOutputDrainMode (ProcessOutputDrainMode outputDrainMode)
+    {
+        if (outputDrainMode is ProcessOutputDrainMode.WaitForCompletion or ProcessOutputDrainMode.BestEffort)
+        {
+            return;
+        }
+
+        throw new ArgumentOutOfRangeException(nameof(outputDrainMode), outputDrainMode, "Unknown process output drain mode.");
     }
 
     /// <summary> Tries to terminate one running process and waits for process exit. </summary>
@@ -174,22 +188,48 @@ internal sealed class ProcessRunner : IProcessRunner
         }
     }
 
-    /// <summary> Best-effort waits for redirected output stream completion. </summary>
+    /// <summary> Drains redirected output streams according to the requested contract. </summary>
     /// <param name="standardOutputCompleted"> The standard-output completion task. </param>
     /// <param name="standardErrorCompleted"> The standard-error completion task. </param>
-    private static async Task TryDrainOutputAsync (
+    /// <param name="outputDrainMode"> The output drain mode requested by the caller. </param>
+    /// <param name="cancellationToken"> A cancellation token for required output completion. </param>
+    private static async Task DrainOutputAsync (
+        Task standardOutputCompleted,
+        Task standardErrorCompleted,
+        ProcessOutputDrainMode outputDrainMode,
+        CancellationToken cancellationToken)
+    {
+        switch (outputDrainMode)
+        {
+            case ProcessOutputDrainMode.WaitForCompletion:
+                await Task.WhenAll(standardOutputCompleted, standardErrorCompleted)
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return;
+
+            case ProcessOutputDrainMode.BestEffort:
+                await TryDrainOutputBestEffortAsync(standardOutputCompleted, standardErrorCompleted).ConfigureAwait(false);
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(outputDrainMode), outputDrainMode, "Unknown process output drain mode.");
+        }
+    }
+
+    /// <summary> Observes redirected output stream completion only when it is already available. </summary>
+    /// <param name="standardOutputCompleted"> The standard-output completion task. </param>
+    /// <param name="standardErrorCompleted"> The standard-error completion task. </param>
+    private static async Task TryDrainOutputBestEffortAsync (
         Task standardOutputCompleted,
         Task standardErrorCompleted)
     {
         var drainTask = Task.WhenAll(standardOutputCompleted, standardErrorCompleted);
-        var completedTask = await Task.WhenAny(
-            drainTask,
-            Task.Delay(OutputDrainTimeout)).ConfigureAwait(false);
-
-        if (completedTask == drainTask)
+        if (!drainTask.IsCompleted)
         {
-            await drainTask.ConfigureAwait(false);
+            return;
         }
+
+        await drainTask.ConfigureAwait(false);
     }
 
     /// <summary> Handles one redirected output line. </summary>

--- a/tests/Ucli.Tests/Features/Testing/Run/Execution/ProcessRunnerTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/Execution/ProcessRunnerTests.cs
@@ -104,7 +104,7 @@ public sealed class ProcessRunnerTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task RunAsync_WhenExitedProcessLeavesDescendantOutputOpen_ReturnsWithoutWaitingForDescendant ()
+    public async Task RunAsync_WhenOutputDrainModeIsBestEffortAndDescendantKeepsOutputOpen_ReturnsAfterParentExit ()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -115,13 +115,40 @@ public sealed class ProcessRunnerTests
 
         var result = await TestAwaiter.WaitAsync(
             runner.RunAsync(
-                CreateExitedProcessWithInheritedOutputHandleRequest(),
+                CreateExitedProcessWithInheritedOutputHandleRequest(
+                    TimeSpan.FromSeconds(10),
+                    ProcessOutputDrainMode.BestEffort),
                 CancellationToken.None),
             "Process runner inherited output handle result",
             TimeSpan.FromSeconds(8));
 
         Assert.Equal(ProcessRunStatus.Exited, result.Status);
         Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task RunAsync_WhenOutputCompletionIsRequiredAndDescendantKeepsOutputOpen_ReturnsTimedOut ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var runner = new ProcessRunner();
+
+        var result = await TestAwaiter.WaitAsync(
+            runner.RunAsync(
+                CreateExitedProcessWithInheritedOutputHandleRequest(
+                    TimeSpan.FromMilliseconds(200),
+                    ProcessOutputDrainMode.WaitForCompletion),
+                CancellationToken.None),
+            "Process runner required output completion timeout result",
+            SignalWaitTimeout);
+
+        Assert.Equal(ProcessRunStatus.TimedOut, result.Status);
+        Assert.Null(result.ExitCode);
+        Assert.False(string.IsNullOrWhiteSpace(result.ErrorMessage));
     }
 
     private static ProcessRunRequest CreateLongOutputRequest (bool captureStandardOutput)
@@ -151,7 +178,9 @@ public sealed class ProcessRunnerTests
             CaptureStandardOutput: captureStandardOutput);
     }
 
-    private static ProcessRunRequest CreateLongRunningRequest (TimeSpan timeout)
+    private static ProcessRunRequest CreateLongRunningRequest (
+        TimeSpan timeout,
+        ProcessOutputDrainMode outputDrainMode = ProcessOutputDrainMode.WaitForCompletion)
     {
         if (OperatingSystem.IsWindows())
         {
@@ -163,7 +192,8 @@ public sealed class ProcessRunnerTests
                     "-Command",
                     "Start-Sleep -Seconds 30",
                 ],
-                Timeout: timeout);
+                Timeout: timeout,
+                OutputDrainMode: outputDrainMode);
         }
 
         return new ProcessRunRequest(
@@ -173,10 +203,13 @@ public sealed class ProcessRunnerTests
                 "-c",
                 "sleep 30",
             ],
-            Timeout: timeout);
+            Timeout: timeout,
+            OutputDrainMode: outputDrainMode);
     }
 
-    private static ProcessRunRequest CreateExitedProcessWithInheritedOutputHandleRequest ()
+    private static ProcessRunRequest CreateExitedProcessWithInheritedOutputHandleRequest (
+        TimeSpan timeout,
+        ProcessOutputDrainMode outputDrainMode)
     {
         return new ProcessRunRequest(
             FileName: "/bin/sh",
@@ -185,6 +218,7 @@ public sealed class ProcessRunnerTests
                 "-c",
                 "sleep 15 & exit 0",
             ],
-            Timeout: TimeSpan.FromSeconds(10));
+            Timeout: timeout,
+            OutputDrainMode: outputDrainMode);
     }
 }


### PR DESCRIPTION
## Summary
- Preserve the generic `ProcessRunner` contract by waiting for redirected output completion by default.
- Add an explicit output drain mode so callers can opt out of requiring stream end-of-file after the parent process exits.
- Use best-effort output draining only for Unity oneshot test execution, where descendant processes can keep inherited output handles open.

## Scope
- `ProcessRunner` / `ProcessRunRequest`: add explicit output drain mode and keep wait-for-completion as the default.
- `UnityTestExecutor`: opt Unity oneshot test runs into best-effort drain behavior.
- `ProcessRunnerTests`: cover both best-effort completion and required output-completion timeout behavior.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/verify.sh`, 1091 tests)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to Unity oneshot test process output capture: best-effort mode no longer waits for descendant-held output handles after the Unity parent exits.
- Rollback by reverting this PR restores strict output-completion waiting for Unity oneshot runs, but can reintroduce CI hangs when inherited output handles remain open.

## Checklist
- [x] Generic process output capture still waits for stream completion by default.
- [x] Unity oneshot execution no longer depends on descendant output handle closure.
- [x] Regression coverage added for both contracts.

Issue: none (ad-hoc task)
