### PR TITLE
Formalize operation catalog pipeline

### DIFF
--- a/docs/ops-catalog.md
+++ b/docs/ops-catalog.md
@@ -8,6 +8,21 @@
 
 `ucli.prefab.applyOverrides` と `ucli.prefab.revertOverrides` は全モードで edit lowering 専用 primitive とする。ユーザー入力 JSON の raw `kind:"op"` から直接呼び出された場合は `INVALID_ARGUMENT` で拒否する。
 
+## Catalog pipeline
+
+Operation catalog は Unity 側で生成した operation 登録を `IndexOpEntryJsonContract` に変換し、同じ entry contract を live IPC、readIndex 永続化、CLI 表示、静的検証で共有する。
+
+処理順は次の通りである。
+
+```text
+Unity 生成 -> 契約検証 -> source snapshot -> best-effort 永続化 -> persisted load + freshness -> access policy -> CLI projection
+```
+
+- `IndexOpEntryJsonContract.name` / `kind` / `policy` / `argsSchemaJson` / `resultSchemaJson` は request validation 用 descriptor として使う
+- `ops list` は同じ entry から `name` / `kind` / `policy` だけを表示用 model へ投影する
+- `ops describe` は同じ entry から `description` / `inputs` / `resultContract` / `assurance` / schema object を表示用 model へ投影する
+- persisted catalog の読み込み失敗は access policy で分類し、CLI projection は永続化ファイルや freshness 計算の詳細へ依存しない
+
 ## Play Mode 変更での扱い
 
 `--allowPlayMode` 付きの Play Mode 変更では、`kind:"edit"` の lowering から発生する Scene / GameObject / Component / Prefab / Asset / ProjectSettings 操作だけを許可する。公開 query-only request を許可するための契約ではない。

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessService.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessService.cs
@@ -44,33 +44,34 @@ internal sealed class OpsCatalogAccessService : IOpsCatalogAccessService
             .ConfigureAwait(false);
         if (!persistedCatalogResult.IsSuccess)
         {
-            if (persistedCatalogResult.ErrorCode == UcliCoreErrorCodes.InvalidArgument)
+            var failure = persistedCatalogResult.ReadFailure!;
+            if (failure.Kind == PersistedOpsCatalogReadFailureKind.InvalidArgument)
             {
                 return OpsCatalogReadResult.Failure(
-                    persistedCatalogResult.ErrorMessage!,
-                    UcliCoreErrorCodes.InvalidArgument);
+                    failure.Message,
+                    failure.ErrorCode);
             }
 
             return await ReadCatalogFromSource(
                     context,
-                    persistedCatalogResult.ErrorMessage!,
+                    failure.Message,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
 
         var persistedFreshness = persistedCatalogResult.Freshness!.Value;
-        var persistedGeneratedAtUtc = persistedCatalogResult.GeneratedAtUtc!.Value;
+        var persistedSnapshot = persistedCatalogResult.Snapshot!;
         if (context.ReadIndexMode == ReadIndexMode.AllowStale || persistedFreshness == IndexFreshness.Fresh)
         {
             return OpsCatalogReadResult.Success(
                 new OpsCatalogReadOutput(
-                    Operations: persistedCatalogResult.Entries!.ToArray(),
+                    Snapshot: persistedSnapshot,
                     AccessInfo: new OpsCatalogAccessInfo(
                         Used: true,
                         Hit: true,
                         Source: OpsCatalogSource.Index,
                         Freshness: persistedFreshness,
-                        GeneratedAtUtc: persistedGeneratedAtUtc,
+                        GeneratedAtUtc: persistedSnapshot.GeneratedAtUtc,
                         FallbackReason: null)),
                 "Read-index ops catalog hit.");
         }
@@ -105,13 +106,13 @@ internal sealed class OpsCatalogAccessService : IOpsCatalogAccessService
 
         return OpsCatalogReadResult.Success(
             new OpsCatalogReadOutput(
-                Operations: refreshResult.Operations!.ToArray(),
+                Snapshot: refreshResult.Snapshot!,
                 AccessInfo: new OpsCatalogAccessInfo(
                     Used: false,
                     Hit: true,
                     Source: OpsCatalogSource.Source,
                     Freshness: IndexFreshness.Fresh,
-                    GeneratedAtUtc: refreshResult.GeneratedAtUtc!.Value,
+                    GeneratedAtUtc: refreshResult.Snapshot!.GeneratedAtUtc,
                     FallbackReason: refreshResult.FallbackReason)),
             "Ops catalog read completed.");
     }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogReadOutput.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogReadOutput.cs
@@ -1,8 +1,10 @@
+using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 
 /// <summary> Represents the internal catalog snapshot used by <c>ops</c> subcommands. </summary>
-/// <param name="Operations"> The available operation entries. </param>
+/// <param name="Snapshot"> The validated operation catalog snapshot. </param>
 /// <param name="AccessInfo"> The internal access metadata. </param>
 internal sealed record OpsCatalogReadOutput (
-    IReadOnlyList<IndexOpEntryJsonContract> Operations,
+    OpsCatalogSnapshot Snapshot,
     OpsCatalogAccessInfo AccessInfo);

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
@@ -1,27 +1,25 @@
-using MackySoft.Ucli.Contracts.Ipc;
-
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 
 /// <summary> Represents one operation-catalog fetch result. </summary>
-/// <param name="Response"> The catalog response on success; otherwise <see langword="null" />. </param>
+/// <param name="Snapshot"> The validated catalog snapshot on success; otherwise <see langword="null" />. </param>
 /// <param name="Message"> The user-facing result message. </param>
 /// <param name="ErrorCode"> The machine-readable error code on failure; otherwise <see langword="null" />. </param>
 internal sealed record OpsCatalogFetchResult (
-    IpcOpsReadResponse? Response,
+    OpsCatalogSnapshot? Snapshot,
     string Message,
     UcliErrorCode? ErrorCode)
 {
     /// <summary> Gets a value indicating whether fetch succeeded. </summary>
-    public bool IsSuccess => Response is not null && ErrorCode is null;
+    public bool IsSuccess => Snapshot is not null && ErrorCode is null;
 
     /// <summary> Creates a successful fetch result. </summary>
-    /// <param name="response"> The catalog response. </param>
+    /// <param name="snapshot"> The validated catalog snapshot. </param>
     /// <returns> The successful result. </returns>
-    public static OpsCatalogFetchResult Success (IpcOpsReadResponse response)
+    public static OpsCatalogFetchResult Success (OpsCatalogSnapshot snapshot)
     {
-        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(snapshot);
         return new OpsCatalogFetchResult(
-            Response: response,
+            Snapshot: snapshot,
             Message: "Ops catalog read completed.",
             ErrorCode: null);
     }
@@ -35,7 +33,7 @@ internal sealed record OpsCatalogFetchResult (
         UcliErrorCode errorCode)
     {
         return new OpsCatalogFetchResult(
-            Response: null,
+            Snapshot: null,
             Message: message,
             ErrorCode: errorCode);
     }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSnapshot.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSnapshot.cs
@@ -1,0 +1,42 @@
+namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+
+/// <summary> Represents one validated operation-catalog snapshot. </summary>
+internal sealed record OpsCatalogSnapshot
+{
+    private OpsCatalogSnapshot (
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IndexOpEntryJsonContract> operations)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+
+        GeneratedAtUtc = generatedAtUtc;
+        Operations = operations.ToArray();
+    }
+
+    /// <summary> Gets the catalog generation timestamp. </summary>
+    public DateTimeOffset GeneratedAtUtc { get; }
+
+    /// <summary> Gets the validated operation entries. </summary>
+    public IReadOnlyList<IndexOpEntryJsonContract> Operations { get; }
+
+    /// <summary> Creates a snapshot when the entry collection satisfies the public operation-entry contract. </summary>
+    public static bool TryCreate (
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IndexOpEntryJsonContract>? operations,
+        string propertyName,
+        out OpsCatalogSnapshot? snapshot,
+        out string? error)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
+
+        if (!IndexCatalogContractValidator.TryValidateOpsEntries(operations, propertyName, out error))
+        {
+            snapshot = null;
+            return false;
+        }
+
+        snapshot = new OpsCatalogSnapshot(generatedAtUtc, operations!);
+        error = null;
+        return true;
+    }
+}

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
@@ -2,25 +2,20 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 
 /// <summary> Represents one ops-catalog source refresh result. </summary>
 internal sealed record OpsCatalogSourceRefreshResult (
-    IReadOnlyList<IndexOpEntryJsonContract>? Operations,
-    DateTimeOffset? GeneratedAtUtc,
+    OpsCatalogSnapshot? Snapshot,
     string? FallbackReason,
     string Message,
     UcliErrorCode? ErrorCode)
 {
     /// <summary> Gets a value indicating whether the source refresh succeeded. </summary>
-    public bool IsSuccess => Operations is not null && GeneratedAtUtc.HasValue && ErrorCode is null;
+    public bool IsSuccess => Snapshot is not null && ErrorCode is null;
 
     /// <summary> Creates a successful source refresh result. </summary>
-    public static OpsCatalogSourceRefreshResult Success (
-        IReadOnlyList<IndexOpEntryJsonContract> operations,
-        DateTimeOffset generatedAtUtc,
-        string? fallbackReason)
+    public static OpsCatalogSourceRefreshResult Success (OpsCatalogSnapshot snapshot, string? fallbackReason)
     {
-        ArgumentNullException.ThrowIfNull(operations);
+        ArgumentNullException.ThrowIfNull(snapshot);
         return new OpsCatalogSourceRefreshResult(
-            operations,
-            generatedAtUtc,
+            snapshot,
             fallbackReason,
             "Ops catalog refresh completed.",
             null);
@@ -37,6 +32,6 @@ internal sealed record OpsCatalogSourceRefreshResult (
             throw new ArgumentException("Error code must not be empty.", nameof(errorCode));
         }
 
-        return new OpsCatalogSourceRefreshResult(null, null, null, message, errorCode);
+        return new OpsCatalogSourceRefreshResult(null, null, message, errorCode);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadFailure.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadFailure.cs
@@ -1,0 +1,35 @@
+namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+
+/// <summary> Represents one classified persisted ops-catalog read failure. </summary>
+internal sealed record PersistedOpsCatalogReadFailure
+{
+    /// <summary> Initializes a new instance of the <see cref="PersistedOpsCatalogReadFailure" /> class. </summary>
+    /// <param name="kind"> The policy-facing failure classification. </param>
+    /// <param name="errorCode"> The machine-readable failure code. </param>
+    /// <param name="message"> The user-facing failure message. </param>
+    public PersistedOpsCatalogReadFailure (
+        PersistedOpsCatalogReadFailureKind kind,
+        UcliErrorCode errorCode,
+        string message)
+    {
+        if (!errorCode.IsValid)
+        {
+            throw new ArgumentException("Error code must not be empty.", nameof(errorCode));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        Kind = kind;
+        ErrorCode = errorCode;
+        Message = message;
+    }
+
+    /// <summary> Gets the policy-facing failure classification. </summary>
+    public PersistedOpsCatalogReadFailureKind Kind { get; }
+
+    /// <summary> Gets the machine-readable failure code. </summary>
+    public UcliErrorCode ErrorCode { get; }
+
+    /// <summary> Gets the user-facing failure message. </summary>
+    public string Message { get; }
+}

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadFailureKind.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadFailureKind.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+
+/// <summary> Classifies persisted ops-catalog read failures for access-policy decisions. </summary>
+internal enum PersistedOpsCatalogReadFailureKind
+{
+    /// <summary> Indicates that the resolved persisted artifact path inputs are invalid. </summary>
+    InvalidArgument = 0,
+
+    /// <summary> Indicates that the persisted catalog is unavailable or could not be read. </summary>
+    Unavailable = 1,
+
+    /// <summary> Indicates that the persisted catalog exists but violates its contract. </summary>
+    Malformed = 2,
+
+    /// <summary> Indicates that freshness could not be observed for a loaded persisted catalog. </summary>
+    FreshnessUnavailable = 3,
+}

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReadResult.cs
@@ -1,65 +1,46 @@
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 
 /// <summary> Represents the result of reading one persisted ops catalog. </summary>
-/// <param name="Entries"> The persisted ops entries on success; otherwise <see langword="null" />. </param>
-/// <param name="GeneratedAtUtc"> The persisted generation timestamp on success; otherwise <see langword="null" />. </param>
+/// <param name="Snapshot"> The persisted catalog snapshot on success; otherwise <see langword="null" />. </param>
 /// <param name="Freshness"> The observed persisted freshness on success; otherwise <see langword="null" />. </param>
-/// <param name="ErrorCode"> The machine-readable failure code on failure; otherwise <see langword="null" />. </param>
-/// <param name="ErrorMessage"> The user-facing failure message on failure; otherwise <see langword="null" />. </param>
+/// <param name="ReadFailure"> The classified failure on failure; otherwise <see langword="null" />. </param>
 internal sealed record PersistedOpsCatalogReadResult (
-    IReadOnlyList<IndexOpEntryJsonContract>? Entries,
-    DateTimeOffset? GeneratedAtUtc,
+    OpsCatalogSnapshot? Snapshot,
     IndexFreshness? Freshness,
-    UcliErrorCode? ErrorCode,
-    string? ErrorMessage)
+    PersistedOpsCatalogReadFailure? ReadFailure)
 {
     /// <summary> Gets a value indicating whether reading succeeded. </summary>
-    public bool IsSuccess => Entries is not null
-        && GeneratedAtUtc.HasValue
+    public bool IsSuccess => Snapshot is not null
         && Freshness.HasValue
-        && ErrorCode is null
-        && string.IsNullOrWhiteSpace(ErrorMessage);
+        && ReadFailure is null;
 
     /// <summary> Creates a successful persisted-catalog read result. </summary>
-    /// <param name="entries"> The persisted ops entries. </param>
-    /// <param name="generatedAtUtc"> The persisted generation timestamp. </param>
+    /// <param name="snapshot"> The persisted catalog snapshot. </param>
     /// <param name="freshness"> The observed persisted freshness. </param>
     /// <returns> The successful read result. </returns>
     public static PersistedOpsCatalogReadResult Success (
-        IReadOnlyList<IndexOpEntryJsonContract> entries,
-        DateTimeOffset generatedAtUtc,
+        OpsCatalogSnapshot snapshot,
         IndexFreshness freshness)
     {
-        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(snapshot);
 
         return new PersistedOpsCatalogReadResult(
-            Entries: entries,
-            GeneratedAtUtc: generatedAtUtc,
+            Snapshot: snapshot,
             Freshness: freshness,
-            ErrorCode: null,
-            ErrorMessage: null);
+            ReadFailure: null);
     }
 
     /// <summary> Creates a failed persisted-catalog read result. </summary>
-    /// <param name="errorCode"> The machine-readable failure code. </param>
-    /// <param name="errorMessage"> The user-facing failure message. </param>
+    /// <param name="failure"> The classified failure. </param>
     /// <returns> The failed read result. </returns>
-    public static PersistedOpsCatalogReadResult Failure (
-        UcliErrorCode errorCode,
-        string errorMessage)
+    public static PersistedOpsCatalogReadResult Failure (PersistedOpsCatalogReadFailure failure)
     {
-        if (!errorCode.IsValid)
-        {
-            throw new ArgumentException("Error code must not be empty.", nameof(errorCode));
-        }
-
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        ArgumentNullException.ThrowIfNull(failure);
 
         return new PersistedOpsCatalogReadResult(
-            Entries: null,
-            GeneratedAtUtc: null,
+            Snapshot: null,
             Freshness: null,
-            ErrorCode: errorCode,
-            ErrorMessage: errorMessage);
+            ReadFailure: failure);
     }
+
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReader.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReader.cs
@@ -32,12 +32,24 @@ internal sealed class PersistedOpsCatalogReader : IPersistedOpsCatalogReader
             .ConfigureAwait(false);
         if (!opsCatalogResult.IsSuccess)
         {
-            return PersistedOpsCatalogReadResult.Failure(
-                opsCatalogResult.Error!.Code,
-                opsCatalogResult.Error.Message);
+            return PersistedOpsCatalogReadResult.Failure(CreateArtifactFailure(opsCatalogResult.Error!));
         }
 
         var opsCatalog = opsCatalogResult.Value!;
+        if (!OpsCatalogSnapshot.TryCreate(
+                opsCatalog.GeneratedAtUtc,
+                opsCatalog.Entries,
+                "entries",
+                out var snapshot,
+                out var validationError))
+        {
+            return PersistedOpsCatalogReadResult.Failure(
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.Malformed,
+                    ReadIndexErrorCodes.ReadIndexFormatInvalid,
+                    $"Index contract file 'ops.catalog.json' is malformed. {validationError}"));
+        }
+
         var freshnessResult = await freshnessEvaluator.Observe(
                 unityProject,
                 IndexFreshnessTarget.OpsCatalog,
@@ -47,13 +59,39 @@ internal sealed class PersistedOpsCatalogReader : IPersistedOpsCatalogReader
         if (!freshnessResult.IsSuccess)
         {
             return PersistedOpsCatalogReadResult.Failure(
-                freshnessResult.Error!.Code,
-                freshnessResult.Error.Message);
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.FreshnessUnavailable,
+                    freshnessResult.Error!.Code,
+                    freshnessResult.Error.Message));
         }
 
         return PersistedOpsCatalogReadResult.Success(
-            opsCatalog.Entries!,
-            opsCatalog.GeneratedAtUtc,
+            snapshot!,
             freshnessResult.Freshness);
+    }
+
+    private static PersistedOpsCatalogReadFailure CreateArtifactFailure (IndexServiceError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+
+        return new PersistedOpsCatalogReadFailure(
+            ClassifyArtifactFailure(error.Code),
+            error.Code,
+            error.Message);
+    }
+
+    private static PersistedOpsCatalogReadFailureKind ClassifyArtifactFailure (UcliErrorCode errorCode)
+    {
+        if (errorCode == UcliCoreErrorCodes.InvalidArgument)
+        {
+            return PersistedOpsCatalogReadFailureKind.InvalidArgument;
+        }
+
+        if (errorCode == ReadIndexErrorCodes.ReadIndexFormatInvalid)
+        {
+            return PersistedOpsCatalogReadFailureKind.Malformed;
+        }
+
+        return PersistedOpsCatalogReadFailureKind.Unavailable;
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/Projection/OpsDescribeResultMapper.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/Projection/OpsDescribeResultMapper.cs
@@ -30,7 +30,7 @@ internal sealed class OpsDescribeResultMapper : IOpsDescribeResultMapper
                 UcliCoreErrorCodes.InvalidArgument);
         }
 
-        var operation = output.Operations
+        var operation = output.Snapshot.Operations
             .FirstOrDefault(operation => string.Equals(operation.Name, operationName, StringComparison.Ordinal));
         if (operation == null)
         {

--- a/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/Projection/OpsListResultMapper.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/Projection/OpsListResultMapper.cs
@@ -20,7 +20,7 @@ internal sealed class OpsListResultMapper : IOpsListResultMapper
     {
         ArgumentNullException.ThrowIfNull(output);
 
-        var operations = output.Operations
+        var operations = output.Snapshot.Operations
             .OrderBy(static operation => operation.Name, StringComparer.Ordinal)
             .Select(static operation => new OpsOperationListItem(
                 Name: operation.Name!,

--- a/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/OperationCatalogDiscoveryService.cs
+++ b/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/OperationCatalogDiscoveryService.cs
@@ -67,7 +67,7 @@ internal sealed class OperationCatalogDiscoveryService : IOperationCatalogDiscov
                 catalogResult.ErrorCode);
         }
 
-        return OperationDescriptorMapper.Map(catalogResult.Response!.Operations!, cancellationToken);
+        return OperationDescriptorMapper.Map(catalogResult.Snapshot!.Operations, cancellationToken);
     }
 
     private static ExecutionError CreatePrefixedError (

--- a/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolver.cs
+++ b/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolver.cs
@@ -41,71 +41,50 @@ internal sealed class ReadIndexValidationCatalogResolver : IReadIndexValidationC
         if (!persistedCatalogResult.IsSuccess)
         {
             return HandlePersistedCatalogReadFailure(
-                persistedCatalogResult.ErrorCode!.Value,
-                persistedCatalogResult.ErrorMessage!,
+                persistedCatalogResult.ReadFailure!,
                 readIndexMode);
         }
 
         var freshness = persistedCatalogResult.Freshness!.Value;
-        var generatedAtUtc = persistedCatalogResult.GeneratedAtUtc!.Value;
+        var snapshot = persistedCatalogResult.Snapshot!;
         var freshnessResult = IndexFreshnessPolicy.ApplyModeConstraint(readIndexMode, freshness);
         if (!freshnessResult.IsSuccess)
         {
             return ReadIndexValidationCatalogResolutionResult.Failure(
                 CreateReadIndexHit(
                     freshnessResult.Freshness,
-                    generatedAtUtc,
+                    snapshot.GeneratedAtUtc,
                     freshnessResult.Error!.Message),
                 freshnessResult.Error.Code,
                 freshnessResult.Error.Message);
         }
 
-        IReadOnlyList<UcliOperationDescriptor> operations;
-        try
-        {
-            operations = OperationDescriptorMapper.Map(persistedCatalogResult.Entries!, cancellationToken);
-        }
-        catch (InvalidOperationException exception)
-        {
-            var message = $"Index contract file 'ops.catalog.json' is malformed. {exception.Message}";
-            return ReadIndexValidationCatalogResolutionResult.Failure(
-                CreateReadIndexMiss(message),
-                ReadIndexErrorCodes.ReadIndexFormatInvalid,
-                message);
-        }
-
         return ReadIndexValidationCatalogResolutionResult.Success(
-            RequestStaticValidationCatalog.Available(operations),
+            RequestStaticValidationCatalog.Available(OperationDescriptorMapper.Map(snapshot.Operations, cancellationToken)),
             CreateReadIndexHit(
                 freshness,
-                generatedAtUtc,
+                snapshot.GeneratedAtUtc,
                 fallbackReason: null));
     }
 
     private static ReadIndexValidationCatalogResolutionResult HandlePersistedCatalogReadFailure (
-        UcliErrorCode errorCode,
-        string errorMessage,
+        PersistedOpsCatalogReadFailure failure,
         ReadIndexMode readIndexMode)
     {
-        if (!errorCode.IsValid)
-        {
-            throw new ArgumentException("Error code must not be empty.", nameof(errorCode));
-        }
-
-        ArgumentException.ThrowIfNullOrWhiteSpace(errorMessage);
+        ArgumentNullException.ThrowIfNull(failure);
 
         if ((readIndexMode == ReadIndexMode.AllowStale)
-            && errorCode == ReadIndexErrorCodes.ReadIndexBootstrapFailed)
+            && failure.Kind == PersistedOpsCatalogReadFailureKind.Unavailable)
         {
             return ReadIndexValidationCatalogResolutionResult.Success(
                 RequestStaticValidationCatalog.Unavailable,
-                CreateReadIndexMiss(errorMessage));
+                CreateReadIndexMiss(failure.Message));
         }
 
         return ReadIndexValidationCatalogResolutionResult.Failure(
-            CreateReadIndexMiss(errorMessage),
-            errorCode,
-            errorMessage);
+            CreateReadIndexMiss(failure.Message),
+            failure.ErrorCode,
+            failure.Message);
     }
 
     private static ReadIndexInfo CreateReadIndexMiss (string fallbackReason)

--- a/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
+++ b/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
@@ -1,7 +1,6 @@
 using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context.Project;
-using MackySoft.Ucli.Application.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Application.Shared.Execution.UnityRequest;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -92,13 +91,18 @@ internal sealed class OpsCatalogReader : IOpsCatalogReader
                 UcliCoreErrorCodes.InternalError);
         }
 
-        if (!IndexCatalogContractValidator.TryValidateOpsEntries(payload.Operations, "operations", out var validationError))
+        if (!OpsCatalogSnapshot.TryCreate(
+                payload.GeneratedAtUtc,
+                payload.Operations,
+                "operations",
+                out var snapshot,
+                out var validationError))
         {
             return OpsCatalogFetchResult.Failure(
                 $"{responseSourceName} payload is invalid. {validationError}",
                 UcliCoreErrorCodes.InternalError);
         }
 
-        return OpsCatalogFetchResult.Success(payload);
+        return OpsCatalogFetchResult.Success(snapshot!);
     }
 }

--- a/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshService.cs
+++ b/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshService.cs
@@ -3,7 +3,6 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.ReadIndex;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
-using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.UnityIntegration.Indexing.Core;
 
 namespace MackySoft.Ucli.Features.OperationCatalog.Catalog.Source;
@@ -59,7 +58,7 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
         ArgumentException.ThrowIfNullOrWhiteSpace(fallbackReason);
 
-        IpcOpsReadResponse? response = null;
+        OpsCatalogSnapshot? snapshot = null;
         string? persistFailure = null;
         for (var attempt = 0; attempt < MaxCatalogStabilityAttempts; attempt++)
         {
@@ -73,7 +72,7 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
                 .ConfigureAwait(false);
             if (!attemptResult.FetchResult.IsSuccess)
             {
-                if (response != null)
+                if (snapshot != null)
                 {
                     persistFailure = ReadIndexAccessUtilities.CombineFallbackReasons(
                         persistFailure,
@@ -86,7 +85,7 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
                     attemptResult.FetchResult.ErrorCode!.Value);
             }
 
-            response = attemptResult.FetchResult.Response!;
+            snapshot = attemptResult.FetchResult.Snapshot!;
             persistFailure = attemptResult.PersistFailure;
             if (!attemptResult.ShouldRetry)
             {
@@ -96,8 +95,7 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
 
         var combinedFallbackReason = ReadIndexAccessUtilities.CombineFallbackReasons(fallbackReason, persistFailure);
         return OpsCatalogSourceRefreshResult.Success(
-            response!.Operations!.ToArray(),
-            response.GeneratedAtUtc,
+            snapshot!,
             combinedFallbackReason);
     }
 
@@ -158,8 +156,8 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
             await artifactWriter.WriteOpsCatalog(
                     project.RepositoryRoot,
                     project.ProjectFingerprint,
-                    fetchResult.Response!.GeneratedAtUtc,
-                    fetchResult.Response.Operations!.ToArray(),
+                    fetchResult.Snapshot!.GeneratedAtUtc,
+                    fetchResult.Snapshot.Operations,
                     persistenceInput.SourceInputsHash,
                     persistenceInput.ManifestInputSnapshot,
                     cancellationToken)

--- a/tests/Ucli.Application.Tests/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessServiceTests.cs
@@ -4,22 +4,42 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Contracts.Configuration;
-using MackySoft.Ucli.Contracts.Ipc;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests.Ops.Access;
 
 public sealed class OpsCatalogAccessServiceTests
 {
+    public static TheoryData<string, UcliErrorCode, string> SourceFallbackFailures =>
+        new()
+        {
+            {
+                nameof(PersistedOpsCatalogReadFailureKind.Unavailable),
+                ReadIndexErrorCodes.ReadIndexBootstrapFailed,
+                "Index contract file was not found: ops.catalog.json."
+            },
+            {
+                nameof(PersistedOpsCatalogReadFailureKind.Malformed),
+                ReadIndexErrorCodes.ReadIndexFormatInvalid,
+                "Index contract file 'ops.catalog.json' is malformed."
+            },
+            {
+                nameof(PersistedOpsCatalogReadFailureKind.FreshnessUnavailable),
+                ReadIndexErrorCodes.ReadIndexFreshRequired,
+                "readIndex freshness could not be observed."
+            },
+        };
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task Read_WhenAllowStaleIndexExists_ReturnsPersistedCatalog ()
     {
         var persistedReader = new StubPersistedOpsCatalogReader
         {
-            Result = PersistedOpsCatalogReadResult.Success(
-                [CreateGoDescribeEntry()],
+            Result = CreatePersistedReadResult(
                 DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
-                IndexFreshness.Probable),
+                IndexFreshness.Probable,
+                [CreateGoDescribeEntry()]),
         };
         var sourceRefreshService = new StubOpsCatalogSourceRefreshService();
         var service = new OpsCatalogAccessService(persistedReader, sourceRefreshService);
@@ -40,15 +60,15 @@ public sealed class OpsCatalogAccessServiceTests
     {
         var persistedReader = new StubPersistedOpsCatalogReader
         {
-            Result = PersistedOpsCatalogReadResult.Success(
-                [CreateGoDescribeEntry()],
+            Result = CreatePersistedReadResult(
                 DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
-                IndexFreshness.Stale),
+                IndexFreshness.Stale,
+                [CreateGoDescribeEntry()]),
         };
         var generatedAtUtc = DateTimeOffset.Parse("2026-03-07T00:00:00+00:00");
         var sourceRefreshService = new StubOpsCatalogSourceRefreshService
         {
-            Result = OpsCatalogSourceRefreshResult.Success([CreateSceneSaveEntry()], generatedAtUtc, "Existing ops index freshness is 'stale'."),
+            Result = CreateSourceRefreshResult(generatedAtUtc, [CreateSceneSaveEntry()], "Existing ops index freshness is 'stale'."),
         };
         var service = new OpsCatalogAccessService(persistedReader, sourceRefreshService);
 
@@ -64,13 +84,50 @@ public sealed class OpsCatalogAccessServiceTests
         Assert.Equal("Existing ops index freshness is 'stale'.", sourceRefreshService.LastFallbackReason);
     }
 
+    [Theory]
+    [Trait("Size", "Small")]
+    [MemberData(nameof(SourceFallbackFailures))]
+    public async Task Read_WhenPersistedReadReturnsFallbackFailure_FallsBackToSource (
+        string failureKindName,
+        UcliErrorCode errorCode,
+        string failureMessage)
+    {
+        var failureKind = Enum.Parse<PersistedOpsCatalogReadFailureKind>(failureKindName);
+        var persistedReader = new StubPersistedOpsCatalogReader
+        {
+            Result = PersistedOpsCatalogReadResult.Failure(
+                new PersistedOpsCatalogReadFailure(
+                    failureKind,
+                    errorCode,
+                    failureMessage)),
+        };
+        var generatedAtUtc = DateTimeOffset.Parse("2026-03-07T00:00:00+00:00");
+        var sourceRefreshService = new StubOpsCatalogSourceRefreshService
+        {
+            Result = CreateSourceRefreshResult(generatedAtUtc, [CreateSceneSaveEntry()], failureMessage),
+        };
+        var service = new OpsCatalogAccessService(persistedReader, sourceRefreshService);
+
+        var result = await service.Read(CreatePreflightContext(ReadIndexMode.RequireFresh), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(OpsCatalogSource.Source, result.Output!.AccessInfo.Source);
+        Assert.False(result.Output.AccessInfo.Used);
+        Assert.Equal(generatedAtUtc, result.Output.AccessInfo.GeneratedAtUtc);
+        Assert.Equal(failureMessage, sourceRefreshService.LastFallbackReason);
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task Read_WhenPersistedReadReturnsInvalidArgument_ReturnsFailureWithoutSourceFallback ()
     {
         var persistedReader = new StubPersistedOpsCatalogReader
         {
-            Result = PersistedOpsCatalogReadResult.Failure(UcliCoreErrorCodes.InvalidArgument, "invalid project fingerprint"),
+            Result = PersistedOpsCatalogReadResult.Failure(
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.InvalidArgument,
+                    UcliCoreErrorCodes.InvalidArgument,
+                    "invalid project fingerprint")),
         };
         var sourceRefreshService = new StubOpsCatalogSourceRefreshService();
         var service = new OpsCatalogAccessService(persistedReader, sourceRefreshService);
@@ -89,7 +146,7 @@ public sealed class OpsCatalogAccessServiceTests
         var generatedAtUtc = DateTimeOffset.Parse("2026-03-07T00:00:00+00:00");
         var sourceRefreshService = new StubOpsCatalogSourceRefreshService
         {
-            Result = OpsCatalogSourceRefreshResult.Success([CreateGoDescribeEntry()], generatedAtUtc, "readIndex disabled by mode."),
+            Result = CreateSourceRefreshResult(generatedAtUtc, [CreateGoDescribeEntry()], "readIndex disabled by mode."),
         };
         var service = new OpsCatalogAccessService(new StubPersistedOpsCatalogReader(), sourceRefreshService);
 
@@ -118,53 +175,14 @@ public sealed class OpsCatalogAccessServiceTests
             true);
     }
 
-    private static IndexOpEntryJsonContract CreateGoDescribeEntry ()
-    {
-        return new IndexOpEntryJsonContract(
-            Name: UcliPrimitiveOperationNames.GoDescribe,
-            Kind: "query",
-            Policy: "safe",
-            ArgsSchemaJson: """{"type":"object"}""",
-            ResultSchemaJson: """{"type":"object"}""")
-        {
-            Description = "Returns a GameObject description including components and child hierarchy.",
-            Inputs = Array.Empty<UcliOperationInputContract>(),
-            ResultContract = UcliOperationResultContract.One<GameObjectDescriptionResult>("GameObject description result."),
-            Assurance = new UcliOperationAssuranceContract(
-                Array.Empty<string>(),
-                mayDirty: false,
-                mayPersist: false,
-                Array.Empty<string>(),
-                UcliOperationPlanModeValues.ObservesLiveUnity),
-        };
-    }
-
-    private static IndexOpEntryJsonContract CreateSceneSaveEntry ()
-    {
-        return new IndexOpEntryJsonContract(
-            Name: UcliPrimitiveOperationNames.SceneSave,
-            Kind: "mutation",
-            Policy: "advanced",
-            ArgsSchemaJson: """{"type":"object"}""")
-        {
-            Description = "Saves a Unity scene asset.",
-            Inputs = Array.Empty<UcliOperationInputContract>(),
-            ResultContract = UcliOperationResultContract.NoResult("No operation-specific result is emitted."),
-            Assurance = new UcliOperationAssuranceContract(
-                Array.Empty<string>(),
-                mayDirty: false,
-                mayPersist: true,
-                Array.Empty<string>(),
-                UcliOperationPlanModeValues.ObservesLiveUnity),
-        };
-    }
-
     private sealed class StubPersistedOpsCatalogReader : IPersistedOpsCatalogReader
     {
         public PersistedOpsCatalogReadResult Result { get; set; }
             = PersistedOpsCatalogReadResult.Failure(
-                ReadIndexErrorCodes.ReadIndexBootstrapFailed,
-                "Index contract file was not found: ops.catalog.json.");
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.Unavailable,
+                    ReadIndexErrorCodes.ReadIndexBootstrapFailed,
+                    "Index contract file was not found: ops.catalog.json."));
 
         public ValueTask<PersistedOpsCatalogReadResult> Read (
             ResolvedUnityProjectContext unityProject,

--- a/tests/Ucli.Application.Tests/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReaderTests.cs
+++ b/tests/Ucli.Application.Tests/Features/OperationCatalog/Catalog/Source/PersistedOpsCatalogReaderTests.cs
@@ -1,4 +1,6 @@
 using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+using MackySoft.Ucli.Contracts.Ipc;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests.Ops.Source;
 
@@ -18,8 +20,69 @@ public sealed class PersistedOpsCatalogReaderTests
         var result = await reader.Read(CreateUnityProject(), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal(error.Code, result.ErrorCode);
-        Assert.Equal(error.Message, result.ErrorMessage);
+        Assert.Equal(PersistedOpsCatalogReadFailureKind.Unavailable, result.ReadFailure!.Kind);
+        Assert.Equal(error.Code, result.ReadFailure.ErrorCode);
+        Assert.Equal(error.Message, result.ReadFailure.Message);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenOpsCatalogPathInputIsInvalid_ReturnsInvalidArgumentFailure ()
+    {
+        var error = new IndexServiceError(
+            UcliCoreErrorCodes.InvalidArgument,
+            "Project fingerprint must not be empty.");
+        var reader = new PersistedOpsCatalogReader(
+            new StubReadIndexArtifactReader(ReadIndexArtifactReadResult<IndexOpsCatalogJsonContract>.Failure(error)),
+            new StubIndexFreshnessEvaluator(IndexFreshnessEvaluationResult.Success(IndexFreshness.Fresh)));
+
+        var result = await reader.Read(CreateUnityProject(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PersistedOpsCatalogReadFailureKind.InvalidArgument, result.ReadFailure!.Kind);
+        Assert.Equal(error.Code, result.ReadFailure.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenOpsCatalogContractIsMalformed_ReturnsMalformedFailure ()
+    {
+        var error = new IndexServiceError(
+            ReadIndexErrorCodes.ReadIndexFormatInvalid,
+            "Index contract file 'ops.catalog.json' is malformed.");
+        var reader = new PersistedOpsCatalogReader(
+            new StubReadIndexArtifactReader(ReadIndexArtifactReadResult<IndexOpsCatalogJsonContract>.Failure(error)),
+            new StubIndexFreshnessEvaluator(IndexFreshnessEvaluationResult.Success(IndexFreshness.Fresh)));
+
+        var result = await reader.Read(CreateUnityProject(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PersistedOpsCatalogReadFailureKind.Malformed, result.ReadFailure!.Kind);
+        Assert.Equal(error.Code, result.ReadFailure.ErrorCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenLoadedOpsCatalogEntriesAreInvalid_ReturnsMalformedFailureWithoutObservingFreshness ()
+    {
+        var freshnessEvaluator = new StubIndexFreshnessEvaluator(
+            IndexFreshnessEvaluationResult.Success(IndexFreshness.Fresh));
+        var reader = new PersistedOpsCatalogReader(
+            new StubReadIndexArtifactReader(ReadIndexArtifactReadResult<IndexOpsCatalogJsonContract>.Success(
+                CreateCatalog(new IndexOpEntryJsonContract(
+                    Name: UcliPrimitiveOperationNames.GoDescribe,
+                    Kind: "query",
+                    Policy: "safe",
+                    ArgsSchemaJson: "\"not-an-object\"")))),
+            freshnessEvaluator);
+
+        var result = await reader.Read(CreateUnityProject(), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PersistedOpsCatalogReadFailureKind.Malformed, result.ReadFailure!.Kind);
+        Assert.Equal(ReadIndexErrorCodes.ReadIndexFormatInvalid, result.ReadFailure.ErrorCode);
+        Assert.Contains("ops.catalog.json", result.ReadFailure.Message, StringComparison.Ordinal);
+        Assert.Equal(0, freshnessEvaluator.ObserveCallCount);
     }
 
     [Fact]
@@ -38,8 +101,9 @@ public sealed class PersistedOpsCatalogReaderTests
         var result = await reader.Read(CreateUnityProject(), CancellationToken.None);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal(error.Code, result.ErrorCode);
-        Assert.Equal(error.Message, result.ErrorMessage);
+        Assert.Equal(PersistedOpsCatalogReadFailureKind.FreshnessUnavailable, result.ReadFailure!.Kind);
+        Assert.Equal(error.Code, result.ReadFailure.ErrorCode);
+        Assert.Equal(error.Message, result.ReadFailure.Message);
     }
 
     [Fact]
@@ -57,8 +121,8 @@ public sealed class PersistedOpsCatalogReaderTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(IndexFreshness.Probable, result.Freshness);
-        Assert.Equal(DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"), result.GeneratedAtUtc);
-        Assert.Single(result.Entries!);
+        Assert.Equal(DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"), result.Snapshot!.GeneratedAtUtc);
+        Assert.Single(result.Snapshot.Operations);
         Assert.Same(unityProject, freshnessEvaluator.LastUnityProject);
         Assert.Equal(IndexFreshnessTarget.OpsCatalog, freshnessEvaluator.LastTarget);
         Assert.Equal("source-hash", freshnessEvaluator.LastPersistedSourceInputsHash);
@@ -76,17 +140,18 @@ public sealed class PersistedOpsCatalogReaderTests
 
     private static IndexOpsCatalogJsonContract CreateCatalog ()
     {
+        return CreateCatalog(CreateGoDescribeEntry());
+    }
+
+    private static IndexOpsCatalogJsonContract CreateCatalog (IndexOpEntryJsonContract entry)
+    {
         return new IndexOpsCatalogJsonContract(
             SchemaVersion: 1,
             GeneratedAtUtc: DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
             SourceInputsHash: "source-hash",
             Entries:
             [
-                new IndexOpEntryJsonContract(
-                    Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.GoDescribe,
-                    Kind: "query",
-                    Policy: "safe",
-                    ArgsSchemaJson: """{"type":"object"}"""),
+                entry,
             ]);
     }
 

--- a/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/OpsServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/OpsServiceTests.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Prefligh
 using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Projection;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using static MackySoft.Ucli.Application.Tests.Helpers.ApplicationCommandInputTestHelper;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests.Ops;
 
@@ -42,14 +43,11 @@ public sealed class OpsServiceTests
             Result = OpsPreflightResult.Success(preflightContext),
         };
         var catalogOutput = new OpsCatalogReadOutput(
-            Operations:
-            [
-                new MackySoft.Ucli.Contracts.Index.IndexOpEntryJsonContract(
-                    Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.SceneSave,
-                    Kind: "mutation",
-                    Policy: "advanced",
-                    ArgsSchemaJson: """{"type":"object"}"""),
-            ],
+            Snapshot: CreateSnapshot(
+                DateTimeOffset.UtcNow,
+                [
+                    CreateSceneSaveEntry(),
+                ]),
             AccessInfo: new OpsCatalogAccessInfo(
                 true,
                 true,
@@ -102,7 +100,9 @@ public sealed class OpsServiceTests
             Result = OpsPreflightResult.Success(preflightContext),
         };
         var catalogOutput = new OpsCatalogReadOutput(
-            Operations: Array.Empty<MackySoft.Ucli.Contracts.Index.IndexOpEntryJsonContract>(),
+            Snapshot: CreateSnapshot(
+                DateTimeOffset.UtcNow,
+                Array.Empty<IndexOpEntryJsonContract>()),
             AccessInfo: new OpsCatalogAccessInfo(
                 true,
                 true,
@@ -207,4 +207,5 @@ public sealed class OpsServiceTests
             return Result;
         }
     }
+
 }

--- a/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/Projection/OpsDescribeResultMapperTests.cs
+++ b/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/Projection/OpsDescribeResultMapperTests.cs
@@ -1,6 +1,9 @@
+using System.Reflection;
 using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
+using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Projection;
 using MackySoft.Ucli.Contracts.Ipc;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests.Ops.Mapping;
 
@@ -13,23 +16,13 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            new OpsCatalogReadOutput(
-                Operations:
-                [
-                    CreateDescribedEntry(
-                        name: UcliPrimitiveOperationNames.Resolve,
-                        kind: "query",
-                        policy: "safe",
-                        argsSchemaJson: """{"type":"object"}""",
-                        resultSchemaJson: """{"type":"object","properties":{"globalObjectId":{"type":"string"}}}"""),
-                ],
-                AccessInfo: new OpsCatalogAccessInfo(
-                    true,
-                    true,
-                    OpsCatalogSource.Index,
-                    MackySoft.Ucli.Contracts.Index.IndexFreshness.Fresh,
-                    DateTimeOffset.UtcNow,
-                    null)),
+            CreateReadOutput(
+                CreateDescribedEntry(
+                    name: UcliPrimitiveOperationNames.Resolve,
+                    kind: "query",
+                    policy: "safe",
+                    argsSchemaJson: """{"type":"object"}""",
+                    resultSchemaJson: """{"type":"object","properties":{"globalObjectId":{"type":"string"}}}""")),
             UcliPrimitiveOperationNames.Resolve);
 
         Assert.True(result.IsSuccess);
@@ -49,15 +42,7 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            new OpsCatalogReadOutput(
-                Operations: Array.Empty<MackySoft.Ucli.Contracts.Index.IndexOpEntryJsonContract>(),
-                AccessInfo: new OpsCatalogAccessInfo(
-                    true,
-                    true,
-                    OpsCatalogSource.Index,
-                    MackySoft.Ucli.Contracts.Index.IndexFreshness.Fresh,
-                    DateTimeOffset.UtcNow,
-                    null)),
+            CreateReadOutput(Array.Empty<IndexOpEntryJsonContract>()),
             string.Empty);
 
         Assert.False(result.IsSuccess);
@@ -71,22 +56,12 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            new OpsCatalogReadOutput(
-                Operations:
-                [
-                    CreateDescribedEntry(
-                        name: UcliPrimitiveOperationNames.Resolve,
-                        kind: "query",
-                        policy: "safe",
-                        argsSchemaJson: "\"not-an-object\""),
-                ],
-                AccessInfo: new OpsCatalogAccessInfo(
-                    true,
-                    true,
-                    OpsCatalogSource.Index,
-                    MackySoft.Ucli.Contracts.Index.IndexFreshness.Fresh,
-                    DateTimeOffset.UtcNow,
-                    null)),
+            CreateUncheckedOutput(
+                CreateDescribedEntry(
+                    name: UcliPrimitiveOperationNames.Resolve,
+                    kind: "query",
+                    policy: "safe",
+                    argsSchemaJson: "\"not-an-object\"")),
             UcliPrimitiveOperationNames.Resolve);
 
         Assert.False(result.IsSuccess);
@@ -100,7 +75,7 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            CreateOutput(
+            CreateUncheckedOutput(
                 CreateDescribedEntry(
                     name: UcliPrimitiveOperationNames.Resolve,
                     kind: "query",
@@ -120,7 +95,7 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            CreateOutput(
+            CreateUncheckedOutput(
                 CreateDescribedEntry(
                     name: UcliPrimitiveOperationNames.Resolve,
                     kind: "query",
@@ -140,7 +115,7 @@ public sealed class OpsDescribeResultMapperTests
         var mapper = new OpsDescribeResultMapper(new OpsReadIndexInfoMapper());
 
         var result = mapper.Map(
-            CreateOutput(
+            CreateUncheckedOutput(
                 CreateDescribedEntry(
                     name: UcliPrimitiveOperationNames.Resolve,
                     kind: "query",
@@ -169,7 +144,7 @@ public sealed class OpsDescribeResultMapperTests
             ResultContract = UcliOperationResultContract.NoResult("No result."),
         };
 
-        var result = mapper.Map(CreateOutput(entry), UcliPrimitiveOperationNames.Resolve);
+        var result = mapper.Map(CreateUncheckedOutput(entry), UcliPrimitiveOperationNames.Resolve);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(UcliCoreErrorCodes.InternalError, result.ErrorCode);
@@ -200,19 +175,31 @@ public sealed class OpsDescribeResultMapperTests
             _ => throw new ArgumentOutOfRangeException(nameof(missingField), missingField, "Unsupported field."),
         };
 
-        var result = mapper.Map(CreateOutput(entry), UcliPrimitiveOperationNames.Resolve);
+        var result = mapper.Map(CreateUncheckedOutput(entry), UcliPrimitiveOperationNames.Resolve);
 
         Assert.False(result.IsSuccess);
         Assert.Equal(UcliCoreErrorCodes.InternalError, result.ErrorCode);
     }
 
-    private static OpsCatalogReadOutput CreateOutput (IndexOpEntryJsonContract entry)
+    private static OpsCatalogReadOutput CreateReadOutput (IndexOpEntryJsonContract entry)
+    {
+        return CreateReadOutput([entry]);
+    }
+
+    private static OpsCatalogReadOutput CreateReadOutput (IReadOnlyList<IndexOpEntryJsonContract> entries)
+    {
+        return CreateOutput(CreateSnapshot(DateTimeOffset.UtcNow, entries));
+    }
+
+    private static OpsCatalogReadOutput CreateUncheckedOutput (IndexOpEntryJsonContract entry)
+    {
+        return CreateOutput(CreateUncheckedSnapshot(entry));
+    }
+
+    private static OpsCatalogReadOutput CreateOutput (OpsCatalogSnapshot snapshot)
     {
         return new OpsCatalogReadOutput(
-            Operations:
-            [
-                entry,
-            ],
+            Snapshot: snapshot,
             AccessInfo: new OpsCatalogAccessInfo(
                 true,
                 true,
@@ -220,6 +207,17 @@ public sealed class OpsDescribeResultMapperTests
                 MackySoft.Ucli.Contracts.Index.IndexFreshness.Fresh,
                 DateTimeOffset.UtcNow,
                 null));
+    }
+
+    private static OpsCatalogSnapshot CreateUncheckedSnapshot (params IndexOpEntryJsonContract[] entries)
+    {
+        var constructor = typeof(OpsCatalogSnapshot).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(DateTimeOffset), typeof(IReadOnlyList<IndexOpEntryJsonContract>)],
+            modifiers: null)
+            ?? throw new InvalidOperationException("OpsCatalogSnapshot constructor was not found.");
+        return (OpsCatalogSnapshot)constructor.Invoke([DateTimeOffset.UtcNow, entries]);
     }
 
     private static IndexOpEntryJsonContract CreateDescribedEntry (

--- a/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/Projection/OpsListResultMapperTests.cs
+++ b/tests/Ucli.Application.Tests/Features/OperationCatalog/UseCases/Ops/Projection/OpsListResultMapperTests.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Projection;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests.Ops.Mapping;
 
@@ -13,19 +14,12 @@ public sealed class OpsListResultMapperTests
 
         var result = mapper.Map(
             new OpsCatalogReadOutput(
-                Operations:
-                [
-                    new MackySoft.Ucli.Contracts.Index.IndexOpEntryJsonContract(
-                        Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.SceneSave,
-                        Kind: "mutation",
-                        Policy: "advanced",
-                        ArgsSchemaJson: """{"type":"object"}"""),
-                    new MackySoft.Ucli.Contracts.Index.IndexOpEntryJsonContract(
-                        Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.GoDescribe,
-                        Kind: "query",
-                        Policy: "safe",
-                        ArgsSchemaJson: """{"type":"object"}"""),
-                ],
+                Snapshot: CreateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    [
+                        CreateSceneSaveEntry(),
+                        CreateGoDescribeEntry(),
+                    ]),
                 AccessInfo: new OpsCatalogAccessInfo(
                     true,
                     true,

--- a/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/OperationCatalogDiscoveryServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/OperationCatalogDiscoveryServiceTests.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests;
 
@@ -144,20 +145,35 @@ public sealed class OperationCatalogDiscoveryServiceTests
             ReceivedFailFast = failFast;
             ReceivedRequireReadinessGate = requireReadinessGate;
 
-            return ValueTask.FromResult(OpsCatalogFetchResult.Success(new IpcOpsReadResponse(
-                GeneratedAtUtc: DateTimeOffset.UtcNow,
-                Operations:
-                [
-                    new IndexOpEntryJsonContract(
-                        Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.SceneOpen,
-                        Kind: "query",
-                        Policy: "safe",
-                        ArgsSchemaJson: JsonSerializer.Serialize(new
+            var describe = UcliOperationDescribeContractBuilder.Create<ScenePathArgs, UcliNoResult>(
+                "Opens a Unity scene asset in the editor.",
+                new UcliOperationAssuranceContract(
+                    Array.Empty<UcliOperationSideEffect>(),
+                    mayDirty: false,
+                    mayPersist: false,
+                    Array.Empty<string>(),
+                    UcliOperationPlanMode.ObservesLiveUnity));
+
+            return ValueTask.FromResult(OpsCatalogFetchResult.Success(
+                CreateSnapshot(
+                    DateTimeOffset.UtcNow,
+                    [
+                        new IndexOpEntryJsonContract(
+                            Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.SceneOpen,
+                            Kind: "command",
+                            Policy: "safe",
+                            ArgsSchemaJson: JsonSerializer.Serialize(new
+                            {
+                                type = "object",
+                                additionalProperties = false,
+                            }))
                         {
-                            type = "object",
-                            additionalProperties = false,
-                        })),
-                ])));
+                            Description = describe.Description,
+                            Inputs = describe.Inputs,
+                            ResultContract = describe.ResultContract,
+                            Assurance = describe.Assurance,
+                        },
+                    ])));
         }
     }
 

--- a/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/ReadIndexValidationCatalogResolverTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 using MackySoft.Ucli.Application.Features.Requests.Shared.OperationMetadata;
 using MackySoft.Ucli.Contracts.Configuration;
+using static MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Application.Tests;
 
@@ -10,12 +11,11 @@ public sealed class ReadIndexValidationCatalogResolverTests
     [Trait("Size", "Small")]
     public async Task Resolve_WhenReadIndexDisabled_ReturnsSyntaxOnlySuccess ()
     {
-        var persistedCatalog = CreatePersistedCatalogStub(IndexFreshness.Fresh);
         var loader = new SpyPersistedOpsCatalogReader(
-            PersistedOpsCatalogReadResult.Success(
-                persistedCatalog.Entries,
-                persistedCatalog.GeneratedAtUtc,
-                persistedCatalog.Freshness));
+            CreatePersistedReadResult(
+                DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
+                IndexFreshness.Fresh,
+                [CreateGoDescribeEntry()]));
         var resolver = new ReadIndexValidationCatalogResolver(loader);
 
         var result = await resolver.Resolve(
@@ -39,8 +39,10 @@ public sealed class ReadIndexValidationCatalogResolverTests
     {
         var resolver = new ReadIndexValidationCatalogResolver(new SpyPersistedOpsCatalogReader(
             PersistedOpsCatalogReadResult.Failure(
-                ReadIndexErrorCodes.ReadIndexBootstrapFailed,
-                "Index contract file was not found: ops.catalog.json.")));
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.Unavailable,
+                    ReadIndexErrorCodes.ReadIndexBootstrapFailed,
+                    "Index contract file was not found: ops.catalog.json."))));
 
         var result = await resolver.Resolve(
             CreateUnityProject(),
@@ -58,12 +60,11 @@ public sealed class ReadIndexValidationCatalogResolverTests
     [Trait("Size", "Small")]
     public async Task Resolve_WhenRequireFreshAndPersistedCatalogIsStale_ReturnsFailureWithReadIndexHit ()
     {
-        var persistedCatalog = CreatePersistedCatalogStub(IndexFreshness.Stale);
         var resolver = new ReadIndexValidationCatalogResolver(new SpyPersistedOpsCatalogReader(
-            PersistedOpsCatalogReadResult.Success(
-                persistedCatalog.Entries,
-                persistedCatalog.GeneratedAtUtc,
-                persistedCatalog.Freshness)));
+            CreatePersistedReadResult(
+                DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
+                IndexFreshness.Stale,
+                [CreateGoDescribeEntry()])));
 
         var result = await resolver.Resolve(
             CreateUnityProject(),
@@ -82,24 +83,12 @@ public sealed class ReadIndexValidationCatalogResolverTests
     [Trait("Size", "Small")]
     public async Task Resolve_WhenPersistedCatalogEntryIsMalformed_ReturnsFormatInvalidFailure ()
     {
-        var malformedPersistedCatalog = new
-        {
-            Entries = new IndexOpEntryJsonContract[]
-            {
-                new(
-                    Name: "ucli.invalid",
-                    Kind: "unsupported-kind",
-                    Policy: "safe",
-                    ArgsSchemaJson: """{"type":"object"}"""),
-            },
-            GeneratedAtUtc = DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
-            Freshness = IndexFreshness.Fresh,
-        };
         var resolver = new ReadIndexValidationCatalogResolver(new SpyPersistedOpsCatalogReader(
-            PersistedOpsCatalogReadResult.Success(
-                malformedPersistedCatalog.Entries,
-                malformedPersistedCatalog.GeneratedAtUtc,
-                malformedPersistedCatalog.Freshness)));
+            PersistedOpsCatalogReadResult.Failure(
+                new PersistedOpsCatalogReadFailure(
+                    PersistedOpsCatalogReadFailureKind.Malformed,
+                    ReadIndexErrorCodes.ReadIndexFormatInvalid,
+                    "Index contract file 'ops.catalog.json' is malformed."))));
 
         var result = await resolver.Resolve(
             CreateUnityProject(),
@@ -117,12 +106,11 @@ public sealed class ReadIndexValidationCatalogResolverTests
     [Trait("Size", "Small")]
     public async Task Resolve_WhenPersistedCatalogIsUsable_ReturnsMetadataBackedSuccess ()
     {
-        var persistedCatalog = CreatePersistedCatalogStub(IndexFreshness.Probable);
         var resolver = new ReadIndexValidationCatalogResolver(new SpyPersistedOpsCatalogReader(
-            PersistedOpsCatalogReadResult.Success(
-                persistedCatalog.Entries,
-                persistedCatalog.GeneratedAtUtc,
-                persistedCatalog.Freshness)));
+            CreatePersistedReadResult(
+                DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
+                IndexFreshness.Probable,
+                [CreateGoDescribeEntry()])));
 
         var result = await resolver.Resolve(
             CreateUnityProject(),
@@ -146,26 +134,6 @@ public sealed class ReadIndexValidationCatalogResolverTests
             ProjectFingerprint: "project-fingerprint",
             PathSource: UnityProjectPathSource.CommandOption);
     }
-
-    private static PersistedOpsCatalogReadResultStub CreatePersistedCatalogStub (IndexFreshness freshness)
-    {
-        return new PersistedOpsCatalogReadResultStub(
-            Entries:
-            [
-                new IndexOpEntryJsonContract(
-                    Name: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.GoDescribe,
-                    Kind: "query",
-                    Policy: "safe",
-                    ArgsSchemaJson: """{"type":"object"}"""),
-            ],
-            GeneratedAtUtc: DateTimeOffset.Parse("2026-03-06T00:00:00+00:00"),
-            Freshness: freshness);
-    }
-
-    private sealed record PersistedOpsCatalogReadResultStub (
-        IReadOnlyList<IndexOpEntryJsonContract> Entries,
-        DateTimeOffset GeneratedAtUtc,
-        IndexFreshness Freshness);
 
     private sealed class SpyPersistedOpsCatalogReader : IPersistedOpsCatalogReader
     {

--- a/tests/Ucli.Application.Tests/Helpers/OperationCatalogTestFixtures.cs
+++ b/tests/Ucli.Application.Tests/Helpers/OperationCatalogTestFixtures.cs
@@ -1,0 +1,80 @@
+using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Application.Tests.Helpers.OperationCatalog;
+
+internal static class OperationCatalogTestFixtures
+{
+    public static OpsCatalogSnapshot CreateSnapshot (
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IndexOpEntryJsonContract> operations)
+    {
+        if (!OpsCatalogSnapshot.TryCreate(generatedAtUtc, operations, "operations", out var snapshot, out var error))
+        {
+            throw new InvalidOperationException($"Operation catalog test fixture is invalid. {error}");
+        }
+
+        return snapshot!;
+    }
+
+    public static PersistedOpsCatalogReadResult CreatePersistedReadResult (
+        DateTimeOffset generatedAtUtc,
+        IndexFreshness freshness,
+        IReadOnlyList<IndexOpEntryJsonContract> operations)
+    {
+        return PersistedOpsCatalogReadResult.Success(
+            CreateSnapshot(generatedAtUtc, operations),
+            freshness);
+    }
+
+    public static OpsCatalogSourceRefreshResult CreateSourceRefreshResult (
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IndexOpEntryJsonContract> operations,
+        string? fallbackReason)
+    {
+        return OpsCatalogSourceRefreshResult.Success(
+            CreateSnapshot(generatedAtUtc, operations),
+            fallbackReason);
+    }
+
+    public static IndexOpEntryJsonContract CreateGoDescribeEntry ()
+    {
+        return new IndexOpEntryJsonContract(
+            Name: UcliPrimitiveOperationNames.GoDescribe,
+            Kind: "query",
+            Policy: "safe",
+            ArgsSchemaJson: """{"type":"object"}""",
+            ResultSchemaJson: """{"type":"object"}""")
+        {
+            Description = "Returns a GameObject description including components and child hierarchy.",
+            Inputs = Array.Empty<UcliOperationInputContract>(),
+            ResultContract = UcliOperationResultContract.One<GameObjectDescriptionResult>("GameObject description result."),
+            Assurance = new UcliOperationAssuranceContract(
+                Array.Empty<string>(),
+                mayDirty: false,
+                mayPersist: false,
+                Array.Empty<string>(),
+                UcliOperationPlanModeValues.ObservesLiveUnity),
+        };
+    }
+
+    public static IndexOpEntryJsonContract CreateSceneSaveEntry ()
+    {
+        return new IndexOpEntryJsonContract(
+            Name: UcliPrimitiveOperationNames.SceneSave,
+            Kind: "mutation",
+            Policy: "advanced",
+            ArgsSchemaJson: """{"type":"object"}""")
+        {
+            Description = "Saves a Unity scene asset.",
+            Inputs = Array.Empty<UcliOperationInputContract>(),
+            ResultContract = UcliOperationResultContract.NoResult("No operation-specific result is emitted."),
+            Assurance = new UcliOperationAssuranceContract(
+                Array.Empty<string>(),
+                mayDirty: false,
+                mayPersist: true,
+                Array.Empty<string>(),
+                UcliOperationPlanModeValues.ObservesLiveUnity),
+        };
+    }
+}

--- a/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogReaderTests.cs
+++ b/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogReaderTests.cs
@@ -49,9 +49,9 @@ public sealed class OpsCatalogReaderTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.NotNull(result.Response);
-        Assert.Single(result.Response.Operations!);
-        Assert.Equal(UcliPrimitiveOperationNames.GoDescribe, result.Response.Operations![0].Name);
+        Assert.NotNull(result.Snapshot);
+        Assert.Single(result.Snapshot.Operations);
+        Assert.Equal(UcliPrimitiveOperationNames.GoDescribe, result.Snapshot.Operations[0].Name);
         Assert.Equal(UcliCommandIds.Ops, executor.Command.Name);
         var request = Assert.IsType<UnityRequestPayload.Raw>(executor.Payload);
         Assert.Equal(IpcMethodNames.OpsRead, request.Method);

--- a/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshServiceTests.cs
+++ b/tests/Ucli.Tests/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshServiceTests.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.UnityIntegration.Indexing.Core;
+using static MackySoft.Ucli.Tests.Features.OperationCatalog.OperationCatalogTestFixtures;
 
 namespace MackySoft.Ucli.Tests.Features.OperationCatalog.Catalog.Source;
 
@@ -15,8 +16,7 @@ public sealed class OpsCatalogSourceRefreshServiceTests
         var generatedAtUtc = DateTimeOffset.Parse("2026-03-07T00:00:00+00:00");
         var reader = new StubOpsCatalogReader
         {
-            Result = OpsCatalogFetchResult.Success(
-                new IpcOpsReadResponse(generatedAtUtc, [CreateGoDescribeEntry()])),
+            Result = CreateFetchResult(generatedAtUtc, [CreateGoDescribeEntry()]),
         };
         var fingerprintProvider = new StubReadIndexInputFingerprintProvider
         {
@@ -57,10 +57,9 @@ public sealed class OpsCatalogSourceRefreshServiceTests
     {
         var reader = new StubOpsCatalogReader
         {
-            Result = OpsCatalogFetchResult.Success(
-                new IpcOpsReadResponse(
-                    DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
-                    [CreateGoDescribeEntry()])),
+            Result = CreateFetchResult(
+                DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+                [CreateGoDescribeEntry()]),
         };
         var persistedArtifactsReader = new StubPersistedOpsCatalogPersistenceArtifactsReader
         {
@@ -112,10 +111,9 @@ public sealed class OpsCatalogSourceRefreshServiceTests
     {
         var reader = new StubOpsCatalogReader
         {
-            Result = OpsCatalogFetchResult.Success(
-                new IpcOpsReadResponse(
-                    DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
-                    [CreateGoDescribeEntry()])),
+            Result = CreateFetchResult(
+                DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+                [CreateGoDescribeEntry()]),
         };
         var artifactWriter = new StubReadIndexArtifactWriter
         {
@@ -152,10 +150,9 @@ public sealed class OpsCatalogSourceRefreshServiceTests
     {
         var reader = new StubOpsCatalogReader
         {
-            Result = OpsCatalogFetchResult.Success(
-                new IpcOpsReadResponse(
-                    DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
-                    [CreateGoDescribeEntry()])),
+            Result = CreateFetchResult(
+                DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+                [CreateGoDescribeEntry()]),
         };
         var fingerprintProvider = new StubReadIndexInputFingerprintProvider
         {
@@ -192,10 +189,9 @@ public sealed class OpsCatalogSourceRefreshServiceTests
     public async Task Refresh_ReturnsFirstSourceResultWithRetryFailureReason_WhenRetryCatalogReadFails ()
     {
         var reader = new StubOpsCatalogReader();
-        reader.Enqueue(OpsCatalogFetchResult.Success(
-            new IpcOpsReadResponse(
-                DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
-                [CreateGoDescribeEntry()])));
+        reader.Enqueue(CreateFetchResult(
+            DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+            [CreateGoDescribeEntry()]));
         reader.Enqueue(OpsCatalogFetchResult.Failure("Unity source unavailable.", UcliCoreErrorCodes.InternalError));
         var fingerprintProvider = new StubReadIndexInputFingerprintProvider
         {
@@ -221,8 +217,8 @@ public sealed class OpsCatalogSourceRefreshServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.Single(result.Operations!);
-        Assert.Equal(UcliPrimitiveOperationNames.GoDescribe, result.Operations![0].Name);
+        Assert.Single(result.Snapshot!.Operations);
+        Assert.Equal(UcliPrimitiveOperationNames.GoDescribe, result.Snapshot.Operations[0].Name);
         Assert.Contains("readIndex stale.", result.FallbackReason!, StringComparison.Ordinal);
         Assert.Contains("project inputs changed while the catalog was being read", result.FallbackReason!, StringComparison.Ordinal);
         Assert.Contains("retry catalog read failed. Unity source unavailable.", result.FallbackReason!, StringComparison.Ordinal);
@@ -236,14 +232,12 @@ public sealed class OpsCatalogSourceRefreshServiceTests
     public async Task Refresh_RetriesAndPersists_WhenCoreInputsChangeDuringFirstCatalogRead ()
     {
         var reader = new StubOpsCatalogReader();
-        reader.Enqueue(OpsCatalogFetchResult.Success(
-            new IpcOpsReadResponse(
-                DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
-                [CreateGoDescribeEntry()])));
-        reader.Enqueue(OpsCatalogFetchResult.Success(
-            new IpcOpsReadResponse(
-                DateTimeOffset.Parse("2026-03-07T00:01:00+00:00"),
-                [CreateSceneSaveEntry()])));
+        reader.Enqueue(CreateFetchResult(
+            DateTimeOffset.Parse("2026-03-07T00:00:00+00:00"),
+            [CreateGoDescribeEntry()]));
+        reader.Enqueue(CreateFetchResult(
+            DateTimeOffset.Parse("2026-03-07T00:01:00+00:00"),
+            [CreateSceneSaveEntry()]));
         var fingerprintProvider = new StubReadIndexInputFingerprintProvider
         {
             Snapshot = CreateSnapshot("asset-search", "guid-path", "combined-2"),
@@ -269,8 +263,8 @@ public sealed class OpsCatalogSourceRefreshServiceTests
             CancellationToken.None);
 
         Assert.True(result.IsSuccess);
-        Assert.Single(result.Operations!);
-        Assert.Equal(UcliPrimitiveOperationNames.SceneSave, result.Operations![0].Name);
+        Assert.Single(result.Snapshot!.Operations);
+        Assert.Equal(UcliPrimitiveOperationNames.SceneSave, result.Snapshot.Operations[0].Name);
         Assert.Equal(2, reader.CallCount);
         Assert.Equal(4, fingerprintProvider.CoreCallCount);
         Assert.Equal(1, artifactWriter.OpsCatalogCallCount);
@@ -284,48 +278,6 @@ public sealed class OpsCatalogSourceRefreshServiceTests
             RepositoryRoot: "/repo",
             ProjectFingerprint: "project-fingerprint",
             PathSource: UnityProjectPathSource.CommandOption);
-    }
-
-    private static IndexOpEntryJsonContract CreateGoDescribeEntry ()
-    {
-        return new IndexOpEntryJsonContract(
-            Name: UcliPrimitiveOperationNames.GoDescribe,
-            Kind: "query",
-            Policy: "safe",
-            ArgsSchemaJson: """{"type":"object"}""",
-            ResultSchemaJson: """{"type":"object"}""")
-        {
-            Description = "Returns a GameObject description including components and child hierarchy.",
-            Inputs = Array.Empty<UcliOperationInputContract>(),
-            ResultContract = UcliOperationResultContract.One<GameObjectDescriptionResult>("GameObject description result."),
-            Assurance = new UcliOperationAssuranceContract(
-                Array.Empty<string>(),
-                mayDirty: false,
-                mayPersist: false,
-                Array.Empty<string>(),
-                UcliOperationPlanModeValues.ObservesLiveUnity),
-        };
-    }
-
-    private static IndexOpEntryJsonContract CreateSceneSaveEntry ()
-    {
-        return new IndexOpEntryJsonContract(
-            Name: UcliPrimitiveOperationNames.SceneSave,
-            Kind: "mutation",
-            Policy: "advanced",
-            ArgsSchemaJson: """{"type":"object"}""",
-            ResultSchemaJson: """{"type":"object"}""")
-        {
-            Description = "Saves a Unity scene asset.",
-            Inputs = Array.Empty<UcliOperationInputContract>(),
-            ResultContract = UcliOperationResultContract.NoResult("No operation-specific result is emitted."),
-            Assurance = new UcliOperationAssuranceContract(
-                Array.Empty<string>(),
-                mayDirty: false,
-                mayPersist: true,
-                Array.Empty<string>(),
-                UcliOperationPlanModeValues.ObservesLiveUnity),
-        };
     }
 
     private static ReadIndexCoreInputHashSnapshot CreateCoreSnapshot (string combinedHash)

--- a/tests/Ucli.Tests/Features/OperationCatalog/OperationCatalogTestFixtures.cs
+++ b/tests/Ucli.Tests/Features/OperationCatalog/OperationCatalogTestFixtures.cs
@@ -1,0 +1,60 @@
+using MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Tests.Features.OperationCatalog;
+
+internal static class OperationCatalogTestFixtures
+{
+    public static OpsCatalogFetchResult CreateFetchResult (
+        DateTimeOffset generatedAtUtc,
+        IReadOnlyList<IndexOpEntryJsonContract> operations)
+    {
+        if (!OpsCatalogSnapshot.TryCreate(generatedAtUtc, operations, "operations", out var snapshot, out var error))
+        {
+            throw new InvalidOperationException($"Operation catalog test fixture is invalid. {error}");
+        }
+
+        return OpsCatalogFetchResult.Success(snapshot!);
+    }
+
+    public static IndexOpEntryJsonContract CreateGoDescribeEntry ()
+    {
+        return new IndexOpEntryJsonContract(
+            Name: UcliPrimitiveOperationNames.GoDescribe,
+            Kind: "query",
+            Policy: "safe",
+            ArgsSchemaJson: """{"type":"object"}""",
+            ResultSchemaJson: """{"type":"object"}""")
+        {
+            Description = "Returns a GameObject description including components and child hierarchy.",
+            Inputs = Array.Empty<UcliOperationInputContract>(),
+            ResultContract = UcliOperationResultContract.One<GameObjectDescriptionResult>("GameObject description result."),
+            Assurance = new UcliOperationAssuranceContract(
+                Array.Empty<string>(),
+                mayDirty: false,
+                mayPersist: false,
+                Array.Empty<string>(),
+                UcliOperationPlanModeValues.ObservesLiveUnity),
+        };
+    }
+
+    public static IndexOpEntryJsonContract CreateSceneSaveEntry ()
+    {
+        return new IndexOpEntryJsonContract(
+            Name: UcliPrimitiveOperationNames.SceneSave,
+            Kind: "mutation",
+            Policy: "advanced",
+            ArgsSchemaJson: """{"type":"object"}""")
+        {
+            Description = "Saves a Unity scene asset.",
+            Inputs = Array.Empty<UcliOperationInputContract>(),
+            ResultContract = UcliOperationResultContract.NoResult("No operation-specific result is emitted."),
+            Assurance = new UcliOperationAssuranceContract(
+                Array.Empty<string>(),
+                mayDirty: false,
+                mayPersist: true,
+                Array.Empty<string>(),
+                UcliOperationPlanModeValues.ObservesLiveUnity),
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Formalize the operation catalog flow around a validated internal snapshot.
- Classify persisted catalog read failures and route access policy through those failure kinds.
- Keep public ops list/describe, IPC, and catalog JSON contracts stable while updating tests and docs.

## Verification
- bash scripts/verify.sh

Closes #215