### PR TITLE
Issue #265 launch attempt store と lastLaunchAttempt を実装

### DIFF
--- a/docs/uCLI-property-reference.md
+++ b/docs/uCLI-property-reference.md
@@ -334,15 +334,17 @@ final `daemon start` failure payload では原則として `retryDisposition=wai
 
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |
+| `launchAttemptId` | `string` | yes | 起動 attempt の識別子 |
 | `startupStatus` | `blocked \| timeout \| failed` | yes | 直近の session 未成立 attempt の最終状態。running session と重複する `completed` attempt は返さない |
 | `startupBlockingReason` | `null \| safeMode \| compile \| packageResolution \| ucliPlugin \| precompiledAssemblyConflict \| modalDialog \| endpointNotRegistered \| processExit \| unknown` | yes | startup を止めた理由 |
-| `launchAttemptId` | `string \| null` | yes | 起動 attempt の識別子 |
-| `diagnosisReason` | `string \| null` | yes | 直近 attempt の diagnosis reason |
 | `retryDisposition` | `retryImmediately \| waitThenRetry \| retryAfterFix \| manualActionRequired \| doNotRetry \| unknown` | yes | 直近 attempt の再試行方針 |
 | `processAction` | `none \| kept \| terminated \| unknown` | yes | 起動失敗後に uCLI が process へ行った処理 |
-| `diagnosisPath` | `string \| null` | yes | startup diagnosis artifact path |
-| `artifactPath` | `string \| null` | yes | launch attempt artifact directory |
+| `artifactPath` | `string` | yes | `startup-diagnosis.json` の artifact path |
+| `unityLogPath` | `string \| null` | yes | 参照先 Unity log path。log snapshot は複製しない |
 | `updatedAtUtc` | string | yes | attempt 診断の更新時刻 |
+| `processId` | `integer \| null` | yes | 起動 attempt に関連する process id |
+| `processStartedAtUtc` | `string \| null` | yes | 起動 attempt に関連する process start timestamp |
+| `diagnosis` | `object` | yes | attempt 単体で読める startup failure diagnosis |
 
 #### `daemon list`
 

--- a/src/Ucli.Application/Features/Daemon/Common/CommandContracts/DaemonLaunchAttemptOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/CommandContracts/DaemonLaunchAttemptOutput.cs
@@ -1,0 +1,15 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+
+/// <summary> Represents normalized payload values for one daemon launch-attempt projection. </summary>
+internal sealed record DaemonLaunchAttemptOutput (
+    string LaunchAttemptId,
+    string StartupStatus,
+    string? StartupBlockingReason,
+    string RetryDisposition,
+    string ProcessAction,
+    string ArtifactPath,
+    string? UnityLogPath,
+    DateTimeOffset UpdatedAtUtc,
+    int? ProcessId,
+    DateTimeOffset? ProcessStartedAtUtc,
+    DaemonDiagnosisOutput Diagnosis);

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanupResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanupResult.cs
@@ -1,0 +1,30 @@
+using MackySoft.Ucli.Application.Shared.Foundation;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
+
+/// <summary> Represents stale daemon artifact cleanup result. </summary>
+internal sealed record DaemonArtifactCleanupResult (
+    int DeletedLaunchAttemptCount,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether cleanup succeeded. </summary>
+    public bool IsSuccess => Error is null;
+
+    /// <summary> Creates a successful cleanup result. </summary>
+    /// <param name="deletedLaunchAttemptCount"> The number of deleted launch-attempt directories. </param>
+    /// <returns> The cleanup result. </returns>
+    public static DaemonArtifactCleanupResult Success (int deletedLaunchAttemptCount = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(deletedLaunchAttemptCount);
+        return new DaemonArtifactCleanupResult(deletedLaunchAttemptCount, null);
+    }
+
+    /// <summary> Creates a failed cleanup result. </summary>
+    /// <param name="error"> The structured error. </param>
+    /// <returns> The cleanup result. </returns>
+    public static DaemonArtifactCleanupResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new DaemonArtifactCleanupResult(0, error);
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperation.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperation.cs
@@ -205,7 +205,7 @@ internal sealed class DaemonCleanupOperation : IDaemonCleanupOperation
 
         var cleanupResult = await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
         return cleanupResult.IsSuccess
-            ? DaemonCleanupResult.Completed()
+            ? DaemonCleanupResult.Completed(cleanupResult.DeletedLaunchAttemptCount)
             : DaemonCleanupResult.Failure(cleanupResult.Error!);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupResult.cs
@@ -5,10 +5,12 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
 /// <summary> Represents the result of daemon cleanup operation. </summary>
 /// <param name="Status"> The daemon cleanup outcome. </param>
 /// <param name="SkipReason"> The cleanup skip reason when cleanup was skipped; otherwise <see cref="DaemonCleanupSkipReason.None" />. </param>
+/// <param name="DeletedLaunchAttemptCount"> The number of deleted launch-attempt directories. </param>
 /// <param name="Error"> The structured error when cleanup fails; otherwise <see langword="null" />. </param>
 internal sealed record DaemonCleanupResult (
     DaemonCleanupStatus Status,
     DaemonCleanupSkipReason SkipReason,
+    int DeletedLaunchAttemptCount,
     ExecutionError? Error)
 {
     /// <summary> Gets a value indicating whether daemon cleanup succeeded. </summary>
@@ -18,7 +20,16 @@ internal sealed record DaemonCleanupResult (
     /// <returns> The successful completed result. </returns>
     public static DaemonCleanupResult Completed ()
     {
-        return new DaemonCleanupResult(DaemonCleanupStatus.Completed, DaemonCleanupSkipReason.None, null);
+        return Completed(deletedLaunchAttemptCount: 0);
+    }
+
+    /// <summary> Creates a successful completed result. </summary>
+    /// <param name="deletedLaunchAttemptCount"> The number of deleted launch-attempt directories. </param>
+    /// <returns> The successful completed result. </returns>
+    public static DaemonCleanupResult Completed (int deletedLaunchAttemptCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(deletedLaunchAttemptCount);
+        return new DaemonCleanupResult(DaemonCleanupStatus.Completed, DaemonCleanupSkipReason.None, deletedLaunchAttemptCount, null);
     }
 
     /// <summary> Creates a successful skipped result. </summary>
@@ -32,7 +43,7 @@ internal sealed record DaemonCleanupResult (
             throw new ArgumentOutOfRangeException(nameof(skipReason), skipReason, "Cleanup skip reason must not be None.");
         }
 
-        return new DaemonCleanupResult(DaemonCleanupStatus.Skipped, skipReason, null);
+        return new DaemonCleanupResult(DaemonCleanupStatus.Skipped, skipReason, 0, null);
     }
 
     /// <summary> Creates a failed cleanup result. </summary>
@@ -42,6 +53,6 @@ internal sealed record DaemonCleanupResult (
     public static DaemonCleanupResult Failure (ExecutionError error)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonCleanupResult(DaemonCleanupStatus.Failed, DaemonCleanupSkipReason.None, error);
+        return new DaemonCleanupResult(DaemonCleanupStatus.Failed, DaemonCleanupSkipReason.None, 0, error);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/IDaemonArtifactCleaner.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Cleanup/IDaemonArtifactCleaner.cs
@@ -1,5 +1,3 @@
-using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
-
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
 
 /// <summary> Cleans stale daemon artifacts such as persisted sessions and endpoint residues. </summary>
@@ -8,8 +6,8 @@ internal interface IDaemonArtifactCleaner
     /// <summary> Cleans stale daemon artifacts for the specified Unity project context. </summary>
     /// <param name="unityProject"> The resolved Unity project context. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
-    /// <returns> The cleanup operation result. </returns>
-    ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+    /// <returns> The cleanup result. </returns>
+    ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
         ResolvedUnityProjectContext unityProject,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttempt.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttempt.cs
@@ -1,0 +1,19 @@
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Represents one persisted daemon launch attempt that ended before session registration completed. </summary>
+internal sealed record DaemonLaunchAttempt (
+    string LaunchAttemptId,
+    DateTimeOffset StartedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    string StartupStatus,
+    string? StartupBlockingReason,
+    string RetryDisposition,
+    string ProcessAction,
+    string? EditorMode,
+    int? ProcessId,
+    DateTimeOffset? ProcessStartedAtUtc,
+    string? UnityLogPath,
+    string ArtifactPath,
+    DaemonDiagnosis Diagnosis);

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptReadResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptReadResult.cs
@@ -1,0 +1,32 @@
+using MackySoft.Ucli.Application.Shared.Foundation;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Represents a daemon launch-attempt read result. </summary>
+internal sealed record DaemonLaunchAttemptReadResult (
+    DaemonLaunchAttempt? LaunchAttempt,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether the read operation succeeded. </summary>
+    public bool IsSuccess => Error is null;
+
+    /// <summary> Gets a value indicating whether a launch attempt was found. </summary>
+    public bool Exists => LaunchAttempt is not null;
+
+    /// <summary> Creates a successful read result. </summary>
+    /// <param name="launchAttempt"> The launch attempt when available. </param>
+    /// <returns> The read result. </returns>
+    public static DaemonLaunchAttemptReadResult Success (DaemonLaunchAttempt? launchAttempt)
+    {
+        return new DaemonLaunchAttemptReadResult(launchAttempt, null);
+    }
+
+    /// <summary> Creates a failed read result. </summary>
+    /// <param name="error"> The structured error. </param>
+    /// <returns> The read result. </returns>
+    public static DaemonLaunchAttemptReadResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new DaemonLaunchAttemptReadResult(null, error);
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreOperationResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreOperationResult.cs
@@ -1,0 +1,30 @@
+using MackySoft.Ucli.Application.Shared.Foundation;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Represents a daemon launch-attempt store mutation result. </summary>
+internal sealed record DaemonLaunchAttemptStoreOperationResult (
+    int DeletedCount,
+    ExecutionError? Error)
+{
+    /// <summary> Gets a value indicating whether the store operation succeeded. </summary>
+    public bool IsSuccess => Error is null;
+
+    /// <summary> Creates a successful store operation result. </summary>
+    /// <param name="deletedCount"> The number of deleted launch-attempt directories. </param>
+    /// <returns> The store operation result. </returns>
+    public static DaemonLaunchAttemptStoreOperationResult Success (int deletedCount = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(deletedCount);
+        return new DaemonLaunchAttemptStoreOperationResult(deletedCount, null);
+    }
+
+    /// <summary> Creates a failed store operation result. </summary>
+    /// <param name="error"> The structured error. </param>
+    /// <returns> The store operation result. </returns>
+    public static DaemonLaunchAttemptStoreOperationResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return new DaemonLaunchAttemptStoreOperationResult(0, error);
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/IDaemonLaunchAttemptIdGenerator.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/IDaemonLaunchAttemptIdGenerator.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Generates path-safe daemon launch-attempt identifiers. </summary>
+internal interface IDaemonLaunchAttemptIdGenerator
+{
+    /// <summary> Creates one launch-attempt identifier for the specified UTC timestamp. </summary>
+    /// <param name="startedAtUtc"> The launch-attempt start timestamp. </param>
+    /// <returns> The generated launch-attempt identifier. </returns>
+    string Create (DateTimeOffset startedAtUtc);
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/IDaemonLaunchAttemptStore.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/LaunchAttempts/IDaemonLaunchAttemptStore.cs
@@ -1,0 +1,39 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Persists daemon launch-attempt diagnosis artifacts. </summary>
+internal interface IDaemonLaunchAttemptStore
+{
+    /// <summary> Writes one failed launch attempt. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <param name="launchAttempt"> The launch attempt to persist. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The store operation result. </returns>
+    ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
+        string storageRoot,
+        string projectFingerprint,
+        DaemonLaunchAttempt launchAttempt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary> Reads the most recent failed launch attempt that is safe to expose through public status payloads. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The read result. </returns>
+    ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (
+        string storageRoot,
+        string projectFingerprint,
+        CancellationToken cancellationToken = default);
+
+    /// <summary> Deletes old launch attempts while preserving the most recent entries. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <param name="keepCount"> The number of most recent launch attempts to keep. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> The store operation result. </returns>
+    ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+        string storageRoot,
+        string projectFingerprint,
+        int keepCount,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Recovery/DaemonLaunchCompensationService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Recovery/DaemonLaunchCompensationService.cs
@@ -54,6 +54,9 @@ internal sealed class DaemonLaunchCompensationService : IDaemonLaunchCompensatio
             return stopResult;
         }
 
-        return await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        var cleanupResult = await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        return cleanupResult.IsSuccess
+            ? DaemonSessionStoreOperationResult.Success()
+            : DaemonSessionStoreOperationResult.Failure(cleanupResult.Error!);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Recovery/DaemonSessionCleanupService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Recovery/DaemonSessionCleanupService.cs
@@ -60,7 +60,10 @@ internal sealed class DaemonSessionCleanupService : IDaemonSessionCleanupService
             }
         }
 
-        return await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        var cleanupResult = await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        return cleanupResult.IsSuccess
+            ? DaemonSessionStoreOperationResult.Success()
+            : DaemonSessionStoreOperationResult.Failure(cleanupResult.Error!);
     }
 
     /// <summary> Cleans stale-session artifacts from existing daemon session metadata. </summary>
@@ -95,7 +98,10 @@ internal sealed class DaemonSessionCleanupService : IDaemonSessionCleanupService
             }
         }
 
-        return await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        var cleanupResult = await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        return cleanupResult.IsSuccess
+            ? DaemonSessionStoreOperationResult.Success()
+            : DaemonSessionStoreOperationResult.Failure(cleanupResult.Error!);
     }
 
     private static bool TryCreateUnsafeInvalidSessionRelaunchError (

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupStatusValues.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupStatusValues.cs
@@ -12,4 +12,6 @@ internal static class DaemonStartupStatusValues
     public const string Timeout = "timeout";
 
     public const string Failed = "failed";
+
+    public const string Completed = "completed";
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Status/DaemonStatusOperation.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Status/DaemonStatusOperation.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
@@ -10,6 +11,8 @@ internal sealed class DaemonStatusOperation : IDaemonStatusOperation
     private readonly IDaemonSessionStore daemonSessionStore;
 
     private readonly IDaemonDiagnosisStore daemonDiagnosisStore;
+
+    private readonly IDaemonLaunchAttemptStore launchAttemptStore;
 
     private readonly IDaemonPingClient daemonPingClient;
 
@@ -27,12 +30,14 @@ internal sealed class DaemonStatusOperation : IDaemonStatusOperation
     public DaemonStatusOperation (
         IDaemonSessionStore daemonSessionStore,
         IDaemonDiagnosisStore daemonDiagnosisStore,
+        IDaemonLaunchAttemptStore launchAttemptStore,
         IDaemonPingClient daemonPingClient,
         IDaemonReachabilityClassifier reachabilityClassifier,
         IDaemonSessionDiagnosisResolver daemonSessionDiagnosisResolver)
     {
         this.daemonSessionStore = daemonSessionStore ?? throw new ArgumentNullException(nameof(daemonSessionStore));
         this.daemonDiagnosisStore = daemonDiagnosisStore ?? throw new ArgumentNullException(nameof(daemonDiagnosisStore));
+        this.launchAttemptStore = launchAttemptStore ?? throw new ArgumentNullException(nameof(launchAttemptStore));
         this.daemonPingClient = daemonPingClient ?? throw new ArgumentNullException(nameof(daemonPingClient));
         this.reachabilityClassifier = reachabilityClassifier ?? throw new ArgumentNullException(nameof(reachabilityClassifier));
         this.daemonSessionDiagnosisResolver = daemonSessionDiagnosisResolver ?? throw new ArgumentNullException(nameof(daemonSessionDiagnosisResolver));
@@ -75,7 +80,17 @@ internal sealed class DaemonStatusOperation : IDaemonStatusOperation
 
         if (!readResult.Exists)
         {
-            return DaemonStatusResult.NotRunning(persistedDiagnosis);
+            var launchAttemptReadResult = await launchAttemptStore.ReadLastFailureAsync(
+                    unityProject.RepositoryRoot,
+                    unityProject.ProjectFingerprint,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!launchAttemptReadResult.IsSuccess)
+            {
+                return DaemonStatusResult.Failure(launchAttemptReadResult.Error!);
+            }
+
+            return DaemonStatusResult.NotRunning(persistedDiagnosis, launchAttemptReadResult.LaunchAttempt);
         }
 
         try

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Status/DaemonStatusResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Status/DaemonStatusResult.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
@@ -13,7 +14,8 @@ internal sealed record DaemonStatusResult (
     DaemonStatusKind Status,
     DaemonSession? Session,
     DaemonDiagnosis? Diagnosis,
-    ExecutionError? Error)
+    ExecutionError? Error,
+    DaemonLaunchAttempt? LastLaunchAttempt = null)
 {
     /// <summary> Gets a value indicating whether daemon status query succeeded. </summary>
     public bool IsSuccess => Status != DaemonStatusKind.Failed && Error is null;
@@ -37,6 +39,17 @@ internal sealed record DaemonStatusResult (
     public static DaemonStatusResult NotRunning (DaemonDiagnosis? diagnosis = null)
     {
         return new DaemonStatusResult(DaemonStatusKind.NotRunning, null, diagnosis, null);
+    }
+
+    /// <summary> Creates a not-running result with the most recent launch attempt. </summary>
+    /// <param name="diagnosis"> The persisted daemon diagnosis metadata when available. </param>
+    /// <param name="lastLaunchAttempt"> The most recent session-less launch attempt when available. </param>
+    /// <returns> The not-running result. </returns>
+    public static DaemonStatusResult NotRunning (
+        DaemonDiagnosis? diagnosis,
+        DaemonLaunchAttempt? lastLaunchAttempt)
+    {
+        return new DaemonStatusResult(DaemonStatusKind.NotRunning, null, diagnosis, null, lastLaunchAttempt);
     }
 
     /// <summary> Creates a stale-session result. </summary>

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Stop/DaemonStopOperation.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Stop/DaemonStopOperation.cs
@@ -249,6 +249,9 @@ internal sealed class DaemonStopOperation : IDaemonStopOperation
             }
         }
 
-        return await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        var cleanupResult = await artifactCleaner.CleanupAsync(unityProject, cancellationToken).ConfigureAwait(false);
+        return cleanupResult.IsSuccess
+            ? DaemonSessionStoreOperationResult.Success()
+            : DaemonSessionStoreOperationResult.Failure(cleanupResult.Error!);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/UseCases/Cleanup/DaemonCleanupExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Cleanup/DaemonCleanupExecutionOutput.cs
@@ -4,8 +4,10 @@ namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Cleanup;
 /// <summary> Represents normalized payload values for one daemon-cleanup command execution. </summary>
 /// <param name="CleanupStatus"> The cleanup-status value. </param>
 /// <param name="SkipReason"> The cleanup skip-reason value when cleanup was skipped; otherwise <see langword="null" />. </param>
+/// <param name="DeletedLaunchAttemptCount"> The number of deleted launch-attempt directories. </param>
 /// <param name="TimeoutMilliseconds"> The effective timeout in milliseconds used for daemon cleanup workflow. </param>
 internal sealed record DaemonCleanupExecutionOutput (
     DaemonCleanupStatus CleanupStatus,
     DaemonCleanupSkipReason SkipReason,
+    int DeletedLaunchAttemptCount,
     int TimeoutMilliseconds);

--- a/src/Ucli.Application/Features/Daemon/UseCases/Cleanup/DaemonCleanupService.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Cleanup/DaemonCleanupService.cs
@@ -61,6 +61,7 @@ internal sealed class DaemonCleanupService : IDaemonCleanupService
         var output = new DaemonCleanupExecutionOutput(
             CleanupStatus: cleanupResult.Status,
             SkipReason: cleanupResult.SkipReason,
+            DeletedLaunchAttemptCount: cleanupResult.DeletedLaunchAttemptCount,
             TimeoutMilliseconds: checked((int)executionContext.Timeout.TotalMilliseconds));
         return DaemonCleanupExecutionResult.Success(output);
     }

--- a/src/Ucli.Application/Features/Daemon/UseCases/Status/DaemonStatusExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Status/DaemonStatusExecutionOutput.cs
@@ -18,6 +18,7 @@ namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Status;
 /// <param name="TimeoutMilliseconds"> The effective timeout in milliseconds used for daemon status workflow. </param>
 /// <param name="Session"> The daemon session values when available; otherwise <see langword="null" />. </param>
 /// <param name="Diagnosis"> The daemon diagnosis values when available; otherwise <see langword="null" />. </param>
+/// <param name="LastLaunchAttempt"> The last session-less launch-attempt failure when available; otherwise <see langword="null" />. </param>
 internal sealed record DaemonStatusExecutionOutput (
     DaemonStatusKind DaemonStatus,
     string? ServerVersion,
@@ -31,6 +32,7 @@ internal sealed record DaemonStatusExecutionOutput (
     int TimeoutMilliseconds,
     DaemonSessionOutput? Session,
     DaemonDiagnosisOutput? Diagnosis,
+    DaemonLaunchAttemptOutput? LastLaunchAttempt,
     DateTimeOffset? ObservedAtUtc = null,
     string? ActionRequired = null,
     DaemonPrimaryDiagnosticOutput? PrimaryDiagnostic = null);

--- a/src/Ucli.Application/Features/Daemon/UseCases/Status/DaemonStatusService.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Status/DaemonStatusService.cs
@@ -2,6 +2,7 @@ using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandExecution;
 using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
@@ -286,10 +287,30 @@ internal sealed class DaemonStatusService : IDaemonStatusService
             Diagnosis: diagnosis is null
                 ? null
                 : daemonDiagnosisOutputMapper.ToOutput(diagnosis),
+            LastLaunchAttempt: statusResult.LastLaunchAttempt is null || statusResult.Session is not null
+                ? null
+                : ToLaunchAttemptOutput(statusResult.LastLaunchAttempt),
             ObservedAtUtc: observedAtUtc,
             ActionRequired: actionRequired,
             PrimaryDiagnostic: primaryDiagnostic);
         return DaemonStatusExecutionResult.Success(output);
+    }
+
+    private DaemonLaunchAttemptOutput ToLaunchAttemptOutput (DaemonLaunchAttempt launchAttempt)
+    {
+        ArgumentNullException.ThrowIfNull(launchAttempt);
+        return new DaemonLaunchAttemptOutput(
+            LaunchAttemptId: launchAttempt.LaunchAttemptId,
+            StartupStatus: launchAttempt.StartupStatus,
+            StartupBlockingReason: launchAttempt.StartupBlockingReason,
+            RetryDisposition: launchAttempt.RetryDisposition,
+            ProcessAction: launchAttempt.ProcessAction,
+            ArtifactPath: launchAttempt.ArtifactPath,
+            UnityLogPath: launchAttempt.UnityLogPath,
+            UpdatedAtUtc: launchAttempt.UpdatedAtUtc,
+            ProcessId: launchAttempt.ProcessId,
+            ProcessStartedAtUtc: launchAttempt.ProcessStartedAtUtc,
+            Diagnosis: daemonDiagnosisOutputMapper.ToOutput(launchAttempt.Diagnosis));
     }
 
     private async ValueTask<UnreachableDaemonStatusResolution> ResolveUnreachableRunningSessionAsync (

--- a/src/Ucli.Contracts/Storage/DaemonLaunchAttemptJsonContract.cs
+++ b/src/Ucli.Contracts/Storage/DaemonLaunchAttemptJsonContract.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Contracts.Storage;
+
+/// <summary> Represents persisted daemon launch-attempt <c>startup-diagnosis.json</c> contract fields. </summary>
+internal sealed record DaemonLaunchAttemptJsonContract (
+    int? SchemaVersion,
+    string? LaunchAttemptId,
+    DateTimeOffset StartedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    string? StartupStatus,
+    string? StartupBlockingReason,
+    string? RetryDisposition,
+    string? ProcessAction,
+    string? EditorMode,
+    int? ProcessId,
+    DateTimeOffset? ProcessStartedAtUtc,
+    string? UnityLogPath,
+    DaemonDiagnosisJsonContract? Diagnosis);

--- a/src/Ucli.Contracts/Storage/DaemonLaunchAttemptJsonContractSerializer.cs
+++ b/src/Ucli.Contracts/Storage/DaemonLaunchAttemptJsonContractSerializer.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Contracts.Storage;
+
+/// <summary> Provides shared serializer settings for daemon launch-attempt contracts. </summary>
+internal static class DaemonLaunchAttemptJsonContractSerializer
+{
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+    };
+
+    private static readonly JsonSerializerOptions SerializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+    };
+
+    /// <summary> Deserializes daemon launch-attempt JSON text to contract. </summary>
+    /// <param name="json"> The daemon launch-attempt JSON text. </param>
+    /// <returns> The deserialized contract; or <see langword="null" /> when JSON root is <c>null</c>. </returns>
+    public static DaemonLaunchAttemptJsonContract? Deserialize (string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new ArgumentException("JSON text must not be empty.", nameof(json));
+        }
+
+        return JsonSerializer.Deserialize<DaemonLaunchAttemptJsonContract>(json, DeserializeOptions);
+    }
+
+    /// <summary> Serializes daemon launch-attempt contract to JSON text. </summary>
+    /// <param name="contract"> The daemon launch-attempt contract. </param>
+    /// <returns> The serialized daemon launch-attempt JSON text. </returns>
+    public static string Serialize (DaemonLaunchAttemptJsonContract contract)
+    {
+        if (contract == null)
+        {
+            throw new ArgumentNullException(nameof(contract));
+        }
+
+        return JsonSerializer.Serialize(contract, SerializeOptions);
+    }
+}

--- a/src/Ucli.Contracts/Storage/UcliStoragePathNames.cs
+++ b/src/Ucli.Contracts/Storage/UcliStoragePathNames.cs
@@ -81,6 +81,12 @@ public static class UcliStoragePathNames
     /// <summary> Gets the daemon lifecycle observation file name under one fingerprint directory. </summary>
     public const string DaemonLifecycleFileName = "daemon-lifecycle.json";
 
+    /// <summary> Gets the launch-attempts directory name under one fingerprint directory. </summary>
+    public const string LaunchAttemptsDirectoryName = "launch-attempts";
+
+    /// <summary> Gets the launch-attempt startup diagnosis file name under one launch-attempt directory. </summary>
+    public const string StartupDiagnosisFileName = "startup-diagnosis.json";
+
     /// <summary> Gets the uCLI Unity plugin marker cache file name under one fingerprint directory. </summary>
     public const string UnityUcliPluginMarkerCacheFileName = "ucli-plugin-marker-cache.json";
 

--- a/src/Ucli.Infrastructure/Storage/UcliStoragePathResolver.cs
+++ b/src/Ucli.Infrastructure/Storage/UcliStoragePathResolver.cs
@@ -523,6 +523,49 @@ public static class UcliStoragePathResolver
             UcliStoragePathNames.DaemonLifecycleFileName);
     }
 
+    /// <summary> Resolves the absolute path to the daemon launch-attempts directory under one fingerprint directory. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <returns> The absolute daemon launch-attempts directory path. </returns>
+    public static string ResolveLaunchAttemptsDirectory (
+        string storageRoot,
+        string projectFingerprint)
+    {
+        return Path.Combine(
+            ResolveFingerprintDirectory(storageRoot, projectFingerprint),
+            UcliStoragePathNames.LaunchAttemptsDirectoryName);
+    }
+
+    /// <summary> Resolves the absolute path to one daemon launch-attempt directory. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <param name="launchAttemptId"> The launch-attempt identifier. </param>
+    /// <returns> The absolute daemon launch-attempt directory path. </returns>
+    public static string ResolveLaunchAttemptDirectory (
+        string storageRoot,
+        string projectFingerprint,
+        string launchAttemptId)
+    {
+        return Path.Combine(
+            ResolveLaunchAttemptsDirectory(storageRoot, projectFingerprint),
+            NormalizeLaunchAttemptId(launchAttemptId));
+    }
+
+    /// <summary> Resolves the absolute path to one daemon launch-attempt startup diagnosis file. </summary>
+    /// <param name="storageRoot"> The storage-root path. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. </param>
+    /// <param name="launchAttemptId"> The launch-attempt identifier. </param>
+    /// <returns> The absolute daemon launch-attempt startup diagnosis file path. </returns>
+    public static string ResolveLaunchAttemptStartupDiagnosisPath (
+        string storageRoot,
+        string projectFingerprint,
+        string launchAttemptId)
+    {
+        return Path.Combine(
+            ResolveLaunchAttemptDirectory(storageRoot, projectFingerprint, launchAttemptId),
+            UcliStoragePathNames.StartupDiagnosisFileName);
+    }
+
     /// <summary> Resolves the absolute path to the uCLI Unity plugin marker cache file under one fingerprint directory. </summary>
     /// <param name="storageRoot"> The storage-root path. </param>
     /// <param name="projectFingerprint"> The project fingerprint value. </param>
@@ -621,6 +664,25 @@ public static class UcliStoragePathResolver
         }
 
         return normalizedProjectFingerprint;
+    }
+
+    private static string NormalizeLaunchAttemptId (string launchAttemptId)
+    {
+        if (!TryTrimToNonEmpty(launchAttemptId, out var normalizedLaunchAttemptId))
+        {
+            throw new ArgumentException("Launch attempt identifier must not be empty.", nameof(launchAttemptId));
+        }
+
+        if (normalizedLaunchAttemptId.IndexOfAny(PathSegmentInvalidPathChars) >= 0
+            || string.Equals(normalizedLaunchAttemptId, ".", StringComparison.Ordinal)
+            || string.Equals(normalizedLaunchAttemptId, "..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Launch attempt identifier must be one path segment and must not contain path separator or traversal tokens.",
+                nameof(launchAttemptId));
+        }
+
+        return normalizedLaunchAttemptId;
     }
 
     private static string NormalizeOpsDescribeKey (string opKey)

--- a/src/Ucli/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleaner.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleaner.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Shared.Context.Project;
@@ -17,6 +18,8 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
 
     private readonly IDaemonLifecycleStore daemonLifecycleStore;
 
+    private readonly IDaemonLaunchAttemptStore launchAttemptStore;
+
     private readonly IIpcEndpointResolver endpointResolver;
 
     /// <summary> Initializes a new instance of the <see cref="DaemonArtifactCleaner" /> class. </summary>
@@ -26,10 +29,12 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
     public DaemonArtifactCleaner (
         IDaemonSessionStore daemonSessionStore,
         IDaemonLifecycleStore daemonLifecycleStore,
+        IDaemonLaunchAttemptStore launchAttemptStore,
         IIpcEndpointResolver endpointResolver)
     {
         this.daemonSessionStore = daemonSessionStore ?? throw new ArgumentNullException(nameof(daemonSessionStore));
         this.daemonLifecycleStore = daemonLifecycleStore ?? throw new ArgumentNullException(nameof(daemonLifecycleStore));
+        this.launchAttemptStore = launchAttemptStore ?? throw new ArgumentNullException(nameof(launchAttemptStore));
         this.endpointResolver = endpointResolver ?? throw new ArgumentNullException(nameof(endpointResolver));
     }
 
@@ -38,7 +43,7 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The cleanup operation result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="unityProject" /> is <see langword="null" />. </exception>
-    public async ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+    public async ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
         ResolvedUnityProjectContext unityProject,
         CancellationToken cancellationToken = default)
     {
@@ -52,7 +57,7 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
             .ConfigureAwait(false);
         if (!deleteSessionResult.IsSuccess)
         {
-            return deleteSessionResult;
+            return DaemonArtifactCleanupResult.Failure(deleteSessionResult.Error!);
         }
 
         var deleteLifecycleResult = await daemonLifecycleStore.DeleteAsync(
@@ -62,7 +67,18 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
             .ConfigureAwait(false);
         if (!deleteLifecycleResult.IsSuccess)
         {
-            return DaemonSessionStoreOperationResult.Failure(deleteLifecycleResult.Error!);
+            return DaemonArtifactCleanupResult.Failure(deleteLifecycleResult.Error!);
+        }
+
+        var pruneResult = await launchAttemptStore.PruneAsync(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                keepCount: 20,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!pruneResult.IsSuccess)
+        {
+            return DaemonArtifactCleanupResult.Failure(pruneResult.Error!);
         }
 
         try
@@ -79,11 +95,11 @@ internal sealed class DaemonArtifactCleaner : IDaemonArtifactCleaner
                     UcliIpcEndpointNames.DaemonAddressPrefix);
             }
 
-            return DaemonSessionStoreOperationResult.Success();
+            return DaemonArtifactCleanupResult.Success(pruneResult.DeletedCount);
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
-            return DaemonSessionStoreOperationResult.Failure(ExecutionError.InternalError(
+            return DaemonArtifactCleanupResult.Failure(ExecutionError.InternalError(
                 $"Failed to cleanup daemon endpoint residue. {exception.Message}"));
         }
     }

--- a/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptIdGenerator.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptIdGenerator.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+
+namespace MackySoft.Ucli.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Generates timestamp-prefixed daemon launch-attempt identifiers. </summary>
+internal sealed class DaemonLaunchAttemptIdGenerator : IDaemonLaunchAttemptIdGenerator
+{
+    private const string TimestampFormat = "yyyyMMdd_HHmmss'Z'";
+
+    /// <inheritdoc />
+    public string Create (DateTimeOffset startedAtUtc)
+    {
+        var suffix = RandomNumberGenerator.GetHexString(8).ToLowerInvariant();
+        return $"{startedAtUtc.UtcDateTime.ToString(TimestampFormat, CultureInfo.InvariantCulture)}_{suffix}";
+    }
+}

--- a/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStore.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStore.cs
@@ -105,45 +105,29 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             return DaemonLaunchAttemptReadResult.Success(null);
         }
 
-        var candidates = Directory.EnumerateDirectories(attemptsDirectory)
-            .OrderByDescending(static path => Directory.GetLastWriteTimeUtc(path))
-            .ThenByDescending(static path => Path.GetFileName(path), StringComparer.Ordinal)
-            .ToArray();
-        foreach (var attemptDirectory in candidates)
+        var entriesResult = await ReadDirectoryEntriesAsync(
+                storageRoot,
+                projectFingerprint,
+                attemptsDirectory,
+                failOnInvalidPayload: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!entriesResult.IsSuccess)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var launchAttemptId = Path.GetFileName(attemptDirectory);
-            string diagnosisPath;
-            try
-            {
-                diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
-                    storageRoot,
-                    projectFingerprint,
-                    launchAttemptId);
-            }
-            catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
-            {
-                return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
-                    $"Daemon launch-attempt path is invalid. {exception.Message}"));
-            }
-
-            var readResult = await ReadOneAsync(diagnosisPath, cancellationToken).ConfigureAwait(false);
-            if (!readResult.IsSuccess)
-            {
-                return readResult;
-            }
-
-            if (readResult.Exists && IsPublicFailureStatus(readResult.LaunchAttempt!.StartupStatus))
-            {
-                return readResult;
-            }
+            return DaemonLaunchAttemptReadResult.Failure(entriesResult.Error!);
         }
 
-        return DaemonLaunchAttemptReadResult.Success(null);
+        var latestFailure = entriesResult.Entries
+            .Where(static entry => entry.LaunchAttempt is not null
+                && IsPublicFailureStatus(entry.LaunchAttempt.StartupStatus))
+            .OrderByDescending(static entry => entry.LaunchAttempt!.UpdatedAtUtc)
+            .ThenByDescending(static entry => entry.LaunchAttemptId, StringComparer.Ordinal)
+            .FirstOrDefault();
+        return DaemonLaunchAttemptReadResult.Success(latestFailure?.LaunchAttempt);
     }
 
     /// <inheritdoc />
-    public ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+    public async ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
         string storageRoot,
         string projectFingerprint,
         int keepCount,
@@ -159,48 +143,165 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
         {
-            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
-                $"Daemon launch-attempt path is invalid. {exception.Message}")));
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid. {exception.Message}"));
         }
 
         if (!Directory.Exists(attemptsDirectory))
         {
-            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Success());
+            return DaemonLaunchAttemptStoreOperationResult.Success();
+        }
+
+        var entriesResult = await ReadDirectoryEntriesAsync(
+                storageRoot,
+                projectFingerprint,
+                attemptsDirectory,
+                failOnInvalidPayload: false,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (!entriesResult.IsSuccess)
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(entriesResult.Error!);
         }
 
         try
         {
-            var attemptsToDelete = Directory.EnumerateDirectories(attemptsDirectory)
-                .OrderByDescending(static path => Directory.GetLastWriteTimeUtc(path))
-                .ThenByDescending(static path => Path.GetFileName(path), StringComparer.Ordinal)
+            var attemptsToDelete = entriesResult.Entries
+                .OrderByDescending(static entry => entry.UpdatedAtUtc)
+                .ThenByDescending(static entry => entry.LaunchAttemptId, StringComparer.Ordinal)
                 .Skip(keepCount)
                 .ToArray();
             var deletedCount = 0;
-            foreach (var attemptDirectory in attemptsToDelete)
+            foreach (var entry in attemptsToDelete)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                Directory.Delete(attemptDirectory, recursive: true);
+                Directory.Delete(entry.DirectoryPath, recursive: true);
                 deletedCount++;
             }
 
-            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Success(deletedCount));
-        }
-        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
-        {
-            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
-                $"Daemon launch-attempt path is invalid: {attemptsDirectory}. {exception.Message}")));
+            return DaemonLaunchAttemptStoreOperationResult.Success(deletedCount);
         }
         catch (Exception exception) when (IsIoFailure(exception))
         {
-            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError(
-                $"Failed to prune daemon launch-attempt artifacts: {attemptsDirectory}. {exception.Message}")));
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError(
+                $"Failed to prune daemon launch-attempt artifacts: {attemptsDirectory}. {exception.Message}"));
         }
     }
 
+    private static async ValueTask<LaunchAttemptDirectoryEntriesReadResult> ReadDirectoryEntriesAsync (
+        string storageRoot,
+        string projectFingerprint,
+        string attemptsDirectory,
+        bool failOnInvalidPayload,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            FileSystemAccessBoundary.EnsureSecureDirectory(attemptsDirectory);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid: {attemptsDirectory}. {exception.Message}"));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InternalError(
+                $"Daemon launch-attempt directory is unsafe: {attemptsDirectory}. {exception.Message}"));
+        }
+
+        string[] attemptDirectories;
+        try
+        {
+            attemptDirectories = Directory.EnumerateDirectories(attemptsDirectory).ToArray();
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InternalError(
+                $"Failed to enumerate daemon launch-attempt directories: {attemptsDirectory}. {exception.Message}"));
+        }
+
+        var entries = new List<LaunchAttemptDirectoryEntry>();
+        foreach (var attemptDirectory in attemptDirectories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                EnsureSafeLaunchAttemptDirectory(attemptsDirectory, attemptDirectory);
+            }
+            catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+            {
+                return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InvalidArgument(
+                    $"Daemon launch-attempt path is invalid: {attemptDirectory}. {exception.Message}"));
+            }
+            catch (Exception exception) when (IsIoFailure(exception))
+            {
+                return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InternalError(
+                    $"Daemon launch-attempt directory is unsafe: {attemptDirectory}. {exception.Message}"));
+            }
+
+            var launchAttemptId = Path.GetFileName(attemptDirectory);
+            string diagnosisPath;
+            try
+            {
+                diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+                    storageRoot,
+                    projectFingerprint,
+                    launchAttemptId);
+            }
+            catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+            {
+                return LaunchAttemptDirectoryEntriesReadResult.Failure(ExecutionError.InvalidArgument(
+                    $"Daemon launch-attempt path is invalid. {exception.Message}"));
+            }
+
+            var readResult = await ReadOneAsync(attemptDirectory, diagnosisPath, cancellationToken).ConfigureAwait(false);
+            if (!readResult.IsSuccess)
+            {
+                if (failOnInvalidPayload)
+                {
+                    return LaunchAttemptDirectoryEntriesReadResult.Failure(readResult.Error!);
+                }
+
+                entries.Add(new LaunchAttemptDirectoryEntry(
+                    attemptDirectory,
+                    launchAttemptId,
+                    GetLastWriteTimeUtc(attemptDirectory),
+                    LaunchAttempt: null));
+                continue;
+            }
+
+            var updatedAtUtc = readResult.LaunchAttempt?.UpdatedAtUtc ?? GetLastWriteTimeUtc(attemptDirectory);
+            entries.Add(new LaunchAttemptDirectoryEntry(
+                attemptDirectory,
+                launchAttemptId,
+                updatedAtUtc,
+                readResult.LaunchAttempt));
+        }
+
+        return LaunchAttemptDirectoryEntriesReadResult.Success(entries);
+    }
+
     private static async ValueTask<DaemonLaunchAttemptReadResult> ReadOneAsync (
+        string attemptDirectory,
         string diagnosisPath,
         CancellationToken cancellationToken)
     {
+        try
+        {
+            EnsureSafeStartupDiagnosisFile(attemptDirectory, diagnosisPath);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid: {diagnosisPath}. {exception.Message}"));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InternalError(
+                $"Daemon launch-attempt file is unsafe: {diagnosisPath}. {exception.Message}"));
+        }
+
         string? json;
         try
         {
@@ -348,6 +449,7 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             launchAttempt.StartedAtUtc,
             launchAttempt.UpdatedAtUtc,
             launchAttempt.StartupStatus,
+            launchAttempt.StartupBlockingReason,
             launchAttempt.RetryDisposition,
             launchAttempt.ProcessAction,
             launchAttempt.Diagnosis,
@@ -382,6 +484,7 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             contract.StartedAtUtc,
             contract.UpdatedAtUtc,
             contract.StartupStatus,
+            contract.StartupBlockingReason,
             contract.RetryDisposition,
             contract.ProcessAction,
             ToDiagnosisForValidation(contract.Diagnosis),
@@ -393,6 +496,7 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
         DateTimeOffset startedAtUtc,
         DateTimeOffset updatedAtUtc,
         string? startupStatus,
+        string? startupBlockingReason,
         string? retryDisposition,
         string? processAction,
         DaemonDiagnosis? diagnosis,
@@ -414,6 +518,13 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
         if (!IsSupportedStartupStatus(startupStatus))
         {
             error = ExecutionError.InvalidArgument($"Daemon launch-attempt startupStatus is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (StringValueNormalizer.TrimToNull(startupBlockingReason) is not string normalizedStartupBlockingReason
+            || !IsSupportedStartupBlockingReason(normalizedStartupBlockingReason))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt startupBlockingReason is invalid: {diagnosisPath}");
             return false;
         }
 
@@ -492,7 +603,8 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             return false;
         }
 
-        if (!StringValueNormalizer.TryTrimToNonEmpty(diagnosis.ReportedBy, out _))
+        if (!StringValueNormalizer.TryTrimToNonEmpty(diagnosis.ReportedBy, out var reportedBy)
+            || !DaemonDiagnosisReportedByValues.IsSupported(reportedBy))
         {
             error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.reportedBy is invalid: {diagnosisPath}");
             return false;
@@ -510,6 +622,97 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             return false;
         }
 
+        if (!TryValidateOptionalStartupPhase(diagnosis.StartupPhase, diagnosisPath, out error))
+        {
+            return false;
+        }
+
+        if (!TryValidateOptionalActionRequired(diagnosis.ActionRequired, diagnosisPath, out error))
+        {
+            return false;
+        }
+
+        if (!TryValidatePrimaryDiagnostic(diagnosis.PrimaryDiagnostic, diagnosisPath, out error))
+        {
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryValidateOptionalStartupPhase (
+        string? startupPhase,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (StringValueNormalizer.TrimToNull(startupPhase) is not string normalizedStartupPhase)
+        {
+            error = null;
+            return true;
+        }
+
+        if (!DaemonDiagnosisStartupPhaseValues.IsSupported(normalizedStartupPhase))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.startupPhase is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryValidateOptionalActionRequired (
+        string? actionRequired,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (StringValueNormalizer.TrimToNull(actionRequired) is not string normalizedActionRequired)
+        {
+            error = null;
+            return true;
+        }
+
+        if (!DaemonDiagnosisActionRequiredValues.IsSupported(normalizedActionRequired))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.actionRequired is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryValidatePrimaryDiagnostic (
+        DaemonPrimaryDiagnostic? primaryDiagnostic,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (primaryDiagnostic is null)
+        {
+            error = null;
+            return true;
+        }
+
+        if (!StringValueNormalizer.TryTrimToNonEmpty(primaryDiagnostic.Kind, out var normalizedKind)
+            || !DaemonDiagnosisPrimaryDiagnosticKindValues.IsSupported(normalizedKind))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.primaryDiagnostic.kind is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (primaryDiagnostic.Line is <= 0)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.primaryDiagnostic.line is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (primaryDiagnostic.Column is <= 0)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.primaryDiagnostic.column is invalid: {diagnosisPath}");
+            return false;
+        }
+
         error = null;
         return true;
     }
@@ -522,11 +725,79 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
             or DaemonStartupStatusValues.Completed;
     }
 
+    private static bool IsSupportedStartupBlockingReason (string startupBlockingReason)
+    {
+        return startupBlockingReason is DaemonStartupBlockingReasonValues.SafeMode
+            or DaemonStartupBlockingReasonValues.Compile
+            or DaemonStartupBlockingReasonValues.PackageResolution
+            or DaemonStartupBlockingReasonValues.UcliPlugin
+            or DaemonStartupBlockingReasonValues.PrecompiledAssemblyConflict
+            or DaemonStartupBlockingReasonValues.ModalDialog
+            or DaemonStartupBlockingReasonValues.EndpointNotRegistered
+            or DaemonStartupBlockingReasonValues.ProcessExit
+            or DaemonStartupBlockingReasonValues.Unknown;
+    }
+
     private static bool IsPublicFailureStatus (string startupStatus)
     {
         return startupStatus is DaemonStartupStatusValues.Blocked
             or DaemonStartupStatusValues.Timeout
             or DaemonStartupStatusValues.Failed;
+    }
+
+    private static void EnsureSafeLaunchAttemptDirectory (
+        string attemptsDirectory,
+        string attemptDirectory)
+    {
+        if (!IsPathUnderDirectory(attemptDirectory, attemptsDirectory))
+        {
+            throw new IOException($"Launch-attempt deletion target must remain under launch-attempts directory: {attemptDirectory}");
+        }
+
+        if ((File.GetAttributes(attemptDirectory) & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException($"Launch-attempt deletion target must not be a reparse point: {attemptDirectory}");
+        }
+    }
+
+    private static void EnsureSafeStartupDiagnosisFile (
+        string attemptDirectory,
+        string diagnosisPath)
+    {
+        if (!IsPathUnderDirectory(diagnosisPath, attemptDirectory))
+        {
+            throw new IOException($"Launch-attempt diagnosis file must remain under attempt directory: {diagnosisPath}");
+        }
+
+        if (!File.Exists(diagnosisPath))
+        {
+            return;
+        }
+
+        if ((File.GetAttributes(diagnosisPath) & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException($"Launch-attempt diagnosis file must not be a reparse point: {diagnosisPath}");
+        }
+    }
+
+    private static DateTimeOffset GetLastWriteTimeUtc (string path)
+    {
+        return new DateTimeOffset(Directory.GetLastWriteTimeUtc(path), TimeSpan.Zero);
+    }
+
+    private static bool IsPathUnderDirectory (
+        string childPath,
+        string parentDirectoryPath)
+    {
+        var childFullPath = Path.GetFullPath(childPath);
+        var parentFullPath = Path.GetFullPath(parentDirectoryPath);
+        var relativePath = Path.GetRelativePath(parentFullPath, childFullPath);
+        return !string.IsNullOrWhiteSpace(relativePath)
+            && !string.Equals(relativePath, ".", StringComparison.Ordinal)
+            && !Path.IsPathRooted(relativePath)
+            && !relativePath.Equals("..", StringComparison.Ordinal)
+            && !relativePath.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            && !relativePath.StartsWith($"..{Path.AltDirectorySeparatorChar}", StringComparison.Ordinal);
     }
 
     private static bool IsSupportedRetryDisposition (string? retryDisposition)
@@ -551,5 +822,30 @@ internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
     {
         return exception is IOException
             or UnauthorizedAccessException;
+    }
+
+    private sealed record LaunchAttemptDirectoryEntry (
+        string DirectoryPath,
+        string LaunchAttemptId,
+        DateTimeOffset UpdatedAtUtc,
+        DaemonLaunchAttempt? LaunchAttempt);
+
+    private sealed record LaunchAttemptDirectoryEntriesReadResult (
+        IReadOnlyList<LaunchAttemptDirectoryEntry> Entries,
+        ExecutionError? Error)
+    {
+        public bool IsSuccess => Error is null;
+
+        public static LaunchAttemptDirectoryEntriesReadResult Success (IReadOnlyList<LaunchAttemptDirectoryEntry> entries)
+        {
+            ArgumentNullException.ThrowIfNull(entries);
+            return new LaunchAttemptDirectoryEntriesReadResult(entries, null);
+        }
+
+        public static LaunchAttemptDirectoryEntriesReadResult Failure (ExecutionError error)
+        {
+            ArgumentNullException.ThrowIfNull(error);
+            return new LaunchAttemptDirectoryEntriesReadResult(Array.Empty<LaunchAttemptDirectoryEntry>(), error);
+        }
     }
 }

--- a/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStore.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStore.cs
@@ -1,0 +1,555 @@
+using System.Text.Json;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Contracts.Text;
+using MackySoft.Ucli.Infrastructure.Paths;
+using MackySoft.Ucli.Infrastructure.Storage;
+
+namespace MackySoft.Ucli.Features.Daemon.Lifecycle.LaunchAttempts;
+
+/// <summary> Implements filesystem-backed daemon launch-attempt artifact persistence. </summary>
+internal sealed class DaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
+{
+    private const int SchemaVersion = 1;
+
+    /// <inheritdoc />
+    public async ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
+        string storageRoot,
+        string projectFingerprint,
+        DaemonLaunchAttempt launchAttempt,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(launchAttempt);
+
+        string diagnosisPath;
+        try
+        {
+            diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+                storageRoot,
+                projectFingerprint,
+                launchAttempt.LaunchAttemptId);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid. {exception.Message}"));
+        }
+
+        var normalizedLaunchAttempt = launchAttempt with
+        {
+            ArtifactPath = diagnosisPath,
+        };
+        if (!TryValidate(normalizedLaunchAttempt, diagnosisPath, out var validationError))
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(validationError!);
+        }
+
+        var contract = ToContract(normalizedLaunchAttempt);
+        string json;
+        try
+        {
+            json = DaemonLaunchAttemptJsonContractSerializer.Serialize(contract) + Environment.NewLine;
+        }
+        catch (Exception exception)
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError(
+                $"Failed to serialize daemon launch-attempt JSON. {exception.Message}"));
+        }
+
+        try
+        {
+            var directoryPath = Path.GetDirectoryName(diagnosisPath)
+                ?? throw new InvalidOperationException($"Daemon launch-attempt directory path could not be resolved: {diagnosisPath}");
+            FileSystemAccessBoundary.EnsureSecureDirectory(directoryPath);
+            await FileUtilities.WriteAllTextAtomicallyAsync(diagnosisPath, json, cancellationToken).ConfigureAwait(false);
+            return DaemonLaunchAttemptStoreOperationResult.Success();
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid: {diagnosisPath}. {exception.Message}"));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError(
+                $"Failed to write daemon launch-attempt file: {diagnosisPath}. {exception.Message}"));
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (
+        string storageRoot,
+        string projectFingerprint,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string attemptsDirectory;
+        try
+        {
+            attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(storageRoot, projectFingerprint);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid. {exception.Message}"));
+        }
+
+        if (!Directory.Exists(attemptsDirectory))
+        {
+            return DaemonLaunchAttemptReadResult.Success(null);
+        }
+
+        var candidates = Directory.EnumerateDirectories(attemptsDirectory)
+            .OrderByDescending(static path => Directory.GetLastWriteTimeUtc(path))
+            .ThenByDescending(static path => Path.GetFileName(path), StringComparer.Ordinal)
+            .ToArray();
+        foreach (var attemptDirectory in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var launchAttemptId = Path.GetFileName(attemptDirectory);
+            string diagnosisPath;
+            try
+            {
+                diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+                    storageRoot,
+                    projectFingerprint,
+                    launchAttemptId);
+            }
+            catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+            {
+                return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                    $"Daemon launch-attempt path is invalid. {exception.Message}"));
+            }
+
+            var readResult = await ReadOneAsync(diagnosisPath, cancellationToken).ConfigureAwait(false);
+            if (!readResult.IsSuccess)
+            {
+                return readResult;
+            }
+
+            if (readResult.Exists && IsPublicFailureStatus(readResult.LaunchAttempt!.StartupStatus))
+            {
+                return readResult;
+            }
+        }
+
+        return DaemonLaunchAttemptReadResult.Success(null);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+        string storageRoot,
+        string projectFingerprint,
+        int keepCount,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentOutOfRangeException.ThrowIfNegative(keepCount);
+
+        string attemptsDirectory;
+        try
+        {
+            attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(storageRoot, projectFingerprint);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid. {exception.Message}")));
+        }
+
+        if (!Directory.Exists(attemptsDirectory))
+        {
+            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Success());
+        }
+
+        try
+        {
+            var attemptsToDelete = Directory.EnumerateDirectories(attemptsDirectory)
+                .OrderByDescending(static path => Directory.GetLastWriteTimeUtc(path))
+                .ThenByDescending(static path => Path.GetFileName(path), StringComparer.Ordinal)
+                .Skip(keepCount)
+                .ToArray();
+            var deletedCount = 0;
+            foreach (var attemptDirectory in attemptsToDelete)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Directory.Delete(attemptDirectory, recursive: true);
+                deletedCount++;
+            }
+
+            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Success(deletedCount));
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid: {attemptsDirectory}. {exception.Message}")));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return ValueTask.FromResult(DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError(
+                $"Failed to prune daemon launch-attempt artifacts: {attemptsDirectory}. {exception.Message}")));
+        }
+    }
+
+    private static async ValueTask<DaemonLaunchAttemptReadResult> ReadOneAsync (
+        string diagnosisPath,
+        CancellationToken cancellationToken)
+    {
+        string? json;
+        try
+        {
+            json = await FileUtilities.ReadAllTextOrNullAsync(diagnosisPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt path is invalid: {diagnosisPath}. {exception.Message}"));
+        }
+        catch (Exception exception) when (IsIoFailure(exception))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InternalError(
+                $"Failed to read daemon launch-attempt file: {diagnosisPath}. {exception.Message}"));
+        }
+
+        if (json is null)
+        {
+            return DaemonLaunchAttemptReadResult.Success(null);
+        }
+
+        DaemonLaunchAttemptJsonContract contract;
+        try
+        {
+            contract = DaemonLaunchAttemptJsonContractSerializer.Deserialize(json)
+                ?? throw new JsonException("Daemon launch-attempt JSON is null.");
+        }
+        catch (JsonException exception)
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt JSON is invalid: {diagnosisPath}. {exception.Message}"));
+        }
+        catch (ArgumentException exception)
+        {
+            return DaemonLaunchAttemptReadResult.Failure(ExecutionError.InvalidArgument(
+                $"Daemon launch-attempt JSON is invalid: {diagnosisPath}. {exception.Message}"));
+        }
+
+        if (!TryValidate(contract, diagnosisPath, out var validationError))
+        {
+            return DaemonLaunchAttemptReadResult.Failure(validationError!);
+        }
+
+        return DaemonLaunchAttemptReadResult.Success(ToModel(contract, diagnosisPath));
+    }
+
+    private static DaemonLaunchAttemptJsonContract ToContract (DaemonLaunchAttempt launchAttempt)
+    {
+        return new DaemonLaunchAttemptJsonContract(
+            SchemaVersion: SchemaVersion,
+            LaunchAttemptId: launchAttempt.LaunchAttemptId,
+            StartedAtUtc: launchAttempt.StartedAtUtc,
+            UpdatedAtUtc: launchAttempt.UpdatedAtUtc,
+            StartupStatus: launchAttempt.StartupStatus,
+            StartupBlockingReason: launchAttempt.StartupBlockingReason,
+            RetryDisposition: launchAttempt.RetryDisposition,
+            ProcessAction: launchAttempt.ProcessAction,
+            EditorMode: launchAttempt.EditorMode,
+            ProcessId: launchAttempt.ProcessId,
+            ProcessStartedAtUtc: launchAttempt.ProcessStartedAtUtc,
+            UnityLogPath: launchAttempt.UnityLogPath,
+            Diagnosis: ToContract(launchAttempt.Diagnosis));
+    }
+
+    private static DaemonDiagnosisJsonContract ToContract (DaemonDiagnosis diagnosis)
+    {
+        return new DaemonDiagnosisJsonContract(
+            Reason: diagnosis.Reason,
+            Message: diagnosis.Message,
+            ReportedBy: diagnosis.ReportedBy,
+            IsInferred: diagnosis.IsInferred,
+            UpdatedAtUtc: diagnosis.UpdatedAtUtc,
+            ProcessId: diagnosis.ProcessId,
+            EditorInstancePath: diagnosis.EditorInstancePath,
+            SessionIssuedAtUtc: diagnosis.SessionIssuedAtUtc,
+            ProcessStartedAtUtc: diagnosis.ProcessStartedAtUtc,
+            UnityLogPath: diagnosis.UnityLogPath,
+            StartupPhase: diagnosis.StartupPhase,
+            ActionRequired: diagnosis.ActionRequired,
+            PrimaryDiagnostic: diagnosis.PrimaryDiagnostic is null
+                ? null
+                : new DaemonDiagnosisPrimaryDiagnosticJsonContract(
+                    Kind: diagnosis.PrimaryDiagnostic.Kind,
+                    Code: diagnosis.PrimaryDiagnostic.Code,
+                    File: diagnosis.PrimaryDiagnostic.File,
+                    Line: diagnosis.PrimaryDiagnostic.Line,
+                    Column: diagnosis.PrimaryDiagnostic.Column,
+                    Message: diagnosis.PrimaryDiagnostic.Message));
+    }
+
+    private static DaemonLaunchAttempt ToModel (
+        DaemonLaunchAttemptJsonContract contract,
+        string artifactPath)
+    {
+        var diagnosis = contract.Diagnosis!;
+        return new DaemonLaunchAttempt(
+            LaunchAttemptId: contract.LaunchAttemptId!,
+            StartedAtUtc: contract.StartedAtUtc,
+            UpdatedAtUtc: contract.UpdatedAtUtc,
+            StartupStatus: contract.StartupStatus!,
+            StartupBlockingReason: StringValueNormalizer.TrimToNull(contract.StartupBlockingReason),
+            RetryDisposition: contract.RetryDisposition!,
+            ProcessAction: contract.ProcessAction!,
+            EditorMode: StringValueNormalizer.TrimToNull(contract.EditorMode),
+            ProcessId: contract.ProcessId,
+            ProcessStartedAtUtc: contract.ProcessStartedAtUtc,
+            UnityLogPath: StringValueNormalizer.TrimToNull(contract.UnityLogPath),
+            ArtifactPath: artifactPath,
+            Diagnosis: new DaemonDiagnosis(
+                Reason: diagnosis.Reason!,
+                Message: diagnosis.Message!,
+                ReportedBy: diagnosis.ReportedBy!,
+                IsInferred: diagnosis.IsInferred!.Value,
+                UpdatedAtUtc: diagnosis.UpdatedAtUtc,
+                ProcessId: diagnosis.ProcessId,
+                EditorInstancePath: StringValueNormalizer.TrimToNull(diagnosis.EditorInstancePath),
+                SessionIssuedAtUtc: diagnosis.SessionIssuedAtUtc,
+                ProcessStartedAtUtc: diagnosis.ProcessStartedAtUtc,
+                UnityLogPath: StringValueNormalizer.TrimToNull(diagnosis.UnityLogPath),
+                StartupPhase: StringValueNormalizer.TrimToNull(diagnosis.StartupPhase),
+                ActionRequired: StringValueNormalizer.TrimToNull(diagnosis.ActionRequired),
+                PrimaryDiagnostic: diagnosis.PrimaryDiagnostic is null
+                    ? null
+                    : new DaemonPrimaryDiagnostic(
+                        Kind: StringValueNormalizer.TrimToNull(diagnosis.PrimaryDiagnostic.Kind)!,
+                        Code: StringValueNormalizer.TrimToNull(diagnosis.PrimaryDiagnostic.Code),
+                        File: StringValueNormalizer.TrimToNull(diagnosis.PrimaryDiagnostic.File),
+                        Line: diagnosis.PrimaryDiagnostic.Line,
+                        Column: diagnosis.PrimaryDiagnostic.Column,
+                        Message: StringValueNormalizer.TrimToNull(diagnosis.PrimaryDiagnostic.Message))));
+    }
+
+    private static bool TryValidate (
+        DaemonLaunchAttempt launchAttempt,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (!StringValueNormalizer.TryTrimToNonEmpty(launchAttempt.LaunchAttemptId, out _))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt launchAttemptId is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        return TryValidateFields(
+            launchAttempt.StartedAtUtc,
+            launchAttempt.UpdatedAtUtc,
+            launchAttempt.StartupStatus,
+            launchAttempt.RetryDisposition,
+            launchAttempt.ProcessAction,
+            launchAttempt.Diagnosis,
+            diagnosisPath,
+            out error);
+    }
+
+    private static bool TryValidate (
+        DaemonLaunchAttemptJsonContract contract,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (contract.SchemaVersion != SchemaVersion)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt schemaVersion is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!StringValueNormalizer.TryTrimToNonEmpty(contract.LaunchAttemptId, out _))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt launchAttemptId is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (contract.Diagnosis is null)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        return TryValidateFields(
+            contract.StartedAtUtc,
+            contract.UpdatedAtUtc,
+            contract.StartupStatus,
+            contract.RetryDisposition,
+            contract.ProcessAction,
+            ToDiagnosisForValidation(contract.Diagnosis),
+            diagnosisPath,
+            out error);
+    }
+
+    private static bool TryValidateFields (
+        DateTimeOffset startedAtUtc,
+        DateTimeOffset updatedAtUtc,
+        string? startupStatus,
+        string? retryDisposition,
+        string? processAction,
+        DaemonDiagnosis? diagnosis,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (startedAtUtc == default)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt startedAtUtc is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (updatedAtUtc == default)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt updatedAtUtc is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!IsSupportedStartupStatus(startupStatus))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt startupStatus is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!IsSupportedRetryDisposition(retryDisposition))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt retryDisposition is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!IsSupportedProcessAction(processAction))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt processAction is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (diagnosis is null)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!TryValidateDiagnosis(diagnosis, diagnosisPath, out error))
+        {
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static DaemonDiagnosis? ToDiagnosisForValidation (DaemonDiagnosisJsonContract diagnosis)
+    {
+        if (diagnosis.IsInferred is null)
+        {
+            return null;
+        }
+
+        return new DaemonDiagnosis(
+            Reason: diagnosis.Reason ?? string.Empty,
+            Message: diagnosis.Message ?? string.Empty,
+            ReportedBy: diagnosis.ReportedBy ?? string.Empty,
+            IsInferred: diagnosis.IsInferred.Value,
+            UpdatedAtUtc: diagnosis.UpdatedAtUtc,
+            ProcessId: diagnosis.ProcessId,
+            EditorInstancePath: diagnosis.EditorInstancePath,
+            SessionIssuedAtUtc: diagnosis.SessionIssuedAtUtc,
+            ProcessStartedAtUtc: diagnosis.ProcessStartedAtUtc,
+            UnityLogPath: diagnosis.UnityLogPath,
+            StartupPhase: diagnosis.StartupPhase,
+            ActionRequired: diagnosis.ActionRequired,
+            PrimaryDiagnostic: diagnosis.PrimaryDiagnostic is null
+                ? null
+                : new DaemonPrimaryDiagnostic(
+                    Kind: diagnosis.PrimaryDiagnostic.Kind ?? string.Empty,
+                    Code: diagnosis.PrimaryDiagnostic.Code,
+                    File: diagnosis.PrimaryDiagnostic.File,
+                    Line: diagnosis.PrimaryDiagnostic.Line,
+                    Column: diagnosis.PrimaryDiagnostic.Column,
+                    Message: diagnosis.PrimaryDiagnostic.Message));
+    }
+
+    private static bool TryValidateDiagnosis (
+        DaemonDiagnosis diagnosis,
+        string diagnosisPath,
+        out ExecutionError? error)
+    {
+        if (!StringValueNormalizer.TryTrimToNonEmpty(diagnosis.Reason, out _))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.reason is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!StringValueNormalizer.TryTrimToNonEmpty(diagnosis.Message, out _))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.message is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (!StringValueNormalizer.TryTrimToNonEmpty(diagnosis.ReportedBy, out _))
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.reportedBy is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (diagnosis.UpdatedAtUtc == default)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.updatedAtUtc is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        if (diagnosis.SessionIssuedAtUtc == default)
+        {
+            error = ExecutionError.InvalidArgument($"Daemon launch-attempt diagnosis.sessionIssuedAtUtc is invalid: {diagnosisPath}");
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool IsSupportedStartupStatus (string? startupStatus)
+    {
+        return startupStatus is DaemonStartupStatusValues.Blocked
+            or DaemonStartupStatusValues.Timeout
+            or DaemonStartupStatusValues.Failed
+            or DaemonStartupStatusValues.Completed;
+    }
+
+    private static bool IsPublicFailureStatus (string startupStatus)
+    {
+        return startupStatus is DaemonStartupStatusValues.Blocked
+            or DaemonStartupStatusValues.Timeout
+            or DaemonStartupStatusValues.Failed;
+    }
+
+    private static bool IsSupportedRetryDisposition (string? retryDisposition)
+    {
+        return retryDisposition is DaemonStartupRetryDispositionValues.RetryImmediately
+            or DaemonStartupRetryDispositionValues.WaitThenRetry
+            or DaemonStartupRetryDispositionValues.RetryAfterFix
+            or DaemonStartupRetryDispositionValues.ManualActionRequired
+            or DaemonStartupRetryDispositionValues.DoNotRetry
+            or DaemonStartupRetryDispositionValues.Unknown;
+    }
+
+    private static bool IsSupportedProcessAction (string? processAction)
+    {
+        return processAction is DaemonStartupProcessActionValues.None
+            or DaemonStartupProcessActionValues.Kept
+            or DaemonStartupProcessActionValues.Terminated
+            or DaemonStartupProcessActionValues.Unknown;
+    }
+
+    private static bool IsIoFailure (Exception exception)
+    {
+        return exception is IOException
+            or UnauthorizedAccessException;
+    }
+}

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Launch;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Shutdown;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
@@ -36,6 +37,10 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
 
     private readonly IDaemonDiagnosisStore daemonDiagnosisStore;
 
+    private readonly IDaemonLaunchAttemptIdGenerator launchAttemptIdGenerator;
+
+    private readonly IDaemonLaunchAttemptStore launchAttemptStore;
+
     private readonly TimeProvider timeProvider;
 
     /// <summary> Initializes a new instance of the <see cref="DaemonLaunchService" /> class. </summary>
@@ -56,6 +61,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         IDaemonGuiStartupObserver guiStartupObserver,
         IDaemonLaunchCompensationService daemonLaunchCompensationService,
         IDaemonDiagnosisStore daemonDiagnosisStore,
+        IDaemonLaunchAttemptIdGenerator launchAttemptIdGenerator,
+        IDaemonLaunchAttemptStore launchAttemptStore,
         TimeProvider? timeProvider = null)
     {
         this.daemonLaunchSessionService = daemonLaunchSessionService ?? throw new ArgumentNullException(nameof(daemonLaunchSessionService));
@@ -65,6 +72,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         this.guiStartupObserver = guiStartupObserver ?? throw new ArgumentNullException(nameof(guiStartupObserver));
         this.daemonLaunchCompensationService = daemonLaunchCompensationService ?? throw new ArgumentNullException(nameof(daemonLaunchCompensationService));
         this.daemonDiagnosisStore = daemonDiagnosisStore ?? throw new ArgumentNullException(nameof(daemonDiagnosisStore));
+        this.launchAttemptIdGenerator = launchAttemptIdGenerator ?? throw new ArgumentNullException(nameof(launchAttemptIdGenerator));
+        this.launchAttemptStore = launchAttemptStore ?? throw new ArgumentNullException(nameof(launchAttemptStore));
         this.timeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -88,6 +97,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         ArgumentNullException.ThrowIfNull(unityProject);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(timeout, TimeSpan.Zero);
         var deadline = ExecutionDeadline.Start(timeout, timeProvider);
+        var launchStartedAtUtc = timeProvider.GetUtcNow();
+        var launchAttemptId = CreateUniqueLaunchAttemptId(unityProject, launchStartedAtUtc);
 
         return editorMode switch
         {
@@ -95,12 +106,16 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     unityProject,
                     editorMode,
                     deadline,
+                    launchAttemptId,
+                    launchStartedAtUtc,
                     cancellationToken)
                 .ConfigureAwait(false),
             DaemonEditorMode.Gui => await LaunchGuiAsync(
                     unityProject,
                     deadline,
                     onStartupBlocked,
+                    launchAttemptId,
+                    launchStartedAtUtc,
                     cancellationToken)
                 .ConfigureAwait(false),
             _ => DaemonStartResult.Failure(ExecutionError.InvalidArgument(
@@ -112,6 +127,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         ResolvedUnityProjectContext unityProject,
         DaemonEditorMode editorMode,
         ExecutionDeadline deadline,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
         CancellationToken cancellationToken)
     {
         var initializeSessionResult = await daemonLaunchSessionService.InitializeAsync(
@@ -121,7 +138,21 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             .ConfigureAwait(false);
         if (!initializeSessionResult.IsSuccess)
         {
-            return DaemonStartResult.Failure(initializeSessionResult.Error!);
+            return await CreateFailureWithLaunchAttemptAsync(
+                    unityProject,
+                    launchAttemptId,
+                    launchStartedAtUtc,
+                    processId: null,
+                    processStartedAtUtc: null,
+                    sessionIssuedAtUtc: launchStartedAtUtc,
+                    unityLogPath: null,
+                    editorMode: DaemonEditorModeValues.Batchmode,
+                    initializeSessionResult.Error!,
+                    startupStatus: DaemonStartupStatusValues.Failed,
+                    startupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+                    retryDisposition: DaemonStartupRetryDispositionValues.Unknown,
+                    processAction: DaemonStartupProcessActionValues.None)
+                .ConfigureAwait(false);
         }
         var session = initializeSessionResult.Session!;
         var launchedProcessId = default(int?);
@@ -146,7 +177,12 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                         launchResult.ProcessId,
                         launchResult.ProcessStartedAtUtc,
                         expectedIssuedAtUtc,
+                        launchAttemptId,
+                        launchStartedAtUtc,
+                        DaemonEditorModeValues.Batchmode,
+                        unityLogPath,
                         launchResult.Error!,
+                        DaemonStartupStatusValues.Failed,
                         "Daemon launch failed",
                         "LaunchError")
                     .ConfigureAwait(false);
@@ -169,7 +205,12 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                         launchedProcessId,
                         launchedProcessStartedAtUtc,
                         expectedIssuedAtUtc,
+                        launchAttemptId,
+                        launchStartedAtUtc,
+                        DaemonEditorModeValues.Batchmode,
+                        unityLogPath,
                         updateProcessIdResult.Error!,
+                        DaemonStartupStatusValues.Failed,
                         "Daemon session update failed",
                         "SessionError")
                     .ConfigureAwait(false);
@@ -184,7 +225,12 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                         launchedProcessId,
                         launchedProcessStartedAtUtc,
                         expectedIssuedAtUtc,
+                        launchAttemptId,
+                        launchStartedAtUtc,
+                        DaemonEditorModeValues.Batchmode,
+                        unityLogPath,
                         ExecutionError.Timeout("Timed out before daemon startup readiness probe could begin."),
+                        DaemonStartupStatusValues.Timeout,
                         "Daemon startup readiness probe failed",
                         "ProbeError")
                     .ConfigureAwait(false);
@@ -206,7 +252,14 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     launchedProcessId,
                     launchedProcessStartedAtUtc,
                     expectedIssuedAtUtc,
+                    launchAttemptId,
+                    launchStartedAtUtc,
+                    DaemonEditorModeValues.Batchmode,
+                    unityLogPath,
                     probeResult.Error!,
+                    probeResult.Error!.Kind == ExecutionErrorKind.Timeout
+                        ? DaemonStartupStatusValues.Timeout
+                        : DaemonStartupStatusValues.Failed,
                     "Daemon startup readiness probe failed",
                     "ProbeError")
                 .ConfigureAwait(false);
@@ -227,6 +280,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         ResolvedUnityProjectContext unityProject,
         ExecutionDeadline deadline,
         DaemonStartupBlockedProcessPolicy onStartupBlocked,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
         CancellationToken cancellationToken)
     {
         var unityLogPath = UcliStoragePathResolver.ResolveUnityLogPath(
@@ -239,7 +294,21 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             .ConfigureAwait(false);
         if (!launchResult.IsSuccess)
         {
-            return DaemonStartResult.Failure(launchResult.Error!);
+            return await CreateFailureWithLaunchAttemptAsync(
+                    unityProject,
+                    launchAttemptId,
+                    launchStartedAtUtc,
+                    launchResult.ProcessId,
+                    launchResult.ProcessStartedAtUtc,
+                    launchStartedAtUtc,
+                    unityLogPath,
+                    DaemonEditorModeValues.Gui,
+                    launchResult.Error!,
+                    startupStatus: DaemonStartupStatusValues.Failed,
+                    startupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+                    retryDisposition: DaemonStartupRetryDispositionValues.Unknown,
+                    processAction: DaemonStartupProcessActionValues.None)
+                .ConfigureAwait(false);
         }
 
         var processId = launchResult.ProcessId!.Value;
@@ -251,6 +320,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     processId,
                     processStartedAtUtc,
                     unityLogPath,
+                    launchAttemptId,
+                    launchStartedAtUtc,
                     ExecutionError.Timeout(
                         "Timed out before GUI daemon session registration wait could begin.",
                         ExecutionErrorCodes.IpcTimeout))
@@ -289,6 +360,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             return await CreateGuiStartupBlockedFailureAsync(
                     unityProject,
                     waitResult.Blocker!,
+                    launchAttemptId,
+                    launchStartedAtUtc,
                     onStartupBlocked)
                 .ConfigureAwait(false);
         }
@@ -300,6 +373,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     processId,
                     processStartedAtUtc,
                     unityLogPath,
+                    launchAttemptId,
+                    launchStartedAtUtc,
                     waitResult.Error)
                 .ConfigureAwait(false);
         }
@@ -308,6 +383,9 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 unityProject,
                 processId,
                 processStartedAtUtc,
+                unityLogPath,
+                launchAttemptId,
+                launchStartedAtUtc,
                 waitResult.Error)
             .ConfigureAwait(false);
     }
@@ -317,7 +395,12 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         int? processId,
         DateTimeOffset? processStartedAtUtc,
         DateTimeOffset expectedIssuedAtUtc,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
+        string editorMode,
+        string? unityLogPath,
         ExecutionError primaryError,
+        string startupStatus,
         string primaryErrorMessagePrefix,
         string primaryErrorLabel)
     {
@@ -330,12 +413,28 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             ProcessId: processId,
             EditorInstancePath: null,
             SessionIssuedAtUtc: expectedIssuedAtUtc,
-            ProcessStartedAtUtc: processStartedAtUtc);
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath);
         var diagnosisWriteResult = await daemonDiagnosisStore.WriteAsync(
                 unityProject.RepositoryRoot,
                 unityProject.ProjectFingerprint,
                 diagnosis,
                 CancellationToken.None)
+            .ConfigureAwait(false);
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                diagnosis.UpdatedAtUtc,
+                startupStatus,
+                DaemonStartupBlockingReasonValues.Unknown,
+                DaemonStartupRetryDispositionValues.Unknown,
+                DaemonStartupProcessActionValues.None,
+                editorMode,
+                processId,
+                processStartedAtUtc,
+                unityLogPath,
+                diagnosis)
             .ConfigureAwait(false);
         var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
                 unityProject,
@@ -351,6 +450,15 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 $"{primaryErrorLabel}={primaryError.Message} " +
                 $"DiagnosisError={diagnosisWriteResult.Error!.Message} " +
                 $"CleanupError={compensationResult.Error!.Message}"), diagnosis);
+        }
+
+        if (!launchAttemptWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                $"{primaryErrorMessagePrefix} and launch-attempt artifact persistence failed. " +
+                $"{primaryErrorLabel}={primaryError.Message} " +
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis);
         }
 
         if (!diagnosisWriteResult.IsSuccess)
@@ -372,6 +480,121 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         }
 
         return DaemonStartResult.Failure(primaryError, diagnosis);
+    }
+
+    private async ValueTask<DaemonStartResult> CreateFailureWithLaunchAttemptAsync (
+        ResolvedUnityProjectContext unityProject,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset sessionIssuedAtUtc,
+        string? unityLogPath,
+        string? editorMode,
+        ExecutionError primaryError,
+        string startupStatus,
+        string startupBlockingReason,
+        string retryDisposition,
+        string processAction)
+    {
+        var updatedAtUtc = timeProvider.GetUtcNow();
+        var diagnosis = new DaemonDiagnosis(
+            Reason: DaemonDiagnosisReasonValues.StartupFailed,
+            Message: primaryError.Message,
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: false,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: processId,
+            EditorInstancePath: null,
+            SessionIssuedAtUtc: sessionIssuedAtUtc,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath);
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                updatedAtUtc,
+                startupStatus,
+                startupBlockingReason,
+                retryDisposition,
+                processAction,
+                editorMode,
+                processId,
+                processStartedAtUtc,
+                unityLogPath,
+                diagnosis)
+            .ConfigureAwait(false);
+        var startup = new DaemonStartupObservation(
+            StartupStatus: startupStatus,
+            StartupBlockingReason: startupBlockingReason,
+            LaunchAttemptId: launchAttemptId,
+            ProcessAction: processAction,
+            RetryDisposition: retryDisposition);
+        if (!launchAttemptWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(
+                CreateAugmentedPrimaryError(
+                    primaryError,
+                    "Daemon startup failed and launch-attempt artifact persistence failed. " +
+                    $"StartupError={primaryError.Message} " +
+                    $"ArtifactError={launchAttemptWriteResult.Error!.Message}"),
+                diagnosis,
+                startup);
+        }
+
+        return DaemonStartResult.Failure(primaryError, diagnosis, startup);
+    }
+
+    private async ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteLaunchAttemptAsync (
+        ResolvedUnityProjectContext unityProject,
+        string launchAttemptId,
+        DateTimeOffset startedAtUtc,
+        DateTimeOffset updatedAtUtc,
+        string startupStatus,
+        string startupBlockingReason,
+        string retryDisposition,
+        string processAction,
+        string? editorMode,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        string? unityLogPath,
+        DaemonDiagnosis diagnosis)
+    {
+        var artifactPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+            unityProject.RepositoryRoot,
+            unityProject.ProjectFingerprint,
+            launchAttemptId);
+        var launchAttempt = new DaemonLaunchAttempt(
+            LaunchAttemptId: launchAttemptId,
+            StartedAtUtc: startedAtUtc,
+            UpdatedAtUtc: updatedAtUtc,
+            StartupStatus: startupStatus,
+            StartupBlockingReason: startupBlockingReason,
+            RetryDisposition: retryDisposition,
+            ProcessAction: processAction,
+            EditorMode: editorMode,
+            ProcessId: processId,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath,
+            ArtifactPath: artifactPath,
+            Diagnosis: diagnosis);
+        var writeResult = await launchAttemptStore.WriteFailureAsync(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                launchAttempt,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        if (!writeResult.IsSuccess)
+        {
+            return writeResult;
+        }
+
+        return await launchAttemptStore.PruneAsync(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                keepCount: 20,
+                CancellationToken.None)
+            .ConfigureAwait(false);
     }
 
     private static DaemonProcessTerminationTarget? CreateTerminationTarget (
@@ -413,6 +636,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         int processId,
         DateTimeOffset processStartedAtUtc,
         string unityLogPath,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
         ExecutionError waitError)
     {
         var startResult = await CreateGuiEndpointNotRegisteredFailureAsync(
@@ -421,6 +646,84 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 processStartedAtUtc,
                 unityLogPath,
                 waitError)
+            .ConfigureAwait(false);
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Timeout,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            LaunchAttemptId: launchAttemptId,
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry);
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                timeProvider.GetUtcNow(),
+                startup.StartupStatus,
+                startup.StartupBlockingReason!,
+                startup.RetryDisposition,
+                startup.ProcessAction,
+                DaemonEditorModeValues.Gui,
+                processId,
+                processStartedAtUtc,
+                unityLogPath,
+                startResult.Diagnosis!)
+            .ConfigureAwait(false);
+        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                unityProject,
+                CreateTerminationTarget(processId, processStartedAtUtc),
+                DaemonTimeouts.LaunchCompensationTimeout,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        if (!launchAttemptWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(
+                CreateAugmentedPrimaryError(
+                    startResult.Error!,
+                    "GUI endpoint registration failed and launch-attempt artifact persistence failed. " +
+                    $"RegistrationError={startResult.Error!.Message} " +
+                    $"ArtifactError={launchAttemptWriteResult.Error!.Message}"),
+                startResult.Diagnosis,
+                startup);
+        }
+
+        if (compensationResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(startResult.Error!, startResult.Diagnosis, startup);
+        }
+
+        return DaemonStartResult.Failure(
+            CreateAugmentedPrimaryError(
+                startResult.Error!,
+                "GUI endpoint registration failed and cleanup failed. " +
+                $"RegistrationError={startResult.Error!.Message} " +
+                $"CleanupError={compensationResult.Error!.Message}"),
+            startResult.Diagnosis,
+            startup);
+    }
+
+    private async ValueTask<DaemonStartResult> CreateGuiStartupFailureWithCompensationAsync (
+        ResolvedUnityProjectContext unityProject,
+        int processId,
+        DateTimeOffset processStartedAtUtc,
+        string unityLogPath,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
+        ExecutionError startupError)
+    {
+        var startResult = await CreateFailureWithLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                processId,
+                processStartedAtUtc,
+                launchStartedAtUtc,
+                unityLogPath,
+                DaemonEditorModeValues.Gui,
+                startupError,
+                DaemonStartupStatusValues.Failed,
+                DaemonStartupBlockingReasonValues.Unknown,
+                DaemonStartupRetryDispositionValues.Unknown,
+                DaemonStartupProcessActionValues.None)
             .ConfigureAwait(false);
         var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
                 unityProject,
@@ -436,39 +739,18 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         return DaemonStartResult.Failure(
             CreateAugmentedPrimaryError(
                 startResult.Error!,
-                "GUI endpoint registration failed and cleanup failed. " +
-                $"RegistrationError={startResult.Error!.Message} " +
+                "GUI startup failed and cleanup failed. " +
+                $"StartupError={startResult.Error!.Message} " +
                 $"CleanupError={compensationResult.Error!.Message}"),
-            startResult.Diagnosis);
-    }
-
-    private async ValueTask<DaemonStartResult> CreateGuiStartupFailureWithCompensationAsync (
-        ResolvedUnityProjectContext unityProject,
-        int processId,
-        DateTimeOffset processStartedAtUtc,
-        ExecutionError startupError)
-    {
-        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
-                unityProject,
-                CreateTerminationTarget(processId, processStartedAtUtc),
-                DaemonTimeouts.LaunchCompensationTimeout,
-                CancellationToken.None)
-            .ConfigureAwait(false);
-        if (compensationResult.IsSuccess)
-        {
-            return DaemonStartResult.Failure(startupError);
-        }
-
-        return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
-            startupError,
-            "GUI startup failed and cleanup failed. " +
-            $"StartupError={startupError.Message} " +
-            $"CleanupError={compensationResult.Error!.Message}"));
+            startResult.Diagnosis,
+            startResult.Startup);
     }
 
     private async ValueTask<DaemonStartResult> CreateGuiStartupBlockedFailureAsync (
         ResolvedUnityProjectContext unityProject,
         DaemonGuiStartupBlocker blocker,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
         DaemonStartupBlockedProcessPolicy onStartupBlocked)
     {
         ArgumentNullException.ThrowIfNull(blocker);
@@ -505,8 +787,33 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             .ConfigureAwait(false);
         var startup = CreateGuiStartupBlockedObservation(
             blocker,
+            launchAttemptId,
             processPolicyResult.ProcessAction);
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                updatedAtUtc,
+                startup.StartupStatus,
+                startup.StartupBlockingReason!,
+                startup.RetryDisposition,
+                startup.ProcessAction,
+                DaemonEditorModeValues.Gui,
+                blocker.ProcessId,
+                blocker.ProcessStartedAtUtc,
+                blocker.UnityLogPath,
+                diagnosis)
+            .ConfigureAwait(false);
         var cleanupResult = processPolicyResult.CleanupResult;
+        if (!launchAttemptWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "GUI startup is blocked and launch-attempt artifact persistence failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis, startup);
+        }
+
         if (!diagnosisWriteResult.IsSuccess && cleanupResult is { IsSuccess: false })
         {
             return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
@@ -600,17 +907,40 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
 
     private static DaemonStartupObservation CreateGuiStartupBlockedObservation (
         DaemonGuiStartupBlocker blocker,
+        string launchAttemptId,
         string processAction)
     {
         ArgumentNullException.ThrowIfNull(blocker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(launchAttemptId);
         ArgumentException.ThrowIfNullOrWhiteSpace(processAction);
 
         return new DaemonStartupObservation(
             StartupStatus: DaemonStartupStatusValues.Blocked,
             StartupBlockingReason: blocker.StartupBlockingReason,
-            LaunchAttemptId: null,
+            LaunchAttemptId: launchAttemptId,
             ProcessAction: processAction,
             RetryDisposition: blocker.RetryDisposition);
+    }
+
+    private string CreateUniqueLaunchAttemptId (
+        ResolvedUnityProjectContext unityProject,
+        DateTimeOffset launchStartedAtUtc)
+    {
+        const int maxAttempts = 16;
+        for (var i = 0; i < maxAttempts; i++)
+        {
+            var launchAttemptId = launchAttemptIdGenerator.Create(launchStartedAtUtc);
+            var launchAttemptDirectory = UcliStoragePathResolver.ResolveLaunchAttemptDirectory(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                launchAttemptId);
+            if (!Directory.Exists(launchAttemptDirectory))
+            {
+                return launchAttemptId;
+            }
+        }
+
+        return launchAttemptIdGenerator.Create(launchStartedAtUtc);
     }
 
     private sealed record GuiStartupBlockedProcessPolicyResult (

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -421,6 +421,19 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 diagnosis,
                 CancellationToken.None)
             .ConfigureAwait(false);
+        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                unityProject,
+                CreateTerminationTarget(processId, processStartedAtUtc),
+                DaemonTimeouts.LaunchCompensationTimeout,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
+        var startup = new DaemonStartupObservation(
+            StartupStatus: startupStatus,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+            LaunchAttemptId: launchAttemptId,
+            ProcessAction: processAction,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);
         var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
                 unityProject,
                 launchAttemptId,
@@ -429,18 +442,12 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 startupStatus,
                 DaemonStartupBlockingReasonValues.Unknown,
                 DaemonStartupRetryDispositionValues.Unknown,
-                DaemonStartupProcessActionValues.None,
+                processAction,
                 editorMode,
                 processId,
                 processStartedAtUtc,
                 unityLogPath,
                 diagnosis)
-            .ConfigureAwait(false);
-        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
-                unityProject,
-                CreateTerminationTarget(processId, processStartedAtUtc),
-                DaemonTimeouts.LaunchCompensationTimeout,
-                CancellationToken.None)
             .ConfigureAwait(false);
         if (!diagnosisWriteResult.IsSuccess && !compensationResult.IsSuccess)
         {
@@ -449,7 +456,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 $"{primaryErrorMessagePrefix}, diagnosis persistence failed, and cleanup failed. " +
                 $"{primaryErrorLabel}={primaryError.Message} " +
                 $"DiagnosisError={diagnosisWriteResult.Error!.Message} " +
-                $"CleanupError={compensationResult.Error!.Message}"), diagnosis);
+                $"CleanupError={compensationResult.Error!.Message}"), diagnosis, startup);
         }
 
         if (!launchAttemptWriteResult.IsSuccess)
@@ -458,7 +465,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 primaryError,
                 $"{primaryErrorMessagePrefix} and launch-attempt artifact persistence failed. " +
                 $"{primaryErrorLabel}={primaryError.Message} " +
-                $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis);
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis, startup);
         }
 
         if (!diagnosisWriteResult.IsSuccess)
@@ -467,7 +474,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 primaryError,
                 $"{primaryErrorMessagePrefix} and diagnosis persistence failed. " +
                 $"{primaryErrorLabel}={primaryError.Message} " +
-                $"DiagnosisError={diagnosisWriteResult.Error!.Message}"), diagnosis);
+                $"DiagnosisError={diagnosisWriteResult.Error!.Message}"), diagnosis, startup);
         }
 
         if (!compensationResult.IsSuccess)
@@ -476,10 +483,10 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 primaryError,
                 $"{primaryErrorMessagePrefix} and cleanup failed. " +
                 $"{primaryErrorLabel}={primaryError.Message} " +
-                $"CleanupError={compensationResult.Error!.Message}"), diagnosis);
+                $"CleanupError={compensationResult.Error!.Message}"), diagnosis, startup);
         }
 
-        return DaemonStartResult.Failure(primaryError, diagnosis);
+        return DaemonStartResult.Failure(primaryError, diagnosis, startup);
     }
 
     private async ValueTask<DaemonStartResult> CreateFailureWithLaunchAttemptAsync (
@@ -611,6 +618,21 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             ProcessStartedAtUtc: processStartedAtUtc);
     }
 
+    private static string ResolveCompensatedProcessAction (
+        int? processId,
+        DaemonSessionStoreOperationResult compensationResult)
+    {
+        ArgumentNullException.ThrowIfNull(compensationResult);
+        if (processId is null)
+        {
+            return DaemonStartupProcessActionValues.None;
+        }
+
+        return compensationResult.IsSuccess
+            ? DaemonStartupProcessActionValues.Terminated
+            : DaemonStartupProcessActionValues.Unknown;
+    }
+
     private async ValueTask<DaemonStartResult> CreateGuiEndpointNotRegisteredFailureAsync (
         ResolvedUnityProjectContext unityProject,
         int? processId,
@@ -647,11 +669,18 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 unityLogPath,
                 waitError)
             .ConfigureAwait(false);
+        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                unityProject,
+                CreateTerminationTarget(processId, processStartedAtUtc),
+                DaemonTimeouts.LaunchCompensationTimeout,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
         var startup = new DaemonStartupObservation(
             StartupStatus: DaemonStartupStatusValues.Timeout,
             StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
             LaunchAttemptId: launchAttemptId,
-            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessAction: processAction,
             RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry);
         var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
                 unityProject,
@@ -667,12 +696,6 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 processStartedAtUtc,
                 unityLogPath,
                 startResult.Diagnosis!)
-            .ConfigureAwait(false);
-        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
-                unityProject,
-                CreateTerminationTarget(processId, processStartedAtUtc),
-                DaemonTimeouts.LaunchCompensationTimeout,
-                CancellationToken.None)
             .ConfigureAwait(false);
         if (!launchAttemptWriteResult.IsSuccess)
         {
@@ -710,6 +733,13 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         DateTimeOffset launchStartedAtUtc,
         ExecutionError startupError)
     {
+        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                unityProject,
+                CreateTerminationTarget(processId, processStartedAtUtc),
+                DaemonTimeouts.LaunchCompensationTimeout,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
         var startResult = await CreateFailureWithLaunchAttemptAsync(
                 unityProject,
                 launchAttemptId,
@@ -723,13 +753,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 DaemonStartupStatusValues.Failed,
                 DaemonStartupBlockingReasonValues.Unknown,
                 DaemonStartupRetryDispositionValues.Unknown,
-                DaemonStartupProcessActionValues.None)
-            .ConfigureAwait(false);
-        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
-                unityProject,
-                CreateTerminationTarget(processId, processStartedAtUtc),
-                DaemonTimeouts.LaunchCompensationTimeout,
-                CancellationToken.None)
+                processAction)
             .ConfigureAwait(false);
         if (compensationResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Daemon/DaemonCleanupCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/DaemonCleanupCommand.cs
@@ -77,6 +77,7 @@ internal sealed class DaemonCleanupCommand
                 {
                     cleanupStatus = DaemonCommandOutputProjector.ToCleanupStatus(output.CleanupStatus),
                     skipReason = DaemonCommandOutputProjector.ToCleanupSkipReason(output.SkipReason),
+                    deletedLaunchAttemptCount = output.DeletedLaunchAttemptCount,
                     timeoutMilliseconds = output.TimeoutMilliseconds,
                 });
         }

--- a/src/Ucli/Hosting/Cli/Daemon/DaemonStatusCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/DaemonStatusCommand.cs
@@ -90,6 +90,7 @@ internal sealed class DaemonStatusCommand
                     timeoutMilliseconds = output.TimeoutMilliseconds,
                     session = output.Session,
                     diagnosis = output.Diagnosis,
+                    lastLaunchAttempt = output.LastLaunchAttempt,
                 });
         }
 

--- a/src/Ucli/Hosting/Composition/Features/DaemonServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/DaemonServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Inventory;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.EditorInstance;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Gateway;
@@ -18,6 +19,7 @@ using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Daemon;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Unity;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Features.Daemon.Lifecycle.Inventory;
+using MackySoft.Ucli.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Features.Daemon.Lifecycle.Start.GuiEndpoint;
 using MackySoft.Ucli.UnityIntegration.Ipc.Process;
@@ -46,6 +48,8 @@ internal static class DaemonServiceCollectionExtensions
     {
         services.AddSingleton<IDaemonSessionStore, DaemonSessionStore>();
         services.AddSingleton<IDaemonDiagnosisStore, DaemonDiagnosisStore>();
+        services.AddSingleton<IDaemonLaunchAttemptIdGenerator, DaemonLaunchAttemptIdGenerator>();
+        services.AddSingleton<IDaemonLaunchAttemptStore, DaemonLaunchAttemptStore>();
         services.AddSingleton<IDaemonLifecycleStore, DaemonLifecycleStore>();
         services.AddSingleton<IDaemonSessionDiagnosisResolver, DaemonSessionDiagnosisResolver>();
         services.AddSingleton<DaemonProcessIdentityAssessor>();

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
@@ -949,16 +949,28 @@ public sealed class DaemonStartOperationTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
+        public object NextResult { get; set; } = DaemonArtifactCleanupResult.Success();
 
         public int CallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
-            return ValueTask.FromResult(NextResult);
+            return ValueTask.FromResult(ToArtifactCleanupResult(NextResult));
+        }
+
+        private static DaemonArtifactCleanupResult ToArtifactCleanupResult (object result)
+        {
+            return result switch
+            {
+                DaemonArtifactCleanupResult artifactResult => artifactResult,
+                DaemonSessionStoreOperationResult sessionResult => sessionResult.IsSuccess
+                    ? DaemonArtifactCleanupResult.Success()
+                    : DaemonArtifactCleanupResult.Failure(sessionResult.Error!),
+                _ => throw new ArgumentOutOfRangeException(nameof(result), result, "Unsupported artifact cleanup result."),
+            };
         }
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Recovery/DaemonLaunchCompensationServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Recovery/DaemonLaunchCompensationServiceTests.cs
@@ -149,16 +149,28 @@ public sealed class DaemonLaunchCompensationServiceTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
+        public object NextResult { get; set; } = DaemonArtifactCleanupResult.Success();
 
         public int CallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
-            return ValueTask.FromResult(NextResult);
+            return ValueTask.FromResult(ToArtifactCleanupResult(NextResult));
+        }
+
+        private static DaemonArtifactCleanupResult ToArtifactCleanupResult (object result)
+        {
+            return result switch
+            {
+                DaemonArtifactCleanupResult artifactResult => artifactResult,
+                DaemonSessionStoreOperationResult sessionResult => sessionResult.IsSuccess
+                    ? DaemonArtifactCleanupResult.Success()
+                    : DaemonArtifactCleanupResult.Failure(sessionResult.Error!),
+                _ => throw new ArgumentOutOfRangeException(nameof(result), result, "Unsupported artifact cleanup result."),
+            };
         }
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Recovery/DaemonSessionCleanupServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Recovery/DaemonSessionCleanupServiceTests.cs
@@ -249,16 +249,28 @@ public sealed class DaemonSessionCleanupServiceTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
+        public object NextResult { get; set; } = DaemonArtifactCleanupResult.Success();
 
         public int CallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
-            return ValueTask.FromResult(NextResult);
+            return ValueTask.FromResult(ToArtifactCleanupResult(NextResult));
+        }
+
+        private static DaemonArtifactCleanupResult ToArtifactCleanupResult (object result)
+        {
+            return result switch
+            {
+                DaemonArtifactCleanupResult artifactResult => artifactResult,
+                DaemonSessionStoreOperationResult sessionResult => sessionResult.IsSuccess
+                    ? DaemonArtifactCleanupResult.Success()
+                    : DaemonArtifactCleanupResult.Failure(sessionResult.Error!),
+                _ => throw new ArgumentOutOfRangeException(nameof(result), result, "Unsupported artifact cleanup result."),
+            };
         }
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Stop/DaemonStopOperationTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Stop/DaemonStopOperationTests.cs
@@ -523,16 +523,28 @@ public sealed class DaemonStopOperationTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
+        public object NextResult { get; set; } = DaemonArtifactCleanupResult.Success();
 
         public int CallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
-            return ValueTask.FromResult(NextResult);
+            return ValueTask.FromResult(ToArtifactCleanupResult(NextResult));
+        }
+
+        private static DaemonArtifactCleanupResult ToArtifactCleanupResult (object result)
+        {
+            return result switch
+            {
+                DaemonArtifactCleanupResult artifactResult => artifactResult,
+                DaemonSessionStoreOperationResult sessionResult => sessionResult.IsSuccess
+                    ? DaemonArtifactCleanupResult.Success()
+                    : DaemonArtifactCleanupResult.Failure(sessionResult.Error!),
+                _ => throw new ArgumentOutOfRangeException(nameof(result), result, "Unsupported artifact cleanup result."),
+            };
         }
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Cleanup/DaemonCleanupServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Cleanup/DaemonCleanupServiceTests.cs
@@ -26,6 +26,7 @@ public sealed class DaemonCleanupServiceTests
         var output = Assert.IsType<DaemonCleanupExecutionOutput>(result.Output);
         Assert.Equal(DaemonCleanupStatus.Completed, output.CleanupStatus);
         Assert.Equal(DaemonCleanupSkipReason.None, output.SkipReason);
+        Assert.Equal(0, output.DeletedLaunchAttemptCount);
         Assert.Equal(3400, output.TimeoutMilliseconds);
         Assert.Equal(1, operation.CleanupCallCount);
     }
@@ -49,6 +50,7 @@ public sealed class DaemonCleanupServiceTests
         var output = Assert.IsType<DaemonCleanupExecutionOutput>(result.Output);
         Assert.Equal(DaemonCleanupStatus.Skipped, output.CleanupStatus);
         Assert.Equal(DaemonCleanupSkipReason.UnsafeInvalidSession, output.SkipReason);
+        Assert.Equal(0, output.DeletedLaunchAttemptCount);
         Assert.Equal(UcliCommandIds.DaemonCleanup, resolver.LastTimeoutCommand);
         Assert.Equal("/tmp/unity-project", resolver.LastProjectPath);
         Assert.Equal(3100, resolver.LastTimeoutMilliseconds);

--- a/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Status/DaemonStatusServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Status/DaemonStatusServiceTests.cs
@@ -1,7 +1,11 @@
 using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandExecution;
 using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.UseCases.Status;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Probe;
@@ -258,6 +262,55 @@ public sealed class DaemonStatusServiceTests
         Assert.NotNull(output.Diagnosis);
         Assert.Equal(diagnosisMapper.Output, output.Diagnosis);
         Assert.Equal(1, diagnosisMapper.CallCount);
+        Assert.Equal(diagnosis, diagnosisMapper.LastDiagnosis);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task GetStatus_WhenLastLaunchAttemptExists_MapsLastLaunchAttemptToOutput ()
+    {
+        var context = DaemonServiceTestContext.CreateExecutionContext(timeoutMilliseconds: 2410);
+        var resolver = new DaemonServiceTestContext.StubDaemonCommandExecutionContextResolver(
+            DaemonCommandExecutionContextResolutionResult.Success(context));
+        var diagnosis = DaemonServiceTestContext.CreateDiagnosis();
+        var launchAttempt = new DaemonLaunchAttempt(
+            LaunchAttemptId: "20260312_000000Z_00000001",
+            StartedAtUtc: new DateTimeOffset(2026, 03, 12, 0, 0, 0, TimeSpan.Zero),
+            UpdatedAtUtc: new DateTimeOffset(2026, 03, 12, 0, 0, 5, TimeSpan.Zero),
+            StartupStatus: DaemonStartupStatusValues.Timeout,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry,
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            EditorMode: DaemonEditorModeValues.Gui,
+            ProcessId: 1234,
+            ProcessStartedAtUtc: new DateTimeOffset(2026, 03, 12, 0, 0, 1, TimeSpan.Zero),
+            UnityLogPath: "/tmp/repo-root/.ucli/local/fingerprints/fingerprint/unity.log",
+            ArtifactPath: "/tmp/repo-root/.ucli/local/fingerprints/fingerprint/launch-attempts/20260312_000000Z_00000001/startup-diagnosis.json",
+            Diagnosis: diagnosis);
+        var daemonStatusOperation = new DaemonServiceTestContext.StubDaemonStatusOperation
+        {
+            StatusResult = DaemonStatusResult.NotRunning(diagnosis: null, lastLaunchAttempt: launchAttempt),
+        };
+        var mapper = new DaemonServiceTestContext.StubDaemonSessionOutputMapper();
+        var diagnosisMapper = new DaemonServiceTestContext.StubDaemonDiagnosisOutputMapper();
+        var service = CreateService(resolver, daemonStatusOperation, mapper, diagnosisMapper);
+
+        var result = await service.GetStatusAsync(projectPath: null, timeoutMilliseconds: null, cancellationToken: CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var output = Assert.IsType<DaemonStatusExecutionOutput>(result.Output);
+        var actual = Assert.IsType<DaemonLaunchAttemptOutput>(output.LastLaunchAttempt);
+        Assert.Equal(launchAttempt.LaunchAttemptId, actual.LaunchAttemptId);
+        Assert.Equal(launchAttempt.StartupStatus, actual.StartupStatus);
+        Assert.Equal(launchAttempt.StartupBlockingReason, actual.StartupBlockingReason);
+        Assert.Equal(launchAttempt.RetryDisposition, actual.RetryDisposition);
+        Assert.Equal(launchAttempt.ProcessAction, actual.ProcessAction);
+        Assert.Equal(launchAttempt.ArtifactPath, actual.ArtifactPath);
+        Assert.Equal(launchAttempt.UnityLogPath, actual.UnityLogPath);
+        Assert.Equal(launchAttempt.UpdatedAtUtc, actual.UpdatedAtUtc);
+        Assert.Equal(launchAttempt.ProcessId, actual.ProcessId);
+        Assert.Equal(launchAttempt.ProcessStartedAtUtc, actual.ProcessStartedAtUtc);
+        Assert.Equal(diagnosisMapper.Output, actual.Diagnosis);
         Assert.Equal(diagnosis, diagnosisMapper.LastDiagnosis);
     }
 

--- a/tests/Ucli.Tests/DaemonCleanupCommandTests.cs
+++ b/tests/Ucli.Tests/DaemonCleanupCommandTests.cs
@@ -18,6 +18,7 @@ public sealed class DaemonCleanupCommandTests
             DaemonCleanupExecutionResult.Success(new DaemonCleanupExecutionOutput(
                 CleanupStatus: DaemonCleanupStatus.Skipped,
                 SkipReason: DaemonCleanupSkipReason.UnsafeInvalidSession,
+                DeletedLaunchAttemptCount: 0,
                 TimeoutMilliseconds: 3000)));
         var command = new DaemonCleanupCommand(service, CommandResultTestWriter.Create());
 
@@ -39,6 +40,35 @@ public sealed class DaemonCleanupCommandTests
             .HasProperty("payload", payload => payload
                 .HasString("cleanupStatus", "skipped")
                 .HasString("skipReason", "unsafeInvalidSession")
+                .HasInt32("deletedLaunchAttemptCount", 0)
+                .HasInt32("timeoutMilliseconds", 3000));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Cleanup_WhenCompleted_WritesDeletedLaunchAttemptCountPayload ()
+    {
+        var service = new StubDaemonCleanupService(
+            DaemonCleanupExecutionResult.Success(new DaemonCleanupExecutionOutput(
+                CleanupStatus: DaemonCleanupStatus.Completed,
+                SkipReason: DaemonCleanupSkipReason.None,
+                DeletedLaunchAttemptCount: 3,
+                TimeoutMilliseconds: 3000)));
+        var command = new DaemonCleanupCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.CleanupAsync(
+            projectPath: "/repo/UnityProject",
+            timeout: "3000",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("cleanupStatus", "completed")
+                .IsNull("skipReason")
+                .HasInt32("deletedLaunchAttemptCount", 3)
                 .HasInt32("timeoutMilliseconds", 3000));
     }
 

--- a/tests/Ucli.Tests/DaemonCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/DaemonCliOutputContractTests.cs
@@ -52,7 +52,8 @@ public sealed class DaemonCliOutputContractTests
                 .HasBoolean("canAcceptExecutionRequests", false)
                 .HasInt32("timeoutMilliseconds", UcliContractConstants.Config.IpcTimeoutDefaultDaemonStatusMilliseconds)
                 .IsNull("session")
-                .IsNull("diagnosis"));
+                .IsNull("diagnosis")
+                .IsNull("lastLaunchAttempt"));
         Assert.False(outputJson.RootElement.GetProperty("payload").TryGetProperty("runtime", out _));
     }
 
@@ -112,6 +113,7 @@ public sealed class DaemonCliOutputContractTests
             .HasProperty("payload", payload => payload
                 .HasString("cleanupStatus", "skipped")
                 .HasString("skipReason", "uncertainReachability")
+                .HasInt32("deletedLaunchAttemptCount", 0)
                 .HasInt32("timeoutMilliseconds", UcliContractConstants.Config.IpcTimeoutDefaultDaemonCleanupMilliseconds));
     }
 
@@ -142,6 +144,7 @@ public sealed class DaemonCliOutputContractTests
             .HasProperty("payload", payload => payload
                 .HasString("cleanupStatus", "skipped")
                 .HasString("skipReason", "unsafeInvalidSession")
+                .HasInt32("deletedLaunchAttemptCount", 0)
                 .HasInt32("timeoutMilliseconds", UcliContractConstants.Config.IpcTimeoutDefaultDaemonCleanupMilliseconds));
     }
 

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanerTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanerTests.cs
@@ -1,3 +1,4 @@
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -25,6 +26,7 @@ public sealed class DaemonArtifactCleanerTests
         var cleaner = new DaemonArtifactCleaner(
             new StubDaemonSessionStore(),
             new StubDaemonLifecycleStore(),
+            new StubDaemonLaunchAttemptStore(),
             new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.UnixDomainSocket, socketPath)));
 
         var result = await cleaner.CleanupAsync(
@@ -38,6 +40,32 @@ public sealed class DaemonArtifactCleanerTests
         Assert.True(result.IsSuccess);
         Assert.False(File.Exists(socketPath));
         Assert.False(Directory.Exists(socketDirectoryPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Cleanup_WhenLaunchAttemptStoreDeletesOldAttempts_ReturnsDeletedLaunchAttemptCount ()
+    {
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            PruneResult = DaemonLaunchAttemptStoreOperationResult.Success(deletedCount: 3),
+        };
+        var cleaner = new DaemonArtifactCleaner(
+            new StubDaemonSessionStore(),
+            new StubDaemonLifecycleStore(),
+            launchAttemptStore,
+            new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-pipe")));
+
+        var result = await cleaner.CleanupAsync(
+            new ResolvedUnityProjectContext(
+                UnityProjectRoot: "/tmp/unity-project",
+                RepositoryRoot: "/tmp/repo-root",
+                ProjectFingerprint: "fingerprint-cleanup",
+                PathSource: UnityProjectPathSource.CommandOption),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.DeletedLaunchAttemptCount);
     }
 
     private sealed class StubDaemonSessionStore : IDaemonSessionStore
@@ -83,6 +111,37 @@ public sealed class DaemonArtifactCleanerTests
             CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult(DaemonLifecycleStoreOperationResult.Success());
+        }
+    }
+
+    private sealed class StubDaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
+    {
+        public DaemonLaunchAttemptStoreOperationResult PruneResult { get; init; } = DaemonLaunchAttemptStoreOperationResult.Success();
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            DaemonLaunchAttempt launchAttempt,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+            string storageRoot,
+            string projectFingerprint,
+            int keepCount,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(PruneResult);
         }
     }
 

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanerTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonArtifactCleanerTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Infrastructure.Ipc;
 using MackySoft.Ucli.UnityIntegration.Ipc.Transport;
@@ -66,6 +67,32 @@ public sealed class DaemonArtifactCleanerTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(3, result.DeletedLaunchAttemptCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Cleanup_WhenLaunchAttemptPruneFails_ReturnsFailure ()
+    {
+        var pruneError = ExecutionError.InternalError("prune failed");
+        var cleaner = new DaemonArtifactCleaner(
+            new StubDaemonSessionStore(),
+            new StubDaemonLifecycleStore(),
+            new StubDaemonLaunchAttemptStore
+            {
+                PruneResult = DaemonLaunchAttemptStoreOperationResult.Failure(pruneError),
+            },
+            new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-test-pipe")));
+
+        var result = await cleaner.CleanupAsync(
+            new ResolvedUnityProjectContext(
+                UnityProjectRoot: "/tmp/unity-project",
+                RepositoryRoot: "/tmp/repo-root",
+                ProjectFingerprint: "fingerprint-cleanup",
+                PathSource: UnityProjectPathSource.CommandOption),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(pruneError, result.Error);
     }
 
     private sealed class StubDaemonSessionStore : IDaemonSessionStore

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperationTests.cs
@@ -40,6 +40,29 @@ public sealed class DaemonCleanupOperationTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Cleanup_WhenArtifactCleanerDeletesLaunchAttempts_PropagatesDeletedLaunchAttemptCount ()
+    {
+        var operation = CreateOperation(
+            daemonSessionStore: new StubDaemonSessionStore
+            {
+                ReadResult = DaemonSessionReadResult.Success(null),
+            },
+            daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
+            artifactCleaner: new StubDaemonArtifactCleaner
+            {
+                NextResult = DaemonArtifactCleanupResult.Success(deletedLaunchAttemptCount: 3),
+            },
+            endpointResolver: new StubEndpointResolver(new IpcEndpoint(IpcTransportKind.NamedPipe, "ucli-daemon-test")));
+
+        var result = await operation.CleanupAsync(CreateContext("fingerprint-cleanup-deleted-attempts"), TimeSpan.FromMilliseconds(500), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(DaemonCleanupStatus.Completed, result.Status);
+        Assert.Equal(3, result.DeletedLaunchAttemptCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Cleanup_WhenSessionDoesNotExistAndProbeFindsLiveDaemon_ReturnsSkippedUncertainReachabilityWithoutCleanup ()
     {
         var artifactCleaner = new StubDaemonArtifactCleaner();

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Cleanup/DaemonCleanupOperationTests.cs
@@ -20,7 +20,7 @@ public sealed class DaemonCleanupOperationTests
     {
         var artifactCleaner = new StubDaemonArtifactCleaner
         {
-            NextResult = DaemonSessionStoreOperationResult.Success(),
+            NextResult = DaemonArtifactCleanupResult.Success(),
         };
         var operation = CreateOperation(
             daemonSessionStore: new StubDaemonSessionStore
@@ -136,7 +136,7 @@ public sealed class DaemonCleanupOperationTests
         var session = CreateSession(processId: 2002);
         var artifactCleaner = new StubDaemonArtifactCleaner
         {
-            NextResult = DaemonSessionStoreOperationResult.Success(),
+            NextResult = DaemonArtifactCleanupResult.Success(),
         };
         var operation = CreateOperation(
             daemonSessionStore: new StubDaemonSessionStore
@@ -276,7 +276,7 @@ public sealed class DaemonCleanupOperationTests
         };
         var artifactCleaner = new StubDaemonArtifactCleaner
         {
-            NextResult = DaemonSessionStoreOperationResult.Success(),
+            NextResult = DaemonArtifactCleanupResult.Success(),
         };
         var operation = CreateOperation(
             daemonSessionStore: new StubDaemonSessionStore
@@ -308,7 +308,7 @@ public sealed class DaemonCleanupOperationTests
         var context = CreateContext("fingerprint-cleanup-invalid-null");
         var artifactCleaner = new StubDaemonArtifactCleaner
         {
-            NextResult = DaemonSessionStoreOperationResult.Success(),
+            NextResult = DaemonArtifactCleanupResult.Success(),
         };
         var operation = CreateOperation(
             daemonSessionStore: new StubDaemonSessionStore
@@ -567,11 +567,11 @@ public sealed class DaemonCleanupOperationTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
+        public DaemonArtifactCleanupResult NextResult { get; set; } = DaemonArtifactCleanupResult.Success();
 
         public int CallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreTests.cs
@@ -62,6 +62,48 @@ public sealed class DaemonLaunchAttemptStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenDirectoryTimestampIsNewer_UsesLaunchAttemptIdOrder ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "stable-order");
+        var store = new DaemonLaunchAttemptStore();
+        var older = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var newer = CreateAttempt("20260312_000001Z_00000002", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: 1);
+
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", newer, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", older, CancellationToken.None)).IsSuccess);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId),
+            newer.UpdatedAtUtc.AddMinutes(10).UtcDateTime);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", newer.LaunchAttemptId),
+            older.UpdatedAtUtc.UtcDateTime);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.True(readResult.IsSuccess);
+        Assert.Equal(newer.LaunchAttemptId, readResult.LaunchAttempt!.LaunchAttemptId);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenAttemptsShareSameSecond_UsesUpdatedAtOrder ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "same-second-order");
+        var store = new DaemonLaunchAttemptStore();
+        var older = CreateAttempt("20260312_000000Z_ffffffff", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var newer = CreateAttempt("20260312_000000Z_00000000", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: 1);
+
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", older, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", newer, CancellationToken.None)).IsSuccess);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.True(readResult.IsSuccess);
+        Assert.Equal(newer.LaunchAttemptId, readResult.LaunchAttempt!.LaunchAttemptId);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task ReadLastFailure_WhenStartupDiagnosisJsonIsInvalid_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "invalid-json");
@@ -79,6 +121,64 @@ public sealed class DaemonLaunchAttemptStoreTests
         Assert.False(readResult.IsSuccess);
         var error = Assert.IsType<ExecutionError>(readResult.Error);
         Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenStartupDiagnosisJsonIsSymbolicLink_ReturnsFailureWithoutReadingTarget ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "read-file-symlink");
+        using var targetScope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "read-file-symlink-target");
+        var store = new DaemonLaunchAttemptStore();
+        var attemptId = "20260312_000000Z_00000001";
+        var diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+            scope.FullPath,
+            "fingerprint",
+            attemptId);
+        Directory.CreateDirectory(Path.GetDirectoryName(diagnosisPath)!);
+        var targetPath = Path.Combine(targetScope.FullPath, "target.json");
+        await File.WriteAllTextAsync(targetPath, "{}", CancellationToken.None);
+        File.CreateSymbolicLink(diagnosisPath, targetPath);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.False(readResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(readResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.True(File.Exists(targetPath));
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("\"startupBlockingReason\": \"unknown\"", "\"startupBlockingReason\": \"notSupported\"", "startupBlockingReason")]
+    [InlineData("\"reportedBy\": \"cli\"", "\"reportedBy\": \"notSupported\"", "diagnosis.reportedBy")]
+    [InlineData("\"startupPhase\": \"endpointRegistration\"", "\"startupPhase\": \"notSupported\"", "diagnosis.startupPhase")]
+    [InlineData("\"actionRequired\": \"inspectUnityLog\"", "\"actionRequired\": \"notSupported\"", "diagnosis.actionRequired")]
+    [InlineData("\"kind\": \"compiler\"", "\"kind\": \"notSupported\"", "diagnosis.primaryDiagnostic.kind")]
+    public async Task ReadLastFailure_WhenContractVocabularyIsInvalid_ReturnsInvalidArgument (
+        string oldValue,
+        string newValue,
+        string expectedMessage)
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "invalid-vocabulary");
+        var store = new DaemonLaunchAttemptStore();
+        var attempt = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", attempt, CancellationToken.None)).IsSuccess);
+        var json = await File.ReadAllTextAsync(attempt.ArtifactPath, CancellationToken.None);
+        Assert.Contains(oldValue, json, StringComparison.Ordinal);
+        await File.WriteAllTextAsync(attempt.ArtifactPath, json.Replace(oldValue, newValue, StringComparison.Ordinal), CancellationToken.None);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.False(readResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(readResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Contains(expectedMessage, error.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -124,6 +224,153 @@ public sealed class DaemonLaunchAttemptStoreTests
         Assert.False(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", "20260312_000000Z_00000000")));
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenOldAttemptDirectoryTimestampIsNewer_DeletesOldAttemptByLaunchAttemptIdOrder ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention-stable-order");
+        var store = new DaemonLaunchAttemptStore();
+        var older = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var newer = CreateAttempt("20260312_000001Z_00000002", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: 1);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", newer, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", older, CancellationToken.None)).IsSuccess);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId),
+            newer.UpdatedAtUtc.AddMinutes(10).UtcDateTime);
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 1, CancellationToken.None);
+
+        Assert.True(pruneResult.IsSuccess);
+        Assert.Equal(1, pruneResult.DeletedCount);
+        Assert.False(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId)));
+        Assert.True(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", newer.LaunchAttemptId)));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenAttemptsShareSameSecond_DeletesOldAttemptByUpdatedAtOrder ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention-same-second-order");
+        var store = new DaemonLaunchAttemptStore();
+        var older = CreateAttempt("20260312_000000Z_ffffffff", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var newer = CreateAttempt("20260312_000000Z_00000000", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: 1);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", older, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", newer, CancellationToken.None)).IsSuccess);
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 1, CancellationToken.None);
+
+        Assert.True(pruneResult.IsSuccess);
+        Assert.Equal(1, pruneResult.DeletedCount);
+        Assert.False(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId)));
+        Assert.True(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", newer.LaunchAttemptId)));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenOldStartupDiagnosisJsonIsInvalid_DeletesOldAttemptWithoutFailingRetention ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention-invalid-json");
+        var store = new DaemonLaunchAttemptStore();
+        var older = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var newer = CreateAttempt("20260312_000001Z_00000002", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: 1);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", older, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", newer, CancellationToken.None)).IsSuccess);
+        await File.WriteAllTextAsync(older.ArtifactPath, "{ invalid json", CancellationToken.None);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId),
+            older.UpdatedAtUtc.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", newer.LaunchAttemptId),
+            newer.UpdatedAtUtc.UtcDateTime);
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 1, CancellationToken.None);
+
+        Assert.True(pruneResult.IsSuccess);
+        Assert.Equal(1, pruneResult.DeletedCount);
+        Assert.False(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", older.LaunchAttemptId)));
+        Assert.True(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", newer.LaunchAttemptId)));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenLaunchAttemptsDirectoryIsSymbolicLink_ReturnsFailureWithoutDeletingTarget ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention-symlink");
+        using var targetScope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention-symlink-target");
+        var store = new DaemonLaunchAttemptStore();
+        var attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(scope.FullPath, "fingerprint");
+        Directory.CreateDirectory(Path.GetDirectoryName(attemptsDirectory)!);
+        var targetAttemptDirectory = Path.Combine(targetScope.FullPath, "20260312_000000Z_00000001");
+        Directory.CreateDirectory(targetAttemptDirectory);
+        Directory.CreateSymbolicLink(attemptsDirectory, targetScope.FullPath);
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 0, CancellationToken.None);
+
+        Assert.False(pruneResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(pruneResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.True(Directory.Exists(targetAttemptDirectory));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenAttemptDirectoryIsSymbolicLink_ReturnsFailureWithoutReadingTarget ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "read-attempt-symlink");
+        using var targetScope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "read-attempt-symlink-target");
+        var store = new DaemonLaunchAttemptStore();
+        var attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(scope.FullPath, "fingerprint");
+        Directory.CreateDirectory(attemptsDirectory);
+        var targetAttemptDirectory = Path.Combine(targetScope.FullPath, "target-attempt");
+        Directory.CreateDirectory(targetAttemptDirectory);
+        var attemptDirectory = Path.Combine(attemptsDirectory, "20260312_000000Z_00000001");
+        Directory.CreateSymbolicLink(attemptDirectory, targetAttemptDirectory);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.False(readResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(readResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.True(Directory.Exists(targetAttemptDirectory));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenAttemptDirectoryIsSymbolicLink_ReturnsFailureWithoutDeletingTarget ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "prune-attempt-symlink");
+        using var targetScope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "prune-attempt-symlink-target");
+        var store = new DaemonLaunchAttemptStore();
+        var attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(scope.FullPath, "fingerprint");
+        Directory.CreateDirectory(attemptsDirectory);
+        var targetAttemptDirectory = Path.Combine(targetScope.FullPath, "target-attempt");
+        Directory.CreateDirectory(targetAttemptDirectory);
+        var attemptDirectory = Path.Combine(attemptsDirectory, "20260312_000000Z_00000001");
+        Directory.CreateSymbolicLink(attemptDirectory, targetAttemptDirectory);
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 0, CancellationToken.None);
+
+        Assert.False(pruneResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(pruneResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.True(Directory.Exists(targetAttemptDirectory));
+    }
+
     private static DaemonLaunchAttempt CreateAttempt (
         string launchAttemptId,
         string storageRoot,
@@ -144,7 +391,14 @@ public sealed class DaemonLaunchAttemptStoreTests
             ProcessStartedAtUtc: updatedAtUtc,
             UnityLogPath: unityLogPath,
             StartupPhase: DaemonDiagnosisStartupPhaseValues.EndpointRegistration,
-            ActionRequired: DaemonDiagnosisActionRequiredValues.InspectUnityLog);
+            ActionRequired: DaemonDiagnosisActionRequiredValues.InspectUnityLog,
+            PrimaryDiagnostic: new DaemonPrimaryDiagnostic(
+                Kind: DaemonDiagnosisPrimaryDiagnosticKindValues.Compiler,
+                Code: "CS0103",
+                File: "Assets/Foo.cs",
+                Line: 12,
+                Column: 34,
+                Message: "Missing type"));
         return new DaemonLaunchAttempt(
             LaunchAttemptId: launchAttemptId,
             StartedAtUtc: updatedAtUtc,

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/LaunchAttempts/DaemonLaunchAttemptStoreTests.cs
@@ -1,0 +1,163 @@
+using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Features.Daemon.Lifecycle.LaunchAttempts;
+using MackySoft.Ucli.Infrastructure.Storage;
+
+namespace MackySoft.Ucli.Tests.Daemon;
+
+public sealed class DaemonLaunchAttemptStoreTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteFailureAndReadLastFailure_RoundTripsStartupDiagnosisWithUnityLogPathReference ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "roundtrip");
+        var store = new DaemonLaunchAttemptStore();
+        var attempt = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Blocked);
+
+        var writeResult = await store.WriteFailureAsync(scope.FullPath, "fingerprint", attempt, CancellationToken.None);
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.True(writeResult.IsSuccess);
+        Assert.True(readResult.IsSuccess);
+        var actual = Assert.IsType<DaemonLaunchAttempt>(readResult.LaunchAttempt);
+        Assert.Equal(attempt.LaunchAttemptId, actual.LaunchAttemptId);
+        Assert.Equal(DaemonStartupStatusValues.Blocked, actual.StartupStatus);
+        Assert.Equal(attempt.UnityLogPath, actual.UnityLogPath);
+        Assert.Equal(attempt.UnityLogPath, actual.Diagnosis.UnityLogPath);
+        Assert.EndsWith(
+            Path.Combine("launch-attempts", attempt.LaunchAttemptId, "startup-diagnosis.json"),
+            actual.ArtifactPath,
+            StringComparison.Ordinal);
+        Assert.True(File.Exists(actual.ArtifactPath));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenLatestAttemptIsCompleted_ReturnsLatestPublicFailure ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "completed-hidden");
+        var store = new DaemonLaunchAttemptStore();
+        var failed = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed);
+        var completed = CreateAttempt("20260312_000001Z_00000002", scope.FullPath, startupStatus: DaemonStartupStatusValues.Completed);
+
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", failed, CancellationToken.None)).IsSuccess);
+        Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", completed, CancellationToken.None)).IsSuccess);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", failed.LaunchAttemptId),
+            failed.UpdatedAtUtc.UtcDateTime);
+        Directory.SetLastWriteTimeUtc(
+            UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", completed.LaunchAttemptId),
+            completed.UpdatedAtUtc.UtcDateTime);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.True(readResult.IsSuccess);
+        Assert.Equal(failed.LaunchAttemptId, readResult.LaunchAttempt!.LaunchAttemptId);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task ReadLastFailure_WhenStartupDiagnosisJsonIsInvalid_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "invalid-json");
+        var store = new DaemonLaunchAttemptStore();
+        var attemptId = "20260312_000000Z_00000001";
+        var diagnosisPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+            scope.FullPath,
+            "fingerprint",
+            attemptId);
+        Directory.CreateDirectory(Path.GetDirectoryName(diagnosisPath)!);
+        await File.WriteAllTextAsync(diagnosisPath, "{ invalid json", CancellationToken.None);
+
+        var readResult = await store.ReadLastFailureAsync(scope.FullPath, "fingerprint", CancellationToken.None);
+
+        Assert.False(readResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(readResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WriteFailure_WhenLaunchAttemptIdIsInvalid_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "invalid-id");
+        var store = new DaemonLaunchAttemptStore();
+        var attempt = CreateAttempt("20260312_000000Z_00000001", scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed) with
+        {
+            LaunchAttemptId = " ",
+        };
+
+        var writeResult = await store.WriteFailureAsync(scope.FullPath, "fingerprint", attempt, CancellationToken.None);
+
+        Assert.False(writeResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(writeResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task PruneAsync_WhenMoreThanKeepCountAttemptsExist_DeletesOldAttempts ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-attempt-store", "retention");
+        var store = new DaemonLaunchAttemptStore();
+        for (var i = 0; i < 21; i++)
+        {
+            var id = $"20260312_0000{i:00}Z_{i:00000000}";
+            var attempt = CreateAttempt(id, scope.FullPath, startupStatus: DaemonStartupStatusValues.Failed, minuteOffset: i);
+            Assert.True((await store.WriteFailureAsync(scope.FullPath, "fingerprint", attempt, CancellationToken.None)).IsSuccess);
+            Directory.SetLastWriteTimeUtc(
+                UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", id),
+                attempt.UpdatedAtUtc.UtcDateTime);
+        }
+
+        var pruneResult = await store.PruneAsync(scope.FullPath, "fingerprint", keepCount: 20, CancellationToken.None);
+
+        Assert.True(pruneResult.IsSuccess);
+        Assert.Equal(1, pruneResult.DeletedCount);
+        var attemptsDirectory = UcliStoragePathResolver.ResolveLaunchAttemptsDirectory(scope.FullPath, "fingerprint");
+        Assert.Equal(20, Directory.EnumerateDirectories(attemptsDirectory).Count());
+        Assert.False(Directory.Exists(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(scope.FullPath, "fingerprint", "20260312_000000Z_00000000")));
+    }
+
+    private static DaemonLaunchAttempt CreateAttempt (
+        string launchAttemptId,
+        string storageRoot,
+        string startupStatus,
+        int minuteOffset = 0)
+    {
+        var updatedAtUtc = new DateTimeOffset(2026, 03, 12, 0, minuteOffset, 0, TimeSpan.Zero);
+        var unityLogPath = UcliStoragePathResolver.ResolveUnityLogPath(storageRoot, "fingerprint");
+        var diagnosis = new DaemonDiagnosis(
+            Reason: DaemonDiagnosisReasonValues.StartupFailed,
+            Message: "startup failed",
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: 1234,
+            EditorInstancePath: null,
+            SessionIssuedAtUtc: updatedAtUtc,
+            ProcessStartedAtUtc: updatedAtUtc,
+            UnityLogPath: unityLogPath,
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.EndpointRegistration,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.InspectUnityLog);
+        return new DaemonLaunchAttempt(
+            LaunchAttemptId: launchAttemptId,
+            StartedAtUtc: updatedAtUtc,
+            UpdatedAtUtc: updatedAtUtc,
+            StartupStatus: startupStatus,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown,
+            ProcessAction: DaemonStartupProcessActionValues.None,
+            EditorMode: DaemonEditorModeValues.Gui,
+            ProcessId: 1234,
+            ProcessStartedAtUtc: updatedAtUtc,
+            UnityLogPath: unityLogPath,
+            ArtifactPath: UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(storageRoot, "fingerprint", launchAttemptId),
+            Diagnosis: diagnosis);
+    }
+}

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -130,6 +130,7 @@ public sealed class DaemonLaunchServiceTests
         };
         var compensationService = new StubDaemonLaunchCompensationService();
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             launchSessionService,
             batchmodeLauncher,
@@ -137,7 +138,8 @@ public sealed class DaemonLaunchServiceTests
             compensationService,
             diagnosisStore,
             unityGuiEditorProcessLauncher: guiLauncher,
-            guiStartupObserver: guiStartupObserver);
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -167,6 +169,56 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(1, compensationService.CallCount);
         Assert.Equal(5432, compensationService.LastProcessId);
         Assert.Equal(processStartedAtUtc, compensationService.LastProcessStartedAtUtc);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenEditorModeGuiRegistrationTimesOutAndCompensationFails_RecordsUnknownProcessAction ()
+    {
+        var context = CreateContext("fingerprint-gui-launch-timeout-cleanup-fail");
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 12, 0, 0, 1, TimeSpan.Zero);
+        var guiLauncher = new StubUnityGuiEditorProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(5433, processStartedAtUtc),
+        };
+        var timeoutError = ExecutionError.Timeout("registration timeout", ExecutionErrorCodes.IpcTimeout);
+        var guiStartupObserver = new StubDaemonGuiStartupObserver
+        {
+            NextResult = DaemonGuiStartupObservationResult.Failure(timeoutError),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            NextResult = DaemonSessionStoreOperationResult.Failure(ExecutionError.InternalError("cleanup failed")),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            new StubDaemonLaunchSessionService(),
+            new StubUnityDaemonProcessLauncher(),
+            new StubDaemonStartupReadinessProbe(),
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            unityGuiEditorProcessLauncher: guiLauncher,
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Gui,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.Startup!.ProcessAction);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, launchAttemptStore.LastLaunchAttempt.ProcessAction);
     }
 
     [Fact]
@@ -189,6 +241,7 @@ public sealed class DaemonLaunchServiceTests
             },
         };
         var compensationService = new StubDaemonLaunchCompensationService();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             new StubDaemonLaunchSessionService(),
             new StubUnityDaemonProcessLauncher(),
@@ -196,7 +249,8 @@ public sealed class DaemonLaunchServiceTests
             compensationService,
             new StubDaemonDiagnosisStore(),
             unityGuiEditorProcessLauncher: guiLauncher,
-            guiStartupObserver: guiStartupObserver);
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => service.LaunchAsync(
@@ -228,6 +282,7 @@ public sealed class DaemonLaunchServiceTests
             NextResult = DaemonGuiStartupObservationResult.Failure(startupError),
         };
         var compensationService = new StubDaemonLaunchCompensationService();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             new StubDaemonLaunchSessionService(),
             new StubUnityDaemonProcessLauncher(),
@@ -235,7 +290,8 @@ public sealed class DaemonLaunchServiceTests
             compensationService,
             new StubDaemonDiagnosisStore(),
             unityGuiEditorProcessLauncher: guiLauncher,
-            guiStartupObserver: guiStartupObserver);
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -249,6 +305,11 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(1, compensationService.CallCount);
         Assert.Equal(8765, compensationService.LastProcessId);
         Assert.Equal(processStartedAtUtc, compensationService.LastProcessStartedAtUtc);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Failed, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
     }
 
     [Theory]
@@ -588,12 +649,14 @@ public sealed class DaemonLaunchServiceTests
         var readinessProbe = new StubDaemonStartupReadinessProbe();
         var compensationService = new StubDaemonLaunchCompensationService();
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             launchSessionService,
             launcher,
             readinessProbe,
             compensationService,
-            diagnosisStore);
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -609,6 +672,12 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(0, launcher.CallCount);
         Assert.Equal(0, compensationService.CallCount);
         Assert.Equal(0, diagnosisStore.WriteCallCount);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(1, launchAttemptStore.PruneCallCount);
+        Assert.Equal(result.Startup!.LaunchAttemptId, launchAttemptStore.LastLaunchAttempt!.LaunchAttemptId);
+        Assert.Equal(DaemonStartupStatusValues.Failed, launchAttemptStore.LastLaunchAttempt.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.None, launchAttemptStore.LastLaunchAttempt.ProcessAction);
     }
 
     [Fact]
@@ -632,12 +701,14 @@ public sealed class DaemonLaunchServiceTests
             NextResult = DaemonSessionStoreOperationResult.Success(),
         };
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             launchSessionService,
             launcher,
             readinessProbe,
             compensationService,
-            diagnosisStore);
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -658,6 +729,11 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(launchError.Message, diagnosisStore.LastDiagnosis.Message);
         Assert.Equal(initialSession.IssuedAtUtc, diagnosisStore.LastDiagnosis.SessionIssuedAtUtc);
         Assert.Equal(diagnosisStore.LastDiagnosis, result.Diagnosis);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(1, launchAttemptStore.PruneCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Failed, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.None, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+        Assert.Equal(diagnosisStore.LastDiagnosis, launchAttemptStore.LastLaunchAttempt.Diagnosis);
     }
 
     [Fact]
@@ -683,12 +759,14 @@ public sealed class DaemonLaunchServiceTests
             NextResult = DaemonSessionStoreOperationResult.Success(),
         };
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             launchSessionService,
             launcher,
             readinessProbe,
             compensationService,
-            diagnosisStore);
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -705,6 +783,10 @@ public sealed class DaemonLaunchServiceTests
         Assert.NotNull(compensationService.LastProcessStartedAtUtc);
         Assert.Equal(1, diagnosisStore.WriteCallCount);
         Assert.Equal(processStartedAtUtc, diagnosisStore.LastDiagnosis?.ProcessStartedAtUtc);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Failed, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+        Assert.Equal(processStartedAtUtc, launchAttemptStore.LastLaunchAttempt.ProcessStartedAtUtc);
     }
 
     [Fact]
@@ -734,12 +816,14 @@ public sealed class DaemonLaunchServiceTests
             NextResult = DaemonSessionStoreOperationResult.Success(),
         };
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             launchSessionService,
             launcher,
             readinessProbe,
             compensationService,
-            diagnosisStore);
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -757,6 +841,118 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(1, diagnosisStore.WriteCallCount);
         Assert.Equal(processStartedAtUtc, diagnosisStore.LastDiagnosis?.ProcessStartedAtUtc);
         Assert.Equal(diagnosisStore.LastDiagnosis, result.Diagnosis);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+        Assert.Equal(processStartedAtUtc, launchAttemptStore.LastLaunchAttempt.ProcessStartedAtUtc);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenLaunchAttemptWriteFails_PreservesPrimaryTimeoutFailureAndStartupObservation ()
+    {
+        var context = CreateContext("fingerprint-launch-attempt-write-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7777 };
+        var probeError = ExecutionError.Timeout("probe failed", ExecutionErrorCodes.IpcTimeout);
+        var artifactError = ExecutionError.InternalError("artifact write failed");
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var launcher = new StubUnityDaemonProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(7777, DateTimeOffset.UtcNow),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(probeError),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            WriteResult = DaemonLaunchAttemptStoreOperationResult.Failure(artifactError),
+        };
+        var service = CreateService(
+            launchSessionService,
+            launcher,
+            readinessProbe,
+            new StubDaemonLaunchCompensationService(),
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.Timeout, error.Kind);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, error.Code);
+        Assert.Contains("ProbeError=probe failed", error.Message, StringComparison.Ordinal);
+        Assert.Contains("ArtifactError=artifact write failed", error.Message, StringComparison.Ordinal);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, result.Startup!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup.ProcessAction);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(0, launchAttemptStore.PruneCallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenLaunchAttemptPruneFails_PreservesPrimaryTimeoutFailureAndStartupObservation ()
+    {
+        var context = CreateContext("fingerprint-launch-attempt-prune-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7778 };
+        var probeError = ExecutionError.Timeout("probe failed", ExecutionErrorCodes.IpcTimeout);
+        var artifactError = ExecutionError.InternalError("artifact prune failed");
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var launcher = new StubUnityDaemonProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(7778, DateTimeOffset.UtcNow),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(probeError),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            PruneResult = DaemonLaunchAttemptStoreOperationResult.Failure(artifactError),
+        };
+        var service = CreateService(
+            launchSessionService,
+            launcher,
+            readinessProbe,
+            new StubDaemonLaunchCompensationService(),
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.Timeout, error.Kind);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, error.Code);
+        Assert.Contains("ProbeError=probe failed", error.Message, StringComparison.Ordinal);
+        Assert.Contains("ArtifactError=artifact prune failed", error.Message, StringComparison.Ordinal);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, result.Startup!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup.ProcessAction);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(1, launchAttemptStore.PruneCallCount);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 namespace MackySoft.Ucli.Tests.Daemon;
@@ -7,6 +8,7 @@ using MackySoft.Tests;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Infrastructure.Storage;
 
 public sealed class DaemonLaunchServiceTests
 {
@@ -286,6 +288,7 @@ public sealed class DaemonLaunchServiceTests
         };
         var compensationService = new StubDaemonLaunchCompensationService();
         var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
         var service = CreateService(
             new StubDaemonLaunchSessionService(),
             new StubUnityDaemonProcessLauncher(),
@@ -293,7 +296,8 @@ public sealed class DaemonLaunchServiceTests
             compensationService,
             diagnosisStore,
             unityGuiEditorProcessLauncher: guiLauncher,
-            guiStartupObserver: guiStartupObserver);
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
 
         var result = await service.LaunchAsync(
             context,
@@ -320,6 +324,70 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(DaemonStartupProcessActionValues.Kept, result.Startup!.ProcessAction);
         Assert.Equal(DaemonStartupBlockingReasonValues.Compile, result.Startup.StartupBlockingReason);
         Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, result.Startup.RetryDisposition);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(1, launchAttemptStore.PruneCallCount);
+        Assert.Equal(result.Startup.LaunchAttemptId, launchAttemptStore.LastLaunchAttempt!.LaunchAttemptId);
+        Assert.Equal(DaemonStartupStatusValues.Blocked, launchAttemptStore.LastLaunchAttempt.StartupStatus);
+        Assert.Equal(blocker.UnityLogPath, launchAttemptStore.LastLaunchAttempt.UnityLogPath);
+        Assert.Equal(diagnosisStore.LastDiagnosis, launchAttemptStore.LastLaunchAttempt.Diagnosis);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenLaunchAttemptIdDirectoryAlreadyExists_RegeneratesLaunchAttemptId ()
+    {
+        using var scope = TestDirectories.CreateTempScope("daemon-launch-service", "launch-attempt-id-collision");
+        var context = new ResolvedUnityProjectContext(
+            UnityProjectRoot: Path.Combine(scope.FullPath, "UnityProject"),
+            RepositoryRoot: scope.FullPath,
+            ProjectFingerprint: "fingerprint-id-collision",
+            PathSource: UnityProjectPathSource.CommandOption);
+        Directory.CreateDirectory(UcliStoragePathResolver.ResolveLaunchAttemptDirectory(
+            context.RepositoryRoot,
+            context.ProjectFingerprint,
+            "20260312_000000Z_00000001"));
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 12, 0, 0, 1, TimeSpan.Zero);
+        var guiLauncher = new StubUnityGuiEditorProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(6543, processStartedAtUtc),
+        };
+        var blocker = new DaemonGuiStartupBlocker(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.ProcessExit,
+            Reason: DaemonDiagnosisReasonValues.EditorExitedBeforeBootstrap,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown,
+            Message: "Unity Editor exited before bootstrap completed.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ProcessExit,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.InspectUnityLog,
+            ProcessId: 6543,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: "/tmp/repo-root/.ucli/local/fingerprints/fingerprint-id-collision/unity.log",
+            PrimaryDiagnostic: null);
+        var guiStartupObserver = new StubDaemonGuiStartupObserver
+        {
+            NextResult = DaemonGuiStartupObservationResult.Blocked(blocker),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            new StubDaemonLaunchSessionService(),
+            new StubUnityDaemonProcessLauncher(),
+            new StubDaemonStartupReadinessProbe(),
+            new StubDaemonLaunchCompensationService(),
+            new StubDaemonDiagnosisStore(),
+            unityGuiEditorProcessLauncher: guiLauncher,
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Gui,
+            DaemonStartupBlockedProcessPolicy.Keep,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.NotNull(result.Startup);
+        Assert.Equal("20260312_000000Z_00000002", result.Startup!.LaunchAttemptId);
+        Assert.Equal("20260312_000000Z_00000002", launchAttemptStore.LastLaunchAttempt!.LaunchAttemptId);
     }
 
     [Fact]
@@ -1038,6 +1106,8 @@ public sealed class DaemonLaunchServiceTests
         IDaemonDiagnosisStore? daemonDiagnosisStore = null,
         IUnityGuiEditorProcessLauncher? unityGuiEditorProcessLauncher = null,
         IDaemonGuiStartupObserver? guiStartupObserver = null,
+        IDaemonLaunchAttemptIdGenerator? launchAttemptIdGenerator = null,
+        IDaemonLaunchAttemptStore? launchAttemptStore = null,
         TimeProvider? timeProvider = null)
     {
         return new DaemonLaunchService(
@@ -1048,6 +1118,8 @@ public sealed class DaemonLaunchServiceTests
             guiStartupObserver: guiStartupObserver ?? new StubDaemonGuiStartupObserver(),
             daemonLaunchCompensationService: launchCompensationService,
             daemonDiagnosisStore: daemonDiagnosisStore ?? new StubDaemonDiagnosisStore(),
+            launchAttemptIdGenerator: launchAttemptIdGenerator ?? new StubDaemonLaunchAttemptIdGenerator(),
+            launchAttemptStore: launchAttemptStore ?? new StubDaemonLaunchAttemptStore(),
             timeProvider: timeProvider);
     }
 
@@ -1260,6 +1332,59 @@ public sealed class DaemonLaunchServiceTests
             CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult(DaemonDiagnosisStoreOperationResult.Success());
+        }
+    }
+
+    private sealed class StubDaemonLaunchAttemptIdGenerator : IDaemonLaunchAttemptIdGenerator
+    {
+        private int sequence;
+
+        public string Create (DateTimeOffset startedAtUtc)
+        {
+            sequence++;
+            return $"20260312_000000Z_{sequence:00000000}";
+        }
+    }
+
+    private sealed class StubDaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
+    {
+        public DaemonLaunchAttemptStoreOperationResult WriteResult { get; set; } = DaemonLaunchAttemptStoreOperationResult.Success();
+
+        public DaemonLaunchAttemptStoreOperationResult PruneResult { get; set; } = DaemonLaunchAttemptStoreOperationResult.Success();
+
+        public int WriteCallCount { get; private set; }
+
+        public int PruneCallCount { get; private set; }
+
+        public DaemonLaunchAttempt? LastLaunchAttempt { get; private set; }
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            DaemonLaunchAttempt launchAttempt,
+            CancellationToken cancellationToken = default)
+        {
+            WriteCallCount++;
+            LastLaunchAttempt = launchAttempt;
+            return ValueTask.FromResult(WriteResult);
+        }
+
+        public ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+            string storageRoot,
+            string projectFingerprint,
+            int keepCount,
+            CancellationToken cancellationToken = default)
+        {
+            PruneCallCount++;
+            return ValueTask.FromResult(PruneResult);
         }
     }
 

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Status/DaemonStatusOperationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Status/DaemonStatusOperationTests.cs
@@ -1,5 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.LaunchAttempts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 namespace MackySoft.Ucli.Tests.Daemon;
 
@@ -29,6 +31,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(static () => ValueTask.CompletedTask),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -56,6 +59,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new TimeoutException("probe timeout"))),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -91,6 +95,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new TimeoutException("probe timeout"))),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -122,6 +127,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -152,6 +158,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(static () => ValueTask.CompletedTask),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -162,6 +169,37 @@ public sealed class DaemonStatusOperationTests
         Assert.Equal(DaemonStatusKind.NotRunning, result.Status);
         Assert.Null(result.Session);
         Assert.Equal(diagnosis, result.Diagnosis);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task GetStatus_WhenSessionDoesNotExist_ReturnsLastLaunchAttempt ()
+    {
+        var context = CreateContext("fingerprint-status-last-attempt");
+        var lastLaunchAttempt = CreateLaunchAttempt(context.ProjectFingerprint);
+        var sessionStore = new StubDaemonSessionStore
+        {
+            ReadResult = DaemonSessionReadResult.Success(null),
+        };
+        var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            ReadResult = DaemonLaunchAttemptReadResult.Success(lastLaunchAttempt),
+        };
+        var operation = new DaemonStatusOperation(
+            daemonSessionStore: sessionStore,
+            daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: launchAttemptStore,
+            daemonPingClient: new StubDaemonPingClient(static () => ValueTask.CompletedTask),
+            reachabilityClassifier: new DaemonReachabilityClassifier(),
+            daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
+
+        var result = await operation.GetStatusAsync(context, TimeSpan.FromMilliseconds(500), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(DaemonStatusKind.NotRunning, result.Status);
+        Assert.Null(result.Session);
+        Assert.Equal(lastLaunchAttempt, result.LastLaunchAttempt);
     }
 
     [Fact]
@@ -181,6 +219,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -217,6 +256,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(() => ValueTask.FromException(new SocketException((int)SocketError.ConnectionRefused))),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -249,6 +289,7 @@ public sealed class DaemonStatusOperationTests
         var operation = new DaemonStatusOperation(
             daemonSessionStore: sessionStore,
             daemonDiagnosisStore: diagnosisStore,
+            launchAttemptStore: new StubDaemonLaunchAttemptStore(),
             daemonPingClient: new StubDaemonPingClient(static () => ValueTask.CompletedTask),
             reachabilityClassifier: new DaemonReachabilityClassifier(),
             daemonSessionDiagnosisResolver: new DaemonSessionDiagnosisResolver(diagnosisStore));
@@ -302,6 +343,25 @@ public sealed class DaemonStatusOperationTests
             ProcessId: session.ProcessId,
             EditorInstancePath: null,
             SessionIssuedAtUtc: session.IssuedAtUtc);
+    }
+
+    private static DaemonLaunchAttempt CreateLaunchAttempt (string projectFingerprint)
+    {
+        var diagnosis = CreateDiagnosis(CreateSession(processId: null, projectFingerprint: projectFingerprint), DaemonDiagnosisReasonValues.StartupFailed);
+        return new DaemonLaunchAttempt(
+            LaunchAttemptId: "20260312_000000Z_00000001",
+            StartedAtUtc: diagnosis.UpdatedAtUtc,
+            UpdatedAtUtc: diagnosis.UpdatedAtUtc,
+            StartupStatus: DaemonStartupStatusValues.Failed,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown,
+            ProcessAction: DaemonStartupProcessActionValues.None,
+            EditorMode: DaemonEditorModeValues.Gui,
+            ProcessId: null,
+            ProcessStartedAtUtc: null,
+            UnityLogPath: "/tmp/unity.log",
+            ArtifactPath: "/tmp/startup-diagnosis.json",
+            Diagnosis: diagnosis);
     }
 
     private sealed class StubDaemonSessionStore : IDaemonSessionStore
@@ -387,6 +447,37 @@ public sealed class DaemonStatusOperationTests
             CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult(DaemonDiagnosisStoreOperationResult.Success());
+        }
+    }
+
+    private sealed class StubDaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
+    {
+        public DaemonLaunchAttemptReadResult ReadResult { get; set; } = DaemonLaunchAttemptReadResult.Success(null);
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            DaemonLaunchAttempt launchAttempt,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(ReadResult);
+        }
+
+        public ValueTask<DaemonLaunchAttemptStoreOperationResult> PruneAsync (
+            string storageRoot,
+            string projectFingerprint,
+            int keepCount,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorExitHandlerTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorExitHandlerTests.cs
@@ -22,7 +22,7 @@ public sealed class SupervisorExitHandlerTests
         };
         var artifactCleaner = new StubDaemonArtifactCleaner
         {
-            CleanupResult = DaemonSessionStoreOperationResult.Failure(
+            CleanupResult = DaemonArtifactCleanupResult.Failure(
                 ExecutionError.InternalError("cleanup failed")),
         };
         var exitHandler = new SupervisorExitHandler(
@@ -212,12 +212,12 @@ public sealed class SupervisorExitHandlerTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public DaemonSessionStoreOperationResult CleanupResult { get; set; } =
-            DaemonSessionStoreOperationResult.Success();
+        public DaemonArtifactCleanupResult CleanupResult { get; set; } =
+            DaemonArtifactCleanupResult.Success();
 
         public int CleanupCallCount { get; private set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorProjectCoordinatorTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorProjectCoordinatorTests.cs
@@ -557,7 +557,7 @@ public sealed class SupervisorProjectCoordinatorTests
                 {
                     cleanupStarted.TrySetResult();
                     await cleanupRelease.Task.ConfigureAwait(false);
-                    return DaemonSessionStoreOperationResult.Success();
+                    return DaemonArtifactCleanupResult.Success();
                 },
             });
 
@@ -862,18 +862,18 @@ public sealed class SupervisorProjectCoordinatorTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public Func<ResolvedUnityProjectContext, CancellationToken, ValueTask<DaemonSessionStoreOperationResult>>? CleanupHandler { get; set; }
+        public Func<ResolvedUnityProjectContext, CancellationToken, Task<DaemonArtifactCleanupResult>>? CleanupHandler { get; set; }
 
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
             if (CleanupHandler != null)
             {
-                return CleanupHandler(unityProject, cancellationToken);
+                return new ValueTask<DaemonArtifactCleanupResult>(CleanupHandler(unityProject, cancellationToken));
             }
 
-            return ValueTask.FromResult(DaemonSessionStoreOperationResult.Success());
+            return ValueTask.FromResult(DaemonArtifactCleanupResult.Success());
         }
     }
 }

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcherTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcherTests.cs
@@ -581,11 +581,11 @@ public sealed class SupervisorRequestDispatcherTests
 
     private sealed class StubDaemonArtifactCleaner : IDaemonArtifactCleaner
     {
-        public ValueTask<DaemonSessionStoreOperationResult> CleanupAsync (
+        public ValueTask<DaemonArtifactCleanupResult> CleanupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
-            return ValueTask.FromResult(DaemonSessionStoreOperationResult.Success());
+            return ValueTask.FromResult(DaemonArtifactCleanupResult.Success());
         }
     }
 

--- a/tests/Ucli.Tests/Hosting/Cli/DaemonStatusCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/DaemonStatusCommandTests.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.UseCases.Status;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Daemon;
@@ -41,6 +42,7 @@ public sealed class DaemonStatusCommandTests
                 TimeoutMilliseconds: 3000,
                 Session: session,
                 Diagnosis: null,
+                LastLaunchAttempt: null,
                 ObservedAtUtc: new DateTimeOffset(2026, 03, 12, 1, 3, 0, TimeSpan.Zero),
                 ActionRequired: null,
                 PrimaryDiagnostic: null)));
@@ -75,6 +77,84 @@ public sealed class DaemonStatusCommandTests
         var payloadJson = outputJson.RootElement.GetProperty("payload");
         Assert.False(payloadJson.TryGetProperty("runtimeKind", out _));
         Assert.False(payloadJson.GetProperty("session").TryGetProperty("runtimeKind", out _));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Status_WhenLastLaunchAttemptExists_WritesLastLaunchAttemptPayload ()
+    {
+        var diagnosis = new DaemonDiagnosisOutput(
+            Reason: DaemonDiagnosisReasonValues.GuiEndpointNotRegistered,
+            Message: "GUI endpoint was not registered.",
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 6, TimeSpan.Zero),
+            ProcessId: 1234,
+            EditorInstancePath: null,
+            ProcessStartedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 0, TimeSpan.Zero),
+            UnityLogPath: "/repo/.ucli/local/fingerprints/fp/unity.log",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.EndpointRegistration,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.InspectUnityLog,
+            PrimaryDiagnostic: null);
+        var launchAttempt = new DaemonLaunchAttemptOutput(
+            LaunchAttemptId: "20260312_040500Z_00abcdef",
+            StartupStatus: "timeout",
+            StartupBlockingReason: "endpointNotRegistered",
+            RetryDisposition: "retryFreshLaunch",
+            ProcessAction: "keep",
+            ArtifactPath: "/repo/.ucli/local/fingerprints/fp/launch-attempts/20260312_040500Z_00abcdef/startup-diagnosis.json",
+            UnityLogPath: "/repo/.ucli/local/fingerprints/fp/unity.log",
+            UpdatedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 6, TimeSpan.Zero),
+            ProcessId: 1234,
+            ProcessStartedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 0, TimeSpan.Zero),
+            Diagnosis: diagnosis);
+        var service = new StubDaemonStatusService(
+            DaemonStatusExecutionResult.Success(new DaemonStatusExecutionOutput(
+                DaemonStatus: DaemonStatusKind.NotRunning,
+                ServerVersion: null,
+                EditorMode: null,
+                LifecycleState: null,
+                BlockingReason: null,
+                CompileState: null,
+                CompileGeneration: null,
+                DomainReloadGeneration: null,
+                CanAcceptExecutionRequests: false,
+                TimeoutMilliseconds: 3000,
+                Session: null,
+                Diagnosis: null,
+                LastLaunchAttempt: launchAttempt,
+                ObservedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 6, 0, TimeSpan.Zero),
+                ActionRequired: null,
+                PrimaryDiagnostic: null)));
+        var command = new DaemonStatusCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.StatusAsync(
+            projectPath: "/repo/wt-a/UnityProject",
+            timeout: "3000",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasString("daemonStatus", "notRunning")
+                .HasProperty("lastLaunchAttempt", attemptJson => attemptJson
+                    .HasString("launchAttemptId", "20260312_040500Z_00abcdef")
+                    .HasString("startupStatus", "timeout")
+                    .HasString("startupBlockingReason", "endpointNotRegistered")
+                    .HasString("retryDisposition", "retryFreshLaunch")
+                    .HasString("processAction", "keep")
+                    .HasString("artifactPath", "/repo/.ucli/local/fingerprints/fp/launch-attempts/20260312_040500Z_00abcdef/startup-diagnosis.json")
+                    .HasString("unityLogPath", "/repo/.ucli/local/fingerprints/fp/unity.log")
+                    .HasString("updatedAtUtc", "2026-03-12T04:05:06+00:00")
+                    .HasInt32("processId", 1234)
+                    .HasString("processStartedAtUtc", "2026-03-12T04:05:00+00:00")
+                    .HasProperty("diagnosis", diagnosisJson => diagnosisJson
+                        .HasString("reason", DaemonDiagnosisReasonValues.GuiEndpointNotRegistered)
+                        .HasString("unityLogPath", "/repo/.ucli/local/fingerprints/fp/unity.log")
+                        .HasString("startupPhase", DaemonDiagnosisStartupPhaseValues.EndpointRegistration)
+                        .HasString("actionRequired", DaemonDiagnosisActionRequiredValues.InspectUnityLog))));
     }
 
     private sealed class StubDaemonStatusService : IDaemonStatusService


### PR DESCRIPTION
## Summary
- daemon start の fresh launch 失敗ごとに launchAttemptId を発行し、startup-diagnosis.json へ診断を保存します。
- daemon status は session 未成立時だけ直近 failure attempt を lastLaunchAttempt として返し、running/stale session では null を維持します。
- daemon cleanup は launch attempt retention を実行し、deletedLaunchAttemptCount を返します。

## Scope
- Application: launch-attempt model/store contract、status/cleanup output、daemon lifecycle integration。
- Contracts/Infrastructure: launch-attempt JSON contract、storage path resolver、filesystem store、ID generator。
- CLI: status の lastLaunchAttempt と cleanup の deletedLaunchAttemptCount を JSON payload に追加。
- Tests: store、launch workflow、status/cleanup、CLI contract の回帰テストを追加・更新。

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh`)
- Coverage: N/A

## Risks / Rollback
- リスク: daemon start 失敗時の補助 artifact 書き込みが増えるため、storage path と JSON validation の回帰に注意が必要です。
- Rollback: launch-attempt store の DI 登録と status/cleanup projection を戻すことで、既存 session artifact ベースの挙動に戻せます。

## Checklist
- [x] launchAttemptId を fresh launch ごとに発行する
- [x] startup diagnosis JSON を launch-attempts/<launchAttemptId>/startup-diagnosis.json に保存する
- [x] session 未成立時だけ daemon status が lastLaunchAttempt を返す
- [x] session 成立中は lastLaunchAttempt=null を返す
- [x] completed attempt を lastLaunchAttempt に出さない
- [x] launch attempt failure だけで daemonStatus=stale にしない
- [x] project fingerprint ごとに直近 20 件を保持する
- [x] cleanup が deletedLaunchAttemptCount を返す
- [x] bash scripts/test-dotnet.sh が成功する
- [x] Unity 側変更なしのため Unity test と .meta 更新は不要

Closes #265