### PR TITLE
docs(cli): document contract source boundaries

### DIFF
--- a/docs/json-request-spec.md
+++ b/docs/json-request-spec.md
@@ -1,6 +1,7 @@
 > [!IMPORTANT]
 > この文書は、uCLI の JSON リクエスト入力契約の正本である。
 > 実行時契約とコマンド仕様は [uCLI.md](uCLI.md)、設計原則は [uCLI-design-principles.md](uCLI-design-principles.md) を参照する。
+> operation ごとの `args` / `result` / metadata は `Ucli.Contracts` と `ucli ops describe` を正本とし、この文書では request envelope と edit DSL を定義する。
 
 ## 目的
 

--- a/docs/uCLI-command-reference.md
+++ b/docs/uCLI-command-reference.md
@@ -1,6 +1,7 @@
 > [!IMPORTANT]
 > この文書は、uCLI のコマンド一覧、option table、サブコマンド規則、終了コード、実行例のリファレンスである。
 > 全体契約は [uCLI.md](uCLI.md)、JSON プロパティ定義は [uCLI-property-reference.md](uCLI-property-reference.md)、JSON リクエスト入力契約は [json-request-spec.md](json-request-spec.md) を参照する。
+> 実装登録の正本は `UcliCommandCatalog` と help output であり、この文書は利用者向けの一覧、option、エラー契約、実行例を説明する。
 >
 > 現在の公開 CLI host が登録している top-level command は `init`、`status`、`refresh`、`resolve`、`query`、`validate`、`plan`、`call`、`daemon`、`logs`、`ops`、`skills`、`test` である。
 

--- a/docs/uCLI-property-reference.md
+++ b/docs/uCLI-property-reference.md
@@ -5,6 +5,7 @@
 ## 公開 CLI 出力契約
 
 公開 CLI 出力の種別と意味は [uCLI.md](uCLI.md) を正本とする。ここでは `request-response` 型で使う JSON shape だけを定義する。
+公開 CLI JSON の固定対象は専用 JSON writer、command output DTO、Golden files であり、この文書は property の意味と参照先を説明する。
 
 ### request-response 型の共通エンベロープ
 `request-response` 型の CLI JSON 出力は、次の共通エンベロープを返す。

--- a/docs/uCLI.md
+++ b/docs/uCLI.md
@@ -17,6 +17,19 @@
 - [package-operations.md](package-operations.md)：契約パッケージと Unity 側依存復元の運用手順
 - [uCLI-skills.md](uCLI-skills.md)：agent 向け公式 SKILL の仕様、生成方針、責務境界、配布運用
 
+## 契約正本と検証境界
+
+| 対象 | 正本 | 説明・補助 | 検証 |
+| --- | --- | --- | --- |
+| CLI command set | `UcliCommandCatalog` と help output | [uCLI-command-reference.md](uCLI-command-reference.md) | CLI host の登録結果と help output の一致確認 |
+| 公開 CLI JSON 出力 | 専用 JSON writer、command output DTO、Golden files | [uCLI-property-reference.md](uCLI-property-reference.md) | CLI output contract tests と Golden files |
+| JSON request 入力 | [json-request-spec.md](json-request-spec.md) | [uCLI-command-reference.md](uCLI-command-reference.md) の実行例 | request contract tests と static validation tests |
+| operation args / result / metadata | `Ucli.Contracts` の Args / Result contract 型、contract 属性、`UcliOperationMetadata`、`ucli ops describe` | [ops-catalog.md](ops-catalog.md) | `ucli ops describe` contract tests、operation schema / validator tests、Unity operation authoring tests |
+| package metadata | `Directory.Build.props`、package 固有 `.csproj`、Unity nuspec | [package-operations.md](package-operations.md) | package metadata の評価テストと package verify scripts |
+| 公式 SKILL / README / help | 正本ではなく利用者向け導線 | [uCLI-skills.md](uCLI-skills.md) | SKILL tests、CLI package tests、help registration tests |
+
+README、help、SKILL、補助 catalog には、公開 operation contract や command reference の詳細を複製しない。仕様変更時は正本を更新し、必要な Golden files、contract tests、補助文書を同じ変更単位で揃える。
+
 ## コンセプト
 **安全にUnityを編集できるCLIツール。**
 - Unityを **ヘッドレス（batchmode）** で起動して実行できる（oneshot）
@@ -119,7 +132,7 @@ Project context resolution 由来の入力不正は、公開 CLI JSON の envelo
 - 進行ログと診断ログは `stderr` に出力する
 - `request-response` 型の公開 CLI JSON 出力は、共通の CLI エンベロープを返す
 - `protocolVersion` は `request-response` 型の公開 CLI JSON 出力、CLI が生成する内部 execute request、内部 IPC 応答で必須とする。ユーザー入力 JSON リクエストには含めない
-- 現在の公開 CLI host が登録している command は `init`、`status`、`refresh`、`resolve`、`query`、`validate`、`plan`、`call`、`daemon`、`logs`、`ops`、`test` である
+- 現在の公開 CLI host が登録している command は `init`、`status`、`refresh`、`resolve`、`query`、`validate`、`plan`、`call`、`daemon`、`logs`、`ops`、`skills`、`test` である
 - 内部 execute request では、リクエストにも `protocolVersion` を必須とする
 - 互換性判定は `protocolVersion` で行う
 - ただし、CLIフレームワーク（ConsoleAppFramework）の既定経路（`--help` / `help` / `--version` など）は、既定のテキスト出力を返す。これらは本JSON契約の適用対象外とする


### PR DESCRIPTION
## Summary
- docs/uCLI.md に契約正本と検証境界のマトリクスを追加しました。
- command reference、property reference、JSON request spec に、正本と説明範囲を短く補足しました。
- 登録 command 一覧に欠けていた `skills` を追加しました。

## Scope
- `docs/uCLI.md`: 契約正本マトリクスと登録 command 一覧
- `docs/uCLI-command-reference.md`: command reference の位置付け注記
- `docs/uCLI-property-reference.md`: CLI JSON property reference の位置付け注記
- `docs/json-request-spec.md`: request envelope / edit DSL と operation contract の正本境界

## Verification
- Gate level: Standard
- Format: PASS (`git diff --check HEAD~1 HEAD`)
- Tests: N/A (documentation-only change)
- Coverage: N/A

## Risks / Rollback
- Documentation-only change. Roll back by reverting this commit if the documented source-of-truth boundaries need to be revised.

## Checklist
- [x] 正本関係を `docs/uCLI.md` に集約
- [x] 補助文書へ短い注記を追加
- [x] 登録 command 一覧へ `skills` を追加

Closes #220