### PR TITLE
chore(packaging): centralize package metadata

### DIFF
--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -129,4 +129,4 @@ jobs:
             --pr-title "chore(cli): sync package version to ${PACKAGE_VERSION}" \
             --pr-body "Sync \`MackySoft.Ucli\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
             --verify-workflow verify.yaml \
-            --changed-path "src/Ucli/Ucli.csproj"
+            --changed-path "Directory.Build.props"

--- a/.github/workflows/shared-package-publish.yaml
+++ b/.github/workflows/shared-package-publish.yaml
@@ -117,7 +117,7 @@ jobs:
           cat > "${pr_body_file}" <<EOF
           ## Summary
           - Sync shared package versions to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish.
-          - Update \`src/Ucli.Contracts/Ucli.Contracts.csproj\`, \`src/Ucli.Infrastructure/Ucli.Infrastructure.csproj\`, \`src/Ucli.Unity/Assets/packages.config\`, and \`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec\`.
+          - Update \`Directory.Build.props\`, \`src/Ucli.Unity/Assets/packages.config\`, and \`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec\`.
 
           ## Verification
           - \`shared-package-publish\` packed and published \`${RELEASE_TAG}\` before creating this PR.
@@ -132,7 +132,6 @@ jobs:
             --pr-title "chore(shared): sync package version to ${PACKAGE_VERSION}" \
             --pr-body-file "${pr_body_file}" \
             --verify-workflow verify.yaml \
-            --changed-path "src/Ucli.Contracts/Ucli.Contracts.csproj" \
-            --changed-path "src/Ucli.Infrastructure/Ucli.Infrastructure.csproj" \
+            --changed-path "Directory.Build.props" \
             --changed-path "src/Ucli.Unity/Assets/packages.config" \
             --changed-path "src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <Version>0.18.0</Version>
+    <PackageVersion>$(Version)</PackageVersion>
+    <Authors>Hiroya Aramaki</Authors>
+    <Company>MackySoft</Company>
+    <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Copyright>Copyright (c) 2026 Hiroya Aramaki</Copyright>
+  </PropertyGroup>
+
+</Project>

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -84,7 +84,7 @@ dotnet tool install --global MackySoft.Ucli --version <version>
 dotnet tool update --global MackySoft.Ucli --version <version>
 ```
 
-CLI パッケージは `src/Ucli/Ucli.csproj` を正として `dotnet pack` で生成する。公開 workflow は release tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。
+CLI パッケージは `src/Ucli/Ucli.csproj` と root の `Directory.Build.props` を正として `dotnet pack` で生成する。公開 workflow は release tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。
 
 ```bash
 dotnet pack "src/Ucli/Ucli.csproj" \
@@ -194,12 +194,12 @@ done
 - `push` to `master` では変更差分を判定しつつ、実行 OS は `Linux` のみに絞って post-merge 検証を軽量化する。
 - `workflow_dispatch` は差分判定を使わず、`.NET`、Unity、shared pack、CLI pack、Unity package pack をフル検証する。`.NET` と Unity は `Linux`、`Windows`、`macOS` の 3 OS で実行し、package 検証は `Linux` で実行する。
 - Unity 検証は `src/Ucli`、`src/Ucli.Application`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`src/Ucli.Infrastructure`、`scripts/test-unity.sh`、`scripts/update-local-shared-packages.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、CI とローカル共通の `scripts/test-unity.sh` から `ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
-- CLI pack 検証は `src/Ucli`、`src/Ucli.Contracts`、`src/Ucli.Infrastructure`、`README.md`、`LICENSE`、`cli-package-publish`、`verify` 自体の変更時に動く。`dotnet pack` 後にローカル tool install、`ucli --version`、`ucli --help`、nupkg 内の `DotnetToolSettings.xml` / `README.md` / `LICENSE` を検証する。
+- CLI pack 検証は `Directory.Build.props`、`src/Ucli`、`src/Ucli.Contracts`、`src/Ucli.Infrastructure`、`README.md`、`LICENSE`、`cli-package-publish`、`verify` 自体の変更時に動く。`dotnet pack` 後にローカル tool install、`ucli --version`、`ucli --help`、nupkg 内の `DotnetToolSettings.xml` / `README.md` / `LICENSE` を検証する。
 - Unity package pack 検証は `scripts/pack-unity-plugin.sh` で `MackySoft.Ucli.Unity` nupkg を作成し、`scripts/verify-unity-plugin-package.sh` で必須ファイル、依存定義、ローカル復元後の `ucli-plugin.json` 配置を検証する。
 - `shared-package-publish`: `shared/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
-- `shared-package-publish` は公開後に `chore/shared-sync-<version>` ブランチを作成し、`src/Ucli.Contracts/Ucli.Contracts.csproj`、`src/Ucli.Infrastructure/Ucli.Infrastructure.csproj`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の shared package version を同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
+- `shared-package-publish` は公開後に `chore/shared-sync-<version>` ブランチを作成し、`Directory.Build.props`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の shared package version を同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release mirror まで継続する。
-- `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`src/Ucli/Ucli.csproj` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
+- `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`Directory.Build.props` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `unity-package-publish` は公開後に `chore/unity-sync-<version>` ブランチを作成し、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Unity` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - タグは `v` プレフィックスを付けない（例: `shared/x.y.z`、`cli/x.y.z`、`unity/x.y.z`）。

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -69,7 +69,7 @@ is_dotnet_input() {
 
   case "${file}" in
     # Changes to this detector can alter every downstream job decision.
-    .editorconfig|Ucli.slnx|.github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|.github/workflows/cli-package-publish.yaml|scripts/code-quality.sh|scripts/detect-verify-scopes.sh|scripts/dotnet-common.sh|scripts/test-dotnet.sh|scripts/verify.sh|src/Ucli.Skills/SkillDefinitions/*)
+    .editorconfig|Directory.Build.props|Ucli.slnx|.github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|.github/workflows/cli-package-publish.yaml|scripts/code-quality.sh|scripts/detect-verify-scopes.sh|scripts/dotnet-common.sh|scripts/test-dotnet.sh|scripts/verify.sh|src/Ucli.Skills/SkillDefinitions/*)
       return 0
       ;;
   esac
@@ -132,7 +132,7 @@ is_shared_pack_input() {
   fi
 
   case "${file}" in
-    .github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-shared-package-version.sh)
+    Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-shared-package-version.sh)
       return 0
       ;;
   esac
@@ -159,7 +159,7 @@ is_cli_pack_input() {
   fi
 
   case "${file}" in
-    README.md|LICENSE|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*)
+    README.md|LICENSE|Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*)
       return 0
       ;;
     *)

--- a/scripts/sync-cli-package-version.sh
+++ b/scripts/sync-cli-package-version.sh
@@ -13,6 +13,6 @@ EOF
 }
 
 package_version="$(parse_package_version_arg usage "$@")"
-csproj_path="src/Ucli/Ucli.csproj"
+props_path="Directory.Build.props"
 
-update_xml_element_value "${csproj_path}" "Version" "${package_version}" "CLI csproj version"
+update_xml_element_value "${props_path}" "Version" "${package_version}" "central package version"

--- a/scripts/sync-shared-package-version.sh
+++ b/scripts/sync-shared-package-version.sh
@@ -13,13 +13,11 @@ EOF
 }
 
 package_version="$(parse_package_version_arg usage "$@")"
-contracts_csproj_path="src/Ucli.Contracts/Ucli.Contracts.csproj"
-infrastructure_csproj_path="src/Ucli.Infrastructure/Ucli.Infrastructure.csproj"
+props_path="Directory.Build.props"
 unity_packages_config_path="src/Ucli.Unity/Assets/packages.config"
 unity_package_nuspec_path="src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"
 
-update_xml_element_value "${contracts_csproj_path}" "Version" "${package_version}" "contracts csproj version"
-update_xml_element_value "${infrastructure_csproj_path}" "Version" "${package_version}" "infrastructure csproj version"
+update_xml_element_value "${props_path}" "Version" "${package_version}" "central package version"
 update_xml_attribute_value "${unity_packages_config_path}" '<package id="MackySoft.Ucli.Contracts" version="' "${package_version}" "Unity contracts package version"
 update_xml_attribute_value "${unity_packages_config_path}" '<package id="MackySoft.Ucli.Infrastructure" version="' "${package_version}" "Unity infrastructure package version"
 update_xml_attribute_value "${unity_package_nuspec_path}" '<dependency id="MackySoft.Ucli.Contracts" version="' "${package_version}" "Unity package contracts dependency version"

--- a/src/Ucli.Contracts/Ucli.Contracts.csproj
+++ b/src/Ucli.Contracts/Ucli.Contracts.csproj
@@ -9,12 +9,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Contracts</PackageId>
-    <Version>0.18.0</Version>
     <Description>Shared contract types for uCLI IPC protocol.</Description>
-    <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;ipc</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ucli.Infrastructure/Ucli.Infrastructure.csproj
+++ b/src/Ucli.Infrastructure/Ucli.Infrastructure.csproj
@@ -9,12 +9,8 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>MackySoft.Ucli.Infrastructure</PackageId>
-    <Version>0.18.0</Version>
     <Description>Shared infrastructure services for uCLI runtime components.</Description>
-    <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
     <PackageTags>ucli;unity;infrastructure</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -12,15 +12,8 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ucli</ToolCommandName>
     <PackageId>MackySoft.Ucli</PackageId>
-    <Version>0.18.0</Version>
-    <Authors>Hiroya Aramaki</Authors>
-    <Company>MackySoft</Company>
     <Description>CLI workflow for Unity automation.</Description>
-    <RepositoryUrl>https://github.com/mackysoft/ucli</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageTags>ucli;unity;cli;automation</PackageTags>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -58,6 +58,7 @@ public sealed class PackageMetadataTests
     [Trait("Size", "Medium")]
     public async Task Packable_projects_evaluate_expected_nuget_metadata ()
     {
+        IReadOnlyDictionary<string, string> centralProperties = ReadDirectoryBuildProperties();
         var expectedMetadataByProject = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
         {
             ["src/Ucli/Ucli.csproj"] = new(StringComparer.Ordinal)
@@ -97,15 +98,15 @@ public sealed class PackageMetadataTests
                 "Description",
                 "PackageTags");
 
-            AssertEvaluatedProperty(properties, projectPath, "Version", "0.18.0");
-            AssertEvaluatedProperty(properties, projectPath, "PackageVersion", "0.18.0");
-            AssertEvaluatedProperty(properties, projectPath, "Authors", "Hiroya Aramaki");
-            AssertEvaluatedProperty(properties, projectPath, "Company", "MackySoft");
-            AssertEvaluatedProperty(properties, projectPath, "RepositoryUrl", "https://github.com/mackysoft/ucli");
-            AssertEvaluatedProperty(properties, projectPath, "RepositoryType", "git");
-            AssertEvaluatedProperty(properties, projectPath, "PackageLicenseFile", "LICENSE");
-            AssertEvaluatedProperty(properties, projectPath, "PackageReadmeFile", "README.md");
-            AssertEvaluatedProperty(properties, projectPath, "Copyright", "Copyright (c) 2026 Hiroya Aramaki");
+            AssertEvaluatedProperty(properties, projectPath, "Version", centralProperties["Version"]);
+            AssertEvaluatedProperty(properties, projectPath, "PackageVersion", centralProperties["Version"]);
+            AssertEvaluatedProperty(properties, projectPath, "Authors", centralProperties["Authors"]);
+            AssertEvaluatedProperty(properties, projectPath, "Company", centralProperties["Company"]);
+            AssertEvaluatedProperty(properties, projectPath, "RepositoryUrl", centralProperties["RepositoryUrl"]);
+            AssertEvaluatedProperty(properties, projectPath, "RepositoryType", centralProperties["RepositoryType"]);
+            AssertEvaluatedProperty(properties, projectPath, "PackageLicenseFile", centralProperties["PackageLicenseFile"]);
+            AssertEvaluatedProperty(properties, projectPath, "PackageReadmeFile", centralProperties["PackageReadmeFile"]);
+            AssertEvaluatedProperty(properties, projectPath, "Copyright", centralProperties["Copyright"]);
 
             foreach ((string propertyName, string expectedValue) in projectMetadata)
             {
@@ -230,6 +231,7 @@ public sealed class PackageMetadataTests
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     ["EVENT_NAME"] = "pull_request",
+                    ["GITHUB_OUTPUT"] = string.Empty,
                     ["PR_BASE_SHA"] = baseSha,
                     ["PR_HEAD_SHA"] = headSha,
                 });
@@ -310,6 +312,7 @@ public sealed class PackageMetadataTests
             "RepositoryType",
             "PackageLicenseFile",
             "PackageReadmeFile",
+            "Copyright",
         };
 
         return requiredProperties.ToDictionary(
@@ -382,8 +385,8 @@ public sealed class PackageMetadataTests
         ArgumentNullException.ThrowIfNull(output);
 
         var values = new Dictionary<string, string>(StringComparer.Ordinal);
-        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-        foreach (string line in lines)
+        using var reader = new StringReader(output);
+        while (reader.ReadLine() is { } line)
         {
             int separatorIndex = line.IndexOf('=');
             if (separatorIndex <= 0)

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -1,0 +1,501 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace MackySoft.Ucli.Tests.Packaging;
+
+public sealed class PackageMetadataTests
+{
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
+
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Source_projects_do_not_redefine_central_package_metadata ()
+    {
+        var centrallyOwnedProperties = new[]
+        {
+            "Version",
+            "PackageVersion",
+            "Authors",
+            "Company",
+            "RepositoryUrl",
+            "RepositoryType",
+            "PackageLicenseFile",
+            "PackageReadmeFile",
+            "Copyright",
+        };
+        var sourceProjectPaths = new[]
+        {
+            "src/Ucli/Ucli.csproj",
+            "src/Ucli.Application/Ucli.Application.csproj",
+            "src/Ucli.Contracts/Ucli.Contracts.csproj",
+            "src/Ucli.Infrastructure/Ucli.Infrastructure.csproj",
+            "src/Ucli.Skills/Ucli.Skills.csproj",
+        };
+        var violations = new List<string>();
+
+        foreach (string projectPath in sourceProjectPaths)
+        {
+            XDocument document = XDocument.Load(Path.Combine(RepositoryRoot, projectPath));
+            foreach (string propertyName in centrallyOwnedProperties)
+            {
+                if (document.Descendants(propertyName).Any())
+                {
+                    violations.Add($"{projectPath} redefines {propertyName}.");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Package metadata must be defined in Directory.Build.props only: " + string.Join(", ", violations));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Packable_projects_evaluate_expected_nuget_metadata ()
+    {
+        var expectedMetadataByProject = new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
+        {
+            ["src/Ucli/Ucli.csproj"] = new(StringComparer.Ordinal)
+            {
+                ["PackageId"] = "MackySoft.Ucli",
+                ["Description"] = "CLI workflow for Unity automation.",
+                ["PackageTags"] = "ucli;unity;cli;automation",
+            },
+            ["src/Ucli.Contracts/Ucli.Contracts.csproj"] = new(StringComparer.Ordinal)
+            {
+                ["PackageId"] = "MackySoft.Ucli.Contracts",
+                ["Description"] = "Shared contract types for uCLI IPC protocol.",
+                ["PackageTags"] = "ucli;unity;ipc",
+            },
+            ["src/Ucli.Infrastructure/Ucli.Infrastructure.csproj"] = new(StringComparer.Ordinal)
+            {
+                ["PackageId"] = "MackySoft.Ucli.Infrastructure",
+                ["Description"] = "Shared infrastructure services for uCLI runtime components.",
+                ["PackageTags"] = "ucli;unity;infrastructure",
+            },
+        };
+
+        foreach ((string projectPath, Dictionary<string, string> projectMetadata) in expectedMetadataByProject)
+        {
+            IReadOnlyDictionary<string, string> properties = await ReadEvaluatedPropertiesAsync(
+                projectPath,
+                "Version",
+                "PackageVersion",
+                "Authors",
+                "Company",
+                "RepositoryUrl",
+                "RepositoryType",
+                "PackageLicenseFile",
+                "PackageReadmeFile",
+                "Copyright",
+                "PackageId",
+                "Description",
+                "PackageTags");
+
+            AssertEvaluatedProperty(properties, projectPath, "Version", "0.18.0");
+            AssertEvaluatedProperty(properties, projectPath, "PackageVersion", "0.18.0");
+            AssertEvaluatedProperty(properties, projectPath, "Authors", "Hiroya Aramaki");
+            AssertEvaluatedProperty(properties, projectPath, "Company", "MackySoft");
+            AssertEvaluatedProperty(properties, projectPath, "RepositoryUrl", "https://github.com/mackysoft/ucli");
+            AssertEvaluatedProperty(properties, projectPath, "RepositoryType", "git");
+            AssertEvaluatedProperty(properties, projectPath, "PackageLicenseFile", "LICENSE");
+            AssertEvaluatedProperty(properties, projectPath, "PackageReadmeFile", "README.md");
+            AssertEvaluatedProperty(properties, projectPath, "Copyright", "Copyright (c) 2026 Hiroya Aramaki");
+
+            foreach ((string propertyName, string expectedValue) in projectMetadata)
+            {
+                AssertEvaluatedProperty(properties, projectPath, propertyName, expectedValue);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Cli_tool_metadata_evaluates_expected_properties ()
+    {
+        const string projectPath = "src/Ucli/Ucli.csproj";
+
+        IReadOnlyDictionary<string, string> properties = await ReadEvaluatedPropertiesAsync(
+            projectPath,
+            "PackAsTool",
+            "ToolCommandName");
+
+        AssertEvaluatedProperty(properties, projectPath, "PackAsTool", "true");
+        AssertEvaluatedProperty(properties, projectPath, "ToolCommandName", "ucli");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Projects_declare_expected_packability ()
+    {
+        var expectedPackabilityByProject = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["src/Ucli.Application/Ucli.Application.csproj"] = "false",
+            ["src/Ucli.Contracts/Ucli.Contracts.csproj"] = "true",
+            ["src/Ucli.Infrastructure/Ucli.Infrastructure.csproj"] = "true",
+            ["src/Ucli.Skills/Ucli.Skills.csproj"] = "false",
+            ["src/Ucli/Ucli.csproj"] = "true",
+            ["tests/Tests.Helper/Tests.Helper.csproj"] = "false",
+            ["tests/Ucli.Application.Tests/Ucli.Application.Tests.csproj"] = "false",
+            ["tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj"] = "false",
+            ["tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj"] = "false",
+            ["tests/Ucli.Infrastructure.Tests/Ucli.Infrastructure.Tests.csproj"] = "false",
+            ["tests/Ucli.Skills.Tests/Ucli.Skills.Tests.csproj"] = "false",
+            ["tests/Ucli.Tests/Ucli.Tests.csproj"] = "false",
+        };
+
+        string[] actualProjectPaths = Directory
+            .EnumerateFiles(RepositoryRoot, "*.csproj", SearchOption.AllDirectories)
+            .Select(NormalizeRepositoryRelativePath)
+            .Where(static path => !path.StartsWith("src/Ucli.Unity/", StringComparison.Ordinal))
+            .OrderBy(static path => path, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            expectedPackabilityByProject.Keys.OrderBy(static path => path, StringComparer.Ordinal),
+            actualProjectPaths);
+
+        foreach ((string projectPath, string expectedIsPackable) in expectedPackabilityByProject)
+        {
+            XDocument document = XDocument.Load(Path.Combine(RepositoryRoot, projectPath));
+            string actualIsPackable = document.Descendants("IsPackable").Single().Value;
+            Assert.Equal(expectedIsPackable, actualIsPackable);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Unity_nuspec_metadata_matches_central_package_metadata ()
+    {
+        IReadOnlyDictionary<string, string> centralProperties = ReadDirectoryBuildProperties();
+        XNamespace nuspecNamespace = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
+        XDocument nuspecDocument = XDocument.Load(Path.Combine(RepositoryRoot, "src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec"));
+        XElement metadata = nuspecDocument.Root?.Element(nuspecNamespace + "metadata")
+            ?? throw new InvalidOperationException("Unity nuspec metadata element was not found.");
+
+        Assert.Equal(centralProperties["Authors"], ReadRequiredElementValue(metadata, nuspecNamespace, "authors"));
+        Assert.Equal(centralProperties["Company"], ReadRequiredElementValue(metadata, nuspecNamespace, "owners"));
+        Assert.Equal("file", ReadRequiredElement(metadata, nuspecNamespace, "license").Attribute("type")?.Value);
+        Assert.Equal(centralProperties["PackageLicenseFile"], ReadRequiredElementValue(metadata, nuspecNamespace, "license"));
+        Assert.Equal(centralProperties["PackageReadmeFile"], ReadRequiredElementValue(metadata, nuspecNamespace, "readme"));
+        Assert.Equal(centralProperties["RepositoryType"], ReadRequiredElement(metadata, nuspecNamespace, "repository").Attribute("type")?.Value);
+        Assert.Equal(centralProperties["RepositoryUrl"], ReadRequiredElement(metadata, nuspecNamespace, "repository").Attribute("url")?.Value);
+
+        IReadOnlyDictionary<string, string> packageConfigVersions = ReadUnityPackageConfigVersions();
+        IReadOnlyDictionary<string, string> nuspecDependencyVersions = ReadNuspecDependencyVersions(metadata, nuspecNamespace);
+        Assert.Equal(centralProperties["Version"], packageConfigVersions["MackySoft.Ucli.Contracts"]);
+        Assert.Equal(centralProperties["Version"], packageConfigVersions["MackySoft.Ucli.Infrastructure"]);
+        Assert.Equal(packageConfigVersions["MackySoft.Ucli.Contracts"], nuspecDependencyVersions["MackySoft.Ucli.Contracts"]);
+        Assert.Equal(packageConfigVersions["MackySoft.Ucli.Infrastructure"], nuspecDependencyVersions["MackySoft.Ucli.Infrastructure"]);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Verify_scope_detector_tracks_directory_build_props_changes ()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), "ucli-verify-scope-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            await RunProcessAsync("git", ["init"], tempDirectory);
+            await RunProcessAsync("git", ["config", "user.email", "ucli-tests@example.invalid"], tempDirectory);
+            await RunProcessAsync("git", ["config", "user.name", "uCLI Tests"], tempDirectory);
+
+            string propsPath = Path.Combine(tempDirectory, "Directory.Build.props");
+            await File.WriteAllTextAsync(
+                propsPath,
+                "<Project><PropertyGroup><Version>0.18.0</Version></PropertyGroup></Project>",
+                Encoding.UTF8);
+            await RunProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
+            await RunProcessAsync("git", ["commit", "-m", "initial"], tempDirectory);
+            string baseSha = (await RunProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
+
+            await File.WriteAllTextAsync(
+                propsPath,
+                "<Project><PropertyGroup><Version>0.18.1</Version></PropertyGroup></Project>",
+                Encoding.UTF8);
+            await RunProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
+            await RunProcessAsync("git", ["commit", "-m", "change props"], tempDirectory);
+            string headSha = (await RunProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
+
+            ProcessResult result = await RunProcessAsync(
+                "bash",
+                [Path.Combine(RepositoryRoot, "scripts", "detect-verify-scopes.sh")],
+                tempDirectory,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["EVENT_NAME"] = "pull_request",
+                    ["PR_BASE_SHA"] = baseSha,
+                    ["PR_HEAD_SHA"] = headSha,
+                });
+
+            Assert.Equal(0, result.ExitCode);
+            IReadOnlyDictionary<string, string> outputs = ParseDetectorOutputs(result.StdOut);
+            Assert.Equal("true", outputs["needs_dotnet"]);
+            Assert.Equal("true", outputs["needs_shared_pack"]);
+            Assert.Equal("true", outputs["needs_cli_pack"]);
+            Assert.Equal("false", outputs["needs_unity"]);
+            Assert.Equal("false", outputs["needs_unity_pack"]);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+    }
+
+    private static async Task<IReadOnlyDictionary<string, string>> ReadEvaluatedPropertiesAsync (
+        string projectPath,
+        params string[] propertyNames)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectPath);
+        ArgumentNullException.ThrowIfNull(propertyNames);
+
+        var arguments = new List<string>
+        {
+            "msbuild",
+            projectPath,
+            "-nologo",
+        };
+        foreach (string propertyName in propertyNames.Append("MSBuildProjectName"))
+        {
+            arguments.Add("-getProperty:" + propertyName);
+        }
+
+        ProcessResult result = await RunProcessAsync("dotnet", arguments, RepositoryRoot);
+        Assert.True(
+            result.ExitCode == 0,
+            $"dotnet msbuild failed for {projectPath}.{Environment.NewLine}{result.StdErr}");
+
+        using JsonDocument document = JsonDocument.Parse(result.StdOut);
+        JsonElement propertiesElement = document.RootElement.GetProperty("Properties");
+        return propertyNames.ToDictionary(
+            static propertyName => propertyName,
+            propertyName => propertiesElement.TryGetProperty(propertyName, out JsonElement value) ? value.GetString() ?? string.Empty : string.Empty,
+            StringComparer.Ordinal);
+    }
+
+    private static void AssertEvaluatedProperty (
+        IReadOnlyDictionary<string, string> properties,
+        string projectPath,
+        string propertyName,
+        string expectedValue)
+    {
+        ArgumentNullException.ThrowIfNull(properties);
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
+
+        Assert.True(
+            properties.TryGetValue(propertyName, out string? actualValue),
+            $"{projectPath} did not evaluate {propertyName}.");
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadDirectoryBuildProperties ()
+    {
+        XDocument document = XDocument.Load(Path.Combine(RepositoryRoot, "Directory.Build.props"));
+        var requiredProperties = new[]
+        {
+            "Version",
+            "Authors",
+            "Company",
+            "RepositoryUrl",
+            "RepositoryType",
+            "PackageLicenseFile",
+            "PackageReadmeFile",
+        };
+
+        return requiredProperties.ToDictionary(
+            static propertyName => propertyName,
+            propertyName => document.Descendants(propertyName).Single().Value,
+            StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadUnityPackageConfigVersions ()
+    {
+        XDocument document = XDocument.Load(Path.Combine(RepositoryRoot, "src/Ucli.Unity/Assets/packages.config"));
+        return document
+            .Descendants("package")
+            .Select(static element => new
+            {
+                Id = element.Attribute("id")?.Value,
+                Version = element.Attribute("version")?.Value,
+            })
+            .Where(static package => !string.IsNullOrWhiteSpace(package.Id) && !string.IsNullOrWhiteSpace(package.Version))
+            .ToDictionary(
+                static package => package.Id!,
+                static package => package.Version!,
+                StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadNuspecDependencyVersions (
+        XElement metadata,
+        XNamespace nuspecNamespace)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        return metadata
+            .Element(nuspecNamespace + "dependencies")
+            ?.Elements(nuspecNamespace + "dependency")
+            .Select(static element => new
+            {
+                Id = element.Attribute("id")?.Value,
+                Version = element.Attribute("version")?.Value,
+            })
+            .Where(static dependency => !string.IsNullOrWhiteSpace(dependency.Id) && !string.IsNullOrWhiteSpace(dependency.Version))
+            .ToDictionary(
+                static dependency => dependency.Id!,
+                static dependency => dependency.Version!,
+                StringComparer.Ordinal)
+            ?? throw new InvalidOperationException("Unity nuspec dependencies element was not found.");
+    }
+
+    private static XElement ReadRequiredElement (
+        XElement parent,
+        XNamespace xmlNamespace,
+        string elementName)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+        ArgumentException.ThrowIfNullOrWhiteSpace(elementName);
+
+        return parent.Element(xmlNamespace + elementName)
+            ?? throw new InvalidOperationException($"Required element was not found: {elementName}");
+    }
+
+    private static string ReadRequiredElementValue (
+        XElement parent,
+        XNamespace xmlNamespace,
+        string elementName)
+    {
+        return ReadRequiredElement(parent, xmlNamespace, elementName).Value;
+    }
+
+    private static IReadOnlyDictionary<string, string> ParseDetectorOutputs (string output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        string[] lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        foreach (string line in lines)
+        {
+            int separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0)
+            {
+                continue;
+            }
+
+            values[line[..separatorIndex]] = line[(separatorIndex + 1)..];
+        }
+
+        return values;
+    }
+
+    private static async Task<ProcessResult> RunProcessAsync (
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string>? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var process = new Process();
+        ProcessStartInfo startInfo = process.StartInfo;
+        startInfo.FileName = fileName;
+        startInfo.WorkingDirectory = workingDirectory;
+        startInfo.UseShellExecute = false;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.StandardOutputEncoding = Encoding.UTF8;
+        startInfo.StandardErrorEncoding = Encoding.UTF8;
+        startInfo.CreateNoWindow = true;
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        if (environment is not null)
+        {
+            foreach ((string name, string value) in environment)
+            {
+                startInfo.Environment[name] = value;
+            }
+        }
+
+        bool started = process.Start();
+        Assert.True(started, $"Failed to start process: {fileName}");
+
+        Task<string> stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        Task<string> stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        using CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(ProcessTimeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            TryKillProcess(process);
+            throw new TimeoutException($"{fileName} did not exit within {ProcessTimeout}.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            await stdOutTask,
+            await stdErrTask);
+    }
+
+    private static void TryKillProcess (Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+        }
+        catch (NotSupportedException)
+        {
+        }
+    }
+
+    private static string NormalizeRepositoryRelativePath (string fullPath)
+    {
+        return Path.GetRelativePath(RepositoryRoot, fullPath).Replace('\\', '/');
+    }
+
+    private static string FindRepositoryRoot ()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory != null)
+        {
+            if (File.Exists(Path.Combine(currentDirectory.FullName, "Ucli.slnx")))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
+    }
+
+    private sealed record ProcessResult (int ExitCode, string StdOut, string StdErr);
+}

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -225,8 +225,9 @@ public sealed class PackageMetadataTests
             string headSha = (await RunRequiredProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
 
             string detectorScriptPath = ToBashPath(Path.Combine(RepositoryRoot, "scripts", "detect-verify-scopes.sh"));
+            string bashFileName = ResolveBashFileName();
             ProcessResult result = await RunRequiredProcessAsync(
-                "bash",
+                bashFileName,
                 [detectorScriptPath],
                 tempDirectory,
                 new Dictionary<string, string>(StringComparer.Ordinal)
@@ -451,6 +452,46 @@ public sealed class PackageMetadataTests
         }
 
         return fullPath;
+    }
+
+    private static string ResolveBashFileName ()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return "bash";
+        }
+
+        foreach (string candidatePath in EnumerateGitBashCandidatePaths())
+        {
+            if (File.Exists(candidatePath))
+            {
+                return candidatePath;
+            }
+        }
+
+        return "bash";
+    }
+
+    private static IEnumerable<string> EnumerateGitBashCandidatePaths ()
+    {
+        var visitedRootPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string?[] rootPaths =
+        [
+            Environment.GetEnvironmentVariable("ProgramFiles"),
+            Environment.GetEnvironmentVariable("ProgramW6432"),
+            Environment.GetEnvironmentVariable("ProgramFiles(x86)"),
+        ];
+
+        foreach (string? rootPath in rootPaths)
+        {
+            if (string.IsNullOrWhiteSpace(rootPath) || !visitedRootPaths.Add(rootPath))
+            {
+                continue;
+            }
+
+            yield return Path.Combine(rootPath, "Git", "bin", "bash.exe");
+            yield return Path.Combine(rootPath, "Git", "usr", "bin", "bash.exe");
+        }
     }
 
     private static async Task<ProcessResult> RunRequiredProcessAsync (

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -246,10 +246,7 @@ public sealed class PackageMetadataTests
         }
         finally
         {
-            if (Directory.Exists(tempDirectory))
-            {
-                Directory.Delete(tempDirectory, recursive: true);
-            }
+            DeleteDirectoryBestEffort(tempDirectory);
         }
     }
 
@@ -398,6 +395,43 @@ public sealed class PackageMetadataTests
         }
 
         return values;
+    }
+
+    private static void DeleteDirectoryBestEffort (string directoryPath)
+    {
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                if (!Directory.Exists(directoryPath))
+                {
+                    return;
+                }
+
+                ClearReadOnlyAttributes(directoryPath);
+                Directory.Delete(directoryPath, recursive: true);
+                return;
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(50));
+            }
+        }
+    }
+
+    private static void ClearReadOnlyAttributes (string directoryPath)
+    {
+        foreach (string filePath in Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(filePath, File.GetAttributes(filePath) & ~FileAttributes.ReadOnly);
+        }
+
+        foreach (string childDirectoryPath in Directory.EnumerateDirectories(directoryPath, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(childDirectoryPath, File.GetAttributes(childDirectoryPath) & ~FileAttributes.ReadOnly);
+        }
+
+        File.SetAttributes(directoryPath, File.GetAttributes(directoryPath) & ~FileAttributes.ReadOnly);
     }
 
     private static async Task<ProcessResult> RunProcessAsync (

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -203,30 +203,31 @@ public sealed class PackageMetadataTests
 
         try
         {
-            await RunProcessAsync("git", ["init"], tempDirectory);
-            await RunProcessAsync("git", ["config", "user.email", "ucli-tests@example.invalid"], tempDirectory);
-            await RunProcessAsync("git", ["config", "user.name", "uCLI Tests"], tempDirectory);
+            await RunRequiredProcessAsync("git", ["init"], tempDirectory);
+            await RunRequiredProcessAsync("git", ["config", "user.email", "ucli-tests@example.invalid"], tempDirectory);
+            await RunRequiredProcessAsync("git", ["config", "user.name", "uCLI Tests"], tempDirectory);
 
             string propsPath = Path.Combine(tempDirectory, "Directory.Build.props");
             await File.WriteAllTextAsync(
                 propsPath,
                 "<Project><PropertyGroup><Version>0.18.0</Version></PropertyGroup></Project>",
                 Encoding.UTF8);
-            await RunProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
-            await RunProcessAsync("git", ["commit", "-m", "initial"], tempDirectory);
-            string baseSha = (await RunProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
+            await RunRequiredProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
+            await RunRequiredProcessAsync("git", ["commit", "-m", "initial"], tempDirectory);
+            string baseSha = (await RunRequiredProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
 
             await File.WriteAllTextAsync(
                 propsPath,
                 "<Project><PropertyGroup><Version>0.18.1</Version></PropertyGroup></Project>",
                 Encoding.UTF8);
-            await RunProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
-            await RunProcessAsync("git", ["commit", "-m", "change props"], tempDirectory);
-            string headSha = (await RunProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
+            await RunRequiredProcessAsync("git", ["add", "Directory.Build.props"], tempDirectory);
+            await RunRequiredProcessAsync("git", ["commit", "-m", "change props"], tempDirectory);
+            string headSha = (await RunRequiredProcessAsync("git", ["rev-parse", "HEAD"], tempDirectory)).StdOut.Trim();
 
-            ProcessResult result = await RunProcessAsync(
+            string detectorScriptPath = ToBashPath(Path.Combine(RepositoryRoot, "scripts", "detect-verify-scopes.sh"));
+            ProcessResult result = await RunRequiredProcessAsync(
                 "bash",
-                [Path.Combine(RepositoryRoot, "scripts", "detect-verify-scopes.sh")],
+                [detectorScriptPath],
                 tempDirectory,
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
@@ -236,7 +237,6 @@ public sealed class PackageMetadataTests
                     ["PR_HEAD_SHA"] = headSha,
                 });
 
-            Assert.Equal(0, result.ExitCode);
             IReadOnlyDictionary<string, string> outputs = ParseDetectorOutputs(result.StdOut);
             Assert.Equal("true", outputs["needs_dotnet"]);
             Assert.Equal("true", outputs["needs_shared_pack"]);
@@ -432,6 +432,46 @@ public sealed class PackageMetadataTests
         }
 
         File.SetAttributes(directoryPath, File.GetAttributes(directoryPath) & ~FileAttributes.ReadOnly);
+    }
+
+    private static string ToBashPath (string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        string fullPath = Path.GetFullPath(path).Replace('\\', '/');
+        if (!OperatingSystem.IsWindows())
+        {
+            return fullPath;
+        }
+
+        if (fullPath.Length >= 2 && fullPath[1] == ':')
+        {
+            char driveLetter = char.ToLowerInvariant(fullPath[0]);
+            return "/" + driveLetter + fullPath[2..];
+        }
+
+        return fullPath;
+    }
+
+    private static async Task<ProcessResult> RunRequiredProcessAsync (
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string>? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        ProcessResult result = await RunProcessAsync(
+            fileName,
+            arguments,
+            workingDirectory,
+            environment,
+            cancellationToken);
+        Assert.True(
+            result.ExitCode == 0,
+            $"{fileName} {string.Join(" ", arguments)} failed in {workingDirectory} with exit code {result.ExitCode}." +
+            $"{Environment.NewLine}StdOut:{Environment.NewLine}{result.StdOut}" +
+            $"{Environment.NewLine}StdErr:{Environment.NewLine}{result.StdErr}");
+        return result;
     }
 
     private static async Task<ProcessResult> RunProcessAsync (


### PR DESCRIPTION
## Summary
- Centralizes shared NuGet package metadata for CLI, Contracts, and Infrastructure in `Directory.Build.props`.
- Leaves package-specific metadata in each project file and keeps release version sync scripts aligned with the new central source.
- Adds package metadata contract tests for evaluated MSBuild properties, CLI tool metadata, packability, Unity nuspec alignment, and verify scope detection.

## Scope
- Packaging metadata: `Directory.Build.props` plus the three packable project files.
- Release and CI routing: version sync scripts, verify scope detection, and package publish workflow changed paths.
- Tests and docs: `PackageMetadataTests` and package operation notes.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh tests/Ucli.Tests/Ucli.Tests.csproj --filter FullyQualifiedName~PackageMetadataTests`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to NuGet package metadata evaluation and CI scope routing; package ids and published version values are unchanged.
- Rollback is to revert the metadata centralization commits and restore per-project metadata definitions.

## Checklist
- [x] Central metadata source added
- [x] Package-specific project metadata retained
- [x] Contract tests added
- [x] Verify scope updated for `Directory.Build.props`
- [x] Full verification passed

Closes #213
