### PR TITLE
Unity daemon 起動と停止タイミングを安定化する

### DIFF
--- a/src/Ucli/Features/Daemon/Lifecycle/Process/DaemonProcessTerminationService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Process/DaemonProcessTerminationService.cs
@@ -10,7 +10,7 @@ namespace MackySoft.Ucli.Features.Daemon.Lifecycle.Process;
 /// <summary> Implements process termination checks and force-kill fallback by process identifier. </summary>
 internal sealed class DaemonProcessTerminationService : IDaemonProcessTerminationService
 {
-    private static readonly TimeSpan PassiveExitWaitTimeoutCap = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan PassiveExitWaitTimeoutCap = UnityProcessTerminationPolicy.GracefulThenKill.GraceTimeout;
 
     private readonly DaemonProcessIdentityAssessor daemonProcessIdentityAssessor;
 
@@ -80,8 +80,15 @@ internal sealed class DaemonProcessTerminationService : IDaemonProcessTerminatio
             }
 
             var deadline = ExecutionDeadline.Start(timeout);
-            // NOTE: Stop may have already sent a shutdown IPC request; give Unity a short chance to exit normally first.
-            var passiveExitWaitTimeout = GetPassiveExitWaitTimeout(timeout);
+            // NOTE: Stop may have already sent a shutdown IPC request; Unity needs a few seconds to
+            // complete its own shutdown path and remove Temp/UnityLockfile before SIGTERM is used.
+            if (!deadline.TryGetRemainingTimeout(out var remainingTimeout))
+            {
+                return DaemonSessionStoreOperationResult.Failure(ExecutionError.Timeout(
+                    $"Timed out while waiting for daemon process '{processId.Value}' to stop."));
+            }
+
+            var passiveExitWaitTimeout = GetPassiveExitWaitTimeout(remainingTimeout);
             if (passiveExitWaitTimeout > TimeSpan.Zero
                 && await WaitUntilExitedAsync(process, passiveExitWaitTimeout, cancellationToken).ConfigureAwait(false))
             {
@@ -128,19 +135,23 @@ internal sealed class DaemonProcessTerminationService : IDaemonProcessTerminatio
     }
 
     /// <summary> Calculates the passive wait budget used before sending a termination request. </summary>
-    /// <param name="timeout"> The total process-stop timeout. Must be greater than <see cref="TimeSpan.Zero" />. </param>
+    /// <param name="remainingTimeout"> The remaining process-stop timeout. Must be greater than <see cref="TimeSpan.Zero" />. </param>
     /// <returns> A bounded passive wait duration, or <see cref="TimeSpan.Zero" /> when the budget is too small. </returns>
-    private static TimeSpan GetPassiveExitWaitTimeout (TimeSpan timeout)
+    private static TimeSpan GetPassiveExitWaitTimeout (TimeSpan remainingTimeout)
     {
-        var totalMilliseconds = Math.Ceiling(timeout.TotalMilliseconds);
-        if (totalMilliseconds <= 2)
+        var totalMilliseconds = Math.Ceiling(remainingTimeout.TotalMilliseconds);
+        var fallbackPolicy = UnityProcessTerminationPolicy.GracefulThenKill;
+        var fallbackTimeout = fallbackPolicy.GraceTimeout + fallbackPolicy.ForceKillWaitTimeout;
+        var fallbackMilliseconds = Math.Ceiling(fallbackTimeout.TotalMilliseconds);
+        var passiveExitWaitBudgetMilliseconds = totalMilliseconds - fallbackMilliseconds;
+        if (passiveExitWaitBudgetMilliseconds <= 0)
         {
             return TimeSpan.Zero;
         }
 
         var passiveExitWaitMilliseconds = Math.Min(
             PassiveExitWaitTimeoutCap.TotalMilliseconds,
-            totalMilliseconds - 2);
+            passiveExitWaitBudgetMilliseconds);
         return TimeSpan.FromMilliseconds(passiveExitWaitMilliseconds);
     }
 

--- a/src/Ucli/Features/Daemon/Lifecycle/Process/DaemonStartupReadinessProbe.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Process/DaemonStartupReadinessProbe.cs
@@ -61,8 +61,9 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             cancellationToken.ThrowIfCancellationRequested();
             if (daemonProcessId is int processId && !ProcessLivenessProbe.IsAlive(processId))
             {
-                var startupFailureError = await TryClassifyStartupFailure(
+                var startupFailureError = await TryClassifyStartupFailureAsync(
                         unityProject,
+                        includeProjectLockFile: true,
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (startupFailureError is not null)
@@ -124,8 +125,12 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             }
             catch (Exception exception) when (DaemonProbeExceptionClassifier.IsNotRunning(exception))
             {
-                var startupFailureError = await TryClassifyStartupFailure(
+                // NOTE:
+                // A Unity process launched by uCLI creates Temp/UnityLockfile before its IPC server
+                // is ready. Treat that lock as external only when no launched process id is known.
+                var startupFailureError = await TryClassifyStartupFailureAsync(
                         unityProject,
+                        includeProjectLockFile: daemonProcessId is null,
                         cancellationToken)
                     .ConfigureAwait(false);
                 if (startupFailureError is not null)
@@ -223,14 +228,18 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.DomainReloading, StringComparison.Ordinal);
     }
 
-    private async ValueTask<ExecutionError?> TryClassifyStartupFailure (
+    private async ValueTask<ExecutionError?> TryClassifyStartupFailureAsync (
         ResolvedUnityProjectContext unityProject,
+        bool includeProjectLockFile,
         CancellationToken cancellationToken)
     {
-        var projectAlreadyOpenError = TryCreateProjectAlreadyOpenErrorFromUnityLock(unityProject.UnityProjectRoot);
-        if (projectAlreadyOpenError != null)
+        if (includeProjectLockFile)
         {
-            return projectAlreadyOpenError;
+            var projectAlreadyOpenError = TryCreateProjectAlreadyOpenErrorFromUnityLock(unityProject.UnityProjectRoot);
+            if (projectAlreadyOpenError != null)
+            {
+                return projectAlreadyOpenError;
+            }
         }
 
         var logReadResult = await unityLogReader.ReadTail(

--- a/src/Ucli/Features/Daemon/Supervisor/Bootstrap/SupervisorBootstrapper.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Bootstrap/SupervisorBootstrapper.cs
@@ -13,8 +13,6 @@ internal sealed class SupervisorBootstrapper
 {
     private const int MaxLaunchAttempts = 2;
 
-    private const int ManifestPublicationGraceProbeCount = 2;
-
     private const string LaunchFailureMessage =
         "Supervisor launch did not publish a reachable manifest before startup completed.";
 
@@ -107,13 +105,20 @@ internal sealed class SupervisorBootstrapper
 
         await using var acquiredLock = lockHandle;
         var launchAttemptCount = 0;
-        var manifestMissCountAfterLaunch = 0;
+        long? latestLaunchTimestamp = null;
 
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var manifestProbe = await ProbeManifestAvailability(normalizedStorageRoot, deadline, cancellationToken).ConfigureAwait(false);
+            var isWithinLaunchGrace = latestLaunchTimestamp is long launchTimestamp
+                && IsWithinManifestPublicationGrace(launchTimestamp);
+            var manifestProbe = await ProbeManifestAvailabilityAsync(
+                    normalizedStorageRoot,
+                    deadline,
+                    isWithinLaunchGrace,
+                    cancellationToken)
+                .ConfigureAwait(false);
             if (manifestProbe.ReadyManifest != null)
             {
                 return SupervisorBootstrapResult.Success(manifestProbe.ReadyManifest);
@@ -126,74 +131,73 @@ internal sealed class SupervisorBootstrapper
 
             if (manifestProbe.ShouldLaunchSupervisor)
             {
-                var shouldDelayBeforeRelaunch = false;
-                if (launchAttemptCount > 0)
+                // NOTE:
+                // launchd/systemd/dotnet startup can take several seconds before the supervisor
+                // writes manifest.json. During that window, relaunching or deleting the socket can
+                // destroy a healthy startup path before it becomes observable to the bootstrapper.
+                if (launchAttemptCount > 0 && isWithinLaunchGrace)
                 {
-                    manifestMissCountAfterLaunch++;
-                    if (manifestMissCountAfterLaunch < ManifestPublicationGraceProbeCount)
-                    {
-                        shouldDelayBeforeRelaunch = true;
-                    }
-                    else if (launchAttemptCount >= MaxLaunchAttempts)
-                    {
-                        return SupervisorBootstrapResult.Failure(ExecutionError.InternalError(
-                            $"{LaunchFailureMessage} Attempts={launchAttemptCount}."));
-                    }
-                }
-
-                if (!shouldDelayBeforeRelaunch)
-                {
-                    if (!deadline.TryGetRemainingTimeout(out var launchTimeout))
+                    if (!await TryDelayBeforeNextProbeAsync(deadline, cancellationToken).ConfigureAwait(false))
                     {
                         return SupervisorBootstrapResult.Failure(ExecutionError.Timeout(
-                            "Timed out before supervisor launch could begin."));
+                            $"Timed out while waiting for supervisor bootstrap. Timeout={timeout.TotalMilliseconds:0}ms."));
                     }
 
-                    ExecutionError? launchError;
-                    using var launchCancellationScope = TimeProviderCancellationScope.CreateLinked(
-                        cancellationToken,
-                        launchTimeout,
-                        timeProvider);
-                    try
-                    {
-                        launchError = await processLauncher.Launch(
-                                normalizedStorageRoot,
-                                launchCancellationScope.Token)
-                            .ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested
-                                                              && launchCancellationScope.HasTimedOut)
-                    {
-                        return SupervisorBootstrapResult.Failure(ExecutionError.Timeout(
-                            $"Timed out while launching supervisor. Timeout={launchTimeout.TotalMilliseconds:0}ms."));
-                    }
-
-                    if (launchError != null)
-                    {
-                        return SupervisorBootstrapResult.Failure(launchError);
-                    }
-
-                    launchAttemptCount++;
-                    manifestMissCountAfterLaunch = 0;
+                    continue;
                 }
+
+                if (launchAttemptCount >= MaxLaunchAttempts)
+                {
+                    return SupervisorBootstrapResult.Failure(ExecutionError.InternalError(
+                        $"{LaunchFailureMessage} Attempts={launchAttemptCount}."));
+                }
+
+                if (!deadline.TryGetRemainingTimeout(out var launchTimeout))
+                {
+                    return SupervisorBootstrapResult.Failure(ExecutionError.Timeout(
+                        "Timed out before supervisor launch could begin."));
+                }
+
+                ExecutionError? launchError;
+                using var launchCancellationScope = TimeProviderCancellationScope.CreateLinked(
+                    cancellationToken,
+                    launchTimeout,
+                    timeProvider);
+                try
+                {
+                    launchError = await processLauncher.Launch(
+                            normalizedStorageRoot,
+                            launchCancellationScope.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested
+                                                          && launchCancellationScope.HasTimedOut)
+                {
+                    return SupervisorBootstrapResult.Failure(ExecutionError.Timeout(
+                        $"Timed out while launching supervisor. Timeout={launchTimeout.TotalMilliseconds:0}ms."));
+                }
+
+                if (launchError != null)
+                {
+                    return SupervisorBootstrapResult.Failure(launchError);
+                }
+
+                launchAttemptCount++;
+                latestLaunchTimestamp = timeProvider.GetTimestamp();
             }
-            else
-            {
-                manifestMissCountAfterLaunch = 0;
-            }
-            if (!deadline.TryGetRemainingTimeout(out _))
+
+            if (!await TryDelayBeforeNextProbeAsync(deadline, cancellationToken).ConfigureAwait(false))
             {
                 return SupervisorBootstrapResult.Failure(ExecutionError.Timeout(
                     $"Timed out while waiting for supervisor bootstrap. Timeout={timeout.TotalMilliseconds:0}ms."));
             }
-
-            await TimeProviderDelay.Delay(SupervisorConstants.BootstrapPollDelay, timeProvider, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private async ValueTask<ManifestAvailabilityProbe> ProbeManifestAvailability (
+    private async ValueTask<ManifestAvailabilityProbe> ProbeManifestAvailabilityAsync (
         string storageRoot,
         ExecutionDeadline deadline,
+        bool preserveUnreachableManifest,
         CancellationToken cancellationToken)
     {
         if (!deadline.TryGetRemainingTimeout(out var manifestReadTimeout))
@@ -217,7 +221,7 @@ internal sealed class SupervisorBootstrapper
         }
         catch (Exception exception) when (exception is JsonException or InvalidDataException)
         {
-            await CleanupStaleRuntimeState(storageRoot, manifest: null).ConfigureAwait(false);
+            await CleanupStaleRuntimeStateAsync(storageRoot).ConfigureAwait(false);
             return ManifestAvailabilityProbe.ShouldLaunch();
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
@@ -256,13 +260,16 @@ internal sealed class SupervisorBootstrapper
             return ManifestAvailabilityProbe.Pending();
         }
 
-        await CleanupStaleRuntimeState(storageRoot, manifest).ConfigureAwait(false);
+        if (preserveUnreachableManifest)
+        {
+            return ManifestAvailabilityProbe.Pending();
+        }
+
+        await CleanupStaleRuntimeStateAsync(storageRoot).ConfigureAwait(false);
         return ManifestAvailabilityProbe.ShouldLaunch();
     }
 
-    private async ValueTask CleanupStaleRuntimeState (
-        string storageRoot,
-        SupervisorInstanceManifest? manifest)
+    private async ValueTask CleanupStaleRuntimeStateAsync (string storageRoot)
     {
         try
         {
@@ -276,9 +283,10 @@ internal sealed class SupervisorBootstrapper
 
         try
         {
-            var endpoint = manifest != null && IpcTransportKindCodec.TryParse(manifest.EndpointTransportKind, out var transportKind)
-                ? new IpcEndpoint(transportKind, manifest.EndpointAddress)
-                : endpointResolver.Resolve(storageRoot);
+            // NOTE:
+            // The manifest may be stale or corrupted. Cleanup only deletes the deterministic
+            // endpoint owned by the current storage root, never a path read from manifest JSON.
+            var endpoint = endpointResolver.Resolve(storageRoot);
             if (endpoint.TransportKind == IpcTransportKind.UnixDomainSocket)
             {
                 FileUtilities.DeleteIfExists(endpoint.Address);
@@ -296,6 +304,32 @@ internal sealed class SupervisorBootstrapper
         }
 
         await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    private bool IsWithinManifestPublicationGrace (long launchTimestamp)
+    {
+        return timeProvider.GetElapsedTime(launchTimestamp) < SupervisorConstants.ManifestPublicationTimeout;
+    }
+
+    private async ValueTask<bool> TryDelayBeforeNextProbeAsync (
+        ExecutionDeadline deadline,
+        CancellationToken cancellationToken)
+    {
+        if (!deadline.TryGetRemainingTimeout(out var remainingTimeout))
+        {
+            return false;
+        }
+
+        var delay = remainingTimeout < SupervisorConstants.BootstrapPollDelay
+            ? remainingTimeout
+            : SupervisorConstants.BootstrapPollDelay;
+        if (delay <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        await TimeProviderDelay.Delay(delay, timeProvider, cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     private readonly record struct ManifestAvailabilityProbe (

--- a/src/Ucli/Features/Daemon/Supervisor/Transport/SupervisorConstants.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Transport/SupervisorConstants.cs
@@ -15,6 +15,9 @@ internal static class SupervisorConstants
     /// <summary> Gets the retry delay used while waiting for bootstrap completion. </summary>
     public static readonly TimeSpan BootstrapPollDelay = TimeSpan.FromMilliseconds(100);
 
+    /// <summary> Gets the grace period allowed for a launched supervisor to publish a reachable manifest. </summary>
+    public static readonly TimeSpan ManifestPublicationTimeout = TimeSpan.FromSeconds(15);
+
     /// <summary> Gets the idle delay after which an unused supervisor exits. </summary>
     public static readonly TimeSpan IdleShutdownDelay = TimeSpan.FromSeconds(10);
 

--- a/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 using MackySoft.Ucli.Application.Shared.Execution.Lifecycle;
@@ -10,6 +11,7 @@ using MackySoft.Ucli.Infrastructure.Storage;
 using MackySoft.Ucli.Shared.Unity.Process;
 using MackySoft.Ucli.Shared.Unity.ProjectLock;
 using MackySoft.Ucli.UnityIntegration.Ipc.Dispatch;
+using MackySoft.Ucli.UnityIntegration.Ipc.Execution;
 using MackySoft.Ucli.UnityIntegration.Ipc.Failures;
 using MackySoft.Ucli.UnityIntegration.Ipc.Process;
 using MackySoft.Ucli.UnityIntegration.Ipc.Transport;
@@ -129,6 +131,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
                 var startupProbeError = await WaitUntilReachableAsync(
                         unityProject,
                         sessionToken,
+                        ResolveStartupProbeFailFast(dispatchRequest),
                         deadline,
                         processHandle,
                         timeout,
@@ -214,6 +217,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
     /// <summary> Waits until the launched oneshot Unity process accepts the startup probe request. </summary>
     /// <param name="unityProject"> The resolved Unity project context. </param>
     /// <param name="sessionToken"> The session token assigned to the launched oneshot process. Must not be null or white-space. </param>
+    /// <param name="failFast"> Whether readiness probing should fail immediately instead of waiting for lifecycle readiness. </param>
     /// <param name="deadline"> The shared request deadline. </param>
     /// <param name="processHandle"> The launched process handle. </param>
     /// <param name="timeout"> The original request timeout used for diagnostics. Must be greater than <see cref="TimeSpan.Zero" />. </param>
@@ -222,6 +226,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
     private async ValueTask<ExecutionError?> WaitUntilReachableAsync (
         ResolvedUnityProjectContext unityProject,
         string sessionToken,
+        bool failFast,
         ExecutionDeadline deadline,
         IUnityBatchmodeProcessHandle processHandle,
         TimeSpan timeout,
@@ -270,8 +275,26 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
                         $"Unity oneshot startup probe returned an invalid response. {error!.Message}");
                 }
 
-                _ = payload!;
-                return null;
+                var readinessDecision = UnityDaemonReadinessPolicy.Evaluate(payload!, failFast);
+                if (readinessDecision.IsReady)
+                {
+                    return null;
+                }
+
+                if (readinessDecision.IsFailure)
+                {
+                    return ExecutionError.InternalError(
+                        readinessDecision.ErrorMessage!,
+                        readinessDecision.ErrorCode);
+                }
+
+                if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
+                {
+                    return ExecutionError.Timeout(
+                        $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.");
+                }
+
+                await Task.Delay(GetRetryDelay(remainingTimeout), cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -279,6 +302,12 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
             }
             catch (Exception exception) when (IsStartupRetryable(exception))
             {
+                if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
+                {
+                    return ExecutionError.Timeout(
+                        $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.");
+                }
+
                 await Task.Delay(GetRetryDelay(remainingTimeout), cancellationToken).ConfigureAwait(false);
             }
         }
@@ -342,7 +371,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
     private static bool IsStartupRetryable (Exception exception)
     {
         ArgumentNullException.ThrowIfNull(exception);
-        return exception is IpcConnectTimeoutException or System.Net.Sockets.SocketException;
+        return exception is TimeoutException or System.Net.Sockets.SocketException;
     }
 
     /// <summary> Calculates one startup retry delay bounded by the remaining timeout. </summary>
@@ -356,6 +385,37 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
         }
 
         return StartupRetryDelay;
+    }
+
+    /// <summary> Resolves whether the dispatch payload requests fail-fast readiness behavior. </summary>
+    /// <param name="dispatchRequest"> The dispatch request to inspect. Must not be <see langword="null" />. </param>
+    /// <returns> <see langword="true" /> when a known request payload requests fail-fast readiness; otherwise <see langword="false" />. </returns>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="dispatchRequest" /> is <see langword="null" />. </exception>
+    private static bool ResolveStartupProbeFailFast (UnityIpcDispatchRequest dispatchRequest)
+    {
+        ArgumentNullException.ThrowIfNull(dispatchRequest);
+
+        return dispatchRequest.Method switch
+        {
+            IpcMethodNames.Execute => TryReadFailFast<IpcExecuteRequest>(dispatchRequest.Payload, static request => request.FailFast),
+            IpcMethodNames.TestRun => TryReadFailFast<IpcTestRunRequest>(dispatchRequest.Payload, static request => request.FailFast),
+            IpcMethodNames.OpsRead => TryReadFailFast<IpcOpsReadRequest>(
+                dispatchRequest.Payload,
+                static request => request.RequireReadinessGate && request.FailFast),
+            IpcMethodNames.IndexAssetsRead => TryReadFailFast<IpcIndexAssetsReadRequest>(dispatchRequest.Payload, static request => request.FailFast),
+            IpcMethodNames.IndexSceneTreeLiteRead => TryReadFailFast<IpcIndexSceneTreeLiteReadRequest>(dispatchRequest.Payload, static request => request.FailFast),
+            _ => false,
+        };
+    }
+
+    private static bool TryReadFailFast<TRequest> (
+        JsonElement payload,
+        Func<TRequest, bool> selector)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        return IpcPayloadCodec.TryDeserialize(payload, out TRequest request, out _)
+            && selector(request);
     }
 
     /// <summary> Creates one opaque session token for correlating the launched oneshot Unity process. </summary>

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/DaemonProcessTerminationServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/DaemonProcessTerminationServiceTests.cs
@@ -92,7 +92,7 @@ public sealed class DaemonProcessTerminationServiceTests
             var result = await service.EnsureStopped(
                 process.Id,
                 DateTimeOffset.UtcNow,
-                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(10),
                 CancellationToken.None);
 
             Assert.True(result.IsSuccess);
@@ -109,7 +109,7 @@ public sealed class DaemonProcessTerminationServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task EnsureStopped_WhenMatchingProcessExitsDuringPassiveWait_DoesNotRequestGracefulTermination ()
+    public async Task EnsureStopped_WhenExtraTimeoutBudgetAndMatchingProcessExitsDuringPassiveWait_DoesNotRequestGracefulTermination ()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -139,7 +139,101 @@ public sealed class DaemonProcessTerminationServiceTests
             var result = await service.EnsureStopped(
                 process.Id,
                 DateTimeOffset.UtcNow,
+                TimeSpan.FromSeconds(15),
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.False(File.Exists(markerPath));
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task EnsureStopped_WhenDefaultTimeoutAndMatchingProcessExitsAfterOneSecond_RequestsGracefulTermination ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-process-termination", "delayed-passive-exit");
+        var readyPath = scope.GetPath("ready-marker");
+        var markerPath = scope.GetPath("term-marker");
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            ArgumentList =
+            {
+                "-c",
+                $"trap 'printf term > {ShellSingleQuote(markerPath)}; exit 0' TERM; printf ready > {ShellSingleQuote(readyPath)}; sleep 1; exit 0",
+            },
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        }) ?? throw new InvalidOperationException("Test process could not be started.");
+        var service = CreateService();
+
+        try
+        {
+            await WaitForFileExistsAsync(readyPath, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+            var result = await service.EnsureStopped(
+                process.Id,
+                DateTimeOffset.UtcNow,
                 TimeSpan.FromSeconds(10),
+                CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.True(File.Exists(markerPath));
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task EnsureStopped_WhenExtraTimeoutBudgetAndMatchingProcessExitsAfterOneSecond_DoesNotRequestGracefulTermination ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-process-termination", "extra-budget-passive-exit");
+        var readyPath = scope.GetPath("ready-marker");
+        var markerPath = scope.GetPath("term-marker");
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            ArgumentList =
+            {
+                "-c",
+                $"trap 'printf term > {ShellSingleQuote(markerPath)}; exit 0' TERM; printf ready > {ShellSingleQuote(readyPath)}; sleep 1; exit 0",
+            },
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        }) ?? throw new InvalidOperationException("Test process could not be started.");
+        var service = CreateService();
+
+        try
+        {
+            await WaitForFileExistsAsync(readyPath, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+            var result = await service.EnsureStopped(
+                process.Id,
+                DateTimeOffset.UtcNow,
+                TimeSpan.FromSeconds(15),
                 CancellationToken.None);
 
             Assert.True(result.IsSuccess);

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/DaemonStartupReadinessProbeTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/DaemonStartupReadinessProbeTests.cs
@@ -212,6 +212,43 @@ public sealed class DaemonStartupReadinessProbeTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task WaitUntilReady_WhenLaunchedProcessIsAliveAndProjectLockFileExists_RetriesUntilReady ()
+    {
+        var attempt = 0;
+        var pingClient = new StubDaemonPingInfoClient(() =>
+        {
+            attempt++;
+            return attempt == 1
+                ? ValueTask.FromException<IpcPingResponse>(new SocketException((int)SocketError.ConnectionRefused))
+                : ValueTask.FromResult(CreatePingPayload(canAcceptExecutionRequests: true));
+        });
+        var logReader = new StubUnityLogReader
+        {
+            NextResult = UnityLogReadResult.Success(
+                "daemon bootstrap in progress\n",
+                truncated: false,
+                path: "/tmp/unity.log",
+                sizeBytes: 32),
+        };
+        var probe = CreateProbe(
+            pingClient,
+            logReader,
+            UnityProjectLockFileProbeResult.Locked("/tmp/unity-project/Temp/UnityLockfile"));
+
+        var result = await probe.WaitUntilReady(
+            CreateContext("fingerprint-readiness-lock-during-startup"),
+            TimeSpan.FromSeconds(5),
+            daemonProcessId: Environment.ProcessId,
+            cancellationToken: CancellationToken.None);
+
+        Assert.True(result.IsReady);
+        Assert.Null(result.Error);
+        Assert.Equal(2, pingClient.CallCount);
+        Assert.Equal(1, logReader.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task WaitUntilReady_WhenProjectLockFileExistsAfterDaemonIsNotRunning_ReturnsProjectAlreadyOpenImmediately ()
     {
         var pingClient = new StubDaemonPingInfoClient(() => ValueTask.FromException<IpcPingResponse>(new SocketException((int)SocketError.ConnectionRefused)));
@@ -303,6 +340,39 @@ public sealed class DaemonStartupReadinessProbeTests
         Assert.Contains($"ProcessId={int.MaxValue}", error.Message, StringComparison.Ordinal);
         Assert.Equal(0, pingClient.CallCount);
         Assert.Equal(1, logReader.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WaitUntilReady_WhenDaemonProcessExitedAndProjectLockFileExists_ReturnsProjectAlreadyOpenImmediately ()
+    {
+        var pingClient = new StubDaemonPingInfoClient(static () => ValueTask.FromResult(CreatePingPayload(canAcceptExecutionRequests: true)));
+        var logReader = new StubUnityLogReader
+        {
+            NextResult = UnityLogReadResult.Success(
+                "daemon bootstrap in progress\n",
+                truncated: false,
+                path: "/tmp/unity.log",
+                sizeBytes: 32),
+        };
+        var probe = CreateProbe(
+            pingClient,
+            logReader,
+            UnityProjectLockFileProbeResult.Locked("/tmp/unity-project/Temp/UnityLockfile"));
+
+        var result = await probe.WaitUntilReady(
+            CreateContext("fingerprint-readiness-exited-lock-file"),
+            TimeSpan.FromSeconds(5),
+            daemonProcessId: int.MaxValue,
+            cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsReady);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(UnityProcessErrorCodes.UnityProjectAlreadyOpen, error.Code);
+        Assert.Contains("already open", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, pingClient.CallCount);
+        Assert.Equal(0, logReader.CallCount);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Bootstrap/SupervisorBootstrapperTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Bootstrap/SupervisorBootstrapperTests.cs
@@ -1,6 +1,8 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Ipc;
 
 namespace MackySoft.Ucli.Tests.Supervisor;
 
@@ -133,9 +135,75 @@ public sealed class SupervisorBootstrapperTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task EnsureReady_WhenManifestAppearsDuringLaunchGrace_DoesNotRelaunch ()
+    {
+        using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "delayed-manifest");
+        var timeProvider = new ManualTimeProvider();
+        var launchCount = 0;
+        var manifest = new SupervisorInstanceManifest(
+            ProcessId: 2468,
+            SessionToken: "supervisor-session-token",
+            EndpointTransportKind: "unixDomainSocket",
+            EndpointAddress: "/tmp/ucli-supervisor-test.sock",
+            IssuedAtUtc: new DateTimeOffset(2026, 03, 12, 0, 0, 0, TimeSpan.Zero));
+        var manifestStore = new SupervisorManifestStore(
+            readAllTextOrNull: (path, cancellationToken) => ValueTask.FromResult<string?>(
+                timeProvider.GetUtcNow() >= DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(3)
+                    ? JsonSerializer.Serialize(manifest)
+                    : null),
+            writeAllTextAtomically: static (_, _, _) => ValueTask.CompletedTask,
+            deleteIfExists: static _ => { },
+            timeProvider: timeProvider);
+        var transportClient = new MackySoft.Ucli.Tests.Daemon.DaemonServiceTestContext.StubIpcTransportClient
+        {
+            SendHandler = (endpoint, request, _, _) => ValueTask.FromResult(
+                MackySoft.Ucli.Tests.Daemon.DaemonServiceTestContext.CreateSuccessResponse(
+                    request,
+                    new SupervisorIpcContracts.PingResponse(manifest.ProcessId, manifest.IssuedAtUtc))),
+        };
+        var launcher = new StubSupervisorProcessLauncher
+        {
+            LaunchHandler = _ =>
+            {
+                launchCount++;
+                return ValueTask.FromResult<ExecutionError?>(null);
+            },
+        };
+        var bootstrapper = new SupervisorBootstrapper(
+            manifestStore,
+            new SupervisorClient(transportClient),
+            launcher,
+            new SupervisorBootstrapLockProvider(),
+            new SupervisorEndpointResolver(),
+            timeProvider);
+
+        var resultTask = bootstrapper.EnsureReady(
+                scope.FullPath,
+                TimeSpan.FromSeconds(30),
+                CancellationToken.None)
+            .AsTask();
+        for (var i = 0; i < 40 && !resultTask.IsCompleted; i++)
+        {
+            await WaitForActiveTimerAsync(timeProvider, resultTask, SignalWaitTimeout, CancellationToken.None);
+            if (!resultTask.IsCompleted)
+            {
+                timeProvider.Advance(SupervisorConstants.BootstrapPollDelay);
+            }
+        }
+
+        var result = await TestAwaiter.WaitAsync(resultTask, "Supervisor delayed manifest result", SignalWaitTimeout);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Manifest);
+        Assert.Equal(1, launchCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task EnsureReady_WhenInitialLaunchDoesNotPublishManifest_RelaunchesAndSucceeds ()
     {
         using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "relaunch-success");
+        var timeProvider = new ManualTimeProvider();
         var launchCount = 0;
         var manifest = new SupervisorInstanceManifest(
             ProcessId: 2468,
@@ -168,12 +236,27 @@ public sealed class SupervisorBootstrapperTests
             new SupervisorClient(transportClient),
             launcher,
             new SupervisorBootstrapLockProvider(),
-            new SupervisorEndpointResolver());
+            new SupervisorEndpointResolver(),
+            timeProvider);
 
-        var result = await bootstrapper.EnsureReady(
-            scope.FullPath,
-            TimeSpan.FromSeconds(2),
-            CancellationToken.None);
+        var resultTask = bootstrapper.EnsureReady(
+                scope.FullPath,
+                TimeSpan.FromSeconds(60),
+                CancellationToken.None)
+            .AsTask();
+        for (var i = 0; i < 10 && !resultTask.IsCompleted; i++)
+        {
+            await WaitForActiveTimerAsync(timeProvider, resultTask, SignalWaitTimeout, CancellationToken.None);
+            if (!resultTask.IsCompleted)
+            {
+                timeProvider.Advance(
+                    launchCount < 2
+                        ? SupervisorConstants.ManifestPublicationTimeout
+                        : SupervisorConstants.BootstrapPollDelay);
+            }
+        }
+
+        var result = await TestAwaiter.WaitAsync(resultTask, "Supervisor relaunch success result", SignalWaitTimeout);
 
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Manifest);
@@ -182,7 +265,7 @@ public sealed class SupervisorBootstrapperTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task EnsureReady_WhenLaunchNeverPublishesManifest_ReturnsInternalErrorBeforeTimeout ()
+    public async Task EnsureReady_WhenLaunchNeverPublishesManifest_ReturnsInternalErrorAfterLaunchGrace ()
     {
         using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "launch-no-manifest");
         var timeProvider = new ManualTimeProvider();
@@ -213,18 +296,16 @@ public sealed class SupervisorBootstrapperTests
 
         var resultTask = bootstrapper.EnsureReady(
                 scope.FullPath,
-                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(60),
                 CancellationToken.None)
             .AsTask();
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < 10 && !resultTask.IsCompleted; i++)
         {
             await WaitForActiveTimerAsync(timeProvider, resultTask, SignalWaitTimeout, CancellationToken.None);
-            if (resultTask.IsCompleted)
+            if (!resultTask.IsCompleted)
             {
-                break;
+                timeProvider.Advance(SupervisorConstants.ManifestPublicationTimeout);
             }
-
-            timeProvider.Advance(SupervisorConstants.BootstrapPollDelay);
         }
 
         var result = await TestAwaiter.WaitAsync(resultTask, "Supervisor manifest publication failure result", SignalWaitTimeout);
@@ -234,6 +315,105 @@ public sealed class SupervisorBootstrapperTests
         Assert.Equal(ExecutionErrorKind.InternalError, result.Error.Kind);
         Assert.Contains("did not publish a reachable manifest", result.Error.Message, StringComparison.Ordinal);
         Assert.Equal(2, launchCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task EnsureReady_WhenLaunchPollDelayWouldExceedDeadline_ReturnsTimeoutAtDeadline ()
+    {
+        using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "launch-poll-deadline");
+        var timeProvider = new ManualTimeProvider();
+        var transportClient = new MackySoft.Ucli.Tests.Daemon.DaemonServiceTestContext.StubIpcTransportClient
+        {
+            SendHandler = static (_, _, _, _) => throw new InvalidOperationException("Supervisor transport should not be called without a manifest."),
+        };
+        var launcher = new StubSupervisorProcessLauncher
+        {
+            LaunchHandler = static _ => ValueTask.FromResult<ExecutionError?>(null),
+        };
+        var bootstrapper = new SupervisorBootstrapper(
+            new SupervisorManifestStore(),
+            new SupervisorClient(transportClient),
+            launcher,
+            new SupervisorBootstrapLockProvider(),
+            new SupervisorEndpointResolver(),
+            timeProvider);
+
+        var resultTask = bootstrapper.EnsureReady(
+                scope.FullPath,
+                TimeSpan.FromMilliseconds(50),
+                CancellationToken.None)
+            .AsTask();
+        await WaitForActiveTimerAsync(timeProvider, resultTask, SignalWaitTimeout, CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+
+        var result = await TestAwaiter.WaitAsync(resultTask, "Supervisor poll deadline result", SignalWaitTimeout);
+
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.Error);
+        Assert.Equal(ExecutionErrorKind.Timeout, result.Error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task EnsureReady_WhenManifestIsUnreachable_DeletesOnlyResolvedSupervisorEndpoint ()
+    {
+        using var scope = TestDirectories.CreateTempScope("supervisor-bootstrapper", "stale-manifest-cleanup");
+        var endpointResolver = new SupervisorEndpointResolver();
+        var resolvedEndpoint = endpointResolver.Resolve(scope.FullPath);
+        if (resolvedEndpoint.TransportKind == IpcTransportKind.UnixDomainSocket)
+        {
+            var resolvedEndpointDirectoryPath = Path.GetDirectoryName(resolvedEndpoint.Address);
+            if (!string.IsNullOrWhiteSpace(resolvedEndpointDirectoryPath))
+            {
+                Directory.CreateDirectory(resolvedEndpointDirectoryPath);
+            }
+
+            File.WriteAllText(resolvedEndpoint.Address, "stale supervisor socket placeholder");
+        }
+
+        var manifestDeleted = false;
+        var maliciousPath = scope.GetPath("do-not-delete.txt");
+        File.WriteAllText(maliciousPath, "must remain");
+        var manifest = new SupervisorInstanceManifest(
+            ProcessId: 2468,
+            SessionToken: "supervisor-session-token",
+            EndpointTransportKind: IpcTransportKindValues.UnixDomainSocket,
+            EndpointAddress: maliciousPath,
+            IssuedAtUtc: new DateTimeOffset(2026, 03, 12, 0, 0, 0, TimeSpan.Zero));
+        var manifestStore = new SupervisorManifestStore(
+            readAllTextOrNull: (_, _) => ValueTask.FromResult<string?>(
+                manifestDeleted ? null : JsonSerializer.Serialize(manifest)),
+            writeAllTextAtomically: static (_, _, _) => ValueTask.CompletedTask,
+            deleteIfExists: _ => manifestDeleted = true);
+        var transportClient = new MackySoft.Ucli.Tests.Daemon.DaemonServiceTestContext.StubIpcTransportClient
+        {
+            SendHandler = static (_, _, _, _) => throw new SocketException((int)SocketError.ConnectionRefused),
+        };
+        var launcher = new StubSupervisorProcessLauncher
+        {
+            LaunchHandler = static _ => ValueTask.FromResult<ExecutionError?>(
+                ExecutionError.InternalError("stop after cleanup")),
+        };
+        var bootstrapper = new SupervisorBootstrapper(
+            manifestStore,
+            new SupervisorClient(transportClient),
+            launcher,
+            new SupervisorBootstrapLockProvider(),
+            endpointResolver);
+
+        var result = await bootstrapper.EnsureReady(
+            scope.FullPath,
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(manifestDeleted);
+        Assert.True(File.Exists(maliciousPath));
+        if (resolvedEndpoint.TransportKind == IpcTransportKind.UnixDomainSocket)
+        {
+            Assert.False(File.Exists(resolvedEndpoint.Address));
+        }
     }
 
     private static async Task WaitForActiveTimerAsync (

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
@@ -70,11 +70,13 @@ public sealed class UnityOneshotIpcClientTests
         Assert.Equal(0, processHandle.TerminateCallCount);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Small")]
-    public async Task SendAsync_WhenStartupPingReportsStarting_SendsRequestAfterFirstSuccessfulPing ()
+    [InlineData(IpcEditorLifecycleStateCodec.Starting)]
+    public async Task SendAsync_WhenStartupPingReportsWaitableState_RetriesUntilReadyBeforeSendingRequest (
+        string lifecycleState)
     {
-        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "startup-retry");
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", $"startup-retry-{lifecycleState}");
         var unityProject = CreateUnityProject(scope);
         var endpoint = new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock");
         var processHandle = new StubUnityBatchmodeProcessHandle();
@@ -86,7 +88,7 @@ public sealed class UnityOneshotIpcClientTests
             {
                 IpcMethodNames.Ping => CreatePingResponse(
                     request.RequestId,
-                    lifecycleState: ++pingAttempt == 1 ? IpcEditorLifecycleStateCodec.Starting : IpcEditorLifecycleStateCodec.Ready,
+                    lifecycleState: ++pingAttempt == 1 ? lifecycleState : IpcEditorLifecycleStateCodec.Ready,
                     canAcceptExecutionRequests: pingAttempt != 1),
                 IpcMethodNames.OpsRead => CreateSuccessResponse(request.RequestId),
                 _ => throw new Xunit.Sdk.XunitException($"Unexpected method: {request.Method}"),
@@ -106,9 +108,88 @@ public sealed class UnityOneshotIpcClientTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.Equal(2, transportClient.CallCount);
+        Assert.Equal(3, transportClient.CallCount);
         Assert.Equal(IpcMethodNames.Ping, transportClient.Requests[0].Method);
-        Assert.Equal(IpcMethodNames.OpsRead, transportClient.Requests[1].Method);
+        Assert.Equal(IpcMethodNames.Ping, transportClient.Requests[1].Method);
+        Assert.Equal(IpcMethodNames.OpsRead, transportClient.Requests[2].Method);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenStartupPingReportsWaitableStateAndRequestIsFailFast_ReturnsLifecycleFailureWithoutDispatch ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "startup-fail-fast");
+        var unityProject = CreateUnityProject(scope);
+        var endpoint = new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock");
+        var processHandle = new StubUnityBatchmodeProcessHandle();
+        var launcher = new StubUnityBatchmodeProcessLauncher(UnityBatchmodeProcessLaunchResult.Success(processHandle));
+        var transportClient = new StubUnityIpcTransportClient(request =>
+        {
+            return request.Method switch
+            {
+                IpcMethodNames.Ping => CreatePingResponse(
+                    request.RequestId,
+                    lifecycleState: IpcEditorLifecycleStateCodec.Starting,
+                    canAcceptExecutionRequests: false),
+                _ => throw new Xunit.Sdk.XunitException($"Unexpected method: {request.Method}"),
+            };
+        });
+        var client = new UnityOneshotIpcClient(
+            launcher,
+            new StubIpcEndpointResolver(endpoint),
+            transportClient,
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe());
+
+        var result = await client.SendAsync(
+            unityProject,
+            CreateOpsReadDispatchRequest(failFast: true, requireReadinessGate: true),
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(EditorLifecycleErrorCodes.EditorStarting, result.ErrorCode);
+        Assert.Equal(1, transportClient.CallCount);
+        Assert.Equal(IpcMethodNames.Ping, transportClient.Requests[0].Method);
+        Assert.Equal(1, processHandle.TerminateCallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenStartupPingTimesOut_RetriesUntilReachable ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "startup-timeout-retry");
+        var unityProject = CreateUnityProject(scope);
+        var endpoint = new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock");
+        var processHandle = new StubUnityBatchmodeProcessHandle();
+        var launcher = new StubUnityBatchmodeProcessLauncher(UnityBatchmodeProcessLaunchResult.Success(processHandle));
+        var pingAttempt = 0;
+        var transportClient = new StubUnityIpcTransportClient(request =>
+        {
+            return request.Method switch
+            {
+                IpcMethodNames.Ping when ++pingAttempt == 1 => throw new TimeoutException("startup ping timed out"),
+                IpcMethodNames.Ping => CreatePingResponse(request.RequestId),
+                IpcMethodNames.OpsRead => CreateSuccessResponse(request.RequestId),
+                _ => throw new Xunit.Sdk.XunitException($"Unexpected method: {request.Method}"),
+            };
+        });
+        var client = new UnityOneshotIpcClient(
+            launcher,
+            new StubIpcEndpointResolver(endpoint),
+            transportClient,
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe());
+
+        var result = await client.SendAsync(
+            unityProject,
+            CreateDispatchRequest(),
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, transportClient.CallCount);
+        Assert.Equal(0, processHandle.TerminateCallCount);
     }
 
     [Fact]
@@ -293,6 +374,15 @@ public sealed class UnityOneshotIpcClientTests
     private static UnityIpcDispatchRequest CreateDispatchRequest ()
     {
         return new UnityIpcDispatchRequest(IpcMethodNames.OpsRead, CreateDispatchPayload());
+    }
+
+    private static UnityIpcDispatchRequest CreateOpsReadDispatchRequest (
+        bool failFast,
+        bool requireReadinessGate)
+    {
+        return new UnityIpcDispatchRequest(
+            IpcMethodNames.OpsRead,
+            IpcPayloadCodec.SerializeToElement(new IpcOpsReadRequest(failFast, requireReadinessGate)));
     }
 
     private static IpcResponse CreateSuccessResponse (string requestId)


### PR DESCRIPTION
## Summary
- Reserve graceful termination budget before passive daemon stop waiting.
- Avoid treating uCLI-owned startup Temp/UnityLockfile as an external Unity lock while the launched process is alive.
- Add supervisor manifest publication grace and oneshot readiness-policy probing.

## Scope
- Daemon stop timeout budgeting.
- Daemon startup failure classification.
- Supervisor bootstrap relaunch timing.
- Oneshot startup readiness probing.
- Focused unit tests for the timing paths.

## Verification
- Gate level: Standard
- Format: PASS (`git diff --check`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, 857 tests)
- Coverage: N/A

## Risks / Rollback
- Main risk is daemon startup wait timing; covered by unit tests and live daemon validation from three separate worktrees.
- Rollback is reverting this PR commit.

## Checklist
- [x] .NET tests passed
- [x] Three-worktree daemon startup validation completed
- [x] Validation daemons stopped and no UnityLockfile residue found

Refs #241
