### PR TITLE
Add ucli skills command surface

### DIFF
--- a/src/Ucli.Skills/Distribution/OfficialSkillPackageProvider.cs
+++ b/src/Ucli.Skills/Distribution/OfficialSkillPackageProvider.cs
@@ -1,0 +1,45 @@
+using MackySoft.Ucli.Skills.Generation;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Distribution;
+
+/// <summary> Provides official SKILL packages generated from bundled source definitions. </summary>
+public sealed class OfficialSkillPackageProvider
+{
+    private readonly BundledSkillDefinitionRootResolver definitionRootResolver;
+    private readonly SkillPackageGenerationService generationService;
+
+    /// <summary> Initializes a new instance of the <see cref="OfficialSkillPackageProvider" /> class. </summary>
+    /// <param name="definitionRootResolver"> The bundled SKILL definition root resolver. </param>
+    /// <param name="generationService"> The canonical package generation service. </param>
+    public OfficialSkillPackageProvider (
+        BundledSkillDefinitionRootResolver definitionRootResolver,
+        SkillPackageGenerationService generationService)
+    {
+        this.definitionRootResolver = definitionRootResolver ?? throw new ArgumentNullException(nameof(definitionRootResolver));
+        this.generationService = generationService ?? throw new ArgumentNullException(nameof(generationService));
+    }
+
+    /// <summary> Gets all official SKILL packages from the bundled source definitions. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The official canonical packages, or a source-resolution failure. </returns>
+    public async ValueTask<SkillOperationResult<IReadOnlyList<CanonicalSkillPackage>>> GetPackagesAsync (
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string definitionsRoot;
+        try
+        {
+            definitionsRoot = definitionRootResolver.Resolve();
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            return SkillOperationResult<IReadOnlyList<CanonicalSkillPackage>>.FailureResult(
+                SkillFailureCodes.SourceInvalid,
+                ex.Message);
+        }
+
+        return await generationService.GenerateAllAsync(definitionsRoot, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Ucli/Hosting/Cli/Common/Contracts/UcliCommandNames.cs
+++ b/src/Ucli/Hosting/Cli/Common/Contracts/UcliCommandNames.cs
@@ -74,6 +74,9 @@ internal static class UcliCommandNames
     /// <summary> Gets the top-level command name for ops. </summary>
     public const string Ops = "ops";
 
+    /// <summary> Gets the top-level command name for skills. </summary>
+    public const string Skills = "skills";
+
     /// <summary> Gets the command name for <c>logs daemon</c> result payloads. </summary>
     public const string LogsDaemon = "logs.daemon";
 
@@ -85,6 +88,18 @@ internal static class UcliCommandNames
 
     /// <summary> Gets the command name for <c>ops describe</c> result payloads. </summary>
     public const string OpsDescribe = "ops.describe";
+
+    /// <summary> Gets the command name for <c>skills list</c> result payloads. </summary>
+    public const string SkillsList = "skills.list";
+
+    /// <summary> Gets the command name for <c>skills export</c> result payloads. </summary>
+    public const string SkillsExport = "skills.export";
+
+    /// <summary> Gets the command name for <c>skills install</c> result payloads. </summary>
+    public const string SkillsInstall = "skills.install";
+
+    /// <summary> Gets the command name for <c>skills doctor</c> result payloads. </summary>
+    public const string SkillsDoctor = "skills.doctor";
 
     /// <summary> Gets the top-level command name for test. </summary>
     public const string Test = "test";
@@ -109,6 +124,15 @@ internal static class UcliCommandNames
 
     /// <summary> Gets the nested command name for <c>ops describe</c>. </summary>
     public const string DescribeSubcommand = "describe";
+
+    /// <summary> Gets the nested command name for <c>skills export</c>. </summary>
+    public const string ExportSubcommand = "export";
+
+    /// <summary> Gets the nested command name for <c>skills install</c>. </summary>
+    public const string InstallSubcommand = "install";
+
+    /// <summary> Gets the nested command name for <c>skills doctor</c>. </summary>
+    public const string DoctorSubcommand = "doctor";
 
     /// <summary> Gets the nested command name for daemon start. </summary>
     public const string StartSubcommand = "start";
@@ -159,6 +183,7 @@ internal static class UcliCommandNames
         Daemon,
         Logs,
         Ops,
+        Skills,
         Test,
     };
 
@@ -317,6 +342,35 @@ internal static class UcliCommandNames
             }
 
             return Ops;
+        }
+
+        if (string.Equals(firstArgument, Skills, StringComparison.Ordinal))
+        {
+            if (args.Length >= 2
+                && string.Equals(args[1], ListSubcommand, StringComparison.Ordinal))
+            {
+                return SkillsList;
+            }
+
+            if (args.Length >= 2
+                && string.Equals(args[1], ExportSubcommand, StringComparison.Ordinal))
+            {
+                return SkillsExport;
+            }
+
+            if (args.Length >= 2
+                && string.Equals(args[1], InstallSubcommand, StringComparison.Ordinal))
+            {
+                return SkillsInstall;
+            }
+
+            if (args.Length >= 2
+                && string.Equals(args[1], DoctorSubcommand, StringComparison.Ordinal))
+            {
+                return SkillsDoctor;
+            }
+
+            return Skills;
         }
 
         return IsRegistered(firstArgument) ? firstArgument : Root;

--- a/src/Ucli/Hosting/Cli/Common/Parsing/SubcommandValidationHelper.cs
+++ b/src/Ucli/Hosting/Cli/Common/Parsing/SubcommandValidationHelper.cs
@@ -50,4 +50,54 @@ internal static class SubcommandValidationHelper
             command: commandName,
             message: $"Subcommand '{secondArgument}' is not recognized for command '{commandName}'.");
     }
+
+    /// <summary> Creates one invalid-argument result when a leaf subcommand receives an unsupported extra argument. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <param name="commandName"> The validated top-level command name. </param>
+    /// <param name="subcommandName"> The leaf subcommand name. </param>
+    /// <param name="resultCommandName"> The command name emitted in the error envelope. </param>
+    /// <param name="expectedArgumentCount"> The total argument count accepted by the leaf command. </param>
+    /// <returns>
+    /// <para> One error result when the leaf command should stop before framework dispatch. </para>
+    /// <para> Otherwise, <see langword="null" />. </para>
+    /// </returns>
+    /// <exception cref="ArgumentException"> Thrown when a command name is invalid. </exception>
+    /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="expectedArgumentCount" /> cannot include command and subcommand tokens. </exception>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="args" /> is <see langword="null" />. </exception>
+    public static CommandResult? TryCreateUnexpectedLeafArgumentResult (
+        string[] args,
+        string commandName,
+        string subcommandName,
+        string resultCommandName,
+        int expectedArgumentCount)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subcommandName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resultCommandName);
+
+        if (expectedArgumentCount < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedArgumentCount), expectedArgumentCount, "Expected argument count must include command and subcommand tokens.");
+        }
+
+        if (args.Length <= expectedArgumentCount
+            || args.Length < 2
+            || !string.Equals(args[0], commandName, StringComparison.Ordinal)
+            || !string.Equals(args[1], subcommandName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var unexpectedArgument = args[expectedArgumentCount];
+        if (CommandTokenClassifier.IsHelpOptionToken(unexpectedArgument)
+            || CommandTokenClassifier.IsVersionOptionToken(unexpectedArgument))
+        {
+            return null;
+        }
+
+        return CommandResult.InvalidArgument(
+            command: resultCommandName,
+            message: $"Argument '{unexpectedArgument}' is not recognized.");
+    }
 }

--- a/src/Ucli/Hosting/Cli/Common/Startup/CliCommandRegistrar.cs
+++ b/src/Ucli/Hosting/Cli/Common/Startup/CliCommandRegistrar.cs
@@ -4,6 +4,7 @@ using MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 using MackySoft.Ucli.Hosting.Cli.Init;
 using MackySoft.Ucli.Hosting.Cli.Ops;
 using MackySoft.Ucli.Hosting.Cli.Requests;
+using MackySoft.Ucli.Hosting.Cli.Skills;
 using MackySoft.Ucli.Hosting.Cli.Status;
 using MackySoft.Ucli.Hosting.Cli.Testing;
 
@@ -41,6 +42,10 @@ internal static class CliCommandRegistrar
         app.Add<LogsUnityCommand>("logs");
         app.Add<OpsListCommand>("ops");
         app.Add<OpsDescribeCommand>("ops");
+        app.Add<SkillsListCommand>("skills");
+        app.Add<SkillsExportCommand>("skills");
+        app.Add<SkillsInstallCommand>("skills");
+        app.Add<SkillsDoctorCommand>("skills");
         app.Add<TestRunCommand>("test");
         app.Add<TestProfileInitCommand>("test profile");
         return app;

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -1,0 +1,104 @@
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+using MackySoft.Ucli.Skills.Installation;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Normalizes common <c>ucli skills</c> command options. </summary>
+internal static class SkillsCommandOptionNormalizer
+{
+    private const string ProjectScopeLiteral = "project";
+
+    /// <summary> Normalizes a required host option to its canonical host key. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="host"> The raw host option. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The canonical host key, or <see langword="null" /> when normalization fails. </returns>
+    public static string? NormalizeHost (
+        string command,
+        string? host,
+        SkillHostAdapterSet hostAdapters,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(hostAdapters);
+
+        errorResult = null;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--host' is required.");
+            return null;
+        }
+
+        var adapterResult = hostAdapters.GetAdapter(host);
+        if (!adapterResult.IsSuccess)
+        {
+            errorResult = SkillsCommandResultFactory.CreateSkillFailure(command, adapterResult.Failure!);
+            return null;
+        }
+
+        return adapterResult.Value!.Descriptor.HostKey;
+    }
+
+    /// <summary> Normalizes a required project scope option. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="scope"> The raw scope option. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The normalized scope kind, or <see langword="null" /> when normalization fails. </returns>
+    public static SkillScopeKind? NormalizeProjectScope (
+        string command,
+        string? scope,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        errorResult = null;
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--scope' is required.");
+            return null;
+        }
+
+        if (!string.Equals(scope, ProjectScopeLiteral, StringComparison.OrdinalIgnoreCase))
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"Unsupported SKILL scope: {scope}. Supported scopes: {ProjectScopeLiteral}.");
+            return null;
+        }
+
+        return SkillScopeKind.Project;
+    }
+
+    /// <summary> Normalizes a required filesystem path option to a full path. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="optionName"> The option name used in error messages. </param>
+    /// <param name="value"> The raw option value. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The full path, or <see langword="null" /> when normalization fails. </returns>
+    public static string? NormalizeRequiredFullPath (
+        string command,
+        string optionName,
+        string? value,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(optionName);
+
+        errorResult = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"Option '--{optionName}' is required.");
+            return null;
+        }
+
+        try
+        {
+            return Path.GetFullPath(value);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"Option '--{optionName}' is invalid: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -1,0 +1,243 @@
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Skills.Doctor;
+using MackySoft.Ucli.Skills.Generation;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+using MackySoft.Ucli.Skills.Installation;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Creates command-level JSON results for <c>skills</c> commands. </summary>
+internal static class SkillsCommandResultFactory
+{
+    private const string ProjectScopeLiteral = "project";
+
+    /// <summary> Creates a successful command result for <c>skills list</c>. </summary>
+    /// <param name="packages"> The official SKILL packages. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    public static CommandResult CreateList (
+        IReadOnlyList<CanonicalSkillPackage> packages,
+        SkillHostAdapterSet hostAdapters)
+    {
+        ArgumentNullException.ThrowIfNull(packages);
+        ArgumentNullException.ThrowIfNull(hostAdapters);
+
+        return CommandResult.Success(
+            command: UcliCommandNames.SkillsList,
+            message: "uCLI official SKILL package list retrieval completed.",
+            payload: new
+            {
+                skills = packages
+                    .OrderBy(static package => package.SkillName, StringComparer.Ordinal)
+                    .Select(static package => new
+                    {
+                        package.SkillName,
+                        package.DisplayName,
+                        package.Description,
+                        package.Manifest.ContentDigest,
+                        package.Manifest.HostArtifacts,
+                    })
+                    .ToArray(),
+                supportedHosts = hostAdapters.Adapters
+                    .Select(static adapter => new
+                    {
+                        host = adapter.Descriptor.HostKey,
+                        adapter.Descriptor.ProjectTargetDirectory,
+                    })
+                    .ToArray(),
+            });
+    }
+
+    /// <summary> Creates a command result for <c>skills export</c>. </summary>
+    /// <param name="result"> The export result. </param>
+    /// <param name="packages"> The exported packages. </param>
+    /// <param name="host"> The normalized host key. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    public static CommandResult CreateExport (
+        SkillOperationResult<string> result,
+        IReadOnlyList<CanonicalSkillPackage> packages,
+        string host)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(packages);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+
+        if (!result.IsSuccess)
+        {
+            return CreateSkillFailure(UcliCommandNames.SkillsExport, result.Failure!);
+        }
+
+        return CommandResult.Success(
+            command: UcliCommandNames.SkillsExport,
+            message: "uCLI official SKILL packages exported.",
+            payload: new
+            {
+                host,
+                outputRoot = result.Value!,
+                skills = CreateSkillNameList(packages),
+                skillCount = packages.Count,
+            });
+    }
+
+    /// <summary> Creates a command result for <c>skills install</c>. </summary>
+    /// <param name="result"> The install result. </param>
+    /// <param name="host"> The normalized host key. </param>
+    /// <param name="repositoryRoot"> The canonical repository root. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    public static CommandResult CreateInstall (
+        SkillOperationResult<SkillInstallResult> result,
+        string host,
+        string repositoryRoot)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+
+        if (!result.IsSuccess)
+        {
+            return CreateSkillFailure(UcliCommandNames.SkillsInstall, result.Failure!);
+        }
+
+        var installResult = result.Value!;
+        var actions = installResult.Actions
+            .OrderBy(static action => action.Identity.SkillName, StringComparer.Ordinal)
+            .Select(static action => new
+            {
+                action.Identity.SkillName,
+                action = ToActionLiteral(action.ActionKind),
+                action.Identity.TargetRoot,
+            })
+            .ToArray();
+
+        return CommandResult.Success(
+            command: UcliCommandNames.SkillsInstall,
+            message: "uCLI official SKILL packages installed.",
+            payload: new
+            {
+                host,
+                scope = ProjectScopeLiteral,
+                repositoryRoot,
+                installResult.TargetRoot,
+                actions,
+                createdCount = installResult.Actions.Count(static action => action.ActionKind == SkillInstallActionKind.Created),
+                noOpCount = installResult.Actions.Count(static action => action.ActionKind == SkillInstallActionKind.NoOp),
+            });
+    }
+
+    /// <summary> Creates a command result for <c>skills doctor</c>. </summary>
+    /// <param name="result"> The doctor result. </param>
+    /// <param name="repositoryRoot"> The canonical repository root. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    public static CommandResult CreateDoctor (
+        SkillDoctorResult result,
+        string repositoryRoot)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryRoot);
+
+        var payload = new
+        {
+            host = result.Host,
+            scope = ProjectScopeLiteral,
+            repositoryRoot,
+            result.TargetRoot,
+            result.IsHealthy,
+            diagnostics = result.Diagnostics
+                .Select(static diagnostic => new
+                {
+                    severity = ToSeverityLiteral(diagnostic.Severity),
+                    diagnostic.Code,
+                    diagnostic.Message,
+                    diagnostic.SkillName,
+                })
+                .ToArray(),
+        };
+
+        if (result.IsHealthy)
+        {
+            return CommandResult.Success(
+                command: UcliCommandNames.SkillsDoctor,
+                message: "uCLI official SKILL packages are healthy.",
+                payload: payload);
+        }
+
+        var errorDiagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Severity == SkillDoctorSeverity.Error)
+            .ToArray();
+        var errors = errorDiagnostics.Length == 0
+            ? [new CommandError(IpcErrorCodes.InternalError, "uCLI skills doctor reported an unknown error.", null)]
+            : errorDiagnostics
+                .Select(static diagnostic => new CommandError(diagnostic.Code, diagnostic.Message, null))
+                .ToArray();
+
+        return new CommandResult(
+            ProtocolVersion: IpcProtocol.CurrentVersion,
+            Command: UcliCommandNames.SkillsDoctor,
+            Status: IpcProtocol.StatusError,
+            ExitCode: (int)CliExitCode.ToolError,
+            Message: "uCLI skills doctor reported errors.",
+            Payload: payload,
+            Errors: errors);
+    }
+
+    /// <summary> Creates one command failure from a SKILL library failure. </summary>
+    /// <param name="command"> The command name. </param>
+    /// <param name="failure"> The SKILL operation failure. </param>
+    /// <returns> The command result serialized to stdout. </returns>
+    public static CommandResult CreateSkillFailure (
+        string command,
+        SkillFailure failure)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return new CommandResult(
+            ProtocolVersion: IpcProtocol.CurrentVersion,
+            Command: command,
+            Status: IpcProtocol.StatusError,
+            ExitCode: (int)ResolveExitCode(failure.Code),
+            Message: failure.Message,
+            Payload: new { },
+            Errors:
+            [
+                new CommandError(failure.Code, failure.Message, null),
+            ]);
+    }
+
+    private static string[] CreateSkillNameList (IReadOnlyList<CanonicalSkillPackage> packages)
+    {
+        return packages
+            .Select(static package => package.SkillName)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static CliExitCode ResolveExitCode (string code)
+    {
+        return code is SkillFailureCodes.HostUnsupported or SkillFailureCodes.PathUnsafe
+            ? CliExitCode.InvalidArgument
+            : CliExitCode.ToolError;
+    }
+
+    private static string ToActionLiteral (SkillInstallActionKind actionKind)
+    {
+        return actionKind switch
+        {
+            SkillInstallActionKind.Created => "created",
+            SkillInstallActionKind.NoOp => "noOp",
+            _ => actionKind.ToString(),
+        };
+    }
+
+    private static string ToSeverityLiteral (SkillDoctorSeverity severity)
+    {
+        return severity switch
+        {
+            SkillDoctorSeverity.Info => "info",
+            SkillDoctorSeverity.Error => "error",
+            _ => severity.ToString(),
+        };
+    }
+}

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -1,0 +1,112 @@
+using ConsoleAppFramework;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Skills.Distribution;
+using MackySoft.Ucli.Skills.Doctor;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+using MackySoft.Ucli.Skills.Installation;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Provides the skills doctor CLI command entry point. </summary>
+internal sealed class SkillsDoctorCommand
+{
+    private readonly OfficialSkillPackageProvider packageProvider;
+    private readonly SkillHostAdapterSet hostAdapters;
+    private readonly SkillInstallTargetResolver targetResolver;
+    private readonly SkillDoctorService doctorService;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillsDoctorCommand" /> class. </summary>
+    /// <param name="packageProvider"> The official SKILL package provider. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    /// <param name="targetResolver"> The SKILL install target resolver. </param>
+    /// <param name="doctorService"> The SKILL doctor service. </param>
+    public SkillsDoctorCommand (
+        OfficialSkillPackageProvider packageProvider,
+        SkillHostAdapterSet hostAdapters,
+        SkillInstallTargetResolver targetResolver,
+        SkillDoctorService doctorService)
+    {
+        this.packageProvider = packageProvider ?? throw new ArgumentNullException(nameof(packageProvider));
+        this.hostAdapters = hostAdapters ?? throw new ArgumentNullException(nameof(hostAdapters));
+        this.targetResolver = targetResolver ?? throw new ArgumentNullException(nameof(targetResolver));
+        this.doctorService = doctorService ?? throw new ArgumentNullException(nameof(doctorService));
+    }
+
+    /// <summary> Executes the skills doctor command and emits the JSON result contract. </summary>
+    /// <param name="host"> Required target host (claude|copilot|openai). </param>
+    /// <param name="scope"> Required install scope. Only project is supported. </param>
+    /// <param name="repoRoot"> --repoRoot, Required repository root. </param>
+    /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.DoctorSubcommand)]
+    public async Task<int> Doctor (
+        string? host = null,
+        string? scope = null,
+        string? repoRoot = null,
+        string? targetDir = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CommandExecutionState.MarkStarted();
+
+        var normalizedHost = SkillsCommandOptionNormalizer.NormalizeHost(
+            UcliCommandNames.SkillsDoctor,
+            host,
+            hostAdapters,
+            out var errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var normalizedScope = SkillsCommandOptionNormalizer.NormalizeProjectScope(
+            UcliCommandNames.SkillsDoctor,
+            scope,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var repositoryRoot = SkillsCommandOptionNormalizer.NormalizeRequiredFullPath(
+            UcliCommandNames.SkillsDoctor,
+            "repoRoot",
+            repoRoot,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var targetResult = targetResolver.ResolveTarget(new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir));
+        if (!targetResult.IsSuccess)
+        {
+            var targetErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsDoctor, targetResult.Failure!);
+            CommandResultWriter.WriteToStandardOutput(targetErrorResult);
+            return targetErrorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        if (!packagesResult.IsSuccess)
+        {
+            var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsDoctor, packagesResult.Failure!);
+            CommandResultWriter.WriteToStandardOutput(packageErrorResult);
+            return packageErrorResult.ExitCode;
+        }
+
+        var doctorResult = await doctorService.DiagnoseAsync(
+                packagesResult.Value!,
+                normalizedHost!,
+                targetResult.Value!.TargetRoot,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var commandResult = SkillsCommandResultFactory.CreateDoctor(doctorResult, repositoryRoot!);
+        CommandResultWriter.WriteToStandardOutput(commandResult);
+        return commandResult.ExitCode;
+    }
+}

--- a/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
@@ -1,0 +1,84 @@
+using ConsoleAppFramework;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Skills.Distribution;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Provides the skills export CLI command entry point. </summary>
+internal sealed class SkillsExportCommand
+{
+    private readonly OfficialSkillPackageProvider packageProvider;
+    private readonly SkillHostAdapterSet hostAdapters;
+    private readonly SkillExportService exportService;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillsExportCommand" /> class. </summary>
+    /// <param name="packageProvider"> The official SKILL package provider. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    /// <param name="exportService"> The SKILL export service. </param>
+    public SkillsExportCommand (
+        OfficialSkillPackageProvider packageProvider,
+        SkillHostAdapterSet hostAdapters,
+        SkillExportService exportService)
+    {
+        this.packageProvider = packageProvider ?? throw new ArgumentNullException(nameof(packageProvider));
+        this.hostAdapters = hostAdapters ?? throw new ArgumentNullException(nameof(hostAdapters));
+        this.exportService = exportService ?? throw new ArgumentNullException(nameof(exportService));
+    }
+
+    /// <summary> Executes the skills export command and emits the JSON result contract. </summary>
+    /// <param name="host"> Required target host (claude|copilot|openai). </param>
+    /// <param name="output"> Required output directory. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.ExportSubcommand)]
+    public async Task<int> Export (
+        string? host = null,
+        string? output = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CommandExecutionState.MarkStarted();
+
+        var normalizedHost = SkillsCommandOptionNormalizer.NormalizeHost(
+            UcliCommandNames.SkillsExport,
+            host,
+            hostAdapters,
+            out var errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var outputRoot = SkillsCommandOptionNormalizer.NormalizeRequiredFullPath(
+            UcliCommandNames.SkillsExport,
+            "output",
+            output,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        if (!packagesResult.IsSuccess)
+        {
+            var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsExport, packagesResult.Failure!);
+            CommandResultWriter.WriteToStandardOutput(packageErrorResult);
+            return packageErrorResult.ExitCode;
+        }
+
+        var exportResult = await exportService.ExportAsync(
+                packagesResult.Value!,
+                normalizedHost!,
+                outputRoot!,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var commandResult = SkillsCommandResultFactory.CreateExport(exportResult, packagesResult.Value!, normalizedHost!);
+        CommandResultWriter.WriteToStandardOutput(commandResult);
+        return commandResult.ExitCode;
+    }
+}

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -1,0 +1,98 @@
+using ConsoleAppFramework;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Skills.Distribution;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+using MackySoft.Ucli.Skills.Installation;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Provides the skills install CLI command entry point. </summary>
+internal sealed class SkillsInstallCommand
+{
+    private readonly OfficialSkillPackageProvider packageProvider;
+    private readonly SkillHostAdapterSet hostAdapters;
+    private readonly SkillInstallService installService;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillsInstallCommand" /> class. </summary>
+    /// <param name="packageProvider"> The official SKILL package provider. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    /// <param name="installService"> The SKILL install service. </param>
+    public SkillsInstallCommand (
+        OfficialSkillPackageProvider packageProvider,
+        SkillHostAdapterSet hostAdapters,
+        SkillInstallService installService)
+    {
+        this.packageProvider = packageProvider ?? throw new ArgumentNullException(nameof(packageProvider));
+        this.hostAdapters = hostAdapters ?? throw new ArgumentNullException(nameof(hostAdapters));
+        this.installService = installService ?? throw new ArgumentNullException(nameof(installService));
+    }
+
+    /// <summary> Executes the skills install command and emits the JSON result contract. </summary>
+    /// <param name="host"> Required target host (claude|copilot|openai). </param>
+    /// <param name="scope"> Required install scope. Only project is supported. </param>
+    /// <param name="repoRoot"> --repoRoot, Required repository root. </param>
+    /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.InstallSubcommand)]
+    public async Task<int> Install (
+        string? host = null,
+        string? scope = null,
+        string? repoRoot = null,
+        string? targetDir = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CommandExecutionState.MarkStarted();
+
+        var normalizedHost = SkillsCommandOptionNormalizer.NormalizeHost(
+            UcliCommandNames.SkillsInstall,
+            host,
+            hostAdapters,
+            out var errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var normalizedScope = SkillsCommandOptionNormalizer.NormalizeProjectScope(
+            UcliCommandNames.SkillsInstall,
+            scope,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var repositoryRoot = SkillsCommandOptionNormalizer.NormalizeRequiredFullPath(
+            UcliCommandNames.SkillsInstall,
+            "repoRoot",
+            repoRoot,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            CommandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        if (!packagesResult.IsSuccess)
+        {
+            var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsInstall, packagesResult.Failure!);
+            CommandResultWriter.WriteToStandardOutput(packageErrorResult);
+            return packageErrorResult.ExitCode;
+        }
+
+        var installResult = await installService.InstallAsync(
+                packagesResult.Value!,
+                new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir),
+                cancellationToken)
+            .ConfigureAwait(false);
+        var commandResult = SkillsCommandResultFactory.CreateInstall(installResult, normalizedHost!, repositoryRoot!);
+        CommandResultWriter.WriteToStandardOutput(commandResult);
+        return commandResult.ExitCode;
+    }
+}

--- a/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
@@ -1,0 +1,42 @@
+using ConsoleAppFramework;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Skills.Distribution;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Provides the skills list CLI command entry point. </summary>
+internal sealed class SkillsListCommand
+{
+    private readonly OfficialSkillPackageProvider packageProvider;
+    private readonly SkillHostAdapterSet hostAdapters;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillsListCommand" /> class. </summary>
+    /// <param name="packageProvider"> The official SKILL package provider. </param>
+    /// <param name="hostAdapters"> The supported host adapter set. </param>
+    public SkillsListCommand (
+        OfficialSkillPackageProvider packageProvider,
+        SkillHostAdapterSet hostAdapters)
+    {
+        this.packageProvider = packageProvider ?? throw new ArgumentNullException(nameof(packageProvider));
+        this.hostAdapters = hostAdapters ?? throw new ArgumentNullException(nameof(hostAdapters));
+    }
+
+    /// <summary> Executes the skills list command and emits the JSON result contract. </summary>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The exit code contained in the emitted command result. </returns>
+    [Command(UcliCommandNames.ListSubcommand)]
+    public async Task<int> List (CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CommandExecutionState.MarkStarted();
+
+        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var commandResult = packagesResult.IsSuccess
+            ? SkillsCommandResultFactory.CreateList(packagesResult.Value!, hostAdapters)
+            : SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsList, packagesResult.Failure!);
+        CommandResultWriter.WriteToStandardOutput(commandResult);
+        return commandResult.ExitCode;
+    }
+}

--- a/src/Ucli/Hosting/Composition/Common/UcliServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Common/UcliServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ internal static class UcliServiceCollectionExtensions
         services.AddUcliDaemonFeatureServices();
         services.AddUcliTestingFeatureServices();
         services.AddUcliStatusFeatureServices();
+        services.AddUcliSkillsFeatureServices();
         return services;
     }
 }

--- a/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Skills.Distribution;
 using MackySoft.Ucli.Skills.Doctor;
 using MackySoft.Ucli.Skills.Generation;
 using MackySoft.Ucli.Skills.Hosts.Claude;
+using MackySoft.Ucli.Skills.Hosts.Contracts;
 using MackySoft.Ucli.Skills.Hosts.Copilot;
 using MackySoft.Ucli.Skills.Hosts.OpenAi;
 using MackySoft.Ucli.Skills.Hosts.Registration;
@@ -26,12 +27,10 @@ internal static class SkillsServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton(static _ => new SkillHostAdapterSet(
-        [
-            new ClaudeSkillHostAdapter(),
-            new CopilotSkillHostAdapter(),
-            new OpenAiSkillHostAdapter(),
-        ]));
+        services.AddSingleton<ISkillHostAdapter, ClaudeSkillHostAdapter>();
+        services.AddSingleton<ISkillHostAdapter, CopilotSkillHostAdapter>();
+        services.AddSingleton<ISkillHostAdapter, OpenAiSkillHostAdapter>();
+        services.AddSingleton<SkillHostAdapterSet>();
         services.AddSingleton<BundledSkillDefinitionRootResolver>();
         services.AddSingleton<SkillSourceDefinitionReader>();
         services.AddSingleton<SkillDigestCalculator>();

--- a/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+using MackySoft.Ucli.Skills.Digests;
+using MackySoft.Ucli.Skills.Distribution;
+using MackySoft.Ucli.Skills.Doctor;
+using MackySoft.Ucli.Skills.Generation;
+using MackySoft.Ucli.Skills.Hosts.Claude;
+using MackySoft.Ucli.Skills.Hosts.Copilot;
+using MackySoft.Ucli.Skills.Hosts.OpenAi;
+using MackySoft.Ucli.Skills.Hosts.Registration;
+using MackySoft.Ucli.Skills.Installation;
+using MackySoft.Ucli.Skills.Installation.Validation;
+using MackySoft.Ucli.Skills.Manifests;
+using MackySoft.Ucli.Skills.Materialization;
+using MackySoft.Ucli.Skills.Sources;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MackySoft.Ucli.Hosting.Composition.Features;
+
+/// <summary> Provides DI registration for official SKILL distribution commands. </summary>
+internal static class SkillsServiceCollectionExtensions
+{
+    /// <summary> Registers services required by <c>ucli skills</c> commands. </summary>
+    /// <param name="services"> The target service collection. </param>
+    /// <returns> The updated service collection. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="services" /> is <see langword="null" />. </exception>
+    public static IServiceCollection AddUcliSkillsFeatureServices (this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton(static _ => new SkillHostAdapterSet(
+        [
+            new ClaudeSkillHostAdapter(),
+            new CopilotSkillHostAdapter(),
+            new OpenAiSkillHostAdapter(),
+        ]));
+        services.AddSingleton<BundledSkillDefinitionRootResolver>();
+        services.AddSingleton<SkillSourceDefinitionReader>();
+        services.AddSingleton<SkillDigestCalculator>();
+        services.AddSingleton<SkillManifestJsonSerializer>();
+        services.AddSingleton<SkillManifestValidator>();
+        services.AddSingleton<SkillPackageGenerationService>();
+        services.AddSingleton<OfficialSkillPackageProvider>();
+        services.AddSingleton<SkillMaterializationService>();
+        services.AddSingleton<SkillExportService>();
+        services.AddSingleton<SkillInstallTargetResolver>();
+        services.AddSingleton<SkillInstalledManifestReader>();
+        services.AddSingleton<SkillInstalledContentDigestVerifier>();
+        services.AddSingleton<SkillInstalledFileSetVerifier>();
+        services.AddSingleton<SkillHostMaterializationInspector>();
+        services.AddSingleton<SkillInstalledPackageValidator>();
+        services.AddSingleton<SkillInstallService>();
+        services.AddSingleton<SkillInstallationScanner>();
+        services.AddSingleton<SkillDoctorService>();
+
+        return services;
+    }
+}

--- a/src/Ucli/Hosting/Program.cs
+++ b/src/Ucli/Hosting/Program.cs
@@ -44,6 +44,14 @@ internal static class Program
         UcliCommandNames.DescribeSubcommand,
     ];
 
+    private static readonly string[] SkillsSubcommands =
+    [
+        UcliCommandNames.ListSubcommand,
+        UcliCommandNames.ExportSubcommand,
+        UcliCommandNames.InstallSubcommand,
+        UcliCommandNames.DoctorSubcommand,
+    ];
+
     private static readonly string[] QuerySubcommands =
     [
         UcliCommandNames.AssetsSubcommand,
@@ -222,6 +230,18 @@ internal static class Program
             return true;
         }
 
+        if (string.Equals(firstArgument, UcliCommandNames.Skills, StringComparison.Ordinal)
+            && TryHandleInvalidSubcommand(args, UcliCommandNames.Skills, SkillsSubcommands))
+        {
+            return true;
+        }
+
+        if (string.Equals(firstArgument, UcliCommandNames.Skills, StringComparison.Ordinal)
+            && TryHandleInvalidSkillsListArgument(args))
+        {
+            return true;
+        }
+
         if (string.Equals(firstArgument, UcliCommandNames.Query, StringComparison.Ordinal)
             && TryHandleInvalidSubcommand(args, UcliCommandNames.Query, QuerySubcommands))
         {
@@ -338,6 +358,30 @@ internal static class Program
             message: $"Subcommand '{subcommand}' is not recognized for command 'query {group}'.");
         CommandResultWriter.WriteToStandardOutput(invalidResult);
         Environment.ExitCode = invalidResult.ExitCode;
+        return true;
+    }
+
+    private static bool TryHandleInvalidSkillsListArgument (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length <= 2
+            || !string.Equals(args[1], UcliCommandNames.ListSubcommand, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var argument = args[2];
+        if (CommandTokenClassifier.IsHelpOptionToken(argument)
+            || CommandTokenClassifier.IsVersionOptionToken(argument))
+        {
+            return false;
+        }
+
+        var message = $"Argument '{argument}' is not recognized.";
+        var result = CommandResult.InvalidArgument(UcliCommandNames.SkillsList, message);
+        CommandResultWriter.WriteToStandardOutput(result);
+        Environment.ExitCode = result.ExitCode;
         return true;
     }
 }

--- a/src/Ucli/Hosting/Program.cs
+++ b/src/Ucli/Hosting/Program.cs
@@ -237,7 +237,12 @@ internal static class Program
         }
 
         if (string.Equals(firstArgument, UcliCommandNames.Skills, StringComparison.Ordinal)
-            && TryHandleInvalidSkillsListArgument(args))
+            && TryHandleUnexpectedLeafArgument(
+                args,
+                UcliCommandNames.Skills,
+                UcliCommandNames.ListSubcommand,
+                UcliCommandNames.SkillsList,
+                expectedArgumentCount: 2))
         {
             return true;
         }
@@ -361,25 +366,34 @@ internal static class Program
         return true;
     }
 
-    private static bool TryHandleInvalidSkillsListArgument (string[] args)
+    /// <summary> Handles unexpected extra arguments for leaf commands before framework dispatch starts. </summary>
+    /// <param name="args"> The command-line arguments passed to the process. </param>
+    /// <param name="commandName"> The top-level command name. </param>
+    /// <param name="subcommandName"> The leaf subcommand name. </param>
+    /// <param name="resultCommandName"> The command name emitted in the error envelope. </param>
+    /// <param name="expectedArgumentCount"> The total argument count accepted by the leaf command. </param>
+    /// <returns>
+    /// <para> <see langword="true" /> when this method writes an error response and sets <see cref="Environment.ExitCode" />. </para>
+    /// <para> Otherwise, <see langword="false" />. </para>
+    /// </returns>
+    private static bool TryHandleUnexpectedLeafArgument (
+        string[] args,
+        string commandName,
+        string subcommandName,
+        string resultCommandName,
+        int expectedArgumentCount)
     {
-        ArgumentNullException.ThrowIfNull(args);
-
-        if (args.Length <= 2
-            || !string.Equals(args[1], UcliCommandNames.ListSubcommand, StringComparison.Ordinal))
+        var result = SubcommandValidationHelper.TryCreateUnexpectedLeafArgumentResult(
+            args,
+            commandName,
+            subcommandName,
+            resultCommandName,
+            expectedArgumentCount);
+        if (result == null)
         {
             return false;
         }
 
-        var argument = args[2];
-        if (CommandTokenClassifier.IsHelpOptionToken(argument)
-            || CommandTokenClassifier.IsVersionOptionToken(argument))
-        {
-            return false;
-        }
-
-        var message = $"Argument '{argument}' is not recognized.";
-        var result = CommandResult.InvalidArgument(UcliCommandNames.SkillsList, message);
         CommandResultWriter.WriteToStandardOutput(result);
         Environment.ExitCode = result.ExitCode;
         return true;

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <ProjectReference Include="../Ucli.Contracts/Ucli.Contracts.csproj" />
     <ProjectReference Include="../Ucli.Infrastructure/Ucli.Infrastructure.csproj" />
+    <ProjectReference Include="../Ucli.Skills/Ucli.Skills.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ucli.Tests/Hosting/Cli/UcliCommandNamesTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/UcliCommandNamesTests.cs
@@ -93,6 +93,36 @@ public sealed class UcliCommandNamesTests
 
     [Theory]
     [Trait("Size", "Small")]
+    [InlineData(UcliCommandNames.ListSubcommand, UcliCommandNames.SkillsList)]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    [InlineData("foo", UcliCommandNames.Skills)]
+    [InlineData(null, UcliCommandNames.Skills)]
+    public void ResolveResultCommandName_WhenSkillsCommandSpecified_ReturnsExpectedCommandName (
+        string? subcommand,
+        string expected)
+    {
+        var args = subcommand is null
+            ? [UcliCommandNames.Skills]
+            : new[] { UcliCommandNames.Skills, subcommand };
+
+        var commandName = UcliCommandNames.ResolveResultCommandName(args);
+
+        Assert.Equal(expected, commandName);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void IsRegistered_WhenSkillsCommandSpecified_ReturnsTrue ()
+    {
+        var result = UcliCommandNames.IsRegistered(UcliCommandNames.Skills);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
     [InlineData(UcliCommandNames.AssetsSubcommand, UcliCommandNames.FindSubcommand, UcliCommandNames.QueryAssetsFind)]
     [InlineData(UcliCommandNames.SceneSubcommand, UcliCommandNames.TreeSubcommand, UcliCommandNames.QuerySceneTree)]
     [InlineData(UcliCommandNames.GoSubcommand, UcliCommandNames.DescribeSubcommand, UcliCommandNames.QueryGoDescribe)]

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -8,6 +8,7 @@ namespace MackySoft.Ucli.Tests;
 public sealed class SkillsCliOutputContractTests
 {
     private const string HostUnsupportedCode = "SKILL_HOST_UNSUPPORTED";
+    private const string InstallTargetDigestMismatchCode = "SKILL_INSTALL_TARGET_DIGEST_MISMATCH";
     private const string InstallTargetHostConflictCode = "SKILL_INSTALL_TARGET_HOST_CONFLICT";
     private const string InstallTargetUnmanagedCode = "SKILL_INSTALL_TARGET_UNMANAGED";
     private const string InvalidArgumentCode = "INVALID_ARGUMENT";
@@ -157,17 +158,40 @@ public sealed class SkillsCliOutputContractTests
         }
     }
 
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsSubcommand_WithoutHost_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"missing-host-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+        var args = CreateRequiredHostScenarioArgs(subcommand, repoRoot, scope.GetPath("exported"));
+
+        var result = await CliProcessRunner.RunCommand(args);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
     [Fact]
     [Trait("Size", "Medium")]
-    public async Task SkillsExport_WithoutHost_ReturnsInvalidArgument ()
+    public async Task SkillsExport_WithoutOutput_ReturnsInvalidArgument ()
     {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "export-missing-host");
-
         var result = await CliProcessRunner.RunCommand(
             UcliCommandNames.Skills,
             UcliCommandNames.ExportSubcommand,
-            "--output",
-            scope.GetPath("exported"));
+            "--host",
+            "openai");
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
@@ -179,56 +203,73 @@ public sealed class SkillsCliOutputContractTests
         CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Medium")]
-    public async Task SkillsInstall_WithoutScope_ReturnsInvalidArgument ()
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsScopedSubcommand_WithoutScope_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
     {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-missing-scope");
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"missing-scope-{subcommand}");
         var repoRoot = scope.CreateDirectory("repo");
 
-        var result = await CliProcessRunner.RunCommand(
-            UcliCommandNames.Skills,
-            UcliCommandNames.InstallSubcommand,
-            "--host",
-            "openai",
-            "--repoRoot",
-            repoRoot);
+        var result = await RunScopedCommand(subcommand, repoRoot, host: "openai", scope: null, targetDir: null);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
-            command: UcliCommandNames.SkillsInstall,
+            command: expectedCommand,
             status: "error",
             exitCode: (int)CliExitCode.InvalidArgument);
         CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Medium")]
-    public async Task SkillsInstall_WithUnsupportedHostAndTargetDir_ReturnsHostUnsupported ()
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsScopedSubcommand_WithInvalidScope_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
     {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-unsupported-host");
-        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-unsupported-host-outside");
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"invalid-scope-{subcommand}");
         var repoRoot = scope.CreateDirectory("repo");
 
-        var result = await CliProcessRunner.RunCommand(
-            UcliCommandNames.Skills,
-            UcliCommandNames.InstallSubcommand,
-            "--host",
-            "generic",
-            "--scope",
-            "project",
-            "--repoRoot",
-            repoRoot,
-            "--targetDir",
-            outsideScope.FullPath);
+        var result = await RunScopedCommand(subcommand, repoRoot, host: "openai", scope: "user", targetDir: null);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
-            command: UcliCommandNames.SkillsInstall,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsSubcommand_WithUnsupportedHost_ReturnsHostUnsupported (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"unsupported-host-{subcommand}");
+        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"unsupported-host-outside-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+        var args = CreateUnsupportedHostScenarioArgs(subcommand, repoRoot, outsideScope.FullPath, scope.GetPath("exported"));
+
+        var result = await CliProcessRunner.RunCommand(args);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
             status: "error",
             exitCode: (int)CliExitCode.InvalidArgument);
         CommandResultAssert.HasSingleError(outputJson.RootElement, HostUnsupportedCode);
@@ -303,21 +344,25 @@ public sealed class SkillsCliOutputContractTests
         CommandResultAssert.HasSingleError(outputJson.RootElement, InstallTargetHostConflictCode);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Medium")]
-    public async Task SkillsInstall_WithTargetDirOutsideRepositoryRoot_ReturnsPathUnsafe ()
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsScopedSubcommand_WithTargetDirOutsideRepositoryRoot_ReturnsPathUnsafe (
+        string subcommand,
+        string expectedCommand)
     {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-outside-target");
-        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-outside-target-root");
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"outside-target-{subcommand}");
+        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"outside-target-root-{subcommand}");
         var repoRoot = scope.CreateDirectory("repo");
 
-        var result = await RunInstall(repoRoot, host: "openai", targetDir: outsideScope.FullPath);
+        var result = await RunScopedCommand(subcommand, repoRoot, host: "openai", scope: "project", targetDir: outsideScope.FullPath);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
-            command: UcliCommandNames.SkillsInstall,
+            command: expectedCommand,
             status: "error",
             exitCode: (int)CliExitCode.InvalidArgument);
         CommandResultAssert.HasSingleError(outputJson.RootElement, PathUnsafeCode);
@@ -351,6 +396,40 @@ public sealed class SkillsCliOutputContractTests
                 .HasArrayLength("diagnostics", 1)
                 .HasProperty("diagnostics", 0, static diagnostic => diagnostic
                     .HasString("severity", "info")));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsDoctor_WithDriftedTarget_ReturnsUnhealthyDiagnostics ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "doctor-drift");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+
+        using (var installJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(install.StdOut))
+        {
+            var targetRoot = installJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+            await File.AppendAllTextAsync(Path.Combine(targetRoot, ExpectedSkillNames[0], "SKILL.md"), "\nDrifted content.\n");
+        }
+
+        var doctor = await RunOpenAiDoctor(repoRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(doctor.StdOut);
+        Assert.Equal((int)CliExitCode.ToolError, doctor.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsDoctor,
+            status: "error",
+            exitCode: (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InstallTargetDigestMismatchCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("isHealthy", false)
+                .HasProperty("diagnostics", 0, static diagnostic => diagnostic
+                    .HasString("severity", "error")
+                    .HasString("code", InstallTargetDigestMismatchCode)
+                    .HasString("skillName", ExpectedSkillNames[0])));
     }
 
     [Fact]
@@ -389,17 +468,38 @@ public sealed class SkillsCliOutputContractTests
         string host,
         string? targetDir)
     {
+        return RunScopedCommand(UcliCommandNames.InstallSubcommand, repoRoot, host, "project", targetDir);
+    }
+
+    private static Task<CommandExecutionResult> RunScopedCommand (
+        string subcommand,
+        string repoRoot,
+        string? host,
+        string? scope,
+        string? targetDir)
+    {
         var args = new List<string>
         {
             UcliCommandNames.Skills,
-            UcliCommandNames.InstallSubcommand,
-            "--host",
-            host,
-            "--scope",
-            "project",
+            subcommand,
+        };
+        if (host is not null)
+        {
+            args.Add("--host");
+            args.Add(host);
+        }
+
+        if (scope is not null)
+        {
+            args.Add("--scope");
+            args.Add(scope);
+        }
+
+        args.AddRange([
             "--repoRoot",
             repoRoot,
-        };
+        ]);
+
         if (targetDir is not null)
         {
             args.Add("--targetDir");
@@ -411,14 +511,35 @@ public sealed class SkillsCliOutputContractTests
 
     private static Task<CommandExecutionResult> RunOpenAiDoctor (string repoRoot)
     {
-        return CliProcessRunner.RunCommand(
-            UcliCommandNames.Skills,
-            UcliCommandNames.DoctorSubcommand,
-            "--host",
-            "openai",
-            "--scope",
-            "project",
-            "--repoRoot",
-            repoRoot);
+        return RunScopedCommand(UcliCommandNames.DoctorSubcommand, repoRoot, "openai", "project", targetDir: null);
+    }
+
+    private static string[] CreateRequiredHostScenarioArgs (
+        string subcommand,
+        string repoRoot,
+        string outputRoot)
+    {
+        return subcommand switch
+        {
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
+            _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
+        };
+    }
+
+    private static string[] CreateUnsupportedHostScenarioArgs (
+        string subcommand,
+        string repoRoot,
+        string targetDir,
+        string outputRoot)
+    {
+        return subcommand switch
+        {
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
+        };
     }
 }

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -1,0 +1,424 @@
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class SkillsCliOutputContractTests
+{
+    private const string HostUnsupportedCode = "SKILL_HOST_UNSUPPORTED";
+    private const string InstallTargetHostConflictCode = "SKILL_INSTALL_TARGET_HOST_CONFLICT";
+    private const string InstallTargetUnmanagedCode = "SKILL_INSTALL_TARGET_UNMANAGED";
+    private const string InvalidArgumentCode = "INVALID_ARGUMENT";
+    private const string PathUnsafeCode = "SKILL_PATH_UNSAFE";
+    private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+
+    private static readonly string[] ExpectedSkillNames =
+    [
+        "ucli-plan-apply",
+        "ucli-read-project",
+        "ucli-troubleshoot",
+        "ucli-verify-changes",
+    ];
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Skills_WithoutSubcommand_ReturnsJsonEnvelopeError ()
+    {
+        var result = await CliProcessRunner.RunCommand(UcliCommandNames.Skills);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.Skills,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Skills_WithUnknownSubcommand_ReturnsJsonEnvelopeError ()
+    {
+        var result = await CliProcessRunner.RunCommand(UcliCommandNames.Skills, "unknown");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.Skills,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.ListSubcommand, UcliCommandNames.SkillsList)]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsSubcommand_WithUnknownOption_ReturnsInvalidArgumentAsSingleJson (
+        string subcommand,
+        string expectedCommand)
+    {
+        var result = await CliProcessRunner.RunCommand(UcliCommandNames.Skills, subcommand, UcliContractConstants.CliOption.Unknown);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+        Assert.Contains(UnknownOptionMessage, outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsList_ReturnsOfficialSkillsAndSupportedHosts ()
+    {
+        var result = await CliProcessRunner.RunCommand(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        CommandResultAssert.HasNoErrors(outputJson.RootElement);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        JsonAssert.For(payload)
+            .HasArrayLength("skills", ExpectedSkillNames.Length)
+            .HasArrayLength("supportedHosts", 3)
+            .HasProperty("skills", 0, static skill => skill
+                .HasString("skillName", ExpectedSkillNames[0])
+                .HasValueKind("displayName", JsonValueKind.String)
+                .HasValueKind("description", JsonValueKind.String)
+                .HasValueKind("contentDigest", JsonValueKind.String)
+                .HasArrayLength("hostArtifacts", 3))
+            .HasProperty("supportedHosts", 0, static host => host
+                .HasString("host", "claude")
+                .HasString("projectTargetDirectory", ".claude/skills"))
+            .HasProperty("supportedHosts", 1, static host => host
+                .HasString("host", "copilot")
+                .HasString("projectTargetDirectory", ".github/skills"))
+            .HasProperty("supportedHosts", 2, static host => host
+                .HasString("host", "openai")
+                .HasString("projectTargetDirectory", ".agents/skills"));
+
+        Assert.Equal(ExpectedSkillNames, payload
+            .GetProperty("skills")
+            .EnumerateArray()
+            .Select(static skill => skill.GetProperty("skillName").GetString())
+            .ToArray());
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsExport_WithOpenAiHost_WritesMaterializedPackages ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "export-openai");
+        var outputRoot = scope.GetPath("exported");
+
+        var result = await CliProcessRunner.RunCommand(
+            UcliCommandNames.Skills,
+            UcliCommandNames.ExportSubcommand,
+            "--host",
+            "openai",
+            "--output",
+            outputRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsExport,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        CommandResultAssert.HasNoErrors(outputJson.RootElement);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("host", "openai")
+                .HasString("outputRoot", outputRoot)
+                .HasArrayLength("skills", ExpectedSkillNames.Length)
+                .HasInt32("skillCount", ExpectedSkillNames.Length));
+
+        foreach (var skillName in ExpectedSkillNames)
+        {
+            Assert.True(File.Exists(Path.Combine(outputRoot, skillName, "SKILL.md")), skillName);
+            Assert.True(File.Exists(Path.Combine(outputRoot, skillName, "ucli-skill.json")), skillName);
+            Assert.True(File.Exists(Path.Combine(outputRoot, skillName, "agents", "openai.yaml")), skillName);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsExport_WithoutHost_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "export-missing-host");
+
+        var result = await CliProcessRunner.RunCommand(
+            UcliCommandNames.Skills,
+            UcliCommandNames.ExportSubcommand,
+            "--output",
+            scope.GetPath("exported"));
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsExport,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithoutScope_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-missing-scope");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await CliProcessRunner.RunCommand(
+            UcliCommandNames.Skills,
+            UcliCommandNames.InstallSubcommand,
+            "--host",
+            "openai",
+            "--repoRoot",
+            repoRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithUnsupportedHostAndTargetDir_ReturnsHostUnsupported ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-unsupported-host");
+        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-unsupported-host-outside");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await CliProcessRunner.RunCommand(
+            UcliCommandNames.Skills,
+            UcliCommandNames.InstallSubcommand,
+            "--host",
+            "generic",
+            "--scope",
+            "project",
+            "--repoRoot",
+            repoRoot,
+            "--targetDir",
+            outsideScope.FullPath);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, HostUnsupportedCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithProjectScope_CreatesThenNoOps ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-openai");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var created = await RunOpenAiInstall(repoRoot);
+        var noOp = await RunOpenAiInstall(repoRoot);
+
+        using var createdJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(created.StdOut);
+        Assert.Equal((int)CliExitCode.Success, created.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            createdJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        JsonAssert.For(createdJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("host", "openai")
+                .HasString("scope", "project")
+                .HasString("repositoryRoot", repoRoot)
+                .HasValueKind("targetRoot", JsonValueKind.String)
+                .HasArrayLength("actions", ExpectedSkillNames.Length)
+                .HasInt32("createdCount", ExpectedSkillNames.Length)
+                .HasInt32("noOpCount", 0)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "created")));
+
+        using var noOpJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(noOp.StdOut);
+        Assert.Equal((int)CliExitCode.Success, noOp.ExitCode);
+        JsonAssert.For(noOpJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasInt32("createdCount", 0)
+                .HasInt32("noOpCount", ExpectedSkillNames.Length)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("action", "noOp")));
+
+        var targetRoot = createdJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        Assert.EndsWith(Path.Combine(".agents", "skills"), targetRoot, StringComparison.Ordinal);
+        foreach (var skillName in ExpectedSkillNames)
+        {
+            Assert.True(File.Exists(Path.Combine(targetRoot, skillName, "SKILL.md")), skillName);
+            Assert.True(File.Exists(Path.Combine(targetRoot, skillName, "ucli-skill.json")), skillName);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithSharedTargetRootAcrossHosts_ReturnsHostConflict ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-host-conflict");
+        var repoRoot = scope.CreateDirectory("repo");
+        var claude = await RunInstall(repoRoot, host: "claude", targetDir: "shared-skills");
+        Assert.Equal((int)CliExitCode.Success, claude.ExitCode);
+
+        var openAi = await RunInstall(repoRoot, host: "openai", targetDir: "shared-skills");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(openAi.StdOut);
+        Assert.Equal((int)CliExitCode.ToolError, openAi.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InstallTargetHostConflictCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithTargetDirOutsideRepositoryRoot_ReturnsPathUnsafe ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-outside-target");
+        using var outsideScope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-outside-target-root");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunInstall(repoRoot, host: "openai", targetDir: outsideScope.FullPath);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, PathUnsafeCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsDoctor_WithInstalledTarget_ReturnsHealthy ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "doctor-healthy");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+
+        var doctor = await RunOpenAiDoctor(repoRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(doctor.StdOut);
+        Assert.Equal((int)CliExitCode.Success, doctor.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsDoctor,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        CommandResultAssert.HasNoErrors(outputJson.RootElement);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("host", "openai")
+                .HasString("scope", "project")
+                .HasString("repositoryRoot", repoRoot)
+                .HasBoolean("isHealthy", true)
+                .HasArrayLength("diagnostics", 1)
+                .HasProperty("diagnostics", 0, static diagnostic => diagnostic
+                    .HasString("severity", "info")));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsDoctor_WithMissingTarget_ReturnsUnhealthyDiagnostics ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "doctor-missing-target");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunOpenAiDoctor(repoRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.ToolError, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsDoctor,
+            status: "error",
+            exitCode: (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InstallTargetUnmanagedCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("isHealthy", false)
+                .HasArrayLength("diagnostics", 1)
+                .HasProperty("diagnostics", 0, static diagnostic => diagnostic
+                    .HasString("severity", "error")
+                    .HasString("code", InstallTargetUnmanagedCode)));
+    }
+
+    private static Task<CommandExecutionResult> RunOpenAiInstall (string repoRoot)
+    {
+        return RunInstall(repoRoot, "openai", targetDir: null);
+    }
+
+    private static Task<CommandExecutionResult> RunInstall (
+        string repoRoot,
+        string host,
+        string? targetDir)
+    {
+        var args = new List<string>
+        {
+            UcliCommandNames.Skills,
+            UcliCommandNames.InstallSubcommand,
+            "--host",
+            host,
+            "--scope",
+            "project",
+            "--repoRoot",
+            repoRoot,
+        };
+        if (targetDir is not null)
+        {
+            args.Add("--targetDir");
+            args.Add(targetDir);
+        }
+
+        return CliProcessRunner.RunCommand(args.ToArray());
+    }
+
+    private static Task<CommandExecutionResult> RunOpenAiDoctor (string repoRoot)
+    {
+        return CliProcessRunner.RunCommand(
+            UcliCommandNames.Skills,
+            UcliCommandNames.DoctorSubcommand,
+            "--host",
+            "openai",
+            "--scope",
+            "project",
+            "--repoRoot",
+            repoRoot);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ucli skills list/export/install/doctor` as CLI adapters that delegate package generation, install, and doctor behavior to `Ucli.Skills`.
- Wires the official SKILL package provider and supported host adapters into CLI composition.
- Keeps #187 scope on runtime generation from `SkillDefinitions` without adding root `skills/**` packaging assets.

## Scope
- `src/Ucli.Skills`: official package provider for bundled definitions.
- `src/Ucli`: command names, subcommand routing, DI registration, command adapters, option normalization, and result contracts.
- DI composition: supported host adapters are registered as individual `ISkillHostAdapter` singletons and collected by `SkillHostAdapterSet`.
- CLI parsing: extra leaf-command argument validation is shared through `SubcommandValidationHelper`.
- `tests/Ucli.Tests`: command name and CLI output contract coverage for payloads, invalid options, required options, unsupported hosts, invalid scopes, install safety, and doctor diagnostics.

## Verification
- PASS: `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~SkillsCliOutputContractTests|FullyQualifiedName~UcliCommandNamesTests"` (64 tests passed)
- PASS: `bash scripts/code-quality.sh format`
- PASS: `bash scripts/code-quality.sh verify`
- PASS: `bash scripts/verify.sh` (1128 tests passed)

## Risks / Rollback
- Risk is limited to the new `skills` CLI surface and shared command dispatch validation.
- Rollback by reverting this PR's commits.

## Follow-up
- `skills/**` package同梱、drift検査、package smoke test は #188 の対象。
- TOCTOU耐性を含む file writer の root-bound write contract は別途セキュリティ設計として扱う。

## Checklist
- [x] stdout JSON contract for request-response commands
- [x] host/scope validation and unsupported host failures
- [x] project target safety and host-conflict behavior
- [x] doctor healthy/unhealthy diagnostics
- [x] no Unity daemon or Unity plugin dependency

Closes #187