### PR TITLE
feat(skills): add dry-run diff force safety

### DIFF
--- a/src/Ucli.Skills/Doctor/SkillDoctorDiagnostic.cs
+++ b/src/Ucli.Skills/Doctor/SkillDoctorDiagnostic.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Skills.Shared;
+
 namespace MackySoft.Ucli.Skills.Doctor;
 
 /// <summary> Represents one SKILL doctor diagnostic. </summary>
@@ -38,6 +40,24 @@ public sealed record SkillDoctorDiagnostic
         string? skillName = null)
     {
         return Create(SkillDoctorSeverity.Error, code, message, skillName);
+    }
+
+    /// <summary> Creates an error diagnostic from a SKILL failure code. </summary>
+    /// <param name="code"> The diagnostic code. </param>
+    /// <param name="message"> The diagnostic message. </param>
+    /// <param name="skillName"> The related skill name, or <see langword="null" /> for target-level diagnostics. </param>
+    /// <returns> The error diagnostic. </returns>
+    public static SkillDoctorDiagnostic Error (
+        SkillFailureCode code,
+        string message,
+        string? skillName = null)
+    {
+        if (!code.IsValid)
+        {
+            throw new ArgumentException("Failure code must be valid.", nameof(code));
+        }
+
+        return Create(SkillDoctorSeverity.Error, code.Value, message, skillName);
     }
 
     /// <summary> Creates an informational diagnostic. </summary>

--- a/src/Ucli.Skills/Installation/ISkillInstalledPackageRemover.cs
+++ b/src/Ucli.Skills/Installation/ISkillInstalledPackageRemover.cs
@@ -8,10 +8,12 @@ public interface ISkillInstalledPackageRemover
     /// <summary> Deletes one installed SKILL package directory. </summary>
     /// <param name="targetRoot"> The resolved host target root. </param>
     /// <param name="skillDirectory"> The resolved skill package directory. </param>
+    /// <param name="precondition"> The optional validation invoked for the target path immediately before move and for the moved tree before commit. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> Success when the directory is deleted or already absent; otherwise a failure. </returns>
     ValueTask<SkillOperationResult<bool>> DeleteAsync (
         string targetRoot,
         string skillDirectory,
+        Func<string, CancellationToken, ValueTask<SkillOperationResult<bool>>>? precondition,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Skills/Installation/ISkillInstalledPackageRemover.cs
+++ b/src/Ucli.Skills/Installation/ISkillInstalledPackageRemover.cs
@@ -1,0 +1,17 @@
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Deletes one installed SKILL package directory under a resolved host target root. </summary>
+public interface ISkillInstalledPackageRemover
+{
+    /// <summary> Deletes one installed SKILL package directory. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="skillDirectory"> The resolved skill package directory. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Success when the directory is deleted or already absent; otherwise a failure. </returns>
+    ValueTask<SkillOperationResult<bool>> DeleteAsync (
+        string targetRoot,
+        string skillDirectory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli.Skills/Installation/ISkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/ISkillMaterializedPackageWriter.cs
@@ -1,0 +1,20 @@
+using MackySoft.Ucli.Skills.Materialization;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Writes one materialized SKILL package into a resolved host target root. </summary>
+public interface ISkillMaterializedPackageWriter
+{
+    /// <summary> Replaces one skill directory with a materialized package. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="skillDirectory"> The resolved skill package directory. </param>
+    /// <param name="materializedPackage"> The materialized package to write. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Success when the directory is atomically replaced; otherwise a failure. </returns>
+    ValueTask<SkillOperationResult<bool>> WriteAsync (
+        string targetRoot,
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli.Skills/Installation/ISkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/ISkillMaterializedPackageWriter.cs
@@ -10,11 +10,15 @@ public interface ISkillMaterializedPackageWriter
     /// <param name="targetRoot"> The resolved host target root. </param>
     /// <param name="skillDirectory"> The resolved skill package directory. </param>
     /// <param name="materializedPackage"> The materialized package to write. </param>
+    /// <param name="writeMode"> The required target existence condition at commit time. </param>
+    /// <param name="precondition"> The optional validation invoked for the target path immediately before move and for the moved tree before commit. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> Success when the directory is atomically replaced; otherwise a failure. </returns>
     ValueTask<SkillOperationResult<bool>> WriteAsync (
         string targetRoot,
         string skillDirectory,
         SkillMaterializedPackage materializedPackage,
+        SkillMaterializedPackageWriteMode writeMode,
+        Func<string, CancellationToken, ValueTask<SkillOperationResult<bool>>>? precondition,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Skills/Installation/ISkillPackageDirectoryOperations.cs
+++ b/src/Ucli.Skills/Installation/ISkillPackageDirectoryOperations.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Provides replaceable directory operations for SKILL package transactions. </summary>
-internal interface ISkillPackageDirectoryOperations
+/// <summary> Provides directory primitives used by SKILL package transactions. </summary>
+public interface ISkillPackageDirectoryOperations
 {
     /// <summary> Determines whether the directory exists. </summary>
     /// <param name="path"> The directory path to inspect. </param>

--- a/src/Ucli.Skills/Installation/ISkillPackageDirectoryOperations.cs
+++ b/src/Ucli.Skills/Installation/ISkillPackageDirectoryOperations.cs
@@ -1,0 +1,24 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Provides replaceable directory operations for SKILL package transactions. </summary>
+internal interface ISkillPackageDirectoryOperations
+{
+    /// <summary> Determines whether the directory exists. </summary>
+    /// <param name="path"> The directory path to inspect. </param>
+    /// <returns> <see langword="true" /> when the directory exists; otherwise <see langword="false" />. </returns>
+    bool Exists (string path);
+
+    /// <summary> Creates a directory and all missing parents. </summary>
+    /// <param name="path"> The directory path to create. </param>
+    void Create (string path);
+
+    /// <summary> Moves a directory to a new path. </summary>
+    /// <param name="sourceDirectoryName"> The existing directory path. </param>
+    /// <param name="destinationDirectoryName"> The destination directory path. </param>
+    void Move (string sourceDirectoryName, string destinationDirectoryName);
+
+    /// <summary> Deletes a directory. </summary>
+    /// <param name="path"> The directory path to delete. </param>
+    /// <param name="recursive"> Whether child entries should be deleted. </param>
+    void Delete (string path, bool recursive);
+}

--- a/src/Ucli.Skills/Installation/SkillActionDiff.cs
+++ b/src/Ucli.Skills/Installation/SkillActionDiff.cs
@@ -1,0 +1,5 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Represents one structured file diff payload for an install action. </summary>
+/// <param name="Files"> The file-level differences. </param>
+public sealed record SkillActionDiff (IReadOnlyList<SkillFileDiff> Files);

--- a/src/Ucli.Skills/Installation/SkillBlockedReason.cs
+++ b/src/Ucli.Skills/Installation/SkillBlockedReason.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Defines blocked action reason literals. </summary>
+public static class SkillBlockedReason
+{
+    /// <summary> The operation would overwrite a managed target without <c>--force</c>. </summary>
+    public const string ManagedOverwriteRequiresForce = "managedOverwriteRequiresForce";
+
+    /// <summary> The operation would overwrite or delete local modifications without <c>--force</c>. </summary>
+    public const string LocalModificationRequiresForce = "localModificationRequiresForce";
+
+    /// <summary> The target directory is not managed by uCLI. </summary>
+    public const string UnmanagedTarget = "unmanagedTarget";
+}

--- a/src/Ucli.Skills/Installation/SkillBlockedReason.cs
+++ b/src/Ucli.Skills/Installation/SkillBlockedReason.cs
@@ -1,14 +1,14 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Defines blocked action reason literals. </summary>
-public static class SkillBlockedReason
+/// <summary> Defines blocked action reason categories. </summary>
+public enum SkillBlockedReason
 {
     /// <summary> The operation would overwrite a managed target without <c>--force</c>. </summary>
-    public const string ManagedOverwriteRequiresForce = "managedOverwriteRequiresForce";
+    ManagedOverwriteRequiresForce = 0,
 
     /// <summary> The operation would overwrite or delete local modifications without <c>--force</c>. </summary>
-    public const string LocalModificationRequiresForce = "localModificationRequiresForce";
+    LocalModificationRequiresForce = 1,
 
     /// <summary> The target directory is not managed by uCLI. </summary>
-    public const string UnmanagedTarget = "unmanagedTarget";
+    UnmanagedTarget = 2,
 }

--- a/src/Ucli.Skills/Installation/SkillDiffChangeKind.cs
+++ b/src/Ucli.Skills/Installation/SkillDiffChangeKind.cs
@@ -1,14 +1,14 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Defines structured SKILL diff change kind literals. </summary>
-public static class SkillDiffChangeKind
+/// <summary> Defines structured SKILL diff change kinds. </summary>
+public enum SkillDiffChangeKind
 {
     /// <summary> A file is added. </summary>
-    public const string Added = "added";
+    Added,
 
     /// <summary> A file is modified. </summary>
-    public const string Modified = "modified";
+    Modified,
 
     /// <summary> A file is deleted. </summary>
-    public const string Deleted = "deleted";
+    Deleted,
 }

--- a/src/Ucli.Skills/Installation/SkillDiffChangeKind.cs
+++ b/src/Ucli.Skills/Installation/SkillDiffChangeKind.cs
@@ -1,0 +1,14 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Defines structured SKILL diff change kind literals. </summary>
+public static class SkillDiffChangeKind
+{
+    /// <summary> A file is added. </summary>
+    public const string Added = "added";
+
+    /// <summary> A file is modified. </summary>
+    public const string Modified = "modified";
+
+    /// <summary> A file is deleted. </summary>
+    public const string Deleted = "deleted";
+}

--- a/src/Ucli.Skills/Installation/SkillFileDiff.cs
+++ b/src/Ucli.Skills/Installation/SkillFileDiff.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Represents one structured file difference. </summary>
+/// <param name="RelativePath"> The slash-separated path relative to the skill directory. </param>
+/// <param name="ChangeKind"> The change kind literal. </param>
+/// <param name="BeforeContent"> The previous file content, or <see langword="null" /> for additions. </param>
+/// <param name="AfterContent"> The next file content, or <see langword="null" /> for deletions. </param>
+public sealed record SkillFileDiff (
+    string RelativePath,
+    string ChangeKind,
+    string? BeforeContent,
+    string? AfterContent);

--- a/src/Ucli.Skills/Installation/SkillFileDiff.cs
+++ b/src/Ucli.Skills/Installation/SkillFileDiff.cs
@@ -2,11 +2,11 @@ namespace MackySoft.Ucli.Skills.Installation;
 
 /// <summary> Represents one structured file difference. </summary>
 /// <param name="RelativePath"> The slash-separated path relative to the skill directory. </param>
-/// <param name="ChangeKind"> The change kind literal. </param>
+/// <param name="ChangeKind"> The change kind. </param>
 /// <param name="BeforeContent"> The previous file content, or <see langword="null" /> for additions. </param>
 /// <param name="AfterContent"> The next file content, or <see langword="null" /> for deletions. </param>
 public sealed record SkillFileDiff (
     string RelativePath,
-    string ChangeKind,
+    SkillDiffChangeKind ChangeKind,
     string? BeforeContent,
     string? AfterContent);

--- a/src/Ucli.Skills/Installation/SkillInstallAction.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallAction.cs
@@ -3,6 +3,10 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill install action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
+/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
+/// <param name="Diffs"> The optional structured diffs. </param>
 public sealed record SkillInstallAction (
     SkillInstallIdentity Identity,
-    SkillInstallActionKind ActionKind);
+    SkillInstallActionKind ActionKind,
+    string? BlockedReason = null,
+    IReadOnlyList<SkillActionDiff>? Diffs = null);

--- a/src/Ucli.Skills/Installation/SkillInstallAction.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallAction.cs
@@ -3,10 +3,10 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill install action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
-/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
+/// <param name="BlockedReason"> The blocked reason category, when the action is blocked. </param>
 /// <param name="Diffs"> The optional structured diffs. </param>
 public sealed record SkillInstallAction (
     SkillInstallIdentity Identity,
     SkillInstallActionKind ActionKind,
-    string? BlockedReason = null,
+    SkillBlockedReason? BlockedReason = null,
     IReadOnlyList<SkillActionDiff>? Diffs = null);

--- a/src/Ucli.Skills/Installation/SkillInstallActionKind.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallActionKind.cs
@@ -3,9 +3,21 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Defines the outcome for one installed official SKILL. </summary>
 public enum SkillInstallActionKind
 {
-    /// <summary> The target skill directory was created. </summary>
+    /// <summary> The target skill directory is planned to be created or was created. </summary>
     Created = 0,
 
+    /// <summary> The managed target skill directory is planned to be replaced or was replaced with the current canonical package. </summary>
+    Updated = 1,
+
     /// <summary> The target skill directory already contained matching content for the same host. </summary>
-    NoOp = 1,
+    NoOp = 2,
+
+    /// <summary> The target contains managed non-current content and force was not enabled. </summary>
+    BlockedManagedOverwrite = 3,
+
+    /// <summary> The target contains local modifications and force was not enabled. </summary>
+    BlockedLocalModification = 4,
+
+    /// <summary> The target is unmanaged and cannot be overwritten. </summary>
+    BlockedUnmanaged = 5,
 }

--- a/src/Ucli.Skills/Installation/SkillInstallInput.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallInput.cs
@@ -2,13 +2,13 @@ using MackySoft.Ucli.Skills.Packaging;
 
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Represents one SKILL update service input. </summary>
-/// <param name="Packages"> The canonical packages to reconcile. </param>
+/// <summary> Represents one SKILL install service input. </summary>
+/// <param name="Packages"> The canonical packages to install. </param>
 /// <param name="TargetRequest"> The host target request. </param>
 /// <param name="DryRun"> Whether to return a plan without writing to the file system. </param>
 /// <param name="Force"> Whether managed local modifications can be overwritten. </param>
 /// <param name="PrintDiff"> Whether per-file diff payloads should be included. </param>
-public sealed record SkillUpdateInput (
+public sealed record SkillInstallInput (
     IReadOnlyList<CanonicalSkillPackage> Packages,
     SkillInstallRequest TargetRequest,
     bool DryRun = false,

--- a/src/Ucli.Skills/Installation/SkillInstallResult.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallResult.cs
@@ -1,8 +1,14 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Represents a completed SKILL install operation. </summary>
+/// <summary> Represents a planned or completed SKILL install operation. </summary>
 /// <param name="TargetRoot"> The canonical absolute target root. </param>
 /// <param name="Actions"> The per-skill install actions. </param>
+/// <param name="DryRun"> Whether the result represents a plan without writes. </param>
+/// <param name="Force"> Whether force overwrite was enabled. </param>
+/// <param name="PrintDiff"> Whether diff payloads were requested. </param>
 public sealed record SkillInstallResult (
     string TargetRoot,
-    IReadOnlyList<SkillInstallAction> Actions);
+    IReadOnlyList<SkillInstallAction> Actions,
+    bool DryRun = false,
+    bool Force = false,
+    bool PrintDiff = false);

--- a/src/Ucli.Skills/Installation/SkillInstallService.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallService.cs
@@ -1,4 +1,3 @@
-using MackySoft.Ucli.Skills.Installation.Validation;
 using MackySoft.Ucli.Skills.Materialization;
 using MackySoft.Ucli.Skills.Packaging;
 using MackySoft.Ucli.Skills.Shared;
@@ -10,20 +9,28 @@ public sealed class SkillInstallService
 {
     private readonly SkillInstallTargetResolver targetResolver;
     private readonly SkillMaterializationService materializationService;
-    private readonly SkillInstalledPackageValidator installedPackageValidator;
+    private readonly SkillInstalledTargetStateAnalyzer targetStateAnalyzer;
+    private readonly ISkillMaterializedPackageWriter packageWriter;
+    private readonly SkillMaterializedPackageDiffBuilder diffBuilder;
 
     /// <summary> Initializes a new instance of the <see cref="SkillInstallService" /> class. </summary>
     /// <param name="targetResolver"> The target resolver. </param>
     /// <param name="materializationService"> The materialization service. </param>
-    /// <param name="installedPackageValidator"> The installed package validator. </param>
+    /// <param name="targetStateAnalyzer"> The installed target state analyzer. </param>
+    /// <param name="packageWriter"> The materialized package writer. </param>
+    /// <param name="diffBuilder"> The structured diff builder. </param>
     public SkillInstallService (
         SkillInstallTargetResolver targetResolver,
         SkillMaterializationService materializationService,
-        SkillInstalledPackageValidator installedPackageValidator)
+        SkillInstalledTargetStateAnalyzer targetStateAnalyzer,
+        ISkillMaterializedPackageWriter packageWriter,
+        SkillMaterializedPackageDiffBuilder diffBuilder)
     {
         this.targetResolver = targetResolver ?? throw new ArgumentNullException(nameof(targetResolver));
         this.materializationService = materializationService ?? throw new ArgumentNullException(nameof(materializationService));
-        this.installedPackageValidator = installedPackageValidator ?? throw new ArgumentNullException(nameof(installedPackageValidator));
+        this.targetStateAnalyzer = targetStateAnalyzer ?? throw new ArgumentNullException(nameof(targetStateAnalyzer));
+        this.packageWriter = packageWriter ?? throw new ArgumentNullException(nameof(packageWriter));
+        this.diffBuilder = diffBuilder ?? throw new ArgumentNullException(nameof(diffBuilder));
     }
 
     /// <summary> Installs official SKILL packages. </summary>
@@ -31,16 +38,28 @@ public sealed class SkillInstallService
     /// <param name="request"> The install request. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The install result or failure. </returns>
-    public async ValueTask<SkillOperationResult<SkillInstallResult>> InstallAsync (
+    public ValueTask<SkillOperationResult<SkillInstallResult>> InstallAsync (
         IReadOnlyList<CanonicalSkillPackage> packages,
         SkillInstallRequest request,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(packages);
-        ArgumentNullException.ThrowIfNull(request);
+        return InstallAsync(new SkillInstallInput(packages, request), cancellationToken);
+    }
+
+    /// <summary> Installs official SKILL packages. </summary>
+    /// <param name="input"> The install input. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The install result or failure. </returns>
+    public async ValueTask<SkillOperationResult<SkillInstallResult>> InstallAsync (
+        SkillInstallInput input,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.Packages);
+        ArgumentNullException.ThrowIfNull(input.TargetRequest);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var targetResult = targetResolver.ResolveTarget(request);
+        var targetResult = targetResolver.ResolveTarget(input.TargetRequest);
         if (!targetResult.IsSuccess)
         {
             return SkillOperationResult<SkillInstallResult>.FailureResult(targetResult.Failure!.Code, targetResult.Failure.Message);
@@ -48,8 +67,8 @@ public sealed class SkillInstallService
 
         var target = targetResult.Value!;
         var targetRoot = target.TargetRoot;
-        var actions = new List<SkillInstallAction>();
-        foreach (var package in packages.OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal))
+        var actionPlans = new List<SkillInstallActionPlan>();
+        foreach (var package in input.Packages.OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -60,51 +79,252 @@ public sealed class SkillInstallService
             }
 
             var skillDirectory = skillDirectoryResult.Value!;
-            var identity = new SkillInstallIdentity(target.Host, request.Scope, targetRoot, package.Manifest.SkillName);
-            if (Directory.Exists(skillDirectory))
+            var identity = new SkillInstallIdentity(target.Host, input.TargetRequest.Scope, targetRoot, package.Manifest.SkillName);
+            var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
+            if (!stateResult.IsSuccess)
             {
-                var existingResult = await ValidateExistingTargetAsync(package, skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
-                if (!existingResult.IsSuccess)
-                {
-                    return SkillOperationResult<SkillInstallResult>.FailureResult(existingResult.Failure!.Code, existingResult.Failure.Message);
-                }
-
-                actions.Add(new SkillInstallAction(identity, SkillInstallActionKind.NoOp));
-                continue;
+                return SkillOperationResult<SkillInstallResult>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
             }
 
-            var materializedResult = materializationService.Materialize(package, target.Host);
-            if (!materializedResult.IsSuccess)
-            {
-                return SkillOperationResult<SkillInstallResult>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
-            }
-
-            var writeResult = await SkillMaterializedPackageWriter.WriteAsync(
-                    targetRoot,
+            var actionPlanResult = await CreateActionPlanAsync(
+                    package,
+                    target.Host,
                     skillDirectory,
-                    materializedResult.Value!,
+                    identity,
+                    stateResult.Value!,
+                    input,
                     cancellationToken)
                 .ConfigureAwait(false);
-            if (!writeResult.IsSuccess)
+            if (!actionPlanResult.IsSuccess)
             {
-                return SkillOperationResult<SkillInstallResult>.FailureResult(writeResult.Failure!.Code, writeResult.Failure.Message);
+                return SkillOperationResult<SkillInstallResult>.FailureResult(actionPlanResult.Failure!.Code, actionPlanResult.Failure.Message);
             }
 
-            actions.Add(new SkillInstallAction(identity, SkillInstallActionKind.Created));
+            actionPlans.Add(actionPlanResult.Value!);
         }
 
-        return SkillOperationResult<SkillInstallResult>.Success(new SkillInstallResult(targetRoot, actions));
+        if (!input.DryRun)
+        {
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (actionPlan.MaterializedPackage is null)
+                {
+                    continue;
+                }
+
+                var writeResult = await packageWriter.WriteAsync(
+                        targetRoot,
+                        actionPlan.SkillDirectory,
+                        actionPlan.MaterializedPackage,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!writeResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillInstallResult>.FailureResult(writeResult.Failure!.Code, writeResult.Failure.Message);
+                }
+            }
+        }
+
+        return SkillOperationResult<SkillInstallResult>.Success(new SkillInstallResult(
+            targetRoot,
+            actionPlans.Select(static actionPlan => actionPlan.Action).ToArray(),
+            input.DryRun,
+            input.Force,
+            input.PrintDiff));
     }
 
-    private async ValueTask<SkillOperationResult<bool>> ValidateExistingTargetAsync (
+    private async ValueTask<SkillOperationResult<SkillInstallActionPlan>> CreateActionPlanAsync (
         CanonicalSkillPackage package,
-        string skillDirectory,
         string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstalledTargetState state,
+        SkillInstallInput input,
         CancellationToken cancellationToken)
     {
-        var validationResult = await installedPackageValidator.ValidateAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
-        return validationResult.IsSuccess
-            ? SkillOperationResult<bool>.Success(true)
-            : SkillOperationResult<bool>.FailureResult(validationResult.Failure!.Code, validationResult.Failure.Message);
+        switch (state.Kind)
+        {
+            case SkillInstalledTargetStateKind.Missing:
+                return await CreateWriteActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        SkillInstallActionKind.Created,
+                        input,
+                        blockedReason: null,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.Current:
+                return SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
+                    new SkillInstallAction(identity, SkillInstallActionKind.NoOp),
+                    skillDirectory,
+                    null));
+            case SkillInstalledTargetStateKind.CleanOutdated:
+                return await CreateManagedMismatchActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        input,
+                        SkillInstallActionKind.BlockedManagedOverwrite,
+                        SkillBlockedReason.ManagedOverwriteRequiresForce,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.LocalModified:
+                return await CreateManagedMismatchActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        input,
+                        SkillInstallActionKind.BlockedLocalModification,
+                        SkillBlockedReason.LocalModificationRequiresForce,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.Unmanaged:
+                if (!input.DryRun)
+                {
+                    return SkillOperationResult<SkillInstallActionPlan>.FailureResult(
+                        SkillFailureCodes.InstallTargetUnmanaged,
+                        $"Target skill directory is not managed by uCLI: {skillDirectory}");
+                }
+
+                return await CreateBlockedActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        SkillInstallActionKind.BlockedUnmanaged,
+                        SkillBlockedReason.UnmanagedTarget,
+                        printDiff: false,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(state), state.Kind, "Unsupported target state.");
+        }
     }
+
+    private async ValueTask<SkillOperationResult<SkillInstallActionPlan>> CreateManagedMismatchActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstallInput input,
+        SkillInstallActionKind blockedActionKind,
+        string blockedReason,
+        CancellationToken cancellationToken)
+    {
+        if (input.Force)
+        {
+            return await CreateWriteActionPlanAsync(
+                    package,
+                    host,
+                    skillDirectory,
+                    identity,
+                    SkillInstallActionKind.Updated,
+                    input,
+                    blockedReason: null,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (input.DryRun)
+        {
+            return await CreateBlockedActionPlanAsync(
+                    package,
+                    host,
+                    skillDirectory,
+                    identity,
+                    blockedActionKind,
+                    blockedReason,
+                    input.PrintDiff,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return SkillOperationResult<SkillInstallActionPlan>.FailureResult(
+            SkillFailureCodes.InstallTargetDigestMismatch,
+            $"Target skill directory differs from the canonical package. Use --force to overwrite: {skillDirectory}");
+    }
+
+    private async ValueTask<SkillOperationResult<SkillInstallActionPlan>> CreateWriteActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstallActionKind actionKind,
+        SkillInstallInput input,
+        string? blockedReason,
+        CancellationToken cancellationToken)
+    {
+        var materializedResult = materializationService.Materialize(package, host);
+        if (!materializedResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+        }
+
+        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, input.PrintDiff, cancellationToken).ConfigureAwait(false);
+        if (!diffResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+        }
+
+        return SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
+            new SkillInstallAction(
+                identity,
+                actionKind,
+                blockedReason,
+                diffResult.Value),
+            skillDirectory,
+            materializedResult.Value!));
+    }
+
+    private async ValueTask<SkillOperationResult<SkillInstallActionPlan>> CreateBlockedActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstallActionKind actionKind,
+        string blockedReason,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        var materializedResult = materializationService.Materialize(package, host);
+        if (!materializedResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+        }
+
+        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
+        return diffResult.IsSuccess
+            ? SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
+                new SkillInstallAction(identity, actionKind, blockedReason, diffResult.Value),
+                skillDirectory,
+                null))
+            : SkillOperationResult<SkillInstallActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>?>> CreateDiffsAsync (
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        if (!printDiff)
+        {
+            return SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(Array.Empty<SkillActionDiff>());
+        }
+
+        var diffResult = await diffBuilder.BuildAsync(skillDirectory, materializedPackage, cancellationToken).ConfigureAwait(false);
+        return diffResult.IsSuccess
+            ? SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(diffResult.Value)
+            : SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+    }
+
+    private sealed record SkillInstallActionPlan (
+        SkillInstallAction Action,
+        string SkillDirectory,
+        SkillMaterializedPackage? MaterializedPackage);
 }

--- a/src/Ucli.Skills/Installation/SkillInstallService.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallService.cs
@@ -153,7 +153,6 @@ public sealed class SkillInstallService
                         identity,
                         SkillInstallActionKind.Created,
                         input,
-                        blockedReason: null,
                         cancellationToken)
                     .ConfigureAwait(false);
             case SkillInstalledTargetStateKind.Current:
@@ -213,7 +212,7 @@ public sealed class SkillInstallService
         SkillInstallIdentity identity,
         SkillInstallInput input,
         SkillInstallActionKind blockedActionKind,
-        string blockedReason,
+        SkillBlockedReason blockedReason,
         CancellationToken cancellationToken)
     {
         if (input.Force)
@@ -225,7 +224,6 @@ public sealed class SkillInstallService
                     identity,
                     SkillInstallActionKind.Updated,
                     input,
-                    blockedReason: null,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -256,29 +254,22 @@ public sealed class SkillInstallService
         SkillInstallIdentity identity,
         SkillInstallActionKind actionKind,
         SkillInstallInput input,
-        string? blockedReason,
         CancellationToken cancellationToken)
     {
-        var materializedResult = materializationService.Materialize(package, host);
-        if (!materializedResult.IsSuccess)
+        var packagePlanResult = await CreateMaterializedPackagePlanAsync(package, host, skillDirectory, input.PrintDiff, cancellationToken).ConfigureAwait(false);
+        if (!packagePlanResult.IsSuccess)
         {
-            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
         }
 
-        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, input.PrintDiff, cancellationToken).ConfigureAwait(false);
-        if (!diffResult.IsSuccess)
-        {
-            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
-        }
-
+        var packagePlan = packagePlanResult.Value!;
         return SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
             new SkillInstallAction(
                 identity,
                 actionKind,
-                blockedReason,
-                diffResult.Value),
+                Diffs: packagePlan.Diffs),
             skillDirectory,
-            materializedResult.Value!));
+            packagePlan.MaterializedPackage));
     }
 
     private async ValueTask<SkillOperationResult<SkillInstallActionPlan>> CreateBlockedActionPlanAsync (
@@ -287,41 +278,41 @@ public sealed class SkillInstallService
         string skillDirectory,
         SkillInstallIdentity identity,
         SkillInstallActionKind actionKind,
-        string blockedReason,
+        SkillBlockedReason blockedReason,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        var packagePlanResult = await CreateMaterializedPackagePlanAsync(package, host, skillDirectory, printDiff, cancellationToken).ConfigureAwait(false);
+        return packagePlanResult.IsSuccess
+            ? SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
+                new SkillInstallAction(identity, actionKind, blockedReason, packagePlanResult.Value!.Diffs),
+                skillDirectory,
+                null))
+            : SkillOperationResult<SkillInstallActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<SkillMaterializedPackagePlan>> CreateMaterializedPackagePlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
         bool printDiff,
         CancellationToken cancellationToken)
     {
         var materializedResult = materializationService.Materialize(package, host);
         if (!materializedResult.IsSuccess)
         {
-            return SkillOperationResult<SkillInstallActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+            return SkillOperationResult<SkillMaterializedPackagePlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
         }
 
-        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
+        var diffResult = await diffBuilder.BuildOptionalAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
         return diffResult.IsSuccess
-            ? SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
-                new SkillInstallAction(identity, actionKind, blockedReason, diffResult.Value),
-                skillDirectory,
-                null))
-            : SkillOperationResult<SkillInstallActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+            ? SkillOperationResult<SkillMaterializedPackagePlan>.Success(new SkillMaterializedPackagePlan(materializedResult.Value!, diffResult.Value!))
+            : SkillOperationResult<SkillMaterializedPackagePlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
     }
 
-    private async ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>?>> CreateDiffsAsync (
-        string skillDirectory,
-        SkillMaterializedPackage materializedPackage,
-        bool printDiff,
-        CancellationToken cancellationToken)
-    {
-        if (!printDiff)
-        {
-            return SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(Array.Empty<SkillActionDiff>());
-        }
-
-        var diffResult = await diffBuilder.BuildAsync(skillDirectory, materializedPackage, cancellationToken).ConfigureAwait(false);
-        return diffResult.IsSuccess
-            ? SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(diffResult.Value)
-            : SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
-    }
+    private sealed record SkillMaterializedPackagePlan (
+        SkillMaterializedPackage MaterializedPackage,
+        IReadOnlyList<SkillActionDiff> Diffs);
 
     private sealed record SkillInstallActionPlan (
         SkillInstallAction Action,

--- a/src/Ucli.Skills/Installation/SkillInstallService.cs
+++ b/src/Ucli.Skills/Installation/SkillInstallService.cs
@@ -113,10 +113,40 @@ public sealed class SkillInstallService
                     continue;
                 }
 
+                var preconditionResult = await ValidateWritePreconditionAsync(
+                        actionPlan.Package,
+                        target.Host,
+                        actionPlan.SkillDirectory,
+                        actionPlan.Action.ActionKind,
+                        input.Force,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!preconditionResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillInstallResult>.FailureResult(preconditionResult.Failure!.Code, preconditionResult.Failure.Message);
+                }
+            }
+
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (actionPlan.MaterializedPackage is null)
+                {
+                    continue;
+                }
+
                 var writeResult = await packageWriter.WriteAsync(
                         targetRoot,
                         actionPlan.SkillDirectory,
                         actionPlan.MaterializedPackage,
+                        ResolveWriteMode(actionPlan.Action.ActionKind),
+                        (directory, token) => ValidateWritePreconditionAsync(
+                            actionPlan.Package,
+                            target.Host,
+                            directory,
+                            actionPlan.Action.ActionKind,
+                            input.Force,
+                            token),
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (!writeResult.IsSuccess)
@@ -159,6 +189,7 @@ public sealed class SkillInstallService
                 return SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
                     new SkillInstallAction(identity, SkillInstallActionKind.NoOp),
                     skillDirectory,
+                    package,
                     null));
             case SkillInstalledTargetStateKind.CleanOutdated:
                 return await CreateManagedMismatchActionPlanAsync(
@@ -264,11 +295,12 @@ public sealed class SkillInstallService
 
         var packagePlan = packagePlanResult.Value!;
         return SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
-            new SkillInstallAction(
-                identity,
-                actionKind,
-                Diffs: packagePlan.Diffs),
+                new SkillInstallAction(
+                    identity,
+                    actionKind,
+                    Diffs: packagePlan.Diffs),
             skillDirectory,
+            package,
             packagePlan.MaterializedPackage));
     }
 
@@ -287,8 +319,57 @@ public sealed class SkillInstallService
             ? SkillOperationResult<SkillInstallActionPlan>.Success(new SkillInstallActionPlan(
                 new SkillInstallAction(identity, actionKind, blockedReason, packagePlanResult.Value!.Diffs),
                 skillDirectory,
+                package,
                 null))
             : SkillOperationResult<SkillInstallActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<bool>> ValidateWritePreconditionAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallActionKind actionKind,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
+        if (!stateResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
+        }
+
+        var state = stateResult.Value!.Kind;
+        var isValid = actionKind switch
+        {
+            SkillInstallActionKind.Created => state == SkillInstalledTargetStateKind.Missing,
+            SkillInstallActionKind.Updated => force && (state == SkillInstalledTargetStateKind.CleanOutdated || state == SkillInstalledTargetStateKind.LocalModified),
+            _ => true,
+        };
+        if (isValid)
+        {
+            return SkillOperationResult<bool>.Success(true);
+        }
+
+        return SkillOperationResult<bool>.FailureResult(
+            ResolveChangedTargetFailureCode(state),
+            $"Target skill directory changed after planning; refusing to write: {skillDirectory}");
+    }
+
+    private static SkillMaterializedPackageWriteMode ResolveWriteMode (SkillInstallActionKind actionKind)
+    {
+        return actionKind switch
+        {
+            SkillInstallActionKind.Created => SkillMaterializedPackageWriteMode.CreateNew,
+            SkillInstallActionKind.Updated => SkillMaterializedPackageWriteMode.ReplaceExisting,
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKind), actionKind, "Action does not write a materialized package."),
+        };
+    }
+
+    private static SkillFailureCode ResolveChangedTargetFailureCode (SkillInstalledTargetStateKind state)
+    {
+        return state == SkillInstalledTargetStateKind.Unmanaged
+            ? SkillFailureCodes.InstallTargetUnmanaged
+            : SkillFailureCodes.InstallTargetDigestMismatch;
     }
 
     private async ValueTask<SkillOperationResult<SkillMaterializedPackagePlan>> CreateMaterializedPackagePlanAsync (
@@ -317,5 +398,6 @@ public sealed class SkillInstallService
     private sealed record SkillInstallActionPlan (
         SkillInstallAction Action,
         string SkillDirectory,
+        CanonicalSkillPackage Package,
         SkillMaterializedPackage? MaterializedPackage);
 }

--- a/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
@@ -1,0 +1,72 @@
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Deletes installed SKILL package directories under a resolved host target root. </summary>
+public sealed class SkillInstalledPackageRemover : ISkillInstalledPackageRemover
+{
+    /// <inheritdoc />
+    public ValueTask<SkillOperationResult<bool>> DeleteAsync (
+        string targetRoot,
+        string skillDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillDirectory);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var targetRootResult = SkillPackagePathBoundary.ResolveUnderRoot(targetRoot, targetRoot);
+        if (!targetRootResult.IsSuccess)
+        {
+            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+                targetRootResult.Failure!.Code,
+                targetRootResult.Failure.Message));
+        }
+
+        var resolvedTargetRoot = targetRootResult.Value!;
+        var skillDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(resolvedTargetRoot, skillDirectory);
+        if (!skillDirectoryResult.IsSuccess)
+        {
+            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+                skillDirectoryResult.Failure!.Code,
+                skillDirectoryResult.Failure.Message));
+        }
+
+        var resolvedSkillDirectory = skillDirectoryResult.Value!;
+        if (IsSamePath(resolvedTargetRoot, resolvedSkillDirectory))
+        {
+            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.PathUnsafe,
+                $"Skill directory must not be the target root: {resolvedSkillDirectory}"));
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Directory.Exists(resolvedSkillDirectory))
+            {
+                Directory.Delete(resolvedSkillDirectory, recursive: true);
+            }
+
+            return ValueTask.FromResult(SkillOperationResult<bool>.Success(true));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"Failed to delete installed SKILL package: {resolvedSkillDirectory}. {ex.Message}"));
+        }
+    }
+
+    private static bool IsSamePath (
+        string left,
+        string right)
+    {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(left),
+            Path.TrimEndingDirectorySeparator(right),
+            comparison);
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
@@ -9,12 +9,9 @@ public sealed class SkillInstalledPackageRemover : ISkillInstalledPackageRemover
     private readonly ISkillPackageDirectoryOperations directoryOperations;
 
     /// <summary> Initializes a new instance of the <see cref="SkillInstalledPackageRemover" /> class. </summary>
-    public SkillInstalledPackageRemover ()
-        : this(new SkillPackageDirectoryOperations())
-    {
-    }
-
-    internal SkillInstalledPackageRemover (ISkillPackageDirectoryOperations directoryOperations)
+    /// <param name="directoryOperations"> The directory operations used by package transactions. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="directoryOperations" /> is <see langword="null" />. </exception>
+    public SkillInstalledPackageRemover (ISkillPackageDirectoryOperations directoryOperations)
     {
         this.directoryOperations = directoryOperations ?? throw new ArgumentNullException(nameof(directoryOperations));
     }

--- a/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledPackageRemover.cs
@@ -6,10 +6,24 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Deletes installed SKILL package directories under a resolved host target root. </summary>
 public sealed class SkillInstalledPackageRemover : ISkillInstalledPackageRemover
 {
+    private readonly ISkillPackageDirectoryOperations directoryOperations;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillInstalledPackageRemover" /> class. </summary>
+    public SkillInstalledPackageRemover ()
+        : this(new SkillPackageDirectoryOperations())
+    {
+    }
+
+    internal SkillInstalledPackageRemover (ISkillPackageDirectoryOperations directoryOperations)
+    {
+        this.directoryOperations = directoryOperations ?? throw new ArgumentNullException(nameof(directoryOperations));
+    }
+
     /// <inheritdoc />
-    public ValueTask<SkillOperationResult<bool>> DeleteAsync (
+    public async ValueTask<SkillOperationResult<bool>> DeleteAsync (
         string targetRoot,
         string skillDirectory,
+        Func<string, CancellationToken, ValueTask<SkillOperationResult<bool>>>? precondition,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(targetRoot);
@@ -19,44 +33,158 @@ public sealed class SkillInstalledPackageRemover : ISkillInstalledPackageRemover
         var targetRootResult = SkillPackagePathBoundary.ResolveUnderRoot(targetRoot, targetRoot);
         if (!targetRootResult.IsSuccess)
         {
-            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+            return SkillOperationResult<bool>.FailureResult(
                 targetRootResult.Failure!.Code,
-                targetRootResult.Failure.Message));
+                targetRootResult.Failure.Message);
         }
 
         var resolvedTargetRoot = targetRootResult.Value!;
         var skillDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(resolvedTargetRoot, skillDirectory);
         if (!skillDirectoryResult.IsSuccess)
         {
-            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+            return SkillOperationResult<bool>.FailureResult(
                 skillDirectoryResult.Failure!.Code,
-                skillDirectoryResult.Failure.Message));
+                skillDirectoryResult.Failure.Message);
         }
 
         var resolvedSkillDirectory = skillDirectoryResult.Value!;
         if (IsSamePath(resolvedTargetRoot, resolvedSkillDirectory))
         {
-            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+            return SkillOperationResult<bool>.FailureResult(
                 SkillFailureCodes.PathUnsafe,
-                $"Skill directory must not be the target root: {resolvedSkillDirectory}"));
+                $"Skill directory must not be the target root: {resolvedSkillDirectory}");
         }
 
+        if (!directoryOperations.Exists(resolvedSkillDirectory))
+        {
+            return SkillOperationResult<bool>.Success(true);
+        }
+
+        var parentDirectory = Path.GetDirectoryName(resolvedSkillDirectory);
+        if (string.IsNullOrWhiteSpace(parentDirectory))
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"Skill directory parent could not be resolved: {resolvedSkillDirectory}");
+        }
+
+        var transactionRootResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            resolvedTargetRoot,
+            Path.Combine(parentDirectory, ".ucli-skill-transactions"));
+        if (!transactionRootResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                transactionRootResult.Failure!.Code,
+                transactionRootResult.Failure.Message);
+        }
+
+        var deletedContainerResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            resolvedTargetRoot,
+            Path.Combine(transactionRootResult.Value!, $"{Path.GetFileName(resolvedSkillDirectory)}.delete.{Guid.NewGuid():N}"));
+        if (!deletedContainerResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                deletedContainerResult.Failure!.Code,
+                deletedContainerResult.Failure.Message);
+        }
+
+        var deletedDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            resolvedTargetRoot,
+            Path.Combine(deletedContainerResult.Value!, Path.GetFileName(resolvedSkillDirectory)));
+        if (!deletedDirectoryResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                deletedDirectoryResult.Failure!.Code,
+                deletedDirectoryResult.Failure.Message);
+        }
+
+        var transactionRoot = transactionRootResult.Value!;
+        var deletedContainer = deletedContainerResult.Value!;
+        var deletedDirectory = deletedDirectoryResult.Value!;
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (Directory.Exists(resolvedSkillDirectory))
+            directoryOperations.Create(transactionRoot);
+            var transactionRootGuard = SkillPackageTransactionPathGuard.ValidateCreatedDirectory(resolvedTargetRoot, transactionRoot);
+            if (!transactionRootGuard.IsSuccess)
             {
-                Directory.Delete(resolvedSkillDirectory, recursive: true);
+                return SkillOperationResult<bool>.FailureResult(
+                    transactionRootGuard.Failure!.Code,
+                    transactionRootGuard.Failure.Message);
             }
 
-            return ValueTask.FromResult(SkillOperationResult<bool>.Success(true));
+            var lockResult = SkillPackageTransactionLock.Acquire(resolvedTargetRoot, transactionRoot);
+            if (!lockResult.IsSuccess)
+            {
+                return SkillOperationResult<bool>.FailureResult(lockResult.Failure!.Code, lockResult.Failure.Message);
+            }
+
+            using var transactionLock = lockResult.Value!;
+            if (precondition is not null)
+            {
+                var preconditionResult = await precondition(resolvedSkillDirectory, cancellationToken).ConfigureAwait(false);
+                if (!preconditionResult.IsSuccess)
+                {
+                    return SkillOperationResult<bool>.FailureResult(preconditionResult.Failure!.Code, preconditionResult.Failure.Message);
+                }
+            }
+
+            if (!directoryOperations.Exists(resolvedSkillDirectory))
+            {
+                return SkillOperationResult<bool>.FailureResult(
+                    SkillFailureCodes.InstallTargetDigestMismatch,
+                    $"Target skill directory changed after planning; refusing to delete: {resolvedSkillDirectory}");
+            }
+
+            directoryOperations.Create(deletedContainer);
+            var deletedContainerGuard = SkillPackageTransactionPathGuard.ValidateCreatedDirectory(resolvedTargetRoot, deletedContainer);
+            if (!deletedContainerGuard.IsSuccess)
+            {
+                return SkillOperationResult<bool>.FailureResult(deletedContainerGuard.Failure!.Code, deletedContainerGuard.Failure.Message);
+            }
+
+            directoryOperations.Move(resolvedSkillDirectory, deletedDirectory);
+            if (precondition is not null)
+            {
+                var movedTargetResult = await precondition(deletedDirectory, cancellationToken).ConfigureAwait(false);
+                if (!movedTargetResult.IsSuccess)
+                {
+                    directoryOperations.Move(deletedDirectory, resolvedSkillDirectory);
+                    return SkillOperationResult<bool>.FailureResult(movedTargetResult.Failure!.Code, movedTargetResult.Failure.Message);
+                }
+            }
+
+            DeleteDirectoryBestEffort(deletedDirectory);
+            DeleteDirectoryBestEffort(transactionRoot);
+
+            return SkillOperationResult<bool>.Success(true);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+            return SkillOperationResult<bool>.FailureResult(
                 SkillFailureCodes.InstallTargetWriteFailed,
-                $"Failed to delete installed SKILL package: {resolvedSkillDirectory}. {ex.Message}"));
+                $"Failed to delete installed SKILL package: {resolvedSkillDirectory}. {ex.Message}");
         }
+        finally
+        {
+            if (!directoryOperations.Exists(deletedDirectory))
+            {
+                DeleteDirectoryBestEffort(transactionRoot);
+            }
+        }
+    }
+
+    /// <summary> Deletes one installed SKILL package directory without an execution precondition. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="skillDirectory"> The resolved skill package directory. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Success when the directory is deleted or already absent; otherwise a failure. </returns>
+    public ValueTask<SkillOperationResult<bool>> DeleteAsync (
+        string targetRoot,
+        string skillDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        return DeleteAsync(targetRoot, skillDirectory, precondition: null, cancellationToken);
     }
 
     private static bool IsSamePath (
@@ -68,5 +196,24 @@ public sealed class SkillInstalledPackageRemover : ISkillInstalledPackageRemover
             Path.TrimEndingDirectorySeparator(left),
             Path.TrimEndingDirectorySeparator(right),
             comparison);
+    }
+
+    private void DeleteDirectoryBestEffort (string path)
+    {
+        if (!directoryOperations.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            directoryOperations.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 }

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetState.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetState.cs
@@ -1,10 +1,5 @@
-using MackySoft.Ucli.Skills.Manifests;
-
 namespace MackySoft.Ucli.Skills.Installation;
 
 /// <summary> Represents the analyzed state of one installed official SKILL target. </summary>
 /// <param name="Kind"> The target state kind. </param>
-/// <param name="InstalledManifest"> The installed manifest when the target is managed and valid. </param>
-public sealed record SkillInstalledTargetState (
-    SkillInstalledTargetStateKind Kind,
-    SkillManifest? InstalledManifest = null);
+public sealed record SkillInstalledTargetState (SkillInstalledTargetStateKind Kind);

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetState.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetState.cs
@@ -1,0 +1,10 @@
+using MackySoft.Ucli.Skills.Manifests;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Represents the analyzed state of one installed official SKILL target. </summary>
+/// <param name="Kind"> The target state kind. </param>
+/// <param name="InstalledManifest"> The installed manifest when the target is managed and valid. </param>
+public sealed record SkillInstalledTargetState (
+    SkillInstalledTargetStateKind Kind,
+    SkillManifest? InstalledManifest = null);

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
@@ -1,0 +1,76 @@
+using MackySoft.Ucli.Skills.Installation.Validation;
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Classifies an installed SKILL target before write or delete operations. </summary>
+public sealed class SkillInstalledTargetStateAnalyzer
+{
+    private readonly SkillInstalledPackageValidator installedPackageValidator;
+    private readonly SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillInstalledTargetStateAnalyzer" /> class. </summary>
+    /// <param name="installedPackageValidator"> The current canonical package validator. </param>
+    /// <param name="installedPackageIntegrityVerifier"> The installed package integrity verifier. </param>
+    public SkillInstalledTargetStateAnalyzer (
+        SkillInstalledPackageValidator installedPackageValidator,
+        SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier)
+    {
+        this.installedPackageValidator = installedPackageValidator ?? throw new ArgumentNullException(nameof(installedPackageValidator));
+        this.installedPackageIntegrityVerifier = installedPackageIntegrityVerifier ?? throw new ArgumentNullException(nameof(installedPackageIntegrityVerifier));
+    }
+
+    /// <summary> Analyzes one target directory against the current canonical package and requested host. </summary>
+    /// <param name="package"> The canonical package. </param>
+    /// <param name="skillDirectory"> The target skill directory. </param>
+    /// <param name="host"> The requested host. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The target state or a hard safety failure. </returns>
+    public async ValueTask<SkillOperationResult<SkillInstalledTargetState>> AnalyzeAsync (
+        CanonicalSkillPackage package,
+        string skillDirectory,
+        string host,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(host);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!Directory.Exists(skillDirectory))
+        {
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.Missing));
+        }
+
+        var currentResult = await installedPackageValidator.ValidateAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
+        if (currentResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(
+                SkillInstalledTargetStateKind.Current,
+                currentResult.Value));
+        }
+
+        if (string.Equals(currentResult.Failure!.Code, SkillFailureCodes.InstallTargetUnmanaged, StringComparison.Ordinal))
+        {
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.Unmanaged));
+        }
+
+        if (!string.Equals(currentResult.Failure.Code, SkillFailureCodes.InstallTargetDigestMismatch, StringComparison.Ordinal))
+        {
+            return SkillOperationResult<SkillInstalledTargetState>.FailureResult(currentResult.Failure.Code, currentResult.Failure.Message);
+        }
+
+        var integrityResult = await installedPackageIntegrityVerifier.VerifyAsync(skillDirectory, host, cancellationToken).ConfigureAwait(false);
+        if (integrityResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(
+                SkillInstalledTargetStateKind.CleanOutdated,
+                integrityResult.Value));
+        }
+
+        return string.Equals(integrityResult.Failure!.Code, SkillFailureCodes.InstallTargetDigestMismatch, StringComparison.Ordinal)
+            ? SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.LocalModified))
+            : SkillOperationResult<SkillInstalledTargetState>.FailureResult(integrityResult.Failure.Code, integrityResult.Failure.Message);
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
@@ -49,12 +49,12 @@ public sealed class SkillInstalledTargetStateAnalyzer
             return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.Current));
         }
 
-        if (string.Equals(currentResult.Failure!.Code, SkillFailureCodes.InstallTargetUnmanaged, StringComparison.Ordinal))
+        if (currentResult.Failure!.Code == SkillFailureCodes.InstallTargetUnmanaged)
         {
             return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.Unmanaged));
         }
 
-        if (!string.Equals(currentResult.Failure.Code, SkillFailureCodes.InstallTargetDigestMismatch, StringComparison.Ordinal))
+        if (currentResult.Failure.Code != SkillFailureCodes.InstallTargetDigestMismatch)
         {
             return SkillOperationResult<SkillInstalledTargetState>.FailureResult(currentResult.Failure.Code, currentResult.Failure.Message);
         }
@@ -65,7 +65,7 @@ public sealed class SkillInstalledTargetStateAnalyzer
             return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.CleanOutdated));
         }
 
-        return string.Equals(integrityResult.Failure!.Code, SkillFailureCodes.InstallTargetDigestMismatch, StringComparison.Ordinal)
+        return integrityResult.Failure!.Code == SkillFailureCodes.InstallTargetDigestMismatch
             ? SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.LocalModified))
             : SkillOperationResult<SkillInstalledTargetState>.FailureResult(integrityResult.Failure.Code, integrityResult.Failure.Message);
     }

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetStateAnalyzer.cs
@@ -46,9 +46,7 @@ public sealed class SkillInstalledTargetStateAnalyzer
         var currentResult = await installedPackageValidator.ValidateAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
         if (currentResult.IsSuccess)
         {
-            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(
-                SkillInstalledTargetStateKind.Current,
-                currentResult.Value));
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.Current));
         }
 
         if (string.Equals(currentResult.Failure!.Code, SkillFailureCodes.InstallTargetUnmanaged, StringComparison.Ordinal))
@@ -64,9 +62,7 @@ public sealed class SkillInstalledTargetStateAnalyzer
         var integrityResult = await installedPackageIntegrityVerifier.VerifyAsync(skillDirectory, host, cancellationToken).ConfigureAwait(false);
         if (integrityResult.IsSuccess)
         {
-            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(
-                SkillInstalledTargetStateKind.CleanOutdated,
-                integrityResult.Value));
+            return SkillOperationResult<SkillInstalledTargetState>.Success(new SkillInstalledTargetState(SkillInstalledTargetStateKind.CleanOutdated));
         }
 
         return string.Equals(integrityResult.Failure!.Code, SkillFailureCodes.InstallTargetDigestMismatch, StringComparison.Ordinal)

--- a/src/Ucli.Skills/Installation/SkillInstalledTargetStateKind.cs
+++ b/src/Ucli.Skills/Installation/SkillInstalledTargetStateKind.cs
@@ -1,0 +1,20 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Defines the state of one installed official SKILL target. </summary>
+public enum SkillInstalledTargetStateKind
+{
+    /// <summary> The target skill directory is absent. </summary>
+    Missing = 0,
+
+    /// <summary> The target matches the current canonical package and requested host. </summary>
+    Current = 1,
+
+    /// <summary> The target is managed and clean, but does not match the current canonical package. </summary>
+    CleanOutdated = 2,
+
+    /// <summary> The target is managed but contains local modifications. </summary>
+    LocalModified = 3,
+
+    /// <summary> The target skill directory exists without a uCLI manifest. </summary>
+    Unmanaged = 4,
+}

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
@@ -1,0 +1,113 @@
+using MackySoft.Ucli.Skills.Materialization;
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Builds structured file diffs between an installed target and a materialized package. </summary>
+public sealed class SkillMaterializedPackageDiffBuilder
+{
+    /// <summary> Builds one structured diff for a target directory and desired materialized package. </summary>
+    /// <param name="skillDirectory"> The target skill directory. </param>
+    /// <param name="materializedPackage"> The desired materialized package. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Structured diffs or a path-safety failure. </returns>
+    public async ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>>> BuildAsync (
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillDirectory);
+        ArgumentNullException.ThrowIfNull(materializedPackage);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var beforeResult = await ReadExistingFilesAsync(skillDirectory, cancellationToken).ConfigureAwait(false);
+        if (!beforeResult.IsSuccess)
+        {
+            return SkillOperationResult<IReadOnlyList<SkillActionDiff>>.FailureResult(
+                beforeResult.Failure!.Code,
+                beforeResult.Failure.Message);
+        }
+
+        var beforeFiles = beforeResult.Value!;
+        var afterFiles = materializedPackage.Files.ToDictionary(
+            static file => file.RelativePath,
+            static file => SkillTextNormalizer.NormalizeToLf(file.Content),
+            StringComparer.Ordinal);
+
+        var relativePaths = beforeFiles.Keys
+            .Concat(afterFiles.Keys)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var fileDiffs = new List<SkillFileDiff>();
+        foreach (var relativePath in relativePaths)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var hasBefore = beforeFiles.TryGetValue(relativePath, out var beforeContent);
+            var hasAfter = afterFiles.TryGetValue(relativePath, out var afterContent);
+            if (hasBefore && hasAfter)
+            {
+                if (!string.Equals(beforeContent, afterContent, StringComparison.Ordinal))
+                {
+                    fileDiffs.Add(new SkillFileDiff(relativePath, SkillDiffChangeKind.Modified, beforeContent, afterContent));
+                }
+
+                continue;
+            }
+
+            if (hasAfter)
+            {
+                fileDiffs.Add(new SkillFileDiff(relativePath, SkillDiffChangeKind.Added, null, afterContent));
+                continue;
+            }
+
+            fileDiffs.Add(new SkillFileDiff(relativePath, SkillDiffChangeKind.Deleted, beforeContent, null));
+        }
+
+        return fileDiffs.Count == 0
+            ? SkillOperationResult<IReadOnlyList<SkillActionDiff>>.Success(Array.Empty<SkillActionDiff>())
+            : SkillOperationResult<IReadOnlyList<SkillActionDiff>>.Success([new SkillActionDiff(fileDiffs)]);
+    }
+
+    private static async ValueTask<SkillOperationResult<Dictionary<string, string>>> ReadExistingFilesAsync (
+        string skillDirectory,
+        CancellationToken cancellationToken)
+    {
+        var files = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (!Directory.Exists(skillDirectory))
+        {
+            return SkillOperationResult<Dictionary<string, string>>.Success(files);
+        }
+
+        try
+        {
+            foreach (var filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var resolvedPathResult = SkillPackagePathBoundary.ResolveUnderRoot(skillDirectory, filePath);
+                if (!resolvedPathResult.IsSuccess)
+                {
+                    return SkillOperationResult<Dictionary<string, string>>.FailureResult(
+                        resolvedPathResult.Failure!.Code,
+                        resolvedPathResult.Failure.Message);
+                }
+
+                var relativePath = Path.GetRelativePath(skillDirectory, resolvedPathResult.Value!).Replace(Path.DirectorySeparatorChar, '/');
+                files[relativePath] = SkillTextNormalizer.NormalizeToLf(
+                    await File.ReadAllTextAsync(resolvedPathResult.Value!, cancellationToken).ConfigureAwait(false));
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return SkillOperationResult<Dictionary<string, string>>.FailureResult(
+                SkillFailureCodes.InstallTargetReadFailed,
+                $"Failed to read SKILL package diff input: {skillDirectory}. {ex.Message}");
+        }
+
+        return SkillOperationResult<Dictionary<string, string>>.Success(files);
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
@@ -93,18 +93,29 @@ public sealed class SkillMaterializedPackageDiffBuilder
         CancellationToken cancellationToken)
     {
         var files = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (!Directory.Exists(skillDirectory))
+        var fullSkillDirectory = Path.GetFullPath(skillDirectory);
+        if (!Directory.Exists(fullSkillDirectory))
         {
             return SkillOperationResult<Dictionary<string, string>>.Success(files);
         }
 
+        var skillDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(fullSkillDirectory, fullSkillDirectory);
+        if (!skillDirectoryResult.IsSuccess)
+        {
+            return SkillOperationResult<Dictionary<string, string>>.FailureResult(
+                skillDirectoryResult.Failure!.Code,
+                skillDirectoryResult.Failure.Message);
+        }
+
+        var resolvedSkillDirectory = skillDirectoryResult.Value!;
+
         try
         {
-            foreach (var filePath in Directory.EnumerateFiles(skillDirectory, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+            foreach (var filePath in Directory.EnumerateFiles(resolvedSkillDirectory, "*", SearchOption.AllDirectories))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var resolvedPathResult = SkillPackagePathBoundary.ResolveUnderRoot(skillDirectory, filePath);
+                var resolvedPathResult = SkillPackagePathBoundary.ResolveUnderRoot(resolvedSkillDirectory, filePath);
                 if (!resolvedPathResult.IsSuccess)
                 {
                     return SkillOperationResult<Dictionary<string, string>>.FailureResult(
@@ -112,7 +123,7 @@ public sealed class SkillMaterializedPackageDiffBuilder
                         resolvedPathResult.Failure.Message);
                 }
 
-                var relativePath = Path.GetRelativePath(skillDirectory, resolvedPathResult.Value!).Replace(Path.DirectorySeparatorChar, '/');
+                var relativePath = Path.GetRelativePath(resolvedSkillDirectory, resolvedPathResult.Value!).Replace(Path.DirectorySeparatorChar, '/');
                 files[relativePath] = SkillTextNormalizer.NormalizeToLf(
                     await File.ReadAllTextAsync(resolvedPathResult.Value!, cancellationToken).ConfigureAwait(false));
             }
@@ -121,7 +132,7 @@ public sealed class SkillMaterializedPackageDiffBuilder
         {
             return SkillOperationResult<Dictionary<string, string>>.FailureResult(
                 SkillFailureCodes.InstallTargetReadFailed,
-                $"Failed to read SKILL package diff input: {skillDirectory}. {ex.Message}");
+                $"Failed to read SKILL package diff input: {resolvedSkillDirectory}. {ex.Message}");
         }
 
         return SkillOperationResult<Dictionary<string, string>>.Success(files);

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
@@ -72,6 +72,23 @@ public sealed class SkillMaterializedPackageDiffBuilder
             : SkillOperationResult<IReadOnlyList<SkillActionDiff>>.Success([new SkillActionDiff(fileDiffs)]);
     }
 
+    /// <summary> Builds structured diffs when requested, or returns an empty diff list. </summary>
+    /// <param name="skillDirectory"> The target skill directory. </param>
+    /// <param name="materializedPackage"> The desired materialized package. </param>
+    /// <param name="printDiff"> Whether structured diffs should be included. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Structured diffs, an empty list, or a path-safety/read failure. </returns>
+    public ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>>> BuildOptionalAsync (
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        bool printDiff,
+        CancellationToken cancellationToken = default)
+    {
+        return printDiff
+            ? BuildAsync(skillDirectory, materializedPackage, cancellationToken)
+            : ValueTask.FromResult(SkillOperationResult<IReadOnlyList<SkillActionDiff>>.Success(Array.Empty<SkillActionDiff>()));
+    }
+
     private static async ValueTask<SkillOperationResult<Dictionary<string, string>>> ReadExistingFilesAsync (
         string skillDirectory,
         CancellationToken cancellationToken)

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageDiffBuilder.cs
@@ -38,8 +38,7 @@ public sealed class SkillMaterializedPackageDiffBuilder
         var relativePaths = beforeFiles.Keys
             .Concat(afterFiles.Keys)
             .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
+            .Order(StringComparer.Ordinal);
 
         var fileDiffs = new List<SkillFileDiff>();
         foreach (var relativePath in relativePaths)

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageWriteMode.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageWriteMode.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Defines the target existence precondition for a materialized package write. </summary>
+public enum SkillMaterializedPackageWriteMode
+{
+    /// <summary> The target directory must be absent at commit time. </summary>
+    CreateNew,
+
+    /// <summary> The target directory must be present and eligible for replacement at commit time. </summary>
+    ReplaceExisting,
+}

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
@@ -7,16 +7,26 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Writes materialized SKILL packages under a resolved host target root. </summary>
 public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWriter
 {
-    /// <summary> Writes all files for one materialized package. </summary>
-    /// <param name="targetRoot"> The resolved host target root. </param>
-    /// <param name="skillDirectory"> The resolved skill package directory. </param>
-    /// <param name="materializedPackage"> The materialized package to write. </param>
-    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
-    /// <returns> Success when all file paths stay under the target root; otherwise a path-safety failure. </returns>
+    private readonly ISkillPackageDirectoryOperations directoryOperations;
+
+    /// <summary> Initializes a new instance of the <see cref="SkillMaterializedPackageWriter" /> class. </summary>
+    public SkillMaterializedPackageWriter ()
+        : this(new SkillPackageDirectoryOperations())
+    {
+    }
+
+    internal SkillMaterializedPackageWriter (ISkillPackageDirectoryOperations directoryOperations)
+    {
+        this.directoryOperations = directoryOperations ?? throw new ArgumentNullException(nameof(directoryOperations));
+    }
+
+    /// <inheritdoc />
     public async ValueTask<SkillOperationResult<bool>> WriteAsync (
         string targetRoot,
         string skillDirectory,
         SkillMaterializedPackage materializedPackage,
+        SkillMaterializedPackageWriteMode writeMode,
+        Func<string, CancellationToken, ValueTask<SkillOperationResult<bool>>>? precondition,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(targetRoot);
@@ -56,23 +66,51 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
             return SkillOperationResult<bool>.FailureResult(stagingDirectoryResult.Failure!.Code, stagingDirectoryResult.Failure.Message);
         }
 
-        var backupDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(
+        var backupContainerResult = SkillPackagePathBoundary.ResolveUnderRoot(
             targetRoot,
             Path.Combine(transactionRoot, $"{Path.GetFileName(resolvedSkillDirectory)}.backup.{Guid.NewGuid():N}"));
+        if (!backupContainerResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(backupContainerResult.Failure!.Code, backupContainerResult.Failure.Message);
+        }
+
+        var backupDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            targetRoot,
+            Path.Combine(backupContainerResult.Value!, Path.GetFileName(resolvedSkillDirectory)));
         if (!backupDirectoryResult.IsSuccess)
         {
             return SkillOperationResult<bool>.FailureResult(backupDirectoryResult.Failure!.Code, backupDirectoryResult.Failure.Message);
         }
 
         var stagingDirectory = stagingDirectoryResult.Value!;
+        var backupContainer = backupContainerResult.Value!;
         var backupDirectory = backupDirectoryResult.Value!;
         var movedExistingToBackup = false;
         var committed = false;
 
         try
         {
-            Directory.CreateDirectory(transactionRoot);
-            Directory.CreateDirectory(stagingDirectory);
+            directoryOperations.Create(transactionRoot);
+            var transactionRootGuard = SkillPackageTransactionPathGuard.ValidateCreatedDirectory(targetRoot, transactionRoot);
+            if (!transactionRootGuard.IsSuccess)
+            {
+                return SkillOperationResult<bool>.FailureResult(transactionRootGuard.Failure!.Code, transactionRootGuard.Failure.Message);
+            }
+
+            var lockResult = SkillPackageTransactionLock.Acquire(targetRoot, transactionRoot);
+            if (!lockResult.IsSuccess)
+            {
+                return SkillOperationResult<bool>.FailureResult(lockResult.Failure!.Code, lockResult.Failure.Message);
+            }
+
+            using var transactionLock = lockResult.Value!;
+            directoryOperations.Create(stagingDirectory);
+            var stagingDirectoryGuard = SkillPackageTransactionPathGuard.ValidateCreatedDirectory(targetRoot, stagingDirectory);
+            if (!stagingDirectoryGuard.IsSuccess)
+            {
+                return SkillOperationResult<bool>.FailureResult(stagingDirectoryGuard.Failure!.Code, stagingDirectoryGuard.Failure.Message);
+            }
+
             foreach (var file in materializedPackage.Files)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -93,13 +131,64 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            if (Directory.Exists(resolvedSkillDirectory))
+            if (precondition is not null)
             {
-                Directory.Move(resolvedSkillDirectory, backupDirectory);
-                movedExistingToBackup = true;
+                var preconditionResult = await precondition(resolvedSkillDirectory, cancellationToken).ConfigureAwait(false);
+                if (!preconditionResult.IsSuccess)
+                {
+                    return SkillOperationResult<bool>.FailureResult(preconditionResult.Failure!.Code, preconditionResult.Failure.Message);
+                }
             }
 
-            Directory.Move(stagingDirectory, resolvedSkillDirectory);
+            var targetExists = directoryOperations.Exists(resolvedSkillDirectory);
+            if (writeMode == SkillMaterializedPackageWriteMode.CreateNew && targetExists)
+            {
+                return SkillOperationResult<bool>.FailureResult(
+                    SkillFailureCodes.InstallTargetDigestMismatch,
+                    $"Target skill directory changed after planning; refusing to write: {resolvedSkillDirectory}");
+            }
+
+            if (writeMode == SkillMaterializedPackageWriteMode.ReplaceExisting && !targetExists)
+            {
+                return SkillOperationResult<bool>.FailureResult(
+                    SkillFailureCodes.InstallTargetDigestMismatch,
+                    $"Target skill directory changed after planning; refusing to write: {resolvedSkillDirectory}");
+            }
+
+            if (targetExists)
+            {
+                directoryOperations.Create(backupContainer);
+                var backupContainerGuard = SkillPackageTransactionPathGuard.ValidateCreatedDirectory(targetRoot, backupContainer);
+                if (!backupContainerGuard.IsSuccess)
+                {
+                    return SkillOperationResult<bool>.FailureResult(backupContainerGuard.Failure!.Code, backupContainerGuard.Failure.Message);
+                }
+
+                directoryOperations.Move(resolvedSkillDirectory, backupDirectory);
+                movedExistingToBackup = true;
+                if (precondition is not null)
+                {
+                    var movedTargetResult = await precondition(backupDirectory, cancellationToken).ConfigureAwait(false);
+                    if (!movedTargetResult.IsSuccess)
+                    {
+                        try
+                        {
+                            directoryOperations.Move(backupDirectory, resolvedSkillDirectory);
+                            movedExistingToBackup = false;
+                        }
+                        catch (Exception restoreException) when (restoreException is IOException or UnauthorizedAccessException)
+                        {
+                            return SkillOperationResult<bool>.FailureResult(
+                                SkillFailureCodes.InstallTargetWriteFailed,
+                                $"Failed to write SKILL package atomically and restore backup: {resolvedSkillDirectory}. Backup remains at: {backupDirectory}. {restoreException.Message}");
+                        }
+
+                        return SkillOperationResult<bool>.FailureResult(movedTargetResult.Failure!.Code, movedTargetResult.Failure.Message);
+                    }
+                }
+            }
+
+            directoryOperations.Move(stagingDirectory, resolvedSkillDirectory);
             committed = true;
             DeleteDirectoryBestEffort(backupDirectory);
 
@@ -107,11 +196,11 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            if (!committed && movedExistingToBackup && !Directory.Exists(resolvedSkillDirectory) && Directory.Exists(backupDirectory))
+            if (!committed && movedExistingToBackup && !directoryOperations.Exists(resolvedSkillDirectory) && directoryOperations.Exists(backupDirectory))
             {
                 try
                 {
-                    Directory.Move(backupDirectory, resolvedSkillDirectory);
+                    directoryOperations.Move(backupDirectory, resolvedSkillDirectory);
                 }
                 catch (Exception restoreException) when (restoreException is IOException or UnauthorizedAccessException)
                 {
@@ -121,7 +210,7 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
                 }
             }
 
-            var backupMessage = !committed && movedExistingToBackup && Directory.Exists(backupDirectory)
+            var backupMessage = !committed && movedExistingToBackup && directoryOperations.Exists(backupDirectory)
                 ? $" Backup remains at: {backupDirectory}."
                 : string.Empty;
             return SkillOperationResult<bool>.FailureResult(
@@ -130,7 +219,7 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
         }
         finally
         {
-            var preserveBackup = !committed && movedExistingToBackup && Directory.Exists(backupDirectory);
+            var preserveBackup = !committed && movedExistingToBackup && directoryOperations.Exists(backupDirectory);
             DeleteDirectoryBestEffort(stagingDirectory);
             if (committed || !movedExistingToBackup)
             {
@@ -144,16 +233,37 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
         }
     }
 
-    private static void DeleteDirectoryBestEffort (string path)
+    /// <summary> Writes all files for one materialized package using the legacy upsert behavior. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="skillDirectory"> The resolved skill package directory. </param>
+    /// <param name="materializedPackage"> The materialized package to write. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> Success when all file paths stay under the target root; otherwise a path-safety failure. </returns>
+    public ValueTask<SkillOperationResult<bool>> WriteAsync (
+        string targetRoot,
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        CancellationToken cancellationToken = default)
     {
-        if (!Directory.Exists(path))
+        return WriteAsync(
+            targetRoot,
+            skillDirectory,
+            materializedPackage,
+            directoryOperations.Exists(skillDirectory) ? SkillMaterializedPackageWriteMode.ReplaceExisting : SkillMaterializedPackageWriteMode.CreateNew,
+            precondition: null,
+            cancellationToken);
+    }
+
+    private void DeleteDirectoryBestEffort (string path)
+    {
+        if (!directoryOperations.Exists(path))
         {
             return;
         }
 
         try
         {
-            Directory.Delete(path, recursive: true);
+            directoryOperations.Delete(path, recursive: true);
         }
         catch (IOException)
         {

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
@@ -10,12 +10,9 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
     private readonly ISkillPackageDirectoryOperations directoryOperations;
 
     /// <summary> Initializes a new instance of the <see cref="SkillMaterializedPackageWriter" /> class. </summary>
-    public SkillMaterializedPackageWriter ()
-        : this(new SkillPackageDirectoryOperations())
-    {
-    }
-
-    internal SkillMaterializedPackageWriter (ISkillPackageDirectoryOperations directoryOperations)
+    /// <param name="directoryOperations"> The directory operations used by package transactions. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="directoryOperations" /> is <see langword="null" />. </exception>
+    public SkillMaterializedPackageWriter (ISkillPackageDirectoryOperations directoryOperations)
     {
         this.directoryOperations = directoryOperations ?? throw new ArgumentNullException(nameof(directoryOperations));
     }

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
@@ -5,7 +5,7 @@ using MackySoft.Ucli.Skills.Shared;
 namespace MackySoft.Ucli.Skills.Installation;
 
 /// <summary> Writes materialized SKILL packages under a resolved host target root. </summary>
-internal static class SkillMaterializedPackageWriter
+public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWriter
 {
     /// <summary> Writes all files for one materialized package. </summary>
     /// <param name="targetRoot"> The resolved host target root. </param>
@@ -13,7 +13,7 @@ internal static class SkillMaterializedPackageWriter
     /// <param name="materializedPackage"> The materialized package to write. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> Success when all file paths stay under the target root; otherwise a path-safety failure. </returns>
-    public static async ValueTask<SkillOperationResult<bool>> WriteAsync (
+    public async ValueTask<SkillOperationResult<bool>> WriteAsync (
         string targetRoot,
         string skillDirectory,
         SkillMaterializedPackage materializedPackage,
@@ -24,19 +24,145 @@ internal static class SkillMaterializedPackageWriter
         ArgumentNullException.ThrowIfNull(materializedPackage);
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var file in materializedPackage.Files)
+        var skillDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(targetRoot, skillDirectory);
+        if (!skillDirectoryResult.IsSuccess)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var filePathResult = SkillPackagePathBoundary.ResolvePackageFilePathUnderRoot(targetRoot, skillDirectory, file.RelativePath);
-            if (!filePathResult.IsSuccess)
-            {
-                return SkillOperationResult<bool>.FailureResult(filePathResult.Failure!.Code, filePathResult.Failure.Message);
-            }
-
-            await SkillPackageFileWriter.WriteAllTextAtomically(filePathResult.Value!, file.Content, cancellationToken).ConfigureAwait(false);
+            return SkillOperationResult<bool>.FailureResult(skillDirectoryResult.Failure!.Code, skillDirectoryResult.Failure.Message);
         }
 
-        return SkillOperationResult<bool>.Success(true);
+        var resolvedSkillDirectory = skillDirectoryResult.Value!;
+        var parentDirectory = Path.GetDirectoryName(resolvedSkillDirectory);
+        if (string.IsNullOrWhiteSpace(parentDirectory))
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"Skill directory parent could not be resolved: {resolvedSkillDirectory}");
+        }
+
+        var transactionRootResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            targetRoot,
+            Path.Combine(parentDirectory, ".ucli-skill-transactions"));
+        if (!transactionRootResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(transactionRootResult.Failure!.Code, transactionRootResult.Failure.Message);
+        }
+
+        var transactionRoot = transactionRootResult.Value!;
+        var stagingDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            targetRoot,
+            Path.Combine(transactionRoot, $"{Path.GetFileName(resolvedSkillDirectory)}.staging.{Guid.NewGuid():N}"));
+        if (!stagingDirectoryResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(stagingDirectoryResult.Failure!.Code, stagingDirectoryResult.Failure.Message);
+        }
+
+        var backupDirectoryResult = SkillPackagePathBoundary.ResolveUnderRoot(
+            targetRoot,
+            Path.Combine(transactionRoot, $"{Path.GetFileName(resolvedSkillDirectory)}.backup.{Guid.NewGuid():N}"));
+        if (!backupDirectoryResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(backupDirectoryResult.Failure!.Code, backupDirectoryResult.Failure.Message);
+        }
+
+        var stagingDirectory = stagingDirectoryResult.Value!;
+        var backupDirectory = backupDirectoryResult.Value!;
+        var movedExistingToBackup = false;
+        var committed = false;
+
+        try
+        {
+            Directory.CreateDirectory(transactionRoot);
+            Directory.CreateDirectory(stagingDirectory);
+            foreach (var file in materializedPackage.Files)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var finalPathResult = SkillPackagePathBoundary.ResolvePackageFilePathUnderRoot(targetRoot, resolvedSkillDirectory, file.RelativePath);
+                if (!finalPathResult.IsSuccess)
+                {
+                    return SkillOperationResult<bool>.FailureResult(finalPathResult.Failure!.Code, finalPathResult.Failure.Message);
+                }
+
+                var stagingPathResult = SkillPackagePathBoundary.ResolvePackageFilePathUnderRoot(targetRoot, stagingDirectory, file.RelativePath);
+                if (!stagingPathResult.IsSuccess)
+                {
+                    return SkillOperationResult<bool>.FailureResult(stagingPathResult.Failure!.Code, stagingPathResult.Failure.Message);
+                }
+
+                await SkillPackageFileWriter.WriteAllTextAtomically(stagingPathResult.Value!, file.Content, cancellationToken).ConfigureAwait(false);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Directory.Exists(resolvedSkillDirectory))
+            {
+                Directory.Move(resolvedSkillDirectory, backupDirectory);
+                movedExistingToBackup = true;
+            }
+
+            Directory.Move(stagingDirectory, resolvedSkillDirectory);
+            committed = true;
+            TryDeleteDirectory(backupDirectory);
+
+            return SkillOperationResult<bool>.Success(true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (!committed && movedExistingToBackup && !Directory.Exists(resolvedSkillDirectory) && Directory.Exists(backupDirectory))
+            {
+                try
+                {
+                    Directory.Move(backupDirectory, resolvedSkillDirectory);
+                }
+                catch (Exception restoreException) when (restoreException is IOException or UnauthorizedAccessException)
+                {
+                    return SkillOperationResult<bool>.FailureResult(
+                        SkillFailureCodes.InstallTargetWriteFailed,
+                        $"Failed to write SKILL package atomically and restore backup: {resolvedSkillDirectory}. Backup remains at: {backupDirectory}. {restoreException.Message}");
+                }
+            }
+
+            var backupMessage = !committed && movedExistingToBackup && Directory.Exists(backupDirectory)
+                ? $" Backup remains at: {backupDirectory}."
+                : string.Empty;
+            return SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"Failed to write SKILL package atomically: {resolvedSkillDirectory}.{backupMessage} {ex.Message}");
+        }
+        finally
+        {
+            var preserveBackup = !committed && movedExistingToBackup && Directory.Exists(backupDirectory);
+            TryDeleteDirectory(stagingDirectory);
+            if (committed || !movedExistingToBackup)
+            {
+                TryDeleteDirectory(backupDirectory);
+            }
+
+            if (!preserveBackup)
+            {
+                TryDeleteDirectory(transactionRoot);
+            }
+        }
+    }
+
+    private static bool TryDeleteDirectory (string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return true;
+        }
+
+        try
+        {
+            Directory.Delete(path, recursive: true);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 }

--- a/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
+++ b/src/Ucli.Skills/Installation/SkillMaterializedPackageWriter.cs
@@ -101,7 +101,7 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
 
             Directory.Move(stagingDirectory, resolvedSkillDirectory);
             committed = true;
-            TryDeleteDirectory(backupDirectory);
+            DeleteDirectoryBestEffort(backupDirectory);
 
             return SkillOperationResult<bool>.Success(true);
         }
@@ -131,38 +131,35 @@ public sealed class SkillMaterializedPackageWriter : ISkillMaterializedPackageWr
         finally
         {
             var preserveBackup = !committed && movedExistingToBackup && Directory.Exists(backupDirectory);
-            TryDeleteDirectory(stagingDirectory);
+            DeleteDirectoryBestEffort(stagingDirectory);
             if (committed || !movedExistingToBackup)
             {
-                TryDeleteDirectory(backupDirectory);
+                DeleteDirectoryBestEffort(backupDirectory);
             }
 
             if (!preserveBackup)
             {
-                TryDeleteDirectory(transactionRoot);
+                DeleteDirectoryBestEffort(transactionRoot);
             }
         }
     }
 
-    private static bool TryDeleteDirectory (string path)
+    private static void DeleteDirectoryBestEffort (string path)
     {
         if (!Directory.Exists(path))
         {
-            return true;
+            return;
         }
 
         try
         {
             Directory.Delete(path, recursive: true);
-            return true;
         }
         catch (IOException)
         {
-            return false;
         }
         catch (UnauthorizedAccessException)
         {
-            return false;
         }
     }
 }

--- a/src/Ucli.Skills/Installation/SkillPackageDirectoryOperations.cs
+++ b/src/Ucli.Skills/Installation/SkillPackageDirectoryOperations.cs
@@ -1,0 +1,33 @@
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Implements SKILL package directory transactions against the local file system. </summary>
+internal sealed class SkillPackageDirectoryOperations : ISkillPackageDirectoryOperations
+{
+    /// <inheritdoc />
+    public bool Exists (string path)
+    {
+        return Directory.Exists(path);
+    }
+
+    /// <inheritdoc />
+    public void Create (string path)
+    {
+        Directory.CreateDirectory(path);
+    }
+
+    /// <inheritdoc />
+    public void Move (
+        string sourceDirectoryName,
+        string destinationDirectoryName)
+    {
+        Directory.Move(sourceDirectoryName, destinationDirectoryName);
+    }
+
+    /// <inheritdoc />
+    public void Delete (
+        string path,
+        bool recursive)
+    {
+        Directory.Delete(path, recursive);
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillPackageDirectoryOperations.cs
+++ b/src/Ucli.Skills/Installation/SkillPackageDirectoryOperations.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Implements SKILL package directory transactions against the local file system. </summary>
-internal sealed class SkillPackageDirectoryOperations : ISkillPackageDirectoryOperations
+/// <summary> Executes SKILL package directory primitives against the local file system. </summary>
+public sealed class SkillPackageDirectoryOperations : ISkillPackageDirectoryOperations
 {
     /// <inheritdoc />
     public bool Exists (string path)

--- a/src/Ucli.Skills/Installation/SkillPackageTransactionLock.cs
+++ b/src/Ucli.Skills/Installation/SkillPackageTransactionLock.cs
@@ -1,0 +1,38 @@
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Acquires cooperative locks for SKILL package transaction directories. </summary>
+internal static class SkillPackageTransactionLock
+{
+    /// <summary> Acquires an exclusive lock file under the transaction directory. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="transactionRoot"> The transaction directory under the target root. </param>
+    /// <returns> A disposable lock handle or a write failure. </returns>
+    public static SkillOperationResult<IDisposable> Acquire (
+        string targetRoot,
+        string transactionRoot)
+    {
+        var lockPathResult = SkillPackagePathBoundary.ResolveUnderRoot(targetRoot, Path.Combine(transactionRoot, ".lock"));
+        if (!lockPathResult.IsSuccess)
+        {
+            return SkillOperationResult<IDisposable>.FailureResult(lockPathResult.Failure!.Code, lockPathResult.Failure.Message);
+        }
+
+        try
+        {
+            return SkillOperationResult<IDisposable>.Success(new FileStream(
+                lockPathResult.Value!,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return SkillOperationResult<IDisposable>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"Failed to acquire SKILL package transaction lock: {lockPathResult.Value}. {ex.Message}");
+        }
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillPackageTransactionPathGuard.cs
+++ b/src/Ucli.Skills/Installation/SkillPackageTransactionPathGuard.cs
@@ -1,0 +1,40 @@
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Installation;
+
+/// <summary> Validates transaction directories before file-system writes or cleanup. </summary>
+internal static class SkillPackageTransactionPathGuard
+{
+    /// <summary> Verifies that a created transaction directory is a regular directory under the target root. </summary>
+    /// <param name="targetRoot"> The resolved host target root. </param>
+    /// <param name="directoryPath"> The transaction directory path. </param>
+    /// <returns> Success when the directory is not a link and resolves under the target root. </returns>
+    public static SkillOperationResult<bool> ValidateCreatedDirectory (
+        string targetRoot,
+        string directoryPath)
+    {
+        var resolvedResult = SkillPackagePathBoundary.ResolveUnderRoot(targetRoot, directoryPath);
+        if (!resolvedResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(resolvedResult.Failure!.Code, resolvedResult.Failure.Message);
+        }
+
+        var directory = new DirectoryInfo(directoryPath);
+        if (!directory.Exists)
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                $"SKILL package transaction directory is missing: {directoryPath}");
+        }
+
+        if (directory.LinkTarget is not null || (directory.Attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            return SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.PathUnsafe,
+                $"SKILL package transaction directory must not be a link: {directoryPath}");
+        }
+
+        return SkillOperationResult<bool>.Success(true);
+    }
+}

--- a/src/Ucli.Skills/Installation/SkillUninstallAction.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallAction.cs
@@ -3,6 +3,8 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill uninstall action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
+/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
 public sealed record SkillUninstallAction (
     SkillInstallIdentity Identity,
-    SkillUninstallActionKind ActionKind);
+    SkillUninstallActionKind ActionKind,
+    string? BlockedReason = null);

--- a/src/Ucli.Skills/Installation/SkillUninstallAction.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallAction.cs
@@ -3,8 +3,8 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill uninstall action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
-/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
+/// <param name="BlockedReason"> The blocked reason category, when the action is blocked. </param>
 public sealed record SkillUninstallAction (
     SkillInstallIdentity Identity,
     SkillUninstallActionKind ActionKind,
-    string? BlockedReason = null);
+    SkillBlockedReason? BlockedReason = null);

--- a/src/Ucli.Skills/Installation/SkillUninstallActionKind.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallActionKind.cs
@@ -3,7 +3,7 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Defines the outcome for one official SKILL uninstall. </summary>
 public enum SkillUninstallActionKind
 {
-    /// <summary> The managed target skill directory was deleted. </summary>
+    /// <summary> The managed target skill directory is planned to be deleted or was deleted. </summary>
     Deleted = 0,
 
     /// <summary> The target skill directory was already absent. </summary>
@@ -11,4 +11,7 @@ public enum SkillUninstallActionKind
 
     /// <summary> The target skill directory exists but is not managed by uCLI. </summary>
     SkippedUnmanaged = 2,
+
+    /// <summary> The target contains local modifications and force was not enabled. </summary>
+    BlockedLocalModification = 3,
 }

--- a/src/Ucli.Skills/Installation/SkillUninstallInput.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallInput.cs
@@ -5,6 +5,10 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one SKILL uninstall service input. </summary>
 /// <param name="Packages"> The canonical packages to remove. </param>
 /// <param name="TargetRequest"> The host target request. </param>
+/// <param name="DryRun"> Whether to return a plan without writing to the file system. </param>
+/// <param name="Force"> Whether managed local modifications can be deleted. </param>
 public sealed record SkillUninstallInput (
     IReadOnlyList<CanonicalSkillPackage> Packages,
-    SkillInstallRequest TargetRequest);
+    SkillInstallRequest TargetRequest,
+    bool DryRun = false,
+    bool Force = false);

--- a/src/Ucli.Skills/Installation/SkillUninstallResult.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallResult.cs
@@ -1,8 +1,12 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Represents a completed SKILL uninstall operation. </summary>
+/// <summary> Represents a planned or completed SKILL uninstall operation. </summary>
 /// <param name="TargetRoot"> The canonical absolute target root. </param>
 /// <param name="Actions"> The per-skill uninstall actions. </param>
+/// <param name="DryRun"> Whether the result represents a plan without writes. </param>
+/// <param name="Force"> Whether force delete was enabled. </param>
 public sealed record SkillUninstallResult (
     string TargetRoot,
-    IReadOnlyList<SkillUninstallAction> Actions);
+    IReadOnlyList<SkillUninstallAction> Actions,
+    bool DryRun = false,
+    bool Force = false);

--- a/src/Ucli.Skills/Installation/SkillUninstallService.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallService.cs
@@ -1,4 +1,3 @@
-using MackySoft.Ucli.Skills.Installation.Validation;
 using MackySoft.Ucli.Skills.Packaging;
 using MackySoft.Ucli.Skills.Shared;
 
@@ -8,17 +7,21 @@ namespace MackySoft.Ucli.Skills.Installation;
 public sealed class SkillUninstallService
 {
     private readonly SkillInstallTargetResolver targetResolver;
-    private readonly SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier;
+    private readonly SkillInstalledTargetStateAnalyzer targetStateAnalyzer;
+    private readonly ISkillInstalledPackageRemover packageRemover;
 
     /// <summary> Initializes a new instance of the <see cref="SkillUninstallService" /> class. </summary>
     /// <param name="targetResolver"> The target resolver. </param>
-    /// <param name="installedPackageIntegrityVerifier"> The installed package integrity verifier. </param>
+    /// <param name="targetStateAnalyzer"> The installed target state analyzer. </param>
+    /// <param name="packageRemover"> The installed package remover. </param>
     public SkillUninstallService (
         SkillInstallTargetResolver targetResolver,
-        SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier)
+        SkillInstalledTargetStateAnalyzer targetStateAnalyzer,
+        ISkillInstalledPackageRemover packageRemover)
     {
         this.targetResolver = targetResolver ?? throw new ArgumentNullException(nameof(targetResolver));
-        this.installedPackageIntegrityVerifier = installedPackageIntegrityVerifier ?? throw new ArgumentNullException(nameof(installedPackageIntegrityVerifier));
+        this.targetStateAnalyzer = targetStateAnalyzer ?? throw new ArgumentNullException(nameof(targetStateAnalyzer));
+        this.packageRemover = packageRemover ?? throw new ArgumentNullException(nameof(packageRemover));
     }
 
     /// <summary> Uninstalls official SKILL packages. </summary>
@@ -43,7 +46,7 @@ public sealed class SkillUninstallService
 
         var target = targetResult.Value!;
         var targetRoot = target.TargetRoot;
-        var actions = new List<SkillUninstallAction>();
+        var actionPlans = new List<SkillUninstallActionPlan>();
         foreach (var package in input.Packages.OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -57,34 +60,108 @@ public sealed class SkillUninstallService
 
             var skillDirectory = skillDirectoryResult.Value!;
             var identity = new SkillInstallIdentity(target.Host, targetRequest.Scope, targetRoot, skillName);
-            if (!Directory.Exists(skillDirectory))
+            var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
+            if (!stateResult.IsSuccess)
             {
-                actions.Add(new SkillUninstallAction(identity, SkillUninstallActionKind.NoOp));
-                continue;
+                return SkillOperationResult<SkillUninstallResult>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
             }
 
-            var manifestPathResult = SkillPackagePathBoundary.ResolvePackageFilePathUnderRoot(targetRoot, skillDirectory, "ucli-skill.json");
-            if (!manifestPathResult.IsSuccess)
+            var actionPlanResult = CreateActionPlan(skillDirectory, identity, stateResult.Value!, input);
+            if (!actionPlanResult.IsSuccess)
             {
-                return SkillOperationResult<SkillUninstallResult>.FailureResult(manifestPathResult.Failure!.Code, manifestPathResult.Failure.Message);
+                return SkillOperationResult<SkillUninstallResult>.FailureResult(actionPlanResult.Failure!.Code, actionPlanResult.Failure.Message);
             }
 
-            if (!File.Exists(manifestPathResult.Value!))
-            {
-                actions.Add(new SkillUninstallAction(identity, SkillUninstallActionKind.SkippedUnmanaged));
-                continue;
-            }
-
-            var integrityResult = await installedPackageIntegrityVerifier.VerifyAsync(skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
-            if (!integrityResult.IsSuccess)
-            {
-                return SkillOperationResult<SkillUninstallResult>.FailureResult(integrityResult.Failure!.Code, integrityResult.Failure.Message);
-            }
-
-            Directory.Delete(skillDirectory, recursive: true);
-            actions.Add(new SkillUninstallAction(identity, SkillUninstallActionKind.Deleted));
+            actionPlans.Add(actionPlanResult.Value!);
         }
 
-        return SkillOperationResult<SkillUninstallResult>.Success(new SkillUninstallResult(targetRoot, actions));
+        if (!input.DryRun)
+        {
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!actionPlan.ShouldDelete)
+                {
+                    continue;
+                }
+
+                var deleteResult = await packageRemover.DeleteAsync(targetRoot, actionPlan.SkillDirectory, cancellationToken).ConfigureAwait(false);
+                if (!deleteResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillUninstallResult>.FailureResult(deleteResult.Failure!.Code, deleteResult.Failure.Message);
+                }
+            }
+        }
+
+        return SkillOperationResult<SkillUninstallResult>.Success(new SkillUninstallResult(
+            targetRoot,
+            actionPlans.Select(static actionPlan => actionPlan.Action).ToArray(),
+            input.DryRun,
+            input.Force));
     }
+
+    private static SkillOperationResult<SkillUninstallActionPlan> CreateActionPlan (
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstalledTargetState state,
+        SkillUninstallInput input)
+    {
+        switch (state.Kind)
+        {
+            case SkillInstalledTargetStateKind.Missing:
+                return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
+                    new SkillUninstallAction(identity, SkillUninstallActionKind.NoOp),
+                    skillDirectory,
+                    ShouldDelete: false));
+            case SkillInstalledTargetStateKind.Current:
+            case SkillInstalledTargetStateKind.CleanOutdated:
+                return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
+                    new SkillUninstallAction(identity, SkillUninstallActionKind.Deleted),
+                    skillDirectory,
+                    ShouldDelete: true));
+            case SkillInstalledTargetStateKind.Unmanaged:
+                return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
+                    new SkillUninstallAction(identity, SkillUninstallActionKind.SkippedUnmanaged),
+                    skillDirectory,
+                    ShouldDelete: false));
+            case SkillInstalledTargetStateKind.LocalModified:
+                return CreateLocalModificationActionPlan(skillDirectory, identity, input);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(state), state.Kind, "Unsupported target state.");
+        }
+    }
+
+    private static SkillOperationResult<SkillUninstallActionPlan> CreateLocalModificationActionPlan (
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillUninstallInput input)
+    {
+        if (input.Force)
+        {
+            return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
+                new SkillUninstallAction(identity, SkillUninstallActionKind.Deleted),
+                skillDirectory,
+                ShouldDelete: true));
+        }
+
+        if (input.DryRun)
+        {
+            return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
+                new SkillUninstallAction(
+                    identity,
+                    SkillUninstallActionKind.BlockedLocalModification,
+                    SkillBlockedReason.LocalModificationRequiresForce),
+                skillDirectory,
+                ShouldDelete: false));
+        }
+
+        return SkillOperationResult<SkillUninstallActionPlan>.FailureResult(
+            SkillFailureCodes.InstallTargetDigestMismatch,
+            $"Target skill directory contains local modifications. Use --force to delete: {skillDirectory}");
+    }
+
+    private sealed record SkillUninstallActionPlan (
+        SkillUninstallAction Action,
+        string SkillDirectory,
+        bool ShouldDelete);
 }

--- a/src/Ucli.Skills/Installation/SkillUninstallService.cs
+++ b/src/Ucli.Skills/Installation/SkillUninstallService.cs
@@ -66,7 +66,7 @@ public sealed class SkillUninstallService
                 return SkillOperationResult<SkillUninstallResult>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
             }
 
-            var actionPlanResult = CreateActionPlan(skillDirectory, identity, stateResult.Value!, input);
+            var actionPlanResult = CreateActionPlan(package, skillDirectory, identity, stateResult.Value!, input);
             if (!actionPlanResult.IsSuccess)
             {
                 return SkillOperationResult<SkillUninstallResult>.FailureResult(actionPlanResult.Failure!.Code, actionPlanResult.Failure.Message);
@@ -85,7 +85,38 @@ public sealed class SkillUninstallService
                     continue;
                 }
 
-                var deleteResult = await packageRemover.DeleteAsync(targetRoot, actionPlan.SkillDirectory, cancellationToken).ConfigureAwait(false);
+                var preconditionResult = await ValidateDeletePreconditionAsync(
+                        actionPlan.Package,
+                        target.Host,
+                        actionPlan.SkillDirectory,
+                        input.Force,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!preconditionResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillUninstallResult>.FailureResult(preconditionResult.Failure!.Code, preconditionResult.Failure.Message);
+                }
+            }
+
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!actionPlan.ShouldDelete)
+                {
+                    continue;
+                }
+
+                var deleteResult = await packageRemover.DeleteAsync(
+                        targetRoot,
+                        actionPlan.SkillDirectory,
+                        (directory, token) => ValidateDeletePreconditionAsync(
+                            actionPlan.Package,
+                            target.Host,
+                            directory,
+                            input.Force,
+                            token),
+                        cancellationToken)
+                    .ConfigureAwait(false);
                 if (!deleteResult.IsSuccess)
                 {
                     return SkillOperationResult<SkillUninstallResult>.FailureResult(deleteResult.Failure!.Code, deleteResult.Failure.Message);
@@ -101,6 +132,7 @@ public sealed class SkillUninstallService
     }
 
     private static SkillOperationResult<SkillUninstallActionPlan> CreateActionPlan (
+        CanonicalSkillPackage package,
         string skillDirectory,
         SkillInstallIdentity identity,
         SkillInstalledTargetState state,
@@ -112,26 +144,30 @@ public sealed class SkillUninstallService
                 return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
                     new SkillUninstallAction(identity, SkillUninstallActionKind.NoOp),
                     skillDirectory,
+                    package,
                     ShouldDelete: false));
             case SkillInstalledTargetStateKind.Current:
             case SkillInstalledTargetStateKind.CleanOutdated:
                 return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
                     new SkillUninstallAction(identity, SkillUninstallActionKind.Deleted),
                     skillDirectory,
+                    package,
                     ShouldDelete: true));
             case SkillInstalledTargetStateKind.Unmanaged:
                 return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
                     new SkillUninstallAction(identity, SkillUninstallActionKind.SkippedUnmanaged),
                     skillDirectory,
+                    package,
                     ShouldDelete: false));
             case SkillInstalledTargetStateKind.LocalModified:
-                return CreateLocalModificationActionPlan(skillDirectory, identity, input);
+                return CreateLocalModificationActionPlan(package, skillDirectory, identity, input);
             default:
                 throw new ArgumentOutOfRangeException(nameof(state), state.Kind, "Unsupported target state.");
         }
     }
 
     private static SkillOperationResult<SkillUninstallActionPlan> CreateLocalModificationActionPlan (
+        CanonicalSkillPackage package,
         string skillDirectory,
         SkillInstallIdentity identity,
         SkillUninstallInput input)
@@ -141,6 +177,7 @@ public sealed class SkillUninstallService
             return SkillOperationResult<SkillUninstallActionPlan>.Success(new SkillUninstallActionPlan(
                 new SkillUninstallAction(identity, SkillUninstallActionKind.Deleted),
                 skillDirectory,
+                package,
                 ShouldDelete: true));
         }
 
@@ -152,6 +189,7 @@ public sealed class SkillUninstallService
                     SkillUninstallActionKind.BlockedLocalModification,
                     SkillBlockedReason.LocalModificationRequiresForce),
                 skillDirectory,
+                package,
                 ShouldDelete: false));
         }
 
@@ -160,8 +198,43 @@ public sealed class SkillUninstallService
             $"Target skill directory contains local modifications. Use --force to delete: {skillDirectory}");
     }
 
+    private async ValueTask<SkillOperationResult<bool>> ValidateDeletePreconditionAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
+        if (!stateResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
+        }
+
+        var state = stateResult.Value!.Kind;
+        var isValid = force
+            ? state is SkillInstalledTargetStateKind.Current or SkillInstalledTargetStateKind.CleanOutdated or SkillInstalledTargetStateKind.LocalModified
+            : state is SkillInstalledTargetStateKind.Current or SkillInstalledTargetStateKind.CleanOutdated;
+        if (isValid)
+        {
+            return SkillOperationResult<bool>.Success(true);
+        }
+
+        return SkillOperationResult<bool>.FailureResult(
+            ResolveChangedTargetFailureCode(state),
+            $"Target skill directory changed after planning; refusing to delete: {skillDirectory}");
+    }
+
+    private static SkillFailureCode ResolveChangedTargetFailureCode (SkillInstalledTargetStateKind state)
+    {
+        return state == SkillInstalledTargetStateKind.Unmanaged
+            ? SkillFailureCodes.InstallTargetUnmanaged
+            : SkillFailureCodes.InstallTargetDigestMismatch;
+    }
+
     private sealed record SkillUninstallActionPlan (
         SkillUninstallAction Action,
         string SkillDirectory,
+        CanonicalSkillPackage Package,
         bool ShouldDelete);
 }

--- a/src/Ucli.Skills/Installation/SkillUpdateAction.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateAction.cs
@@ -3,10 +3,10 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill update action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
-/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
+/// <param name="BlockedReason"> The blocked reason category, when the action is blocked. </param>
 /// <param name="Diffs"> The optional structured diffs. </param>
 public sealed record SkillUpdateAction (
     SkillInstallIdentity Identity,
     SkillUpdateActionKind ActionKind,
-    string? BlockedReason = null,
+    SkillBlockedReason? BlockedReason = null,
     IReadOnlyList<SkillActionDiff>? Diffs = null);

--- a/src/Ucli.Skills/Installation/SkillUpdateAction.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateAction.cs
@@ -3,6 +3,10 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Represents one per-skill update action. </summary>
 /// <param name="Identity"> The install identity. </param>
 /// <param name="ActionKind"> The action kind. </param>
+/// <param name="BlockedReason"> The stable blocked reason literal, when the action is blocked. </param>
+/// <param name="Diffs"> The optional structured diffs. </param>
 public sealed record SkillUpdateAction (
     SkillInstallIdentity Identity,
-    SkillUpdateActionKind ActionKind);
+    SkillUpdateActionKind ActionKind,
+    string? BlockedReason = null,
+    IReadOnlyList<SkillActionDiff>? Diffs = null);

--- a/src/Ucli.Skills/Installation/SkillUpdateActionKind.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateActionKind.cs
@@ -3,12 +3,18 @@ namespace MackySoft.Ucli.Skills.Installation;
 /// <summary> Defines the outcome for one official SKILL update. </summary>
 public enum SkillUpdateActionKind
 {
-    /// <summary> The target skill directory was created because it was missing. </summary>
+    /// <summary> The target skill directory is planned to be created or was created because it was missing. </summary>
     Created = 0,
 
-    /// <summary> The target skill directory was replaced with the current canonical package. </summary>
+    /// <summary> The target skill directory is planned to be replaced or was replaced with the current canonical package. </summary>
     Updated = 1,
 
     /// <summary> The target skill directory already contained current content for the same host. </summary>
     NoOp = 2,
+
+    /// <summary> The target contains local modifications and force was not enabled. </summary>
+    BlockedLocalModification = 3,
+
+    /// <summary> The target is unmanaged and cannot be overwritten. </summary>
+    BlockedUnmanaged = 4,
 }

--- a/src/Ucli.Skills/Installation/SkillUpdateResult.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateResult.cs
@@ -1,8 +1,14 @@
 namespace MackySoft.Ucli.Skills.Installation;
 
-/// <summary> Represents a completed SKILL update operation. </summary>
+/// <summary> Represents a planned or completed SKILL update operation. </summary>
 /// <param name="TargetRoot"> The canonical absolute target root. </param>
 /// <param name="Actions"> The per-skill update actions. </param>
+/// <param name="DryRun"> Whether the result represents a plan without writes. </param>
+/// <param name="Force"> Whether force overwrite was enabled. </param>
+/// <param name="PrintDiff"> Whether diff payloads were requested. </param>
 public sealed record SkillUpdateResult (
     string TargetRoot,
-    IReadOnlyList<SkillUpdateAction> Actions);
+    IReadOnlyList<SkillUpdateAction> Actions,
+    bool DryRun = false,
+    bool Force = false,
+    bool PrintDiff = false);

--- a/src/Ucli.Skills/Installation/SkillUpdateService.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateService.cs
@@ -102,10 +102,40 @@ public sealed class SkillUpdateService
                     continue;
                 }
 
+                var preconditionResult = await ValidateWritePreconditionAsync(
+                        actionPlan.Package,
+                        target.Host,
+                        actionPlan.SkillDirectory,
+                        actionPlan.Action.ActionKind,
+                        input.Force,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!preconditionResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillUpdateResult>.FailureResult(preconditionResult.Failure!.Code, preconditionResult.Failure.Message);
+                }
+            }
+
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (actionPlan.MaterializedPackage is null)
+                {
+                    continue;
+                }
+
                 var writeResult = await packageWriter.WriteAsync(
                         targetRoot,
                         actionPlan.SkillDirectory,
                         actionPlan.MaterializedPackage,
+                        ResolveWriteMode(actionPlan.Action.ActionKind),
+                        (directory, token) => ValidateWritePreconditionAsync(
+                            actionPlan.Package,
+                            target.Host,
+                            directory,
+                            actionPlan.Action.ActionKind,
+                            input.Force,
+                            token),
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (!writeResult.IsSuccess)
@@ -148,6 +178,7 @@ public sealed class SkillUpdateService
                 return SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
                     new SkillUpdateAction(identity, SkillUpdateActionKind.NoOp),
                     skillDirectory,
+                    package,
                     null));
             case SkillInstalledTargetStateKind.CleanOutdated:
                 return await CreateWriteActionPlanAsync(
@@ -254,6 +285,7 @@ public sealed class SkillUpdateService
                 null,
                 packagePlan.Diffs),
             skillDirectory,
+            package,
             packagePlan.MaterializedPackage));
     }
 
@@ -272,8 +304,58 @@ public sealed class SkillUpdateService
             ? SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
                 new SkillUpdateAction(identity, actionKind, blockedReason, packagePlanResult.Value!.Diffs),
                 skillDirectory,
+                package,
                 null))
             : SkillOperationResult<SkillUpdateActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<bool>> ValidateWritePreconditionAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillUpdateActionKind actionKind,
+        bool force,
+        CancellationToken cancellationToken)
+    {
+        var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, host, cancellationToken).ConfigureAwait(false);
+        if (!stateResult.IsSuccess)
+        {
+            return SkillOperationResult<bool>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
+        }
+
+        var state = stateResult.Value!.Kind;
+        var isValid = actionKind switch
+        {
+            SkillUpdateActionKind.Created => state == SkillInstalledTargetStateKind.Missing,
+            SkillUpdateActionKind.Updated when force => state == SkillInstalledTargetStateKind.CleanOutdated || state == SkillInstalledTargetStateKind.LocalModified,
+            SkillUpdateActionKind.Updated => state == SkillInstalledTargetStateKind.CleanOutdated,
+            _ => true,
+        };
+        if (isValid)
+        {
+            return SkillOperationResult<bool>.Success(true);
+        }
+
+        return SkillOperationResult<bool>.FailureResult(
+            ResolveChangedTargetFailureCode(state),
+            $"Target skill directory changed after planning; refusing to write: {skillDirectory}");
+    }
+
+    private static SkillMaterializedPackageWriteMode ResolveWriteMode (SkillUpdateActionKind actionKind)
+    {
+        return actionKind switch
+        {
+            SkillUpdateActionKind.Created => SkillMaterializedPackageWriteMode.CreateNew,
+            SkillUpdateActionKind.Updated => SkillMaterializedPackageWriteMode.ReplaceExisting,
+            _ => throw new ArgumentOutOfRangeException(nameof(actionKind), actionKind, "Action does not write a materialized package."),
+        };
+    }
+
+    private static SkillFailureCode ResolveChangedTargetFailureCode (SkillInstalledTargetStateKind state)
+    {
+        return state == SkillInstalledTargetStateKind.Unmanaged
+            ? SkillFailureCodes.InstallTargetUnmanaged
+            : SkillFailureCodes.InstallTargetDigestMismatch;
     }
 
     private async ValueTask<SkillOperationResult<SkillMaterializedPackagePlan>> CreateMaterializedPackagePlanAsync (
@@ -302,5 +384,6 @@ public sealed class SkillUpdateService
     private sealed record SkillUpdateActionPlan (
         SkillUpdateAction Action,
         string SkillDirectory,
+        CanonicalSkillPackage Package,
         SkillMaterializedPackage? MaterializedPackage);
 }

--- a/src/Ucli.Skills/Installation/SkillUpdateService.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateService.cs
@@ -1,4 +1,3 @@
-using MackySoft.Ucli.Skills.Installation.Validation;
 using MackySoft.Ucli.Skills.Materialization;
 using MackySoft.Ucli.Skills.Packaging;
 using MackySoft.Ucli.Skills.Shared;
@@ -10,24 +9,28 @@ public sealed class SkillUpdateService
 {
     private readonly SkillInstallTargetResolver targetResolver;
     private readonly SkillMaterializationService materializationService;
-    private readonly SkillInstalledPackageValidator installedPackageValidator;
-    private readonly SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier;
+    private readonly SkillInstalledTargetStateAnalyzer targetStateAnalyzer;
+    private readonly ISkillMaterializedPackageWriter packageWriter;
+    private readonly SkillMaterializedPackageDiffBuilder diffBuilder;
 
     /// <summary> Initializes a new instance of the <see cref="SkillUpdateService" /> class. </summary>
     /// <param name="targetResolver"> The target resolver. </param>
     /// <param name="materializationService"> The materialization service. </param>
-    /// <param name="installedPackageValidator"> The current installed package validator. </param>
-    /// <param name="installedPackageIntegrityVerifier"> The installed package integrity verifier. </param>
+    /// <param name="targetStateAnalyzer"> The installed target state analyzer. </param>
+    /// <param name="packageWriter"> The materialized package writer. </param>
+    /// <param name="diffBuilder"> The structured diff builder. </param>
     public SkillUpdateService (
         SkillInstallTargetResolver targetResolver,
         SkillMaterializationService materializationService,
-        SkillInstalledPackageValidator installedPackageValidator,
-        SkillInstalledPackageIntegrityVerifier installedPackageIntegrityVerifier)
+        SkillInstalledTargetStateAnalyzer targetStateAnalyzer,
+        ISkillMaterializedPackageWriter packageWriter,
+        SkillMaterializedPackageDiffBuilder diffBuilder)
     {
         this.targetResolver = targetResolver ?? throw new ArgumentNullException(nameof(targetResolver));
         this.materializationService = materializationService ?? throw new ArgumentNullException(nameof(materializationService));
-        this.installedPackageValidator = installedPackageValidator ?? throw new ArgumentNullException(nameof(installedPackageValidator));
-        this.installedPackageIntegrityVerifier = installedPackageIntegrityVerifier ?? throw new ArgumentNullException(nameof(installedPackageIntegrityVerifier));
+        this.targetStateAnalyzer = targetStateAnalyzer ?? throw new ArgumentNullException(nameof(targetStateAnalyzer));
+        this.packageWriter = packageWriter ?? throw new ArgumentNullException(nameof(packageWriter));
+        this.diffBuilder = diffBuilder ?? throw new ArgumentNullException(nameof(diffBuilder));
     }
 
     /// <summary> Updates official SKILL packages. </summary>
@@ -52,7 +55,7 @@ public sealed class SkillUpdateService
 
         var target = targetResult.Value!;
         var targetRoot = target.TargetRoot;
-        var actions = new List<SkillUpdateAction>();
+        var actionPlans = new List<SkillUpdateActionPlan>();
         foreach (var package in input.Packages.OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -66,62 +69,243 @@ public sealed class SkillUpdateService
 
             var skillDirectory = skillDirectoryResult.Value!;
             var identity = new SkillInstallIdentity(target.Host, targetRequest.Scope, targetRoot, skillName);
-            if (!Directory.Exists(skillDirectory))
+            var stateResult = await targetStateAnalyzer.AnalyzeAsync(package, skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
+            if (!stateResult.IsSuccess)
             {
-                var createResult = await WritePackageAsync(package, target.Host, targetRoot, skillDirectory, cancellationToken).ConfigureAwait(false);
-                if (!createResult.IsSuccess)
-                {
-                    return SkillOperationResult<SkillUpdateResult>.FailureResult(createResult.Failure!.Code, createResult.Failure.Message);
-                }
-
-                actions.Add(new SkillUpdateAction(identity, SkillUpdateActionKind.Created));
-                continue;
+                return SkillOperationResult<SkillUpdateResult>.FailureResult(stateResult.Failure!.Code, stateResult.Failure.Message);
             }
 
-            var currentResult = await installedPackageValidator.ValidateAsync(package, skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
-            if (currentResult.IsSuccess)
+            var actionPlanResult = await CreateActionPlanAsync(
+                    package,
+                    target.Host,
+                    skillDirectory,
+                    identity,
+                    stateResult.Value!,
+                    input,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!actionPlanResult.IsSuccess)
             {
-                actions.Add(new SkillUpdateAction(identity, SkillUpdateActionKind.NoOp));
-                continue;
+                return SkillOperationResult<SkillUpdateResult>.FailureResult(actionPlanResult.Failure!.Code, actionPlanResult.Failure.Message);
             }
 
-            var integrityResult = await installedPackageIntegrityVerifier.VerifyAsync(skillDirectory, target.Host, cancellationToken).ConfigureAwait(false);
-            if (!integrityResult.IsSuccess)
-            {
-                return SkillOperationResult<SkillUpdateResult>.FailureResult(integrityResult.Failure!.Code, integrityResult.Failure.Message);
-            }
-
-            Directory.Delete(skillDirectory, recursive: true);
-            var updateResult = await WritePackageAsync(package, target.Host, targetRoot, skillDirectory, cancellationToken).ConfigureAwait(false);
-            if (!updateResult.IsSuccess)
-            {
-                return SkillOperationResult<SkillUpdateResult>.FailureResult(updateResult.Failure!.Code, updateResult.Failure.Message);
-            }
-
-            actions.Add(new SkillUpdateAction(identity, SkillUpdateActionKind.Updated));
+            actionPlans.Add(actionPlanResult.Value!);
         }
 
-        return SkillOperationResult<SkillUpdateResult>.Success(new SkillUpdateResult(targetRoot, actions));
+        if (!input.DryRun)
+        {
+            foreach (var actionPlan in actionPlans)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (actionPlan.MaterializedPackage is null)
+                {
+                    continue;
+                }
+
+                var writeResult = await packageWriter.WriteAsync(
+                        targetRoot,
+                        actionPlan.SkillDirectory,
+                        actionPlan.MaterializedPackage,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (!writeResult.IsSuccess)
+                {
+                    return SkillOperationResult<SkillUpdateResult>.FailureResult(writeResult.Failure!.Code, writeResult.Failure.Message);
+                }
+            }
+        }
+
+        return SkillOperationResult<SkillUpdateResult>.Success(new SkillUpdateResult(
+            targetRoot,
+            actionPlans.Select(static actionPlan => actionPlan.Action).ToArray(),
+            input.DryRun,
+            input.Force,
+            input.PrintDiff));
     }
 
-    private async ValueTask<SkillOperationResult<bool>> WritePackageAsync (
+    private async ValueTask<SkillOperationResult<SkillUpdateActionPlan>> CreateActionPlanAsync (
         CanonicalSkillPackage package,
         string host,
-        string targetRoot,
         string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillInstalledTargetState state,
+        SkillUpdateInput input,
+        CancellationToken cancellationToken)
+    {
+        switch (state.Kind)
+        {
+            case SkillInstalledTargetStateKind.Missing:
+                return await CreateWriteActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        SkillUpdateActionKind.Created,
+                        input,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.Current:
+                return SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
+                    new SkillUpdateAction(identity, SkillUpdateActionKind.NoOp),
+                    skillDirectory,
+                    null));
+            case SkillInstalledTargetStateKind.CleanOutdated:
+                return await CreateWriteActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        SkillUpdateActionKind.Updated,
+                        input,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.LocalModified:
+                return await CreateLocalModificationActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        input,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            case SkillInstalledTargetStateKind.Unmanaged:
+                if (!input.DryRun)
+                {
+                    return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(
+                        SkillFailureCodes.InstallTargetUnmanaged,
+                        $"Target skill directory is not managed by uCLI: {skillDirectory}");
+                }
+
+                return await CreateBlockedActionPlanAsync(
+                        package,
+                        host,
+                        skillDirectory,
+                        identity,
+                        SkillUpdateActionKind.BlockedUnmanaged,
+                        SkillBlockedReason.UnmanagedTarget,
+                        printDiff: false,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            default:
+                throw new ArgumentOutOfRangeException(nameof(state), state.Kind, "Unsupported target state.");
+        }
+    }
+
+    private async ValueTask<SkillOperationResult<SkillUpdateActionPlan>> CreateLocalModificationActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillUpdateInput input,
+        CancellationToken cancellationToken)
+    {
+        if (input.Force)
+        {
+            return await CreateWriteActionPlanAsync(
+                    package,
+                    host,
+                    skillDirectory,
+                    identity,
+                    SkillUpdateActionKind.Updated,
+                    input,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (input.DryRun)
+        {
+            return await CreateBlockedActionPlanAsync(
+                    package,
+                    host,
+                    skillDirectory,
+                    identity,
+                    SkillUpdateActionKind.BlockedLocalModification,
+                    SkillBlockedReason.LocalModificationRequiresForce,
+                    input.PrintDiff,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(
+            SkillFailureCodes.InstallTargetDigestMismatch,
+            $"Target skill directory contains local modifications. Use --force to overwrite: {skillDirectory}");
+    }
+
+    private async ValueTask<SkillOperationResult<SkillUpdateActionPlan>> CreateWriteActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillUpdateActionKind actionKind,
+        SkillUpdateInput input,
         CancellationToken cancellationToken)
     {
         var materializedResult = materializationService.Materialize(package, host);
         if (!materializedResult.IsSuccess)
         {
-            return SkillOperationResult<bool>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
         }
 
-        return await SkillMaterializedPackageWriter.WriteAsync(
-                targetRoot,
-                skillDirectory,
-                materializedResult.Value!,
-                cancellationToken)
-            .ConfigureAwait(false);
+        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, input.PrintDiff, cancellationToken).ConfigureAwait(false);
+        if (!diffResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+        }
+
+        return SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
+            new SkillUpdateAction(
+                identity,
+                actionKind,
+                null,
+                diffResult.Value),
+            skillDirectory,
+            materializedResult.Value!));
     }
+
+    private async ValueTask<SkillOperationResult<SkillUpdateActionPlan>> CreateBlockedActionPlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
+        SkillInstallIdentity identity,
+        SkillUpdateActionKind actionKind,
+        string blockedReason,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        var materializedResult = materializationService.Materialize(package, host);
+        if (!materializedResult.IsSuccess)
+        {
+            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+        }
+
+        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
+        return diffResult.IsSuccess
+            ? SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
+                new SkillUpdateAction(identity, actionKind, blockedReason, diffResult.Value),
+                skillDirectory,
+                null))
+            : SkillOperationResult<SkillUpdateActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>?>> CreateDiffsAsync (
+        string skillDirectory,
+        SkillMaterializedPackage materializedPackage,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        if (!printDiff)
+        {
+            return SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(Array.Empty<SkillActionDiff>());
+        }
+
+        var diffResult = await diffBuilder.BuildAsync(skillDirectory, materializedPackage, cancellationToken).ConfigureAwait(false);
+        return diffResult.IsSuccess
+            ? SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(diffResult.Value)
+            : SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+    }
+
+    private sealed record SkillUpdateActionPlan (
+        SkillUpdateAction Action,
+        string SkillDirectory,
+        SkillMaterializedPackage? MaterializedPackage);
 }

--- a/src/Ucli.Skills/Installation/SkillUpdateService.cs
+++ b/src/Ucli.Skills/Installation/SkillUpdateService.cs
@@ -240,26 +240,21 @@ public sealed class SkillUpdateService
         SkillUpdateInput input,
         CancellationToken cancellationToken)
     {
-        var materializedResult = materializationService.Materialize(package, host);
-        if (!materializedResult.IsSuccess)
+        var packagePlanResult = await CreateMaterializedPackagePlanAsync(package, host, skillDirectory, input.PrintDiff, cancellationToken).ConfigureAwait(false);
+        if (!packagePlanResult.IsSuccess)
         {
-            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
         }
 
-        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, input.PrintDiff, cancellationToken).ConfigureAwait(false);
-        if (!diffResult.IsSuccess)
-        {
-            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
-        }
-
+        var packagePlan = packagePlanResult.Value!;
         return SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
             new SkillUpdateAction(
                 identity,
                 actionKind,
                 null,
-                diffResult.Value),
+                packagePlan.Diffs),
             skillDirectory,
-            materializedResult.Value!));
+            packagePlan.MaterializedPackage));
     }
 
     private async ValueTask<SkillOperationResult<SkillUpdateActionPlan>> CreateBlockedActionPlanAsync (
@@ -268,41 +263,41 @@ public sealed class SkillUpdateService
         string skillDirectory,
         SkillInstallIdentity identity,
         SkillUpdateActionKind actionKind,
-        string blockedReason,
+        SkillBlockedReason blockedReason,
+        bool printDiff,
+        CancellationToken cancellationToken)
+    {
+        var packagePlanResult = await CreateMaterializedPackagePlanAsync(package, host, skillDirectory, printDiff, cancellationToken).ConfigureAwait(false);
+        return packagePlanResult.IsSuccess
+            ? SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
+                new SkillUpdateAction(identity, actionKind, blockedReason, packagePlanResult.Value!.Diffs),
+                skillDirectory,
+                null))
+            : SkillOperationResult<SkillUpdateActionPlan>.FailureResult(packagePlanResult.Failure!.Code, packagePlanResult.Failure.Message);
+    }
+
+    private async ValueTask<SkillOperationResult<SkillMaterializedPackagePlan>> CreateMaterializedPackagePlanAsync (
+        CanonicalSkillPackage package,
+        string host,
+        string skillDirectory,
         bool printDiff,
         CancellationToken cancellationToken)
     {
         var materializedResult = materializationService.Materialize(package, host);
         if (!materializedResult.IsSuccess)
         {
-            return SkillOperationResult<SkillUpdateActionPlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
+            return SkillOperationResult<SkillMaterializedPackagePlan>.FailureResult(materializedResult.Failure!.Code, materializedResult.Failure.Message);
         }
 
-        var diffResult = await CreateDiffsAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
+        var diffResult = await diffBuilder.BuildOptionalAsync(skillDirectory, materializedResult.Value!, printDiff, cancellationToken).ConfigureAwait(false);
         return diffResult.IsSuccess
-            ? SkillOperationResult<SkillUpdateActionPlan>.Success(new SkillUpdateActionPlan(
-                new SkillUpdateAction(identity, actionKind, blockedReason, diffResult.Value),
-                skillDirectory,
-                null))
-            : SkillOperationResult<SkillUpdateActionPlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
+            ? SkillOperationResult<SkillMaterializedPackagePlan>.Success(new SkillMaterializedPackagePlan(materializedResult.Value!, diffResult.Value!))
+            : SkillOperationResult<SkillMaterializedPackagePlan>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
     }
 
-    private async ValueTask<SkillOperationResult<IReadOnlyList<SkillActionDiff>?>> CreateDiffsAsync (
-        string skillDirectory,
-        SkillMaterializedPackage materializedPackage,
-        bool printDiff,
-        CancellationToken cancellationToken)
-    {
-        if (!printDiff)
-        {
-            return SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(Array.Empty<SkillActionDiff>());
-        }
-
-        var diffResult = await diffBuilder.BuildAsync(skillDirectory, materializedPackage, cancellationToken).ConfigureAwait(false);
-        return diffResult.IsSuccess
-            ? SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.Success(diffResult.Value)
-            : SkillOperationResult<IReadOnlyList<SkillActionDiff>?>.FailureResult(diffResult.Failure!.Code, diffResult.Failure.Message);
-    }
+    private sealed record SkillMaterializedPackagePlan (
+        SkillMaterializedPackage MaterializedPackage,
+        IReadOnlyList<SkillActionDiff> Diffs);
 
     private sealed record SkillUpdateActionPlan (
         SkillUpdateAction Action,

--- a/src/Ucli.Skills/Properties/AssemblyInfo.cs
+++ b/src/Ucli.Skills/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MackySoft.Ucli.Skills.Tests")]

--- a/src/Ucli.Skills/Shared/SkillFailure.cs
+++ b/src/Ucli.Skills/Shared/SkillFailure.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Skills.Shared;
 /// <param name="Code"> The failure code. </param>
 /// <param name="Message"> The user-facing failure message. </param>
 public sealed record SkillFailure (
-    string Code,
+    SkillFailureCode Code,
     string Message)
 {
     /// <summary> Creates one SKILL failure. </summary>
@@ -12,10 +12,14 @@ public sealed record SkillFailure (
     /// <param name="message"> The user-facing failure message. </param>
     /// <returns> The created failure. </returns>
     public static SkillFailure Create (
-        string code,
+        SkillFailureCode code,
         string message)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        if (!code.IsValid)
+        {
+            throw new ArgumentException("Failure code must be valid.", nameof(code));
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
         return new SkillFailure(code, message);
     }

--- a/src/Ucli.Skills/Shared/SkillFailureCode.cs
+++ b/src/Ucli.Skills/Shared/SkillFailureCode.cs
@@ -1,0 +1,64 @@
+namespace MackySoft.Ucli.Skills.Shared;
+
+/// <summary> Represents a non-empty machine-readable SKILL failure code from an open code set. </summary>
+/// <remarks> Unknown values are preserved so new SKILL failure codes can be introduced without closed enum changes. </remarks>
+public readonly record struct SkillFailureCode
+{
+    /// <summary> Initializes a new instance of the <see cref="SkillFailureCode" /> struct. </summary>
+    /// <param name="value"> The raw failure code value. </param>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="value" /> is null, empty, or whitespace. </exception>
+    public SkillFailureCode (string value)
+    {
+        if (!IsValidValue(value))
+        {
+            throw new ArgumentException("Failure code must not be null, empty, or whitespace.", nameof(value));
+        }
+
+        Value = value;
+    }
+
+    /// <summary> Gets the raw failure code value. </summary>
+    public string Value { get; }
+
+    /// <summary> Gets whether this instance contains a valid failure code value. </summary>
+    public bool IsValid => IsValidValue(Value);
+
+    /// <summary> Tries to create one validated failure code. </summary>
+    /// <param name="value"> The raw failure code value. </param>
+    /// <param name="code"> The validated failure code when successful. </param>
+    /// <returns> <see langword="true" /> when the input is valid; otherwise <see langword="false" />. </returns>
+    public static bool TryCreate (
+        string? value,
+        out SkillFailureCode code)
+    {
+        if (!IsValidValue(value))
+        {
+            code = default;
+            return false;
+        }
+
+        code = new SkillFailureCode(value!);
+        return true;
+    }
+
+    /// <summary> Determines whether the specified value can be used as a SKILL failure code. </summary>
+    /// <param name="value"> The raw failure code value. </param>
+    /// <returns> <see langword="true" /> when the value is valid; otherwise <see langword="false" />. </returns>
+    public static bool IsValidValue (string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    /// <summary> Converts the failure code to its raw string value. </summary>
+    /// <param name="code"> The failure code to convert. </param>
+    public static implicit operator string (SkillFailureCode code)
+    {
+        return code.ToString();
+    }
+
+    /// <inheritdoc />
+    public override string ToString ()
+    {
+        return Value ?? string.Empty;
+    }
+}

--- a/src/Ucli.Skills/Shared/SkillFailureCodes.cs
+++ b/src/Ucli.Skills/Shared/SkillFailureCodes.cs
@@ -3,30 +3,30 @@ namespace MackySoft.Ucli.Skills.Shared;
 /// <summary> Defines machine-readable failure codes for SKILL library operations. </summary>
 public static class SkillFailureCodes
 {
-    /// <summary> The requested host is not supported by the global host adapter set. </summary>
-    public const string HostUnsupported = "SKILL_HOST_UNSUPPORTED";
+    /// <summary> Gets the code emitted when the requested host is not supported by the global host adapter set. </summary>
+    public static readonly SkillFailureCode HostUnsupported = new("SKILL_HOST_UNSUPPORTED");
 
-    /// <summary> A source definition is missing or invalid. </summary>
-    public const string SourceInvalid = "SKILL_SOURCE_INVALID";
+    /// <summary> Gets the code emitted when a source definition is missing or invalid. </summary>
+    public static readonly SkillFailureCode SourceInvalid = new("SKILL_SOURCE_INVALID");
 
-    /// <summary> A canonical manifest is missing or invalid. </summary>
-    public const string ManifestInvalid = "SKILL_MANIFEST_INVALID";
+    /// <summary> Gets the code emitted when a canonical manifest is missing or invalid. </summary>
+    public static readonly SkillFailureCode ManifestInvalid = new("SKILL_MANIFEST_INVALID");
 
-    /// <summary> A requested path escapes the allowed target boundary. </summary>
-    public const string PathUnsafe = "SKILL_PATH_UNSAFE";
+    /// <summary> Gets the code emitted when a requested path escapes the allowed target boundary. </summary>
+    public static readonly SkillFailureCode PathUnsafe = new("SKILL_PATH_UNSAFE");
 
-    /// <summary> The target directory is not managed by a canonical uCLI SKILL manifest. </summary>
-    public const string InstallTargetUnmanaged = "SKILL_INSTALL_TARGET_UNMANAGED";
+    /// <summary> Gets the code emitted when the target directory is not managed by a canonical uCLI SKILL manifest. </summary>
+    public static readonly SkillFailureCode InstallTargetUnmanaged = new("SKILL_INSTALL_TARGET_UNMANAGED");
 
-    /// <summary> The target directory contains different SKILL content. </summary>
-    public const string InstallTargetDigestMismatch = "SKILL_INSTALL_TARGET_DIGEST_MISMATCH";
+    /// <summary> Gets the code emitted when the target directory contains different SKILL content. </summary>
+    public static readonly SkillFailureCode InstallTargetDigestMismatch = new("SKILL_INSTALL_TARGET_DIGEST_MISMATCH");
 
-    /// <summary> The target root appears to contain materialized output for another host. </summary>
-    public const string InstallTargetHostConflict = "SKILL_INSTALL_TARGET_HOST_CONFLICT";
+    /// <summary> Gets the code emitted when the target root appears to contain materialized output for another host. </summary>
+    public static readonly SkillFailureCode InstallTargetHostConflict = new("SKILL_INSTALL_TARGET_HOST_CONFLICT");
 
-    /// <summary> The target directory could not be read for planning. </summary>
-    public const string InstallTargetReadFailed = "SKILL_INSTALL_TARGET_READ_FAILED";
+    /// <summary> Gets the code emitted when the target directory could not be read for planning. </summary>
+    public static readonly SkillFailureCode InstallTargetReadFailed = new("SKILL_INSTALL_TARGET_READ_FAILED");
 
-    /// <summary> The target directory could not be written atomically. </summary>
-    public const string InstallTargetWriteFailed = "SKILL_INSTALL_TARGET_WRITE_FAILED";
+    /// <summary> Gets the code emitted when the target directory could not be written atomically. </summary>
+    public static readonly SkillFailureCode InstallTargetWriteFailed = new("SKILL_INSTALL_TARGET_WRITE_FAILED");
 }

--- a/src/Ucli.Skills/Shared/SkillFailureCodes.cs
+++ b/src/Ucli.Skills/Shared/SkillFailureCodes.cs
@@ -23,4 +23,10 @@ public static class SkillFailureCodes
 
     /// <summary> The target root appears to contain materialized output for another host. </summary>
     public const string InstallTargetHostConflict = "SKILL_INSTALL_TARGET_HOST_CONFLICT";
+
+    /// <summary> The target directory could not be read for planning. </summary>
+    public const string InstallTargetReadFailed = "SKILL_INSTALL_TARGET_READ_FAILED";
+
+    /// <summary> The target directory could not be written atomically. </summary>
+    public const string InstallTargetWriteFailed = "SKILL_INSTALL_TARGET_WRITE_FAILED";
 }

--- a/src/Ucli.Skills/Shared/SkillOperationResult.cs
+++ b/src/Ucli.Skills/Shared/SkillOperationResult.cs
@@ -25,7 +25,7 @@ public sealed record SkillOperationResult<T> (
     /// <param name="message"> The user-facing failure message. </param>
     /// <returns> The failed result. </returns>
     public static SkillOperationResult<T> FailureResult (
-        string code,
+        SkillFailureCode code,
         string message)
     {
         return new SkillOperationResult<T>(default, SkillFailure.Create(code, message));

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -108,21 +108,28 @@ internal static class SkillsCommandResultFactory
                 action.Identity.SkillName,
                 action = ToActionLiteral(action.ActionKind),
                 action.Identity.TargetRoot,
+                action.BlockedReason,
+                diffs = CreateDiffPayloads(action.Diffs),
             })
             .ToArray();
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsInstall,
-            message: "uCLI official SKILL packages installed.",
+            message: installResult.DryRun ? "uCLI official SKILL install plan generated." : "uCLI official SKILL packages installed.",
             payload: new
             {
                 host,
                 scope = ProjectScopeLiteral,
                 repositoryRoot,
                 installResult.TargetRoot,
+                installResult.DryRun,
+                installResult.Force,
+                installResult.PrintDiff,
                 actions,
                 createdCount = installResult.Actions.Count(static action => action.ActionKind == SkillInstallActionKind.Created),
+                updatedCount = installResult.Actions.Count(static action => action.ActionKind == SkillInstallActionKind.Updated),
                 noOpCount = installResult.Actions.Count(static action => action.ActionKind == SkillInstallActionKind.NoOp),
+                blockedCount = installResult.Actions.Count(static action => IsBlocked(action.ActionKind)),
             });
     }
 
@@ -153,22 +160,28 @@ internal static class SkillsCommandResultFactory
                 action.Identity.SkillName,
                 action = ToActionLiteral(action.ActionKind),
                 action.Identity.TargetRoot,
+                action.BlockedReason,
+                diffs = CreateDiffPayloads(action.Diffs),
             })
             .ToArray();
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsUpdate,
-            message: "uCLI official SKILL packages updated.",
+            message: updateResult.DryRun ? "uCLI official SKILL update plan generated." : "uCLI official SKILL packages updated.",
             payload: new
             {
                 host,
                 scope = ProjectScopeLiteral,
                 repositoryRoot,
                 updateResult.TargetRoot,
+                updateResult.DryRun,
+                updateResult.Force,
+                updateResult.PrintDiff,
                 actions,
                 createdCount = updateResult.Actions.Count(static action => action.ActionKind == SkillUpdateActionKind.Created),
                 updatedCount = updateResult.Actions.Count(static action => action.ActionKind == SkillUpdateActionKind.Updated),
                 noOpCount = updateResult.Actions.Count(static action => action.ActionKind == SkillUpdateActionKind.NoOp),
+                blockedCount = updateResult.Actions.Count(static action => IsBlocked(action.ActionKind)),
             });
     }
 
@@ -199,22 +212,27 @@ internal static class SkillsCommandResultFactory
                 action.Identity.SkillName,
                 action = ToActionLiteral(action.ActionKind),
                 action.Identity.TargetRoot,
+                action.BlockedReason,
+                diffs = CreateDiffPayloads(null),
             })
             .ToArray();
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsUninstall,
-            message: "uCLI official SKILL packages uninstalled.",
+            message: uninstallResult.DryRun ? "uCLI official SKILL uninstall plan generated." : "uCLI official SKILL packages uninstalled.",
             payload: new
             {
                 host,
                 scope = ProjectScopeLiteral,
                 repositoryRoot,
                 uninstallResult.TargetRoot,
+                uninstallResult.DryRun,
+                uninstallResult.Force,
                 actions,
                 deletedCount = uninstallResult.Actions.Count(static action => action.ActionKind == SkillUninstallActionKind.Deleted),
                 noOpCount = uninstallResult.Actions.Count(static action => action.ActionKind == SkillUninstallActionKind.NoOp),
                 skippedUnmanagedCount = uninstallResult.Actions.Count(static action => action.ActionKind == SkillUninstallActionKind.SkippedUnmanaged),
+                blockedCount = uninstallResult.Actions.Count(static action => IsBlocked(action.ActionKind)),
             });
     }
 
@@ -318,7 +336,11 @@ internal static class SkillsCommandResultFactory
         return actionKind switch
         {
             SkillInstallActionKind.Created => "created",
+            SkillInstallActionKind.Updated => "updated",
             SkillInstallActionKind.NoOp => "noOp",
+            SkillInstallActionKind.BlockedManagedOverwrite => "blockedManagedOverwrite",
+            SkillInstallActionKind.BlockedLocalModification => "blockedLocalModification",
+            SkillInstallActionKind.BlockedUnmanaged => "blockedUnmanaged",
             _ => actionKind.ToString(),
         };
     }
@@ -330,6 +352,8 @@ internal static class SkillsCommandResultFactory
             SkillUpdateActionKind.Created => "created",
             SkillUpdateActionKind.Updated => "updated",
             SkillUpdateActionKind.NoOp => "noOp",
+            SkillUpdateActionKind.BlockedLocalModification => "blockedLocalModification",
+            SkillUpdateActionKind.BlockedUnmanaged => "blockedUnmanaged",
             _ => actionKind.ToString(),
         };
     }
@@ -341,8 +365,45 @@ internal static class SkillsCommandResultFactory
             SkillUninstallActionKind.Deleted => "deleted",
             SkillUninstallActionKind.NoOp => "noOp",
             SkillUninstallActionKind.SkippedUnmanaged => "skippedUnmanaged",
+            SkillUninstallActionKind.BlockedLocalModification => "blockedLocalModification",
             _ => actionKind.ToString(),
         };
+    }
+
+    private static bool IsBlocked (SkillInstallActionKind actionKind)
+    {
+        return actionKind is SkillInstallActionKind.BlockedManagedOverwrite
+            or SkillInstallActionKind.BlockedLocalModification
+            or SkillInstallActionKind.BlockedUnmanaged;
+    }
+
+    private static bool IsBlocked (SkillUpdateActionKind actionKind)
+    {
+        return actionKind is SkillUpdateActionKind.BlockedLocalModification
+            or SkillUpdateActionKind.BlockedUnmanaged;
+    }
+
+    private static bool IsBlocked (SkillUninstallActionKind actionKind)
+    {
+        return actionKind is SkillUninstallActionKind.BlockedLocalModification;
+    }
+
+    private static object[] CreateDiffPayloads (IReadOnlyList<SkillActionDiff>? diffs)
+    {
+        return (diffs ?? Array.Empty<SkillActionDiff>())
+            .Select(static diff => new
+            {
+                files = diff.Files
+                    .Select(static file => new
+                    {
+                        relativePath = file.RelativePath,
+                        changeKind = file.ChangeKind,
+                        beforeContent = file.BeforeContent,
+                        afterContent = file.AfterContent,
+                    })
+                    .ToArray(),
+            })
+            .ToArray();
     }
 
     private static string ToSeverityLiteral (SkillDoctorSeverity severity)

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -418,13 +418,24 @@ internal static class SkillsCommandResultFactory
                     .Select(static file => new
                     {
                         relativePath = file.RelativePath,
-                        changeKind = file.ChangeKind,
+                        changeKind = ToDiffChangeKindLiteral(file.ChangeKind),
                         beforeContent = file.BeforeContent,
                         afterContent = file.AfterContent,
                     })
                     .ToArray(),
             })
             .ToArray();
+    }
+
+    private static string ToDiffChangeKindLiteral (SkillDiffChangeKind changeKind)
+    {
+        return changeKind switch
+        {
+            SkillDiffChangeKind.Added => "added",
+            SkillDiffChangeKind.Modified => "modified",
+            SkillDiffChangeKind.Deleted => "deleted",
+            _ => changeKind.ToString(),
+        };
     }
 
     private static string ToSeverityLiteral (SkillDoctorSeverity severity)

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -101,17 +101,12 @@ internal static class SkillsCommandResultFactory
         }
 
         var installResult = result.Value!;
-        var actions = installResult.Actions
-            .OrderBy(static action => action.Identity.SkillName, StringComparer.Ordinal)
-            .Select(static action => new
-            {
-                action.Identity.SkillName,
-                action = ToActionLiteral(action.ActionKind),
-                action.Identity.TargetRoot,
-                action.BlockedReason,
-                diffs = CreateDiffPayloads(action.Diffs),
-            })
-            .ToArray();
+        var actions = CreateActionPayloads(
+            installResult.Actions,
+            static action => action.Identity,
+            static action => ToActionLiteral(action.ActionKind),
+            static action => action.BlockedReason,
+            static action => action.Diffs);
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsInstall,
@@ -153,17 +148,12 @@ internal static class SkillsCommandResultFactory
         }
 
         var updateResult = result.Value!;
-        var actions = updateResult.Actions
-            .OrderBy(static action => action.Identity.SkillName, StringComparer.Ordinal)
-            .Select(static action => new
-            {
-                action.Identity.SkillName,
-                action = ToActionLiteral(action.ActionKind),
-                action.Identity.TargetRoot,
-                action.BlockedReason,
-                diffs = CreateDiffPayloads(action.Diffs),
-            })
-            .ToArray();
+        var actions = CreateActionPayloads(
+            updateResult.Actions,
+            static action => action.Identity,
+            static action => ToActionLiteral(action.ActionKind),
+            static action => action.BlockedReason,
+            static action => action.Diffs);
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsUpdate,
@@ -205,17 +195,12 @@ internal static class SkillsCommandResultFactory
         }
 
         var uninstallResult = result.Value!;
-        var actions = uninstallResult.Actions
-            .OrderBy(static action => action.Identity.SkillName, StringComparer.Ordinal)
-            .Select(static action => new
-            {
-                action.Identity.SkillName,
-                action = ToActionLiteral(action.ActionKind),
-                action.Identity.TargetRoot,
-                action.BlockedReason,
-                diffs = CreateDiffPayloads(null),
-            })
-            .ToArray();
+        var actions = CreateActionPayloads(
+            uninstallResult.Actions,
+            static action => action.Identity,
+            static action => ToActionLiteral(action.ActionKind),
+            static action => action.BlockedReason,
+            static _ => null);
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsUninstall,
@@ -386,6 +371,42 @@ internal static class SkillsCommandResultFactory
     private static bool IsBlocked (SkillUninstallActionKind actionKind)
     {
         return actionKind is SkillUninstallActionKind.BlockedLocalModification;
+    }
+
+    private static object[] CreateActionPayloads<TAction> (
+        IReadOnlyList<TAction> actions,
+        Func<TAction, SkillInstallIdentity> getIdentity,
+        Func<TAction, string> getActionLiteral,
+        Func<TAction, SkillBlockedReason?> getBlockedReason,
+        Func<TAction, IReadOnlyList<SkillActionDiff>?> getDiffs)
+    {
+        return actions
+            .OrderBy(action => getIdentity(action).SkillName, StringComparer.Ordinal)
+            .Select(action =>
+            {
+                var identity = getIdentity(action);
+                return new
+                {
+                    identity.SkillName,
+                    action = getActionLiteral(action),
+                    identity.TargetRoot,
+                    blockedReason = ToBlockedReasonLiteral(getBlockedReason(action)),
+                    diffs = CreateDiffPayloads(getDiffs(action)),
+                };
+            })
+            .ToArray();
+    }
+
+    private static string? ToBlockedReasonLiteral (SkillBlockedReason? reason)
+    {
+        return reason switch
+        {
+            null => null,
+            SkillBlockedReason.ManagedOverwriteRequiresForce => "managedOverwriteRequiresForce",
+            SkillBlockedReason.LocalModificationRequiresForce => "localModificationRequiresForce",
+            SkillBlockedReason.UnmanagedTarget => "unmanagedTarget",
+            _ => reason.Value.ToString(),
+        };
     }
 
     private static object[] CreateDiffPayloads (IReadOnlyList<SkillActionDiff>? diffs)

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -297,7 +297,7 @@ internal static class SkillsCommandResultFactory
             Payload: new { },
             Errors:
             [
-                new CommandError(new UcliErrorCode(failure.Code), failure.Message, null),
+                new CommandError(new UcliErrorCode(failure.Code.Value), failure.Message, null),
             ]);
     }
 
@@ -309,9 +309,9 @@ internal static class SkillsCommandResultFactory
             .ToArray();
     }
 
-    private static CliExitCode ResolveExitCode (string code)
+    private static CliExitCode ResolveExitCode (SkillFailureCode code)
     {
-        return code is SkillFailureCodes.HostUnsupported or SkillFailureCodes.PathUnsafe
+        return code == SkillFailureCodes.HostUnsupported || code == SkillFailureCodes.PathUnsafe
             ? CliExitCode.InvalidArgument
             : CliExitCode.ToolError;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -37,6 +37,9 @@ internal sealed class SkillsInstallCommand
     /// <param name="scope"> Required install scope. Only project is supported. </param>
     /// <param name="repoRoot"> --repoRoot, Required repository root. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="dryRun"> --dryRun, Whether to return the install plan without writing. </param>
+    /// <param name="force"> Whether managed local modifications can be overwritten. </param>
+    /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.InstallSubcommand)]
@@ -45,6 +48,9 @@ internal sealed class SkillsInstallCommand
         string? scope = null,
         string? repoRoot = null,
         string? targetDir = null,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -91,8 +97,12 @@ internal sealed class SkillsInstallCommand
         }
 
         var installResult = await installService.InstallAsync(
-                packagesResult.Value!,
-                new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir),
+                new SkillInstallInput(
+                    packagesResult.Value!,
+                    new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir),
+                    dryRun,
+                    force,
+                    printDiff),
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = SkillsCommandResultFactory.CreateInstall(installResult, normalizedHost!, repositoryRoot!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -37,6 +37,8 @@ internal sealed class SkillsUninstallCommand
     /// <param name="scope"> Required install scope. Only project is supported. </param>
     /// <param name="repoRoot"> --repoRoot, Required repository root. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="dryRun"> --dryRun, Whether to return the uninstall plan without writing. </param>
+    /// <param name="force"> Whether managed local modifications can be deleted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UninstallSubcommand)]
@@ -45,6 +47,8 @@ internal sealed class SkillsUninstallCommand
         string? scope = null,
         string? repoRoot = null,
         string? targetDir = null,
+        bool dryRun = false,
+        bool force = false,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -93,7 +97,9 @@ internal sealed class SkillsUninstallCommand
         var uninstallResult = await uninstallService.UninstallAsync(
                 new SkillUninstallInput(
                     packagesResult.Value!,
-                    new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir)),
+                    new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir),
+                    dryRun,
+                    force),
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = SkillsCommandResultFactory.CreateUninstall(uninstallResult, normalizedHost!, repositoryRoot!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -37,6 +37,9 @@ internal sealed class SkillsUpdateCommand
     /// <param name="scope"> Required install scope. Only project is supported. </param>
     /// <param name="repoRoot"> --repoRoot, Required repository root. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="dryRun"> --dryRun, Whether to return the update plan without writing. </param>
+    /// <param name="force"> Whether managed local modifications can be overwritten. </param>
+    /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UpdateSubcommand)]
@@ -45,6 +48,9 @@ internal sealed class SkillsUpdateCommand
         string? scope = null,
         string? repoRoot = null,
         string? targetDir = null,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -93,7 +99,10 @@ internal sealed class SkillsUpdateCommand
         var updateResult = await updateService.UpdateAsync(
                 new SkillUpdateInput(
                     packagesResult.Value!,
-                    new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir)),
+                    new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot!, targetDir),
+                    dryRun,
+                    force,
+                    printDiff),
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = SkillsCommandResultFactory.CreateUpdate(updateResult, normalizedHost!, repositoryRoot!);

--- a/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ internal static class SkillsServiceCollectionExtensions
         services.AddSingleton<SkillInstalledPackageValidator>();
         services.AddSingleton<SkillInstalledPackageIntegrityVerifier>();
         services.AddSingleton<SkillInstalledTargetStateAnalyzer>();
+        services.AddSingleton<ISkillPackageDirectoryOperations, SkillPackageDirectoryOperations>();
         services.AddSingleton<ISkillMaterializedPackageWriter, SkillMaterializedPackageWriter>();
         services.AddSingleton<ISkillInstalledPackageRemover, SkillInstalledPackageRemover>();
         services.AddSingleton<SkillMaterializedPackageDiffBuilder>();

--- a/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/SkillsServiceCollectionExtensions.cs
@@ -37,6 +37,10 @@ internal static class SkillsServiceCollectionExtensions
         services.AddSingleton<SkillHostMaterializationInspector>();
         services.AddSingleton<SkillInstalledPackageValidator>();
         services.AddSingleton<SkillInstalledPackageIntegrityVerifier>();
+        services.AddSingleton<SkillInstalledTargetStateAnalyzer>();
+        services.AddSingleton<ISkillMaterializedPackageWriter, SkillMaterializedPackageWriter>();
+        services.AddSingleton<ISkillInstalledPackageRemover, SkillInstalledPackageRemover>();
+        services.AddSingleton<SkillMaterializedPackageDiffBuilder>();
         services.AddSingleton<SkillInstallService>();
         services.AddSingleton<SkillUpdateService>();
         services.AddSingleton<SkillUninstallService>();

--- a/tests/Ucli.Architecture.Tests/Architecture/FriendAssemblyBoundaryTests.cs
+++ b/tests/Ucli.Architecture.Tests/Architecture/FriendAssemblyBoundaryTests.cs
@@ -11,6 +11,7 @@ public sealed class FriendAssemblyBoundaryTests
             "src/Ucli.Application",
             "src/Ucli.Contracts",
             "src/Ucli.Infrastructure",
+            "src/Ucli.Skills",
             "src/Ucli/Hosting",
             "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity",
             "tests/Tests.Helper",
@@ -42,6 +43,10 @@ public sealed class FriendAssemblyBoundaryTests
                 "MackySoft.Ucli.Tests",
                 "MackySoft.Ucli.Unity.Editor",
                 "MackySoft.Ucli.Unity.Tests.Editor",
+            ],
+            ["src/Ucli.Skills/Properties/AssemblyInfo.cs"] =
+            [
+                "MackySoft.Ucli.Skills.Tests",
             ],
             ["src/Ucli/Hosting/AssemblyInfo.cs"] =
             [

--- a/tests/Ucli.Skills.Tests/Doctor/SkillDoctorDiagnosticTests.cs
+++ b/tests/Ucli.Skills.Tests/Doctor/SkillDoctorDiagnosticTests.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Skills.Doctor;
+using MackySoft.Ucli.Skills.Shared;
 
 namespace MackySoft.Ucli.Skills.Tests.Doctor;
 
@@ -12,6 +13,18 @@ public sealed class SkillDoctorDiagnosticTests
 
         Assert.Equal(SkillDoctorSeverity.Error, diagnostic.Severity);
         Assert.Equal("SKILL_ERROR", diagnostic.Code);
+        Assert.Equal("Broken.", diagnostic.Message);
+        Assert.Equal("sample-skill", diagnostic.SkillName);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Error_WithFailureCode_CreatesErrorDiagnostic ()
+    {
+        var diagnostic = SkillDoctorDiagnostic.Error(SkillFailureCodes.ManifestInvalid, "Broken.", "sample-skill");
+
+        Assert.Equal(SkillDoctorSeverity.Error, diagnostic.Severity);
+        Assert.Equal(SkillFailureCodes.ManifestInvalid.Value, diagnostic.Code);
         Assert.Equal("Broken.", diagnostic.Message);
         Assert.Equal("sample-skill", diagnostic.SkillName);
     }

--- a/tests/Ucli.Skills.Tests/Installation/SkillInstallServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillInstallServiceTests.cs
@@ -36,6 +36,50 @@ public sealed class SkillInstallServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task InstallAsync_DryRunCreatesPlanWithoutWritingFiles ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-dry-run-create");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+
+        var result = await service.InstallAsync(new SkillInstallInput(packages, request, DryRun: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        Assert.True(result.Value!.DryRun);
+        Assert.All(result.Value.Actions, static action => Assert.Equal(SkillInstallActionKind.Created, action.ActionKind));
+        Assert.All(result.Value.Actions, static action => Assert.NotEmpty(action.Diffs!));
+        Assert.False(Directory.Exists(result.Value.TargetRoot));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_DryRunBlocksManagedOverwriteWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-dry-run-managed-overwrite");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await service.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        var originalSkill = File.ReadAllText(skillPath);
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
+
+        var result = await service.InstallAsync(
+            new SkillInstallInput(updatedPackages, request, DryRun: true, PrintDiff: true),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single(action => action.Identity.SkillName == packages[0].Manifest.SkillName);
+        Assert.Equal(SkillInstallActionKind.BlockedManagedOverwrite, action.ActionKind);
+        Assert.Equal(SkillBlockedReason.ManagedOverwriteRequiresForce, action.BlockedReason);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.Equal(originalSkill, File.ReadAllText(skillPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task InstallAsync_RejectsSharedTargetRootFromDifferentHost ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-host-conflict");
@@ -96,6 +140,52 @@ public sealed class SkillInstallServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_DryRunBlocksUnmanagedTargetWithoutDiffContent ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-dry-run-unmanaged-no-diff-content");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var unmanagedPath = scope.WriteFile(Path.Combine(".agents", "skills", packages[0].Manifest.SkillName, "SKILL.md"), "# Existing\nsecret=local\n");
+
+        var result = await service.InstallAsync(
+            new SkillInstallInput(
+                [packages[0]],
+                new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath),
+                DryRun: true,
+                PrintDiff: true),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single();
+        Assert.Equal(SkillInstallActionKind.BlockedUnmanaged, action.ActionKind);
+        Assert.Equal(SkillBlockedReason.UnmanagedTarget, action.BlockedReason);
+        Assert.Empty(action.Diffs!);
+        Assert.True(File.Exists(unmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_WhenLaterTargetIsUnmanaged_DoesNotCreateEarlierPackage ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-plan-before-write-unmanaged");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var firstSkillDirectory = Path.Combine(scope.FullPath, ".agents", "skills", packages[0].Manifest.SkillName);
+        var unmanagedPath = scope.WriteFile(Path.Combine(".agents", "skills", packages[1].Manifest.SkillName, "SKILL.md"), "# Existing\n");
+
+        var result = await service.InstallAsync(
+            [packages[0], packages[1]],
+            new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+        Assert.False(Directory.Exists(firstSkillDirectory));
+        Assert.True(File.Exists(unmanagedPath));
     }
 
     [Fact]

--- a/tests/Ucli.Skills.Tests/Installation/SkillInstallServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillInstallServiceTests.cs
@@ -80,6 +80,98 @@ public sealed class SkillInstallServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task InstallAsync_WithForceOverwritesLocalModification ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-force-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await service.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        File.AppendAllText(skillPath, "\nInjected instruction.\n");
+
+        var result = await service.InstallAsync(new SkillInstallInput(packages, request, Force: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single(action => action.Identity.SkillName == packages[0].Manifest.SkillName);
+        Assert.Equal(SkillInstallActionKind.Updated, action.ActionKind);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.DoesNotContain("Injected instruction.", File.ReadAllText(skillPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_WithForceRejectsUnmanagedTarget ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-force-unmanaged");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var unmanagedPath = scope.WriteFile(Path.Combine(".agents", "skills", packages[0].Manifest.SkillName, "SKILL.md"), "# Existing\n");
+
+        var result = await service.InstallAsync(
+            new SkillInstallInput(
+                [packages[0]],
+                new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath),
+                Force: true),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+        Assert.Equal("# Existing\n", File.ReadAllText(unmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_WhenTargetAppearsAfterPlanning_ReturnsFailureWithoutOverwriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-target-race");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var firstSkillDirectory = Path.Combine(scope.FullPath, ".agents", "skills", packages[0].Manifest.SkillName);
+        var unmanagedPath = Path.Combine(firstSkillDirectory, "SKILL.md");
+        var secondPackage = SkillTestData.WithFileEnumerationCallback(packages[1], () =>
+        {
+            Directory.CreateDirectory(firstSkillDirectory);
+            File.WriteAllText(unmanagedPath, "# Race\n");
+        });
+
+        var result = await service.InstallAsync([packages[0], secondPackage], request, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+        Assert.Equal("# Race\n", File.ReadAllText(unmanagedPath));
+        Assert.False(File.Exists(Path.Combine(firstSkillDirectory, "ucli-skill.json")));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task InstallAsync_WhenLaterTargetAppearsAfterPlanning_ReturnsFailureWithoutCreatingEarlierTarget ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-later-target-race");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateInstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var firstSkillDirectory = Path.Combine(scope.FullPath, ".agents", "skills", packages[0].Manifest.SkillName);
+        var secondSkillDirectory = Path.Combine(scope.FullPath, ".agents", "skills", packages[1].Manifest.SkillName);
+        var secondUnmanagedPath = Path.Combine(secondSkillDirectory, "SKILL.md");
+        var secondPackage = SkillTestData.WithFileEnumerationCallback(packages[1], () =>
+        {
+            Directory.CreateDirectory(secondSkillDirectory);
+            File.WriteAllText(secondUnmanagedPath, "# Race\n");
+        });
+
+        var result = await service.InstallAsync([packages[0], secondPackage], request, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+        Assert.False(Directory.Exists(firstSkillDirectory));
+        Assert.Equal("# Race\n", File.ReadAllText(secondUnmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task InstallAsync_RejectsSharedTargetRootFromDifferentHost ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "install-host-conflict");

--- a/tests/Ucli.Skills.Tests/Installation/SkillInstalledPackageRemoverTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillInstalledPackageRemoverTests.cs
@@ -1,0 +1,93 @@
+using MackySoft.Tests;
+using MackySoft.Ucli.Skills.Installation;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Tests.Installation;
+
+public sealed class SkillInstalledPackageRemoverTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task DeleteAsync_WhenMovedDirectoryCleanupFails_CommitsDeletionWithoutRestoringPartialTree ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "remover-delete-failure-restores");
+        var targetRoot = scope.CreateDirectory(".agents/skills");
+        var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
+        scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
+        scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "nested", "file.md"), "# Nested\n");
+        var remover = new SkillInstalledPackageRemover(new DeleteMovedDirectoryFailingOperations());
+
+        var result = await remover.DeleteAsync(targetRoot, skillDirectory, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        Assert.False(Directory.Exists(skillDirectory));
+        var transactionRoot = Path.Combine(targetRoot, ".ucli-skill-transactions");
+        Assert.True(Directory.Exists(transactionRoot));
+        Assert.Contains(Directory.EnumerateDirectories(transactionRoot), static path => path.Contains(".delete.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task DeleteAsync_WhenMovedTargetPreconditionFails_RestoresTargetAndCleansTransactionDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "remover-moved-precondition-failure");
+        var targetRoot = scope.CreateDirectory(".agents/skills");
+        var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
+        var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
+        var remover = new SkillInstalledPackageRemover();
+        var preconditionCallCount = 0;
+
+        var result = await remover.DeleteAsync(
+            targetRoot,
+            skillDirectory,
+            (_, _) => ValueTask.FromResult(
+                ++preconditionCallCount == 1
+                    ? SkillOperationResult<bool>.Success(true)
+                    : SkillOperationResult<bool>.FailureResult(SkillFailureCodes.InstallTargetDigestMismatch, "Synthetic moved target failure.")),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Equal("# Existing\n", File.ReadAllText(skillPath));
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ".ucli-skill-transactions")));
+    }
+
+    private sealed class DeleteMovedDirectoryFailingOperations : ISkillPackageDirectoryOperations
+    {
+        public bool Exists (string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        public void Create (string path)
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        public void Move (
+            string sourceDirectoryName,
+            string destinationDirectoryName)
+        {
+            Directory.Move(sourceDirectoryName, destinationDirectoryName);
+        }
+
+        public void Delete (
+            string path,
+            bool recursive)
+        {
+            if (path.Contains(".delete.", StringComparison.Ordinal))
+            {
+                File.Delete(Path.Combine(path, "SKILL.md"));
+                throw new IOException("Injected moved directory delete failure.");
+            }
+
+            if (path.Contains(".ucli-skill-transactions", StringComparison.Ordinal))
+            {
+                throw new IOException("Injected transaction cleanup failure.");
+            }
+
+            Directory.Delete(path, recursive);
+        }
+    }
+}

--- a/tests/Ucli.Skills.Tests/Installation/SkillInstalledPackageRemoverTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillInstalledPackageRemoverTests.cs
@@ -34,7 +34,7 @@ public sealed class SkillInstalledPackageRemoverTests
         var targetRoot = scope.CreateDirectory(".agents/skills");
         var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
         var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
-        var remover = new SkillInstalledPackageRemover();
+        var remover = SkillTestData.CreatePackageRemover();
         var preconditionCallCount = 0;
 
         var result = await remover.DeleteAsync(

--- a/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageDiffBuilderTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageDiffBuilderTests.cs
@@ -2,7 +2,6 @@ using MackySoft.Tests;
 using MackySoft.Ucli.Skills.Hosts.OpenAi;
 using MackySoft.Ucli.Skills.Installation;
 using MackySoft.Ucli.Skills.Materialization;
-using MackySoft.Ucli.Skills.Packaging;
 using MackySoft.Ucli.Skills.Shared;
 
 namespace MackySoft.Ucli.Skills.Tests.Installation;

--- a/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageDiffBuilderTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageDiffBuilderTests.cs
@@ -1,0 +1,57 @@
+using MackySoft.Tests;
+using MackySoft.Ucli.Skills.Hosts.OpenAi;
+using MackySoft.Ucli.Skills.Installation;
+using MackySoft.Ucli.Skills.Materialization;
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Tests.Installation;
+
+public sealed class SkillMaterializedPackageDiffBuilderTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task BuildAsync_ReturnsAddedModifiedAndDeletedFileDiffs ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "diff-builder-kinds");
+        var skillDirectory = scope.CreateDirectory("sample-skill");
+        scope.WriteFile(Path.Combine("sample-skill", "SKILL.md"), "# Before\n");
+        scope.WriteFile(Path.Combine("sample-skill", "obsolete.md"), "# Obsolete\n");
+        var package = new SkillMaterializedPackage(
+            "sample-skill",
+            OpenAiSkillHostAdapter.HostKey,
+            [
+                SkillPackageFile.Create("SKILL.md", "# After\n"),
+                SkillPackageFile.Create("new.md", "# New\n"),
+            ]);
+        var builder = new SkillMaterializedPackageDiffBuilder();
+
+        var result = await builder.BuildAsync(skillDirectory, package, CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var files = result.Value!.Single().Files.OrderBy(static file => file.RelativePath, StringComparer.Ordinal).ToArray();
+        Assert.Collection(
+            files,
+            static file =>
+            {
+                Assert.Equal("SKILL.md", file.RelativePath);
+                Assert.Equal(SkillDiffChangeKind.Modified, file.ChangeKind);
+                Assert.Equal("# Before\n", file.BeforeContent);
+                Assert.Equal("# After\n", file.AfterContent);
+            },
+            static file =>
+            {
+                Assert.Equal("new.md", file.RelativePath);
+                Assert.Equal(SkillDiffChangeKind.Added, file.ChangeKind);
+                Assert.Null(file.BeforeContent);
+                Assert.Equal("# New\n", file.AfterContent);
+            },
+            static file =>
+            {
+                Assert.Equal("obsolete.md", file.RelativePath);
+                Assert.Equal(SkillDiffChangeKind.Deleted, file.ChangeKind);
+                Assert.Equal("# Obsolete\n", file.BeforeContent);
+                Assert.Null(file.AfterContent);
+            });
+    }
+}

--- a/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
@@ -16,7 +16,7 @@ public sealed class SkillMaterializedPackageWriterTests
         var targetRoot = scope.CreateDirectory(".agents/skills");
         var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
         var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
-        var writer = new SkillMaterializedPackageWriter();
+        var writer = SkillTestData.CreatePackageWriter();
         var package = new SkillMaterializedPackage(
             "sample-skill",
             OpenAiSkillHostAdapter.HostKey,
@@ -69,7 +69,7 @@ public sealed class SkillMaterializedPackageWriterTests
         var targetRoot = scope.CreateDirectory(".agents/skills");
         var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
         var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
-        var writer = new SkillMaterializedPackageWriter();
+        var writer = SkillTestData.CreatePackageWriter();
         var package = new SkillMaterializedPackage(
             "sample-skill",
             OpenAiSkillHostAdapter.HostKey,
@@ -102,7 +102,7 @@ public sealed class SkillMaterializedPackageWriterTests
     {
         using var targetScope = TestDirectories.CreateTempScope("ucli-skills", "writer-target-root");
         using var outsideScope = TestDirectories.CreateTempScope("ucli-skills", "writer-outside-root");
-        var writer = new SkillMaterializedPackageWriter();
+        var writer = SkillTestData.CreatePackageWriter();
         var outsideSkillDirectory = Path.Combine(outsideScope.FullPath, "skill");
 
         var result = await writer.WriteAsync(

--- a/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
@@ -1,0 +1,58 @@
+using MackySoft.Tests;
+using MackySoft.Ucli.Skills.Hosts.OpenAi;
+using MackySoft.Ucli.Skills.Installation;
+using MackySoft.Ucli.Skills.Materialization;
+using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Tests.Installation;
+
+public sealed class SkillMaterializedPackageWriterTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteAsync_WhenStagingWriteFails_PreservesExistingTargetAndCleansTransactionDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "writer-staging-failure-preserves");
+        var targetRoot = scope.CreateDirectory(".agents/skills");
+        var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
+        var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
+        var writer = new SkillMaterializedPackageWriter();
+        var package = new SkillMaterializedPackage(
+            "sample-skill",
+            OpenAiSkillHostAdapter.HostKey,
+            [
+                SkillPackageFile.Create("nested", "file"),
+                SkillPackageFile.Create("nested/file.md", "nested"),
+            ]);
+
+        var result = await writer.WriteAsync(targetRoot, skillDirectory, package, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetWriteFailed, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Equal("# Existing\n", File.ReadAllText(skillPath));
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ".ucli-skill-transactions")));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteAsync_WithOutsideSkillDirectory_ReturnsPathUnsafeWithoutWriting ()
+    {
+        using var targetScope = TestDirectories.CreateTempScope("ucli-skills", "writer-target-root");
+        using var outsideScope = TestDirectories.CreateTempScope("ucli-skills", "writer-outside-root");
+        var writer = new SkillMaterializedPackageWriter();
+        var outsideSkillDirectory = Path.Combine(outsideScope.FullPath, "skill");
+
+        var result = await writer.WriteAsync(
+            targetScope.FullPath,
+            outsideSkillDirectory,
+            new SkillMaterializedPackage("skill", OpenAiSkillHostAdapter.HostKey, []),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
+        Assert.False(Directory.Exists(outsideSkillDirectory));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(outsideScope.FullPath));
+    }
+}

--- a/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillMaterializedPackageWriterTests.cs
@@ -2,7 +2,6 @@ using MackySoft.Tests;
 using MackySoft.Ucli.Skills.Hosts.OpenAi;
 using MackySoft.Ucli.Skills.Installation;
 using MackySoft.Ucli.Skills.Materialization;
-using MackySoft.Ucli.Skills.Packaging;
 using MackySoft.Ucli.Skills.Shared;
 
 namespace MackySoft.Ucli.Skills.Tests.Installation;
@@ -37,6 +36,68 @@ public sealed class SkillMaterializedPackageWriterTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task WriteAsync_WhenCommitMoveFails_RestoresExistingTargetAndCleansTransactionDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "writer-commit-failure-restores");
+        var targetRoot = scope.CreateDirectory(".agents/skills");
+        var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
+        var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
+        var writer = new SkillMaterializedPackageWriter(new CommitMoveFailingDirectoryOperations());
+        var package = new SkillMaterializedPackage(
+            "sample-skill",
+            OpenAiSkillHostAdapter.HostKey,
+            [
+                SkillPackageFile.Create("SKILL.md", "# New\n"),
+                SkillPackageFile.Create("new.md", "# New file\n"),
+            ]);
+
+        var result = await writer.WriteAsync(targetRoot, skillDirectory, package, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetWriteFailed, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Equal("# Existing\n", File.ReadAllText(skillPath));
+        Assert.False(File.Exists(Path.Combine(skillDirectory, "new.md")));
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ".ucli-skill-transactions")));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteAsync_WhenMovedTargetPreconditionFails_RestoresExistingTargetAndCleansTransactionDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "writer-moved-precondition-failure");
+        var targetRoot = scope.CreateDirectory(".agents/skills");
+        var skillDirectory = scope.CreateDirectory(Path.Combine(".agents", "skills", "sample-skill"));
+        var skillPath = scope.WriteFile(Path.Combine(".agents", "skills", "sample-skill", "SKILL.md"), "# Existing\n");
+        var writer = new SkillMaterializedPackageWriter();
+        var package = new SkillMaterializedPackage(
+            "sample-skill",
+            OpenAiSkillHostAdapter.HostKey,
+            [
+                SkillPackageFile.Create("SKILL.md", "# New\n"),
+            ]);
+        var preconditionCallCount = 0;
+
+        var result = await writer.WriteAsync(
+            targetRoot,
+            skillDirectory,
+            package,
+            SkillMaterializedPackageWriteMode.ReplaceExisting,
+            (_, _) => ValueTask.FromResult(
+                ++preconditionCallCount == 1
+                    ? SkillOperationResult<bool>.Success(true)
+                    : SkillOperationResult<bool>.FailureResult(SkillFailureCodes.InstallTargetDigestMismatch, "Synthetic moved target failure.")),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Equal("# Existing\n", File.ReadAllText(skillPath));
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ".ucli-skill-transactions")));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task WriteAsync_WithOutsideSkillDirectory_ReturnsPathUnsafeWithoutWriting ()
     {
         using var targetScope = TestDirectories.CreateTempScope("ucli-skills", "writer-target-root");
@@ -54,5 +115,40 @@ public sealed class SkillMaterializedPackageWriterTests
         Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
         Assert.False(Directory.Exists(outsideSkillDirectory));
         Assert.Empty(Directory.EnumerateFileSystemEntries(outsideScope.FullPath));
+    }
+
+    private sealed class CommitMoveFailingDirectoryOperations : ISkillPackageDirectoryOperations
+    {
+        private int moveCount;
+
+        public bool Exists (string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        public void Create (string path)
+        {
+            Directory.CreateDirectory(path);
+        }
+
+        public void Move (
+            string sourceDirectoryName,
+            string destinationDirectoryName)
+        {
+            moveCount++;
+            if (moveCount == 2)
+            {
+                throw new IOException("Injected commit move failure.");
+            }
+
+            Directory.Move(sourceDirectoryName, destinationDirectoryName);
+        }
+
+        public void Delete (
+            string path,
+            bool recursive)
+        {
+            Directory.Delete(path, recursive);
+        }
     }
 }

--- a/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
@@ -386,7 +386,7 @@ public sealed class SkillUninstallServiceTests
     public async Task PackageRemoverDeleteAsync_RejectsTargetRootDeletion ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-remover-target-root");
-        var remover = new SkillInstalledPackageRemover();
+        var remover = SkillTestData.CreatePackageRemover();
 
         var result = await remover.DeleteAsync(scope.FullPath, scope.FullPath, CancellationToken.None);
 

--- a/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
@@ -157,6 +157,30 @@ public sealed class SkillUninstallServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task UninstallAsync_WhenTargetChangesAfterPlanning_ReturnsFailureWithoutDeleting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-target-race");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var uninstallService = SkillTestData.CreateUninstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0], packages[1]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
+        var skillPath = Path.Combine(skillDirectory, "SKILL.md");
+        var secondPackage = SkillTestData.WithFileEnumerationCallback(packages[1], () =>
+            File.AppendAllText(skillPath, "\nInjected after planning.\n"));
+
+        var result = await uninstallService.UninstallAsync(new SkillUninstallInput([packages[0], secondPackage], request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Contains("Injected after planning.", File.ReadAllText(skillPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task UninstallAsync_DryRunBlocksLocalModificationWithoutDeleting ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-dry-run-local-modification");

--- a/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUninstallServiceTests.cs
@@ -35,6 +35,29 @@ public sealed class SkillUninstallServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task UninstallAsync_DryRunReturnsDeletedPlanWithoutDeleting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-dry-run-delete");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var uninstallService = SkillTestData.CreateUninstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+
+        var result = await uninstallService.UninstallAsync(new SkillUninstallInput(packages, request, DryRun: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        Assert.True(result.Value!.DryRun);
+        Assert.All(result.Value.Actions, static action => Assert.Equal(SkillUninstallActionKind.Deleted, action.ActionKind));
+        foreach (var package in packages)
+        {
+            Assert.True(Directory.Exists(Path.Combine(result.Value.TargetRoot, package.Manifest.SkillName)), package.Manifest.SkillName);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task UninstallAsync_NoOps_WhenTargetRootIsMissing ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-missing-target");
@@ -107,6 +130,73 @@ public sealed class SkillUninstallServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UninstallAsync_WhenLaterTargetHasLocalModification_DoesNotDeleteEarlierPackage ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-plan-before-delete-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var uninstallService = SkillTestData.CreateUninstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0], packages[1]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var firstSkillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
+        var modifiedSkillDirectory = Path.Combine(install.Value.TargetRoot, packages[1].Manifest.SkillName);
+        File.AppendAllText(Path.Combine(modifiedSkillDirectory, "SKILL.md"), "\nInjected instruction.\n");
+
+        var result = await uninstallService.UninstallAsync(new SkillUninstallInput([packages[0], packages[1]], request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        Assert.True(Directory.Exists(firstSkillDirectory));
+        Assert.True(Directory.Exists(modifiedSkillDirectory));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UninstallAsync_DryRunBlocksLocalModificationWithoutDeleting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-dry-run-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var uninstallService = SkillTestData.CreateUninstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
+        File.AppendAllText(Path.Combine(skillDirectory, "SKILL.md"), "\nInjected instruction.\n");
+
+        var result = await uninstallService.UninstallAsync(new SkillUninstallInput(packages, request, DryRun: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single(action => action.Identity.SkillName == packages[0].Manifest.SkillName);
+        Assert.Equal(SkillUninstallActionKind.BlockedLocalModification, action.ActionKind);
+        Assert.Equal(SkillBlockedReason.LocalModificationRequiresForce, action.BlockedReason);
+        Assert.True(Directory.Exists(skillDirectory));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UninstallAsync_WithForceDeletesLocalModification ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-force-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var uninstallService = SkillTestData.CreateUninstallService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
+        File.AppendAllText(Path.Combine(skillDirectory, "SKILL.md"), "\nInjected instruction.\n");
+
+        var result = await uninstallService.UninstallAsync(new SkillUninstallInput([packages[0]], request, Force: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        Assert.Equal(SkillUninstallActionKind.Deleted, result.Value!.Actions.Single().ActionKind);
+        Assert.False(Directory.Exists(skillDirectory));
     }
 
     [Fact]
@@ -265,5 +355,19 @@ public sealed class SkillUninstallServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PackageRemoverDeleteAsync_RejectsTargetRootDeletion ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "uninstall-remover-target-root");
+        var remover = new SkillInstalledPackageRemover();
+
+        var result = await remover.DeleteAsync(scope.FullPath, scope.FullPath, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
+        Assert.True(Directory.Exists(scope.FullPath));
     }
 }

--- a/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
@@ -1,10 +1,8 @@
 using MackySoft.Tests;
-using MackySoft.Ucli.Skills.Digests;
 using MackySoft.Ucli.Skills.Hosts.Claude;
 using MackySoft.Ucli.Skills.Hosts.OpenAi;
 using MackySoft.Ucli.Skills.Installation;
-using MackySoft.Ucli.Skills.Manifests;
-using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Materialization;
 using MackySoft.Ucli.Skills.Shared;
 
 namespace MackySoft.Ucli.Skills.Tests.Installation;
@@ -45,7 +43,7 @@ public sealed class SkillUpdateServiceTests
         var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
         var install = await installService.InstallAsync(packages, request, CancellationToken.None);
         Assert.True(install.IsSuccess, install.Failure?.Message);
-        var updatedPackages = ReplacePackage(packages, CreatePackageWithUpdatedBody(packages[0]));
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
 
         var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, request), CancellationToken.None);
 
@@ -99,6 +97,191 @@ public sealed class SkillUpdateServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task UpdateAsync_DryRunCreatesPlanWithoutWritingFiles ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-dry-run-create");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+
+        var result = await service.UpdateAsync(new SkillUpdateInput([packages[0]], request, DryRun: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single();
+        Assert.Equal(SkillUpdateActionKind.Created, action.ActionKind);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.False(Directory.Exists(Path.Combine(result.Value.TargetRoot, packages[0].Manifest.SkillName)));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_DryRunUpdatesCleanOutdatedPlanWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-dry-run-outdated");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var manifestPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "ucli-skill.json");
+        var originalManifest = File.ReadAllText(manifestPath);
+        var updatedPackage = SkillTestData.CreatePackageWithUpdatedBody(packages[0]);
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput([updatedPackage], request, DryRun: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single();
+        Assert.Equal(SkillUpdateActionKind.Updated, action.ActionKind);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.Equal(originalManifest, File.ReadAllText(manifestPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_DryRunBlocksLocalModificationWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-dry-run-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        File.AppendAllText(skillPath, "\nInjected instruction.\n");
+        var modifiedSkill = File.ReadAllText(skillPath);
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput(packages, request, DryRun: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single(action => action.Identity.SkillName == packages[0].Manifest.SkillName);
+        Assert.Equal(SkillUpdateActionKind.BlockedLocalModification, action.ActionKind);
+        Assert.Equal(SkillBlockedReason.LocalModificationRequiresForce, action.BlockedReason);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.Equal(modifiedSkill, File.ReadAllText(skillPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_WithForceOverwritesLocalModification ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-force-local-modification");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        File.AppendAllText(skillPath, "\nInjected instruction.\n");
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput(packages, request, Force: true, PrintDiff: true), CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single(action => action.Identity.SkillName == packages[0].Manifest.SkillName);
+        Assert.Equal(SkillUpdateActionKind.Updated, action.ActionKind);
+        Assert.NotEmpty(action.Diffs!);
+        Assert.DoesNotContain("Injected instruction.", File.ReadAllText(skillPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_DryRunBlocksUnmanagedTargetEvenWithForce ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-dry-run-unmanaged-force");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var service = SkillTestData.CreateUpdateService();
+        var unmanagedPath = scope.WriteFile(Path.Combine(".agents", "skills", packages[0].Manifest.SkillName, "SKILL.md"), "# Existing\n");
+
+        var result = await service.UpdateAsync(
+            new SkillUpdateInput(
+                [packages[0]],
+                new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath),
+                DryRun: true,
+                Force: true,
+                PrintDiff: true),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess, result.Failure?.Message);
+        var action = result.Value!.Actions.Single();
+        Assert.Equal(SkillUpdateActionKind.BlockedUnmanaged, action.ActionKind);
+        Assert.Equal(SkillBlockedReason.UnmanagedTarget, action.BlockedReason);
+        Assert.Empty(action.Diffs!);
+        Assert.True(File.Exists(unmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_WhenWriterFails_PreservesExistingTarget ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-writer-failure-preserves");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = CreateUpdateService(new FailingPackageWriter());
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync(packages, request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
+        var skillPath = Path.Combine(skillDirectory, "SKILL.md");
+        var originalSkill = File.ReadAllText(skillPath);
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetWriteFailed, result.Failure!.Code);
+        Assert.True(Directory.Exists(skillDirectory));
+        Assert.Equal(originalSkill, File.ReadAllText(skillPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_WhenLaterTargetIsUnmanaged_DoesNotUpdateEarlierPackage ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-plan-before-write-unmanaged");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var manifestPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "ucli-skill.json");
+        var originalManifest = File.ReadAllText(manifestPath);
+        var unmanagedPath = scope.WriteFile(Path.Combine(".agents", "skills", packages[1].Manifest.SkillName, "SKILL.md"), "# Existing\n");
+        var updatedPackage = SkillTestData.CreatePackageWithUpdatedBody(packages[0]);
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput([updatedPackage, packages[1]], request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
+        Assert.Equal(originalManifest, File.ReadAllText(manifestPath));
+        Assert.True(File.Exists(unmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PackageWriterWriteAsync_WithOutsideSkillDirectory_ReturnsPathUnsafeWithoutWriting ()
+    {
+        using var targetScope = TestDirectories.CreateTempScope("ucli-skills", "writer-target-root");
+        using var outsideScope = TestDirectories.CreateTempScope("ucli-skills", "writer-outside-root");
+        var writer = new SkillMaterializedPackageWriter();
+        var outsideSkillDirectory = Path.Combine(outsideScope.FullPath, "skill");
+
+        var result = await writer.WriteAsync(
+            targetScope.FullPath,
+            outsideSkillDirectory,
+            new SkillMaterializedPackage("skill", OpenAiSkillHostAdapter.HostKey, []),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
+        Assert.False(Directory.Exists(outsideSkillDirectory));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(outsideScope.FullPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task UpdateAsync_RejectsLocalEmptyDirectoryBeforeReplacingOutdatedPackage ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-local-empty-directory");
@@ -110,7 +293,7 @@ public sealed class SkillUpdateServiceTests
         Assert.True(install.IsSuccess, install.Failure?.Message);
         var localDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "local-notes");
         Directory.CreateDirectory(localDirectory);
-        var updatedPackages = ReplacePackage(packages, CreatePackageWithUpdatedBody(packages[0]));
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
 
         var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, request), CancellationToken.None);
 
@@ -152,7 +335,7 @@ public sealed class SkillUpdateServiceTests
             return;
         }
 
-        var updatedPackages = ReplacePackage(packages, CreatePackageWithUpdatedBody(packages[0]));
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
 
         var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, request), CancellationToken.None);
 
@@ -199,7 +382,7 @@ public sealed class SkillUpdateServiceTests
         var claude = await installService.InstallAsync(packages, claudeRequest, CancellationToken.None);
         Assert.True(openAi.IsSuccess, openAi.Failure?.Message);
         Assert.True(claude.IsSuccess, claude.Failure?.Message);
-        var updatedPackages = ReplacePackage(packages, CreatePackageWithUpdatedBody(packages[0]));
+        var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
 
         var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, openAiRequest), CancellationToken.None);
 
@@ -235,41 +418,29 @@ public sealed class SkillUpdateServiceTests
         Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
     }
 
-    private static IReadOnlyList<CanonicalSkillPackage> ReplacePackage (
-        IReadOnlyList<CanonicalSkillPackage> packages,
-        CanonicalSkillPackage replacement)
+    private static SkillUpdateService CreateUpdateService (ISkillMaterializedPackageWriter writer)
     {
-        return packages
-            .Select(package => string.Equals(package.Manifest.SkillName, replacement.Manifest.SkillName, StringComparison.Ordinal) ? replacement : package)
-            .ToArray();
+        var hostAdapters = SkillTestData.CreateOfficialHostAdapterSet();
+        var installedPackageValidator = SkillTestData.CreateInstalledPackageValidator(hostAdapters);
+        return new SkillUpdateService(
+            new SkillInstallTargetResolver(hostAdapters),
+            new SkillMaterializationService(hostAdapters),
+            new SkillInstalledTargetStateAnalyzer(installedPackageValidator, SkillTestData.CreateInstalledPackageIntegrityVerifier(hostAdapters)),
+            writer,
+            new SkillMaterializedPackageDiffBuilder());
     }
 
-    private static CanonicalSkillPackage CreatePackageWithUpdatedBody (CanonicalSkillPackage package)
+    private sealed class FailingPackageWriter : ISkillMaterializedPackageWriter
     {
-        var files = package.Files
-            .Select(static file => string.Equals(file.RelativePath, "SKILL.md", StringComparison.Ordinal)
-                ? SkillPackageFile.Create("SKILL.md", file.Content + "\nOfficial update.\n")
-                : file)
-            .ToArray();
-        var contentDigest = new SkillDigestCalculator().ComputeDigest(files
-            .Where(static file => string.Equals(file.RelativePath, "SKILL.md", StringComparison.Ordinal)
-                || file.RelativePath.StartsWith("references/", StringComparison.Ordinal))
-            .Select(static file => new SkillDigestInputFile(file.RelativePath, file.Content)));
-        var manifest = package.Manifest with
+        public ValueTask<SkillOperationResult<bool>> WriteAsync (
+            string targetRoot,
+            string skillDirectory,
+            SkillMaterializedPackage materializedPackage,
+            CancellationToken cancellationToken = default)
         {
-            ContentDigest = contentDigest,
-        };
-        var manifestText = new SkillManifestJsonSerializer().Serialize(manifest);
-        files = files
-            .Select(file => string.Equals(file.RelativePath, "ucli-skill.json", StringComparison.Ordinal)
-                ? SkillPackageFile.Create("ucli-skill.json", manifestText)
-                : file)
-            .ToArray();
-
-        return package with
-        {
-            Manifest = manifest,
-            Files = files,
-        };
+            return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(
+                SkillFailureCodes.InstallTargetWriteFailed,
+                "Synthetic write failure."));
+        }
     }
 }

--- a/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
@@ -256,6 +256,57 @@ public sealed class SkillUpdateServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task UpdateAsync_WhenTargetChangesAfterPlanning_ReturnsFailureWithoutOverwriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-target-race");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0], packages[1]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var skillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        var updatedPackage = SkillTestData.CreatePackageWithUpdatedBody(packages[0]);
+        var secondPackage = SkillTestData.WithFileEnumerationCallback(packages[1], () =>
+            File.AppendAllText(skillPath, "\nInjected after planning.\n"));
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput([updatedPackage, secondPackage], request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        var skillText = File.ReadAllText(skillPath);
+        Assert.Contains("Injected after planning.", skillText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Official update.", skillText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task UpdateAsync_WhenLaterTargetChangesAfterPlanning_ReturnsFailureWithoutUpdatingEarlierTarget ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-later-target-race");
+        var packages = await SkillTestData.GenerateOfficialPackagesAsync();
+        var installService = SkillTestData.CreateInstallService();
+        var updateService = SkillTestData.CreateUpdateService();
+        var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
+        var install = await installService.InstallAsync([packages[0], packages[1]], request, CancellationToken.None);
+        Assert.True(install.IsSuccess, install.Failure?.Message);
+        var firstSkillPath = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName, "SKILL.md");
+        var secondSkillPath = Path.Combine(install.Value.TargetRoot, packages[1].Manifest.SkillName, "SKILL.md");
+        var firstUpdatedPackage = SkillTestData.CreatePackageWithUpdatedBody(packages[0]);
+        var secondUpdatedPackage = SkillTestData.WithFileEnumerationCallback(
+            SkillTestData.CreatePackageWithUpdatedBody(packages[1]),
+            () => File.AppendAllText(secondSkillPath, "\nInjected after planning.\n"));
+
+        var result = await updateService.UpdateAsync(new SkillUpdateInput([firstUpdatedPackage, secondUpdatedPackage], request), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(SkillFailureCodes.InstallTargetDigestMismatch, result.Failure!.Code);
+        Assert.DoesNotContain("Official update.", File.ReadAllText(firstSkillPath), StringComparison.Ordinal);
+        Assert.Contains("Injected after planning.", File.ReadAllText(secondSkillPath), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task UpdateAsync_RejectsLocalEmptyDirectoryBeforeReplacingOutdatedPackage ()
     {
         using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-local-empty-directory");
@@ -398,6 +449,8 @@ public sealed class SkillUpdateServiceTests
             string targetRoot,
             string skillDirectory,
             SkillMaterializedPackage materializedPackage,
+            SkillMaterializedPackageWriteMode writeMode,
+            Func<string, CancellationToken, ValueTask<SkillOperationResult<bool>>>? precondition,
             CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult(SkillOperationResult<bool>.FailureResult(

--- a/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
+++ b/tests/Ucli.Skills.Tests/Installation/SkillUpdateServiceTests.cs
@@ -213,26 +213,21 @@ public sealed class SkillUpdateServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task UpdateAsync_WhenWriterFails_PreservesExistingTarget ()
+    public async Task UpdateAsync_WhenWriterFails_ReturnsWriteFailure ()
     {
-        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-writer-failure-preserves");
+        using var scope = TestDirectories.CreateTempScope("ucli-skills", "update-writer-failure");
         var packages = await SkillTestData.GenerateOfficialPackagesAsync();
         var installService = SkillTestData.CreateInstallService();
-        var updateService = CreateUpdateService(new FailingPackageWriter());
+        var updateService = SkillTestData.CreateUpdateService(new FailingPackageWriter());
         var request = new SkillInstallRequest(OpenAiSkillHostAdapter.HostKey, SkillScopeKind.Project, scope.FullPath);
         var install = await installService.InstallAsync(packages, request, CancellationToken.None);
         Assert.True(install.IsSuccess, install.Failure?.Message);
-        var skillDirectory = Path.Combine(install.Value!.TargetRoot, packages[0].Manifest.SkillName);
-        var skillPath = Path.Combine(skillDirectory, "SKILL.md");
-        var originalSkill = File.ReadAllText(skillPath);
         var updatedPackages = SkillTestData.ReplacePackage(packages, SkillTestData.CreatePackageWithUpdatedBody(packages[0]));
 
         var result = await updateService.UpdateAsync(new SkillUpdateInput(updatedPackages, request), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(SkillFailureCodes.InstallTargetWriteFailed, result.Failure!.Code);
-        Assert.True(Directory.Exists(skillDirectory));
-        Assert.Equal(originalSkill, File.ReadAllText(skillPath));
     }
 
     [Fact]
@@ -257,27 +252,6 @@ public sealed class SkillUpdateServiceTests
         Assert.Equal(SkillFailureCodes.InstallTargetUnmanaged, result.Failure!.Code);
         Assert.Equal(originalManifest, File.ReadAllText(manifestPath));
         Assert.True(File.Exists(unmanagedPath));
-    }
-
-    [Fact]
-    [Trait("Size", "Small")]
-    public async Task PackageWriterWriteAsync_WithOutsideSkillDirectory_ReturnsPathUnsafeWithoutWriting ()
-    {
-        using var targetScope = TestDirectories.CreateTempScope("ucli-skills", "writer-target-root");
-        using var outsideScope = TestDirectories.CreateTempScope("ucli-skills", "writer-outside-root");
-        var writer = new SkillMaterializedPackageWriter();
-        var outsideSkillDirectory = Path.Combine(outsideScope.FullPath, "skill");
-
-        var result = await writer.WriteAsync(
-            targetScope.FullPath,
-            outsideSkillDirectory,
-            new SkillMaterializedPackage("skill", OpenAiSkillHostAdapter.HostKey, []),
-            CancellationToken.None);
-
-        Assert.False(result.IsSuccess);
-        Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
-        Assert.False(Directory.Exists(outsideSkillDirectory));
-        Assert.Empty(Directory.EnumerateFileSystemEntries(outsideScope.FullPath));
     }
 
     [Fact]
@@ -416,18 +390,6 @@ public sealed class SkillUpdateServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(SkillFailureCodes.PathUnsafe, result.Failure!.Code);
-    }
-
-    private static SkillUpdateService CreateUpdateService (ISkillMaterializedPackageWriter writer)
-    {
-        var hostAdapters = SkillTestData.CreateOfficialHostAdapterSet();
-        var installedPackageValidator = SkillTestData.CreateInstalledPackageValidator(hostAdapters);
-        return new SkillUpdateService(
-            new SkillInstallTargetResolver(hostAdapters),
-            new SkillMaterializationService(hostAdapters),
-            new SkillInstalledTargetStateAnalyzer(installedPackageValidator, SkillTestData.CreateInstalledPackageIntegrityVerifier(hostAdapters)),
-            writer,
-            new SkillMaterializedPackageDiffBuilder());
     }
 
     private sealed class FailingPackageWriter : ISkillMaterializedPackageWriter

--- a/tests/Ucli.Skills.Tests/Shared/SkillFailureCodeTests.cs
+++ b/tests/Ucli.Skills.Tests/Shared/SkillFailureCodeTests.cs
@@ -1,0 +1,40 @@
+using MackySoft.Ucli.Skills.Shared;
+
+namespace MackySoft.Ucli.Skills.Tests.Shared;
+
+public sealed class SkillFailureCodeTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Constructor_RetainsUnknownCodeValue ()
+    {
+        SkillFailureCode code = new("SKILL_FUTURE_FAILURE");
+
+        Assert.Equal("SKILL_FUTURE_FAILURE", code.Value);
+        Assert.Equal("SKILL_FUTURE_FAILURE", code.ToString());
+        string rawValue = code;
+        Assert.Equal("SKILL_FUTURE_FAILURE", rawValue);
+        Assert.Equal(new SkillFailureCode("SKILL_FUTURE_FAILURE"), code);
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_RejectsBlankValue (string? value)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => new SkillFailureCode(value!));
+        Assert.False(SkillFailureCode.TryCreate(value, out _));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void TryCreate_ReturnsValidatedCode ()
+    {
+        var result = SkillFailureCode.TryCreate("SKILL_VALID", out var code);
+
+        Assert.True(result);
+        Assert.Equal(new SkillFailureCode("SKILL_VALID"), code);
+    }
+}

--- a/tests/Ucli.Skills.Tests/SkillTestData.cs
+++ b/tests/Ucli.Skills.Tests/SkillTestData.cs
@@ -9,6 +9,7 @@ using MackySoft.Ucli.Skills.Installation.Validation;
 using MackySoft.Ucli.Skills.Manifests;
 using MackySoft.Ucli.Skills.Materialization;
 using MackySoft.Ucli.Skills.Packaging;
+using MackySoft.Ucli.Skills.Shared;
 using MackySoft.Ucli.Skills.Sources;
 
 namespace MackySoft.Ucli.Skills.Tests;
@@ -103,28 +104,35 @@ internal static class SkillTestData
     internal static SkillInstallService CreateInstallService ()
     {
         var hostAdapters = CreateOfficialHostAdapterSet();
+        var installedPackageValidator = CreateInstalledPackageValidator(hostAdapters);
         return new SkillInstallService(
             new SkillInstallTargetResolver(hostAdapters),
             new SkillMaterializationService(hostAdapters),
-            CreateInstalledPackageValidator(hostAdapters));
+            new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
+            new SkillMaterializedPackageWriter(),
+            new SkillMaterializedPackageDiffBuilder());
     }
 
     internal static SkillUpdateService CreateUpdateService ()
     {
         var hostAdapters = CreateOfficialHostAdapterSet();
+        var installedPackageValidator = CreateInstalledPackageValidator(hostAdapters);
         return new SkillUpdateService(
             new SkillInstallTargetResolver(hostAdapters),
             new SkillMaterializationService(hostAdapters),
-            CreateInstalledPackageValidator(hostAdapters),
-            CreateInstalledPackageIntegrityVerifier(hostAdapters));
+            new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
+            new SkillMaterializedPackageWriter(),
+            new SkillMaterializedPackageDiffBuilder());
     }
 
     internal static SkillUninstallService CreateUninstallService ()
     {
         var hostAdapters = CreateOfficialHostAdapterSet();
+        var installedPackageValidator = CreateInstalledPackageValidator(hostAdapters);
         return new SkillUninstallService(
             new SkillInstallTargetResolver(hostAdapters),
-            CreateInstalledPackageIntegrityVerifier(hostAdapters));
+            new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
+            new SkillInstalledPackageRemover());
     }
 
     internal static SkillInstallationScanner CreateInstallationScanner ()
@@ -140,6 +148,44 @@ internal static class SkillTestData
     {
         var hostAdapters = CreateOfficialHostAdapterSet();
         return new SkillDoctorService(hostAdapters, CreateInstalledPackageValidator(hostAdapters));
+    }
+
+    internal static IReadOnlyList<CanonicalSkillPackage> ReplacePackage (
+        IReadOnlyList<CanonicalSkillPackage> packages,
+        CanonicalSkillPackage replacement)
+    {
+        return packages
+            .Select(package => string.Equals(package.Manifest.SkillName, replacement.Manifest.SkillName, StringComparison.Ordinal) ? replacement : package)
+            .ToArray();
+    }
+
+    internal static CanonicalSkillPackage CreatePackageWithUpdatedBody (CanonicalSkillPackage package)
+    {
+        var files = package.Files
+            .Select(static file => string.Equals(file.RelativePath, "SKILL.md", StringComparison.Ordinal)
+                ? SkillPackageFile.Create("SKILL.md", file.Content + "\nOfficial update.\n")
+                : file)
+            .ToArray();
+        var contentDigest = new SkillDigestCalculator().ComputeDigest(files
+            .Where(static file => string.Equals(file.RelativePath, "SKILL.md", StringComparison.Ordinal)
+                || file.RelativePath.StartsWith("references/", StringComparison.Ordinal))
+            .Select(static file => new SkillDigestInputFile(file.RelativePath, file.Content)));
+        var manifest = package.Manifest with
+        {
+            ContentDigest = contentDigest,
+        };
+        var manifestText = new SkillManifestJsonSerializer().Serialize(manifest);
+        files = files
+            .Select(file => string.Equals(file.RelativePath, "ucli-skill.json", StringComparison.Ordinal)
+                ? SkillPackageFile.Create("ucli-skill.json", manifestText)
+                : file)
+            .ToArray();
+
+        return package with
+        {
+            Manifest = manifest,
+            Files = files,
+        };
     }
 
     internal static SkillInstalledPackageValidator CreateInstalledPackageValidator (SkillHostAdapterSet hostAdapters)

--- a/tests/Ucli.Skills.Tests/SkillTestData.cs
+++ b/tests/Ucli.Skills.Tests/SkillTestData.cs
@@ -113,7 +113,7 @@ internal static class SkillTestData
             new SkillMaterializedPackageDiffBuilder());
     }
 
-    internal static SkillUpdateService CreateUpdateService ()
+    internal static SkillUpdateService CreateUpdateService (ISkillMaterializedPackageWriter? packageWriter = null)
     {
         var hostAdapters = CreateOfficialHostAdapterSet();
         var installedPackageValidator = CreateInstalledPackageValidator(hostAdapters);
@@ -121,7 +121,7 @@ internal static class SkillTestData
             new SkillInstallTargetResolver(hostAdapters),
             new SkillMaterializationService(hostAdapters),
             new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
-            new SkillMaterializedPackageWriter(),
+            packageWriter ?? new SkillMaterializedPackageWriter(),
             new SkillMaterializedPackageDiffBuilder());
     }
 

--- a/tests/Ucli.Skills.Tests/SkillTestData.cs
+++ b/tests/Ucli.Skills.Tests/SkillTestData.cs
@@ -109,7 +109,7 @@ internal static class SkillTestData
             new SkillInstallTargetResolver(hostAdapters),
             new SkillMaterializationService(hostAdapters),
             new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
-            new SkillMaterializedPackageWriter(),
+            CreatePackageWriter(),
             new SkillMaterializedPackageDiffBuilder());
     }
 
@@ -121,7 +121,7 @@ internal static class SkillTestData
             new SkillInstallTargetResolver(hostAdapters),
             new SkillMaterializationService(hostAdapters),
             new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
-            packageWriter ?? new SkillMaterializedPackageWriter(),
+            packageWriter ?? CreatePackageWriter(),
             new SkillMaterializedPackageDiffBuilder());
     }
 
@@ -132,7 +132,7 @@ internal static class SkillTestData
         return new SkillUninstallService(
             new SkillInstallTargetResolver(hostAdapters),
             new SkillInstalledTargetStateAnalyzer(installedPackageValidator, CreateInstalledPackageIntegrityVerifier(hostAdapters)),
-            new SkillInstalledPackageRemover());
+            CreatePackageRemover());
     }
 
     internal static SkillInstallationScanner CreateInstallationScanner ()
@@ -142,6 +142,16 @@ internal static class SkillTestData
             hostAdapters,
             CreateInstalledManifestReader(hostAdapters),
             CreateInstalledPackageValidator(hostAdapters));
+    }
+
+    internal static SkillMaterializedPackageWriter CreatePackageWriter ()
+    {
+        return new SkillMaterializedPackageWriter(new SkillPackageDirectoryOperations());
+    }
+
+    internal static SkillInstalledPackageRemover CreatePackageRemover ()
+    {
+        return new SkillInstalledPackageRemover(new SkillPackageDirectoryOperations());
     }
 
     internal static SkillDoctorService CreateDoctorService ()

--- a/tests/Ucli.Skills.Tests/SkillTestData.cs
+++ b/tests/Ucli.Skills.Tests/SkillTestData.cs
@@ -188,6 +188,16 @@ internal static class SkillTestData
         };
     }
 
+    internal static CanonicalSkillPackage WithFileEnumerationCallback (
+        CanonicalSkillPackage package,
+        Action callback)
+    {
+        return package with
+        {
+            Files = new CallbackPackageFileList(package.Files, callback),
+        };
+    }
+
     internal static SkillInstalledPackageValidator CreateInstalledPackageValidator (SkillHostAdapterSet hostAdapters)
     {
         return new SkillInstalledPackageValidator(
@@ -211,5 +221,41 @@ internal static class SkillTestData
         return new SkillInstalledManifestReader(
             new SkillManifestJsonSerializer(),
             new SkillManifestValidator(hostAdapters));
+    }
+
+    private sealed class CallbackPackageFileList : IReadOnlyList<SkillPackageFile>
+    {
+        private readonly IReadOnlyList<SkillPackageFile> files;
+        private readonly Action callback;
+
+        private bool invoked;
+
+        internal CallbackPackageFileList (
+            IReadOnlyList<SkillPackageFile> files,
+            Action callback)
+        {
+            this.files = files ?? throw new ArgumentNullException(nameof(files));
+            this.callback = callback ?? throw new ArgumentNullException(nameof(callback));
+        }
+
+        public SkillPackageFile this[int index] => files[index];
+
+        public int Count => files.Count;
+
+        public IEnumerator<SkillPackageFile> GetEnumerator ()
+        {
+            if (!invoked)
+            {
+                invoked = true;
+                callback();
+            }
+
+            return files.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
+        {
+            return GetEnumerator();
+        }
     }
 }

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -373,7 +373,10 @@ public sealed class SkillsCliOutputContractTests
                             .HasValueKind("afterContent", JsonValueKind.String)))));
 
         var targetRoot = outputJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
-        Assert.False(Directory.Exists(Path.Combine(targetRoot, ExpectedSkillNames[0])));
+        foreach (var skillName in ExpectedSkillNames)
+        {
+            Assert.False(Directory.Exists(Path.Combine(targetRoot, skillName)), skillName);
+        }
     }
 
     [Fact]
@@ -465,7 +468,10 @@ public sealed class SkillsCliOutputContractTests
                     .HasArrayLength("diffs", 1)));
 
         var targetRoot = outputJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
-        Assert.False(Directory.Exists(Path.Combine(targetRoot, ExpectedSkillNames[0])));
+        foreach (var skillName in ExpectedSkillNames)
+        {
+            Assert.False(Directory.Exists(Path.Combine(targetRoot, skillName)), skillName);
+        }
     }
 
     [Fact]

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -337,6 +337,47 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithDryRunAndPrintDiff_ReturnsPlanWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-dry-run-diff");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunOpenAiInstall(repoRoot, dryRun: true, printDiff: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("dryRun", true)
+                .HasBoolean("force", false)
+                .HasBoolean("printDiff", true)
+                .HasInt32("createdCount", ExpectedSkillNames.Length)
+                .HasInt32("updatedCount", 0)
+                .HasInt32("noOpCount", 0)
+                .HasInt32("blockedCount", 0)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "created")
+                    .IsNull("blockedReason")
+                    .HasArrayLength("diffs", 1)
+                    .HasProperty("diffs", 0, static diff => diff
+                        .HasProperty("files", 0, static file => file
+                            .HasString("relativePath", "SKILL.md")
+                            .HasString("changeKind", "added")
+                            .IsNull("beforeContent")
+                            .HasValueKind("afterContent", JsonValueKind.String)))));
+
+        var targetRoot = outputJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ExpectedSkillNames[0])));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task SkillsInstall_WithSharedTargetRootAcrossHosts_ReturnsHostConflict ()
     {
         using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-host-conflict");
@@ -400,6 +441,35 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task SkillsUpdate_WithDryRunAndPrintDiff_ReturnsCreatedPlanWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "update-dry-run-diff");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunOpenAiUpdate(repoRoot, dryRun: true, printDiff: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("dryRun", true)
+                .HasBoolean("force", false)
+                .HasBoolean("printDiff", true)
+                .HasInt32("createdCount", ExpectedSkillNames.Length)
+                .HasInt32("updatedCount", 0)
+                .HasInt32("blockedCount", 0)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "created")
+                    .IsNull("blockedReason")
+                    .HasArrayLength("diffs", 1)));
+
+        var targetRoot = outputJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        Assert.False(Directory.Exists(Path.Combine(targetRoot, ExpectedSkillNames[0])));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task SkillsUpdate_WithCleanOutdatedTarget_ReturnsUpdatedAction ()
     {
         using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "update-outdated");
@@ -427,6 +497,71 @@ public sealed class SkillsCliOutputContractTests
                 .HasProperty("actions", 0, static action => action
                     .HasString("skillName", ExpectedSkillNames[0])
                     .HasString("action", "updated")));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsUpdate_WithDryRunLocalModification_ReturnsBlockedPlanWithoutWriting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "update-dry-run-local-modification");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+        using var installJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(install.StdOut);
+        var targetRoot = installJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        var skillPath = Path.Combine(targetRoot, ExpectedSkillNames[0], "SKILL.md");
+        await File.AppendAllTextAsync(skillPath, "\nInjected instruction.\n");
+        var modifiedSkill = await File.ReadAllTextAsync(skillPath);
+
+        var result = await RunOpenAiUpdate(repoRoot, dryRun: true, printDiff: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("dryRun", true)
+                .HasBoolean("force", false)
+                .HasBoolean("printDiff", true)
+                .HasInt32("updatedCount", 0)
+                .HasInt32("blockedCount", 1)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "blockedLocalModification")
+                    .HasString("blockedReason", "localModificationRequiresForce")
+                    .HasArrayLength("diffs", 1)));
+        Assert.Equal(modifiedSkill, await File.ReadAllTextAsync(skillPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsUpdate_WithForceAndPrintDiff_OverwritesLocalModification ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "update-force-local-modification");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+        using var installJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(install.StdOut);
+        var targetRoot = installJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        var skillPath = Path.Combine(targetRoot, ExpectedSkillNames[0], "SKILL.md");
+        await File.AppendAllTextAsync(skillPath, "\nInjected instruction.\n");
+
+        var result = await RunOpenAiUpdate(repoRoot, force: true, printDiff: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("dryRun", false)
+                .HasBoolean("force", true)
+                .HasBoolean("printDiff", true)
+                .HasInt32("updatedCount", 1)
+                .HasInt32("blockedCount", 0)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "updated")
+                    .IsNull("blockedReason")
+                    .HasArrayLength("diffs", 1)));
+        Assert.DoesNotContain("Injected instruction.", await File.ReadAllTextAsync(skillPath), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -495,6 +630,37 @@ public sealed class SkillsCliOutputContractTests
                     .HasString("skillName", ExpectedSkillNames[0])
                     .HasString("action", "skippedUnmanaged")));
         Assert.True(File.Exists(unmanagedPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsUninstall_WithDryRunLocalModification_ReturnsBlockedPlanWithoutDeleting ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "uninstall-dry-run-local-modification");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+        using var installJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(install.StdOut);
+        var targetRoot = installJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        var skillDirectory = Path.Combine(targetRoot, ExpectedSkillNames[0]);
+        await File.AppendAllTextAsync(Path.Combine(skillDirectory, "SKILL.md"), "\nInjected instruction.\n");
+
+        var result = await RunOpenAiUninstall(repoRoot, dryRun: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("dryRun", true)
+                .HasBoolean("force", false)
+                .HasInt32("deletedCount", ExpectedSkillNames.Length - 1)
+                .HasInt32("blockedCount", 1)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "blockedLocalModification")
+                    .HasString("blockedReason", "localModificationRequiresForce")
+                    .HasArrayLength("diffs", 0)));
+        Assert.True(Directory.Exists(skillDirectory));
     }
 
     [Fact]
@@ -638,9 +804,13 @@ public sealed class SkillsCliOutputContractTests
                     .HasString("code", InstallTargetUnmanagedCode)));
     }
 
-    private static Task<CommandExecutionResult> RunOpenAiInstall (string repoRoot)
+    private static Task<CommandExecutionResult> RunOpenAiInstall (
+        string repoRoot,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false)
     {
-        return RunInstall(repoRoot, "openai", targetDir: null);
+        return RunInstall(repoRoot, "openai", targetDir: null, dryRun, force, printDiff);
     }
 
     private static async Task RewriteInstalledSkillBodyAndManifestAsOlderAsync (
@@ -686,22 +856,32 @@ public sealed class SkillsCliOutputContractTests
         await File.WriteAllTextAsync(manifestPath, serializer.Serialize(manifest));
     }
 
-    private static Task<CommandExecutionResult> RunOpenAiUpdate (string repoRoot)
+    private static Task<CommandExecutionResult> RunOpenAiUpdate (
+        string repoRoot,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false)
     {
-        return RunScopedCommand(UcliCommandNames.UpdateSubcommand, repoRoot, "openai", "project", targetDir: null);
+        return RunScopedCommand(UcliCommandNames.UpdateSubcommand, repoRoot, "openai", "project", targetDir: null, dryRun, force, printDiff);
     }
 
-    private static Task<CommandExecutionResult> RunOpenAiUninstall (string repoRoot)
+    private static Task<CommandExecutionResult> RunOpenAiUninstall (
+        string repoRoot,
+        bool dryRun = false,
+        bool force = false)
     {
-        return RunScopedCommand(UcliCommandNames.UninstallSubcommand, repoRoot, "openai", "project", targetDir: null);
+        return RunScopedCommand(UcliCommandNames.UninstallSubcommand, repoRoot, "openai", "project", targetDir: null, dryRun, force, printDiff: false);
     }
 
     private static Task<CommandExecutionResult> RunInstall (
         string repoRoot,
         string host,
-        string? targetDir)
+        string? targetDir,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false)
     {
-        return RunScopedCommand(UcliCommandNames.InstallSubcommand, repoRoot, host, "project", targetDir);
+        return RunScopedCommand(UcliCommandNames.InstallSubcommand, repoRoot, host, "project", targetDir, dryRun, force, printDiff);
     }
 
     private static Task<CommandExecutionResult> RunScopedCommand (
@@ -709,7 +889,10 @@ public sealed class SkillsCliOutputContractTests
         string repoRoot,
         string? host,
         string? scope,
-        string? targetDir)
+        string? targetDir,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false)
     {
         var args = new List<string>
         {
@@ -737,6 +920,21 @@ public sealed class SkillsCliOutputContractTests
         {
             args.Add("--targetDir");
             args.Add(targetDir);
+        }
+
+        if (dryRun)
+        {
+            args.Add("--dryRun");
+        }
+
+        if (force)
+        {
+            args.Add("--force");
+        }
+
+        if (printDiff)
+        {
+            args.Add("--printDiff");
         }
 
         return CliProcessRunner.RunCommand(args.ToArray());

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -402,6 +402,49 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithForceAndPrintDiff_OverwritesLocalModification ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "install-force-local-modification");
+        var repoRoot = scope.CreateDirectory("repo");
+        var install = await RunOpenAiInstall(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, install.ExitCode);
+        using var installJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(install.StdOut);
+        var targetRoot = installJson.RootElement.GetProperty("payload").GetProperty("targetRoot").GetString()!;
+        var skillPath = Path.Combine(targetRoot, ExpectedSkillNames[0], "SKILL.md");
+        var localPath = Path.Combine(targetRoot, ExpectedSkillNames[0], "local.md");
+        await File.AppendAllTextAsync(skillPath, "\nInjected instruction.\n");
+        await File.WriteAllTextAsync(localPath, "# Local\n");
+
+        var result = await RunOpenAiInstall(repoRoot, force: true, printDiff: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasBoolean("force", true)
+                .HasBoolean("printDiff", true)
+                .HasInt32("updatedCount", 1)
+                .HasInt32("blockedCount", 0)
+                .HasProperty("actions", 0, static action => action
+                    .HasString("skillName", ExpectedSkillNames[0])
+                    .HasString("action", "updated")
+                    .IsNull("blockedReason")
+                    .HasArrayLength("diffs", 1)));
+        var action = FindAction(outputJson.RootElement, ExpectedSkillNames[0]);
+        var modified = FindDiffFile(action, "SKILL.md");
+        Assert.Equal("modified", modified.GetProperty("changeKind").GetString());
+        Assert.Contains("Injected instruction.", modified.GetProperty("beforeContent").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Injected instruction.", modified.GetProperty("afterContent").GetString(), StringComparison.Ordinal);
+        var deleted = FindDiffFile(action, "local.md");
+        Assert.Equal("deleted", deleted.GetProperty("changeKind").GetString());
+        Assert.Equal("# Local\n", deleted.GetProperty("beforeContent").GetString());
+        Assert.Equal(JsonValueKind.Null, deleted.GetProperty("afterContent").ValueKind);
+        Assert.DoesNotContain("Injected instruction.", await File.ReadAllTextAsync(skillPath), StringComparison.Ordinal);
+        Assert.False(File.Exists(localPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task SkillsUpdate_WithProjectScope_CreatesThenNoOps ()
     {
         using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "update-openai");
@@ -567,6 +610,11 @@ public sealed class SkillsCliOutputContractTests
                     .HasString("action", "updated")
                     .IsNull("blockedReason")
                     .HasArrayLength("diffs", 1)));
+        var action = FindAction(outputJson.RootElement, ExpectedSkillNames[0]);
+        var modified = FindDiffFile(action, "SKILL.md");
+        Assert.Equal("modified", modified.GetProperty("changeKind").GetString());
+        Assert.Contains("Injected instruction.", modified.GetProperty("beforeContent").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Injected instruction.", modified.GetProperty("afterContent").GetString(), StringComparison.Ordinal);
         Assert.DoesNotContain("Injected instruction.", await File.ReadAllTextAsync(skillPath), StringComparison.Ordinal);
     }
 
@@ -860,6 +908,26 @@ public sealed class SkillsCliOutputContractTests
             ContentDigest = new SkillDigestCalculator().ComputeDigest(digestInputs),
         };
         await File.WriteAllTextAsync(manifestPath, serializer.Serialize(manifest));
+    }
+
+    private static JsonElement FindAction (
+        JsonElement root,
+        string skillName)
+    {
+        return root.GetProperty("payload")
+            .GetProperty("actions")
+            .EnumerateArray()
+            .Single(action => string.Equals(action.GetProperty("skillName").GetString(), skillName, StringComparison.Ordinal));
+    }
+
+    private static JsonElement FindDiffFile (
+        JsonElement action,
+        string relativePath)
+    {
+        return action.GetProperty("diffs")[0]
+            .GetProperty("files")
+            .EnumerateArray()
+            .Single(file => string.Equals(file.GetProperty("relativePath").GetString(), relativePath, StringComparison.Ordinal));
     }
 
     private static Task<CommandExecutionResult> RunOpenAiUpdate (


### PR DESCRIPTION
## Summary
- Adds planning-first safety for `skills install/update/uninstall`, including `--dryRun`, `--force`, and install/update `--printDiff`.
- Blocks unsafe managed overwrites, unmanaged targets, host conflicts, and path escapes while allowing `--force` only for managed local modifications.
- Uses staged package writes and remover boundaries so failed operations do not leave partial installs.

## Scope
- `Ucli.Skills` Installation: target state analysis, action planning, structured diffs, atomic writer, and package remover.
- CLI skills commands: option wiring and JSON payload projection for counts, actions, blocked reasons, and diffs.
- Tests: service-level dry-run/force/unmanaged/atomic behavior and CLI output contract coverage.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh verify --include ...`; Roslyn workspace warning was emitted, exit code 0)
- Tests: PASS (`bash scripts/test-dotnet.sh`)
- Additional: PASS (`bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk is concentrated in SKILL install/update/uninstall write and delete paths.
- Rollback by reverting the two commits in this branch; official SKILL content and host adapters are unchanged.

## Checklist
- [x] CLI options and JSON payload contract updated
- [x] Managed/unmanaged/local modification safety rules covered
- [x] Atomic write and delete boundaries covered
- [x] PR verification passed

Closes #190