### PR TITLE
daemon start startup failure payload を実装する

### DIFF
--- a/src/Ucli.Application/Features/Daemon/Common/CommandContracts/DaemonStartupObservationOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/CommandContracts/DaemonStartupObservationOutput.cs
@@ -1,0 +1,17 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+
+/// <summary> Represents normalized payload values for one daemon startup observation. </summary>
+internal sealed record DaemonStartupObservationOutput (
+    string StartupStatus,
+    string? StartupBlockingReason,
+    string? LaunchAttemptId,
+    string? EditorMode,
+    string? OwnerKind,
+    bool? CanShutdownProcess,
+    int? ProcessId,
+    DateTimeOffset? StartedAtUtc,
+    int? ElapsedMilliseconds,
+    string ProcessAction,
+    object? ProcessTermination,
+    string? ArtifactPath,
+    string RetryDisposition);

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeResult.cs
@@ -3,32 +3,36 @@ using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 
-/// <summary> Represents daemon startup readiness probing result. </summary>
-/// <param name="IsReady"> Whether daemon startup probe succeeded. </param>
+/// <summary> Represents daemon startup endpoint-registration probing result. </summary>
+/// <param name="IsReady"> Whether daemon endpoint registration probe succeeded. </param>
 /// <param name="Error"> The structured error when probe failed. </param>
 /// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot when probing succeeded. </param>
+/// <param name="FailureClassification"> The classified startup blocker when probing failed with a known blocker. </param>
 internal sealed record DaemonStartupReadinessProbeResult (
     bool IsReady,
     ExecutionError? Error,
-    DaemonStartLifecycleSnapshot? LifecycleSnapshot)
+    DaemonStartLifecycleSnapshot? LifecycleSnapshot,
+    DaemonStartupFailureClassification? FailureClassification)
 {
-    /// <summary> Creates a successful readiness-probe result. </summary>
+    /// <summary> Creates a successful endpoint-registration probe result. </summary>
     /// <param name="lifecycleSnapshot"> The endpoint-registered lifecycle snapshot. </param>
-    /// <returns> The successful readiness-probe result. </returns>
+    /// <returns> The successful endpoint-registration probe result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="lifecycleSnapshot" /> is <see langword="null" />. </exception>
     public static DaemonStartupReadinessProbeResult Ready (DaemonStartLifecycleSnapshot lifecycleSnapshot)
     {
         ArgumentNullException.ThrowIfNull(lifecycleSnapshot);
-        return new DaemonStartupReadinessProbeResult(true, null, lifecycleSnapshot);
+        return new DaemonStartupReadinessProbeResult(true, null, lifecycleSnapshot, null);
     }
 
-    /// <summary> Creates a failed readiness-probe result. </summary>
+    /// <summary> Creates a failed endpoint-registration probe result. </summary>
     /// <param name="error"> The structured error. </param>
     /// <returns> The failed readiness-probe result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
-    public static DaemonStartupReadinessProbeResult Failure (ExecutionError error)
+    public static DaemonStartupReadinessProbeResult Failure (
+        ExecutionError error,
+        DaemonStartupFailureClassification? failureClassification = null)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonStartupReadinessProbeResult(false, error, null);
+        return new DaemonStartupReadinessProbeResult(false, error, null, failureClassification);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeResult.cs
@@ -1,3 +1,4 @@
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
@@ -5,15 +6,20 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 /// <summary> Represents daemon startup readiness probing result. </summary>
 /// <param name="IsReady"> Whether daemon startup probe succeeded. </param>
 /// <param name="Error"> The structured error when probe failed. </param>
+/// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot when probing succeeded. </param>
 internal sealed record DaemonStartupReadinessProbeResult (
     bool IsReady,
-    ExecutionError? Error)
+    ExecutionError? Error,
+    DaemonStartLifecycleSnapshot? LifecycleSnapshot)
 {
     /// <summary> Creates a successful readiness-probe result. </summary>
+    /// <param name="lifecycleSnapshot"> The endpoint-registered lifecycle snapshot. </param>
     /// <returns> The successful readiness-probe result. </returns>
-    public static DaemonStartupReadinessProbeResult Ready ()
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="lifecycleSnapshot" /> is <see langword="null" />. </exception>
+    public static DaemonStartupReadinessProbeResult Ready (DaemonStartLifecycleSnapshot lifecycleSnapshot)
     {
-        return new DaemonStartupReadinessProbeResult(true, null);
+        ArgumentNullException.ThrowIfNull(lifecycleSnapshot);
+        return new DaemonStartupReadinessProbeResult(true, null, lifecycleSnapshot);
     }
 
     /// <summary> Creates a failed readiness-probe result. </summary>
@@ -23,6 +29,6 @@ internal sealed record DaemonStartupReadinessProbeResult (
     public static DaemonStartupReadinessProbeResult Failure (ExecutionError error)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonStartupReadinessProbeResult(false, error);
+        return new DaemonStartupReadinessProbeResult(false, error, null);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/IDaemonStartupReadinessProbe.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Process/Startup/IDaemonStartupReadinessProbe.cs
@@ -1,14 +1,14 @@
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 
-/// <summary> Probes daemon startup readiness until execution requests are accepted, timeout expires, or startup reaches one non-waitable lifecycle state. </summary>
+/// <summary> Probes daemon startup until the daemon endpoint responds with a lifecycle snapshot, timeout expires, or startup fails. </summary>
 internal interface IDaemonStartupReadinessProbe
 {
-    /// <summary> Waits until daemon startup accepts execution requests, or fails when timeout expires or startup reaches one non-waitable lifecycle state. </summary>
+    /// <summary> Waits until daemon startup registers an endpoint and returns one lifecycle snapshot, or fails when timeout expires or startup fails. </summary>
     /// <param name="unityProject"> The resolved Unity project context. </param>
-    /// <param name="timeout"> The startup readiness timeout. Must be greater than <see cref="TimeSpan.Zero" />. </param>
+    /// <param name="timeout"> The startup endpoint-registration timeout. Must be greater than <see cref="TimeSpan.Zero" />. </param>
     /// <param name="daemonProcessId"> The launched Unity daemon process identifier when available. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
-    /// <returns> The readiness probe result. </returns>
+    /// <returns> The endpoint-registration probe result. </returns>
     ValueTask<DaemonStartupReadinessProbeResult> WaitUntilReadyAsync (
         ResolvedUnityProjectContext unityProject,
         TimeSpan timeout,

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartLifecycleSnapshot.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartLifecycleSnapshot.cs
@@ -1,0 +1,58 @@
+using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
+
+/// <summary> Represents endpoint-registered lifecycle values returned with daemon start success. </summary>
+/// <param name="LifecycleState"> The normalized lifecycle-state literal. </param>
+/// <param name="BlockingReason"> The normalized blocking-reason literal when the lifecycle is blocked. </param>
+/// <param name="CanAcceptExecutionRequests"> Whether ordinary execution requests can currently be accepted. </param>
+internal sealed record DaemonStartLifecycleSnapshot (
+    string LifecycleState,
+    string? BlockingReason,
+    bool CanAcceptExecutionRequests)
+{
+    /// <summary> Creates a ready lifecycle snapshot for legacy success paths that do not carry ping details. </summary>
+    /// <returns> The ready lifecycle snapshot. </returns>
+    public static DaemonStartLifecycleSnapshot Ready ()
+    {
+        return new DaemonStartLifecycleSnapshot(
+            IpcEditorLifecycleStateCodec.Ready,
+            null,
+            true);
+    }
+
+    /// <summary> Tries to create a normalized lifecycle snapshot from a ping payload. </summary>
+    /// <param name="pingResponse"> The daemon ping response. </param>
+    /// <param name="snapshot"> The lifecycle snapshot when parsing succeeds. </param>
+    /// <param name="error"> The structured parsing error when parsing fails. </param>
+    /// <returns> <see langword="true" /> when the snapshot was created; otherwise <see langword="false" />. </returns>
+    public static bool TryCreate (
+        IpcPingResponse pingResponse,
+        out DaemonStartLifecycleSnapshot? snapshot,
+        out ExecutionError? error)
+    {
+        ArgumentNullException.ThrowIfNull(pingResponse);
+
+        snapshot = null;
+        if (!IpcEditorLifecycleStateCodec.TryParse(pingResponse.LifecycleState, out var lifecycleState))
+        {
+            error = ExecutionError.InternalError(
+                $"Unity daemon startup probe returned unsupported lifecycleState '{pingResponse.LifecycleState}'.");
+            return false;
+        }
+
+        var blockingReason = string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
+            ? null
+            : IpcEditorBlockingReasonCodec.TryParse(pingResponse.BlockingReason, out var normalizedBlockingReason)
+                ? normalizedBlockingReason
+                : null;
+        snapshot = new DaemonStartLifecycleSnapshot(
+            lifecycleState!,
+            blockingReason,
+            string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
+                && pingResponse.CanAcceptExecutionRequests);
+        error = null;
+        return true;
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartResult.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
@@ -10,12 +11,16 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 /// <param name="Error"> The structured error when start fails. </param>
 /// <param name="Diagnosis"> The failure diagnosis that should be projected with the start response when available. </param>
 /// <param name="Startup"> The endpoint-registration startup observation attached to a failure when available. </param>
+/// <param name="DaemonStatus"> The daemon status after start processing. </param>
+/// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot attached to a successful start. </param>
 internal sealed record DaemonStartResult (
     DaemonStartStatus Status,
     DaemonSession? Session,
     ExecutionError? Error,
     DaemonDiagnosis? Diagnosis,
-    DaemonStartupObservation? Startup)
+    DaemonStartupObservation? Startup,
+    DaemonStatusKind DaemonStatus,
+    DaemonStartLifecycleSnapshot? LifecycleSnapshot)
 {
     /// <summary> Gets a value indicating whether daemon start succeeded or detected an already-running daemon. </summary>
     public bool IsSuccess => (Status == DaemonStartStatus.Started || Status == DaemonStartStatus.AlreadyRunning)
@@ -25,36 +30,65 @@ internal sealed record DaemonStartResult (
 
     /// <summary> Creates a successful start result. </summary>
     /// <param name="session"> The started daemon session metadata. </param>
+    /// <param name="lifecycleSnapshot"> The endpoint-registered lifecycle snapshot when available. </param>
     /// <returns> The successful start result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="session" /> is <see langword="null" />. </exception>
-    public static DaemonStartResult Started (DaemonSession session)
+    public static DaemonStartResult Started (
+        DaemonSession session,
+        DaemonStartLifecycleSnapshot? lifecycleSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(session);
-        return new DaemonStartResult(DaemonStartStatus.Started, session, null, null, null);
+        return new DaemonStartResult(
+            DaemonStartStatus.Started,
+            session,
+            null,
+            null,
+            null,
+            DaemonStatusKind.Running,
+            lifecycleSnapshot);
     }
 
     /// <summary> Creates an already-running result. </summary>
     /// <param name="session"> The existing daemon session metadata. </param>
+    /// <param name="lifecycleSnapshot"> The endpoint-registered lifecycle snapshot when available. </param>
     /// <returns> The already-running result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="session" /> is <see langword="null" />. </exception>
-    public static DaemonStartResult AlreadyRunning (DaemonSession session)
+    public static DaemonStartResult AlreadyRunning (
+        DaemonSession session,
+        DaemonStartLifecycleSnapshot? lifecycleSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(session);
-        return new DaemonStartResult(DaemonStartStatus.AlreadyRunning, session, null, null, null);
+        return new DaemonStartResult(
+            DaemonStartStatus.AlreadyRunning,
+            session,
+            null,
+            null,
+            null,
+            DaemonStatusKind.Running,
+            lifecycleSnapshot);
     }
 
     /// <summary> Creates a failed start result. </summary>
     /// <param name="error"> The structured error. </param>
     /// <param name="diagnosis"> The optional failure diagnosis that should be projected to callers. </param>
     /// <param name="startup"> The optional startup observation attached to the failure. </param>
+    /// <param name="daemonStatus"> The daemon status after start processing. </param>
     /// <returns> The failed start result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
     public static DaemonStartResult Failure (
         ExecutionError error,
         DaemonDiagnosis? diagnosis = null,
-        DaemonStartupObservation? startup = null)
+        DaemonStartupObservation? startup = null,
+        DaemonStatusKind daemonStatus = DaemonStatusKind.NotRunning)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonStartResult(DaemonStartStatus.Failed, null, error, diagnosis, startup);
+        return new DaemonStartResult(
+            DaemonStartStatus.Failed,
+            null,
+            error,
+            diagnosis,
+            startup,
+            daemonStatus,
+            null);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Recovery;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.ExistingSession;
@@ -118,7 +119,8 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
             }
 
             return DaemonStartResult.Failure(ExecutionError.Timeout(
-                $"Timed out while probing existing daemon session. {exception.Message}"));
+                $"Timed out while probing existing daemon session. {exception.Message}"),
+                daemonStatus: DaemonStatusKind.Stale);
         }
         catch (Exception exception) when (reachabilityClassifier.IsNotRunning(exception))
         {
@@ -148,7 +150,9 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
                 .ConfigureAwait(false);
             if (!cleanupResult.IsSuccess)
             {
-                return DaemonStartResult.Failure(cleanupResult.Error!);
+                return DaemonStartResult.Failure(
+                    cleanupResult.Error!,
+                    daemonStatus: DaemonStatusKind.Stale);
             }
 
             return null;
@@ -156,7 +160,8 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
         catch (Exception exception)
         {
             return DaemonStartResult.Failure(ExecutionError.InternalError(
-                $"Failed to probe existing daemon session. {exception.Message}"));
+                $"Failed to probe existing daemon session. {exception.Message}"),
+                daemonStatus: DaemonStatusKind.Stale);
         }
     }
 
@@ -188,7 +193,8 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
             {
                 return DaemonStartResult.Failure(ExecutionError.Timeout(
                     $"Timed out while waiting for recovering daemon session. ProcessId={session.ProcessId}.",
-                    ExecutionErrorCodes.IpcTimeout));
+                    ExecutionErrorCodes.IpcTimeout),
+                    daemonStatus: DaemonStatusKind.Stale);
             }
 
             var attemptTimeout = remainingTimeout < DaemonTimeouts.ProbeAttemptTimeoutCap
@@ -228,14 +234,16 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
             catch (Exception exception)
             {
                 return DaemonStartResult.Failure(ExecutionError.InternalError(
-                    $"Failed to probe recovering daemon session. {exception.Message}"));
+                    $"Failed to probe recovering daemon session. {exception.Message}"),
+                    daemonStatus: DaemonStatusKind.Stale);
             }
 
             if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
             {
                 return DaemonStartResult.Failure(ExecutionError.Timeout(
                     $"Timed out while waiting for recovering daemon session. ProcessId={session.ProcessId}.",
-                    ExecutionErrorCodes.IpcTimeout));
+                    ExecutionErrorCodes.IpcTimeout),
+                    daemonStatus: DaemonStatusKind.Stale);
             }
 
             await TimeProviderDelay.DelayAsync(GetRetryDelay(remainingTimeout), timeProvider, cancellationToken)

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
@@ -9,7 +9,7 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.ExistingSes
 /// <summary> Implements existing-session probe flow for daemon start orchestration. </summary>
 internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionGateService
 {
-    private readonly IDaemonPingClient daemonPingClient;
+    private readonly IDaemonPingInfoClient daemonPingInfoClient;
 
     private readonly IDaemonReachabilityClassifier reachabilityClassifier;
 
@@ -22,7 +22,7 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
     private readonly TimeProvider timeProvider;
 
     /// <summary> Initializes a new instance of the <see cref="DaemonExistingSessionGateService" /> class. </summary>
-    /// <param name="daemonPingClient"> The daemon ping-client dependency. </param>
+    /// <param name="daemonPingInfoClient"> The daemon ping-info client dependency. </param>
     /// <param name="reachabilityClassifier"> The daemon reachability-classifier dependency. </param>
     /// <param name="daemonSessionCleanupService"> The daemon session-cleanup service dependency. </param>
     /// <param name="daemonLifecycleStore"> The daemon lifecycle observation store dependency. </param>
@@ -30,14 +30,14 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
     /// <param name="timeProvider"> The time provider used for timeout-budget accounting. </param>
     /// <exception cref="ArgumentNullException"> Thrown when one dependency is <see langword="null" />. </exception>
     public DaemonExistingSessionGateService (
-        IDaemonPingClient daemonPingClient,
+        IDaemonPingInfoClient daemonPingInfoClient,
         IDaemonReachabilityClassifier reachabilityClassifier,
         IDaemonSessionCleanupService daemonSessionCleanupService,
         IDaemonLifecycleStore daemonLifecycleStore,
         IDaemonProcessIdentityAssessor processIdentityAssessor,
         TimeProvider? timeProvider = null)
     {
-        this.daemonPingClient = daemonPingClient ?? throw new ArgumentNullException(nameof(daemonPingClient));
+        this.daemonPingInfoClient = daemonPingInfoClient ?? throw new ArgumentNullException(nameof(daemonPingInfoClient));
         this.reachabilityClassifier = reachabilityClassifier ?? throw new ArgumentNullException(nameof(reachabilityClassifier));
         this.daemonSessionCleanupService = daemonSessionCleanupService ?? throw new ArgumentNullException(nameof(daemonSessionCleanupService));
         this.daemonLifecycleStore = daemonLifecycleStore ?? throw new ArgumentNullException(nameof(daemonLifecycleStore));
@@ -81,12 +81,17 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
 
         try
         {
-            await daemonPingClient.PingAsync(
+            var pingResponse = await daemonPingInfoClient.PingAndReadAsync(
                     unityProject,
                     pingTimeout,
                     session.SessionToken,
-                    cancellationToken)
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
+            if (!DaemonStartLifecycleSnapshot.TryCreate(pingResponse, out var lifecycleSnapshot, out var lifecycleError))
+            {
+                return DaemonStartResult.Failure(lifecycleError!);
+            }
+
             if (editorMode.HasValue)
             {
                 var requestedEditorMode = DaemonEditorModeCodec.ToValue(editorMode.Value);
@@ -98,7 +103,7 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
                 }
             }
 
-            return DaemonStartResult.AlreadyRunning(session);
+            return DaemonStartResult.AlreadyRunning(session, lifecycleSnapshot);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -202,12 +207,17 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
                 : DaemonTimeouts.ProbeAttemptTimeoutCap;
             try
             {
-                await daemonPingClient.PingAsync(
+                var pingResponse = await daemonPingInfoClient.PingAndReadAsync(
                         unityProject,
                         attemptTimeout,
                         session.SessionToken,
-                        cancellationToken)
+                        cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
+                if (!DaemonStartLifecycleSnapshot.TryCreate(pingResponse, out var lifecycleSnapshot, out var lifecycleError))
+                {
+                    return DaemonStartResult.Failure(lifecycleError!);
+                }
+
                 if (editorMode.HasValue)
                 {
                     var requestedEditorMode = DaemonEditorModeCodec.ToValue(editorMode.Value);
@@ -219,7 +229,7 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
                     }
                 }
 
-                return DaemonStartResult.AlreadyRunning(session);
+                return DaemonStartResult.AlreadyRunning(session, lifecycleSnapshot);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachService.cs
@@ -87,7 +87,7 @@ internal sealed class DaemonGuiEditorAttachService : IDaemonGuiEditorAttachServi
             .ConfigureAwait(false);
         if (waitResult.IsSuccess)
         {
-            return DaemonStartResult.AlreadyRunning(waitResult.Session!);
+            return DaemonStartResult.AlreadyRunning(waitResult.Session!, waitResult.LifecycleSnapshot);
         }
 
         if (waitResult.Error!.Kind != ExecutionErrorKind.Timeout)

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationAwaiter.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationAwaiter.cs
@@ -111,9 +111,14 @@ internal sealed class DaemonGuiSessionRegistrationAwaiter : IDaemonGuiSessionReg
                     validateProjectFingerprint: false,
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
+            if (!DaemonStartLifecycleSnapshot.TryCreate(pingResponse, out var lifecycleSnapshot, out var lifecycleError))
+            {
+                return DaemonGuiSessionRegistrationWaitResult.Failure(lifecycleError!);
+            }
+
             return string.Equals(pingResponse.ProjectFingerprint, unityProject.ProjectFingerprint, StringComparison.Ordinal)
                    && string.Equals(pingResponse.EditorMode, DaemonEditorModeValues.Gui, StringComparison.Ordinal)
-                ? DaemonGuiSessionRegistrationWaitResult.Success(session)
+                ? DaemonGuiSessionRegistrationWaitResult.Success(session, lifecycleSnapshot)
                 : null;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationWaitResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationWaitResult.cs
@@ -5,25 +5,29 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.GuiEndpoint
 
 /// <summary> Represents the result of waiting for a GUI daemon session registration. </summary>
 /// <param name="Session"> The matching GUI daemon session when registration completed. </param>
+/// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot when registration completed. </param>
 /// <param name="Error"> The structured wait error when registration did not complete. </param>
 internal sealed record DaemonGuiSessionRegistrationWaitResult (
     DaemonSession? Session,
+    DaemonStartLifecycleSnapshot? LifecycleSnapshot,
     ExecutionError? Error)
 {
     /// <summary> Gets a value indicating whether the wait succeeded. </summary>
     public bool IsSuccess => Session is not null && Error is null;
 
     /// <summary> Creates a successful GUI session wait result. </summary>
-    public static DaemonGuiSessionRegistrationWaitResult Success (DaemonSession session)
+    public static DaemonGuiSessionRegistrationWaitResult Success (
+        DaemonSession session,
+        DaemonStartLifecycleSnapshot? lifecycleSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(session);
-        return new DaemonGuiSessionRegistrationWaitResult(session, null);
+        return new DaemonGuiSessionRegistrationWaitResult(session, lifecycleSnapshot, null);
     }
 
     /// <summary> Creates a failed GUI session wait result. </summary>
     public static DaemonGuiSessionRegistrationWaitResult Failure (ExecutionError error)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonGuiSessionRegistrationWaitResult(null, error);
+        return new DaemonGuiSessionRegistrationWaitResult(null, null, error);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiStartupObservationResult.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiStartupObservationResult.cs
@@ -5,10 +5,12 @@ namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.GuiEndpoint
 
 /// <summary> Represents the bounded observation result for one CLI-launched GUI daemon startup attempt. </summary>
 /// <param name="Session"> The registered GUI daemon session when startup succeeds. </param>
+/// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot when startup succeeds. </param>
 /// <param name="Blocker"> The terminal startup blocker when one is observed. </param>
 /// <param name="Error"> The structured error when observation fails or times out. </param>
 internal sealed record DaemonGuiStartupObservationResult (
     DaemonSession? Session,
+    DaemonStartLifecycleSnapshot? LifecycleSnapshot,
     DaemonGuiStartupBlocker? Blocker,
     ExecutionError? Error)
 {
@@ -19,23 +21,25 @@ internal sealed record DaemonGuiStartupObservationResult (
     public bool IsBlocked => Session is null && Blocker is not null && Error is null;
 
     /// <summary> Creates a successful observation result. </summary>
-    public static DaemonGuiStartupObservationResult Success (DaemonSession session)
+    public static DaemonGuiStartupObservationResult Success (
+        DaemonSession session,
+        DaemonStartLifecycleSnapshot? lifecycleSnapshot = null)
     {
         ArgumentNullException.ThrowIfNull(session);
-        return new DaemonGuiStartupObservationResult(session, null, null);
+        return new DaemonGuiStartupObservationResult(session, lifecycleSnapshot, null, null);
     }
 
     /// <summary> Creates a blocked observation result. </summary>
     public static DaemonGuiStartupObservationResult Blocked (DaemonGuiStartupBlocker blocker)
     {
         ArgumentNullException.ThrowIfNull(blocker);
-        return new DaemonGuiStartupObservationResult(null, blocker, null);
+        return new DaemonGuiStartupObservationResult(null, null, blocker, null);
     }
 
     /// <summary> Creates a failed observation result. </summary>
     public static DaemonGuiStartupObservationResult Failure (ExecutionError error)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonGuiStartupObservationResult(null, null, error);
+        return new DaemonGuiStartupObservationResult(null, null, null, error);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupObservation.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupObservation.cs
@@ -6,4 +6,11 @@ internal sealed record DaemonStartupObservation (
     string? StartupBlockingReason,
     string? LaunchAttemptId,
     string ProcessAction,
-    string RetryDisposition);
+    string RetryDisposition,
+    string? EditorMode = null,
+    string? OwnerKind = null,
+    bool? CanShutdownProcess = null,
+    int? ProcessId = null,
+    DateTimeOffset? StartedAtUtc = null,
+    int? ElapsedMilliseconds = null,
+    string? ArtifactPath = null);

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartExecutionOutput.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
+using MackySoft.Ucli.Contracts.Ipc;
 namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 
 /// <summary> Represents normalized payload values for one daemon-start command execution. </summary>
@@ -8,8 +9,14 @@ namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 /// <param name="DaemonStatus"> The daemon-status value. </param>
 /// <param name="TimeoutMilliseconds"> The effective timeout in milliseconds used for daemon start workflow. </param>
 /// <param name="Session"> The daemon session values associated with started or already-running daemon process. </param>
+/// <param name="LifecycleState"> The lifecycle-state snapshot observed after endpoint registration. </param>
+/// <param name="BlockingReason"> The blocking-reason snapshot observed after endpoint registration. </param>
+/// <param name="CanAcceptExecutionRequests"> Whether the endpoint can accept ordinary execution requests. </param>
 internal sealed record DaemonStartExecutionOutput (
     DaemonStartStatus StartStatus,
     DaemonStatusKind DaemonStatus,
     int TimeoutMilliseconds,
-    DaemonSessionOutput Session);
+    DaemonSessionOutput Session,
+    string LifecycleState = IpcEditorLifecycleStateCodec.Ready,
+    string? BlockingReason = null,
+    bool CanAcceptExecutionRequests = true);

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartExecutionResult.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartExecutionResult.cs
@@ -1,21 +1,18 @@
-using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 
 /// <summary> Represents the result of one daemon-start command workflow execution. </summary>
 /// <param name="Output"> The daemon-start execution output on success; otherwise <see langword="null" />. </param>
+/// <param name="FailureOutput"> The daemon-start failure output when available; otherwise <see langword="null" />. </param>
 /// <param name="Error"> The structured execution error on failure; otherwise <see langword="null" />. </param>
-/// <param name="Diagnosis"> The daemon diagnosis output attached to a failure; otherwise <see langword="null" />. </param>
-/// <param name="Startup"> The startup observation attached to a failure; otherwise <see langword="null" />. </param>
 internal sealed record DaemonStartExecutionResult (
     DaemonStartExecutionOutput? Output,
-    ExecutionError? Error,
-    DaemonDiagnosisOutput? Diagnosis,
-    DaemonStartupObservation? Startup)
+    DaemonStartFailureExecutionOutput? FailureOutput,
+    ExecutionError? Error)
 {
     /// <summary> Gets a value indicating whether daemon-start workflow execution succeeded. </summary>
-    public bool IsSuccess => Output is not null && Error is null;
+    public bool IsSuccess => Output is not null && FailureOutput is null && Error is null;
 
     /// <summary> Creates a successful daemon-start execution result. </summary>
     /// <param name="output"> The normalized daemon-start execution output. </param>
@@ -24,21 +21,19 @@ internal sealed record DaemonStartExecutionResult (
     public static DaemonStartExecutionResult Success (DaemonStartExecutionOutput output)
     {
         ArgumentNullException.ThrowIfNull(output);
-        return new DaemonStartExecutionResult(output, null, null, null);
+        return new DaemonStartExecutionResult(output, null, null);
     }
 
     /// <summary> Creates a failed daemon-start execution result. </summary>
     /// <param name="error"> The structured execution error. </param>
-    /// <param name="diagnosis"> The optional diagnosis output attached to the failure. </param>
-    /// <param name="startup"> The optional startup observation attached to the failure. </param>
+    /// <param name="failureOutput"> The optional daemon-start failure output. </param>
     /// <returns> The failed daemon-start execution result. </returns>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="error" /> is <see langword="null" />. </exception>
     public static DaemonStartExecutionResult Failure (
         ExecutionError error,
-        DaemonDiagnosisOutput? diagnosis = null,
-        DaemonStartupObservation? startup = null)
+        DaemonStartFailureExecutionOutput? failureOutput = null)
     {
         ArgumentNullException.ThrowIfNull(error);
-        return new DaemonStartExecutionResult(null, error, diagnosis, startup);
+        return new DaemonStartExecutionResult(null, failureOutput, error);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
@@ -14,7 +14,7 @@ namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 internal sealed record DaemonStartFailureExecutionOutput (
     DaemonStatusKind DaemonStatus,
     int TimeoutMilliseconds,
-    DaemonStartupObservation? Startup,
+    DaemonStartupObservationOutput? Startup,
     DaemonDiagnosisOutput? Diagnosis,
     string RetryDisposition,
     bool SafeToRetryImmediately)
@@ -30,7 +30,7 @@ internal sealed record DaemonStartFailureExecutionOutput (
         return new DaemonStartFailureExecutionOutput(
             daemonStatus,
             timeoutMilliseconds,
-            startup,
+            ToOutput(startup, retryDisposition),
             diagnosis,
             retryDisposition,
             string.Equals(retryDisposition, DaemonStartupRetryDispositionValues.RetryImmediately, StringComparison.Ordinal));
@@ -46,5 +46,30 @@ internal sealed record DaemonStartFailureExecutionOutput (
         return string.Equals(startup.RetryDisposition, DaemonStartupRetryDispositionValues.WaitThenRetry, StringComparison.Ordinal)
             ? DaemonStartupRetryDispositionValues.Unknown
             : startup.RetryDisposition;
+    }
+
+    private static DaemonStartupObservationOutput? ToOutput (
+        DaemonStartupObservation? startup,
+        string retryDisposition)
+    {
+        if (startup is null)
+        {
+            return null;
+        }
+
+        return new DaemonStartupObservationOutput(
+            StartupStatus: startup.StartupStatus,
+            StartupBlockingReason: startup.StartupBlockingReason,
+            LaunchAttemptId: startup.LaunchAttemptId,
+            EditorMode: startup.EditorMode,
+            OwnerKind: startup.OwnerKind,
+            CanShutdownProcess: startup.CanShutdownProcess,
+            ProcessId: startup.ProcessId,
+            StartedAtUtc: startup.StartedAtUtc,
+            ElapsedMilliseconds: startup.ElapsedMilliseconds,
+            ProcessAction: startup.ProcessAction,
+            ProcessTermination: null,
+            ArtifactPath: startup.ArtifactPath,
+            RetryDisposition: retryDisposition);
     }
 }

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
@@ -1,0 +1,50 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
+
+/// <summary> Represents normalized payload values for one daemon-start failure. </summary>
+/// <param name="DaemonStatus"> The daemon status after start processing. </param>
+/// <param name="TimeoutMilliseconds"> The effective timeout in milliseconds used for daemon start workflow. </param>
+/// <param name="Startup"> The startup observation attached to the failure when available. </param>
+/// <param name="Diagnosis"> The diagnosis attached to the failure when available. </param>
+/// <param name="RetryDisposition"> The final retry disposition projected to the CLI payload. </param>
+/// <param name="SafeToRetryImmediately"> Whether the failed command can be retried immediately without external changes. </param>
+internal sealed record DaemonStartFailureExecutionOutput (
+    DaemonStatusKind DaemonStatus,
+    int TimeoutMilliseconds,
+    DaemonStartupObservation? Startup,
+    DaemonDiagnosisOutput? Diagnosis,
+    string RetryDisposition,
+    bool SafeToRetryImmediately)
+{
+    /// <summary> Creates one failure output with final-response retry disposition normalization applied. </summary>
+    public static DaemonStartFailureExecutionOutput Create (
+        DaemonStatusKind daemonStatus,
+        int timeoutMilliseconds,
+        DaemonStartupObservation? startup,
+        DaemonDiagnosisOutput? diagnosis)
+    {
+        var retryDisposition = ResolveFinalRetryDisposition(startup);
+        return new DaemonStartFailureExecutionOutput(
+            daemonStatus,
+            timeoutMilliseconds,
+            startup,
+            diagnosis,
+            retryDisposition,
+            string.Equals(retryDisposition, DaemonStartupRetryDispositionValues.RetryImmediately, StringComparison.Ordinal));
+    }
+
+    private static string ResolveFinalRetryDisposition (DaemonStartupObservation? startup)
+    {
+        if (startup is null)
+        {
+            return DaemonStartupRetryDispositionValues.Unknown;
+        }
+
+        return string.Equals(startup.RetryDisposition, DaemonStartupRetryDispositionValues.WaitThenRetry, StringComparison.Ordinal)
+            ? DaemonStartupRetryDispositionValues.Unknown
+            : startup.RetryDisposition;
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartService.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartService.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandExecution;
 using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Preflight;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Shared.Foundation;
@@ -81,13 +82,24 @@ internal sealed class DaemonStartService : IDaemonStartService
             .ConfigureAwait(false);
         if (pluginLocateError != null)
         {
-            return DaemonStartExecutionResult.Failure(pluginLocateError);
+            return DaemonStartExecutionResult.Failure(
+                pluginLocateError,
+                DaemonStartFailureExecutionOutput.Create(
+                    DaemonStatusKind.NotRunning,
+                    checked((int)executionContext.Timeout.TotalMilliseconds),
+                    startup: null,
+                    diagnosis: null));
         }
 
         if (!deadline.TryGetRemainingTimeout(out var ensureRunningTimeout))
         {
             return DaemonStartExecutionResult.Failure(ExecutionError.Timeout(
-                "Timed out before daemon lifecycle orchestration could begin."));
+                "Timed out before daemon lifecycle orchestration could begin."),
+                DaemonStartFailureExecutionOutput.Create(
+                    DaemonStatusKind.NotRunning,
+                    checked((int)executionContext.Timeout.TotalMilliseconds),
+                    startup: null,
+                    diagnosis: null));
         }
 
         var startResult = await daemonProjectLifecycleGateway.EnsureRunningAsync(
@@ -103,14 +115,23 @@ internal sealed class DaemonStartService : IDaemonStartService
                 ? null
                 : daemonDiagnosisOutputMapper.ToOutput(startResult.Diagnosis);
             return DaemonStartExecutionResult.Failure(startResult.Error ?? ExecutionError.InternalError(
-                "Daemon start operation failed without structured error details."), diagnosis, startResult.Startup);
+                "Daemon start operation failed without structured error details."),
+                DaemonStartFailureExecutionOutput.Create(
+                    startResult.DaemonStatus,
+                    checked((int)executionContext.Timeout.TotalMilliseconds),
+                    startResult.Startup,
+                    diagnosis));
         }
 
+        var lifecycleSnapshot = startResult.LifecycleSnapshot ?? DaemonStartLifecycleSnapshot.Ready();
         var output = new DaemonStartExecutionOutput(
             StartStatus: startResult.Status,
             DaemonStatus: DaemonStatusKind.Running,
             TimeoutMilliseconds: checked((int)executionContext.Timeout.TotalMilliseconds),
-            Session: daemonSessionOutputMapper.ToOutput(startResult.Session!));
+            Session: daemonSessionOutputMapper.ToOutput(startResult.Session!),
+            LifecycleState: lifecycleSnapshot.LifecycleState,
+            BlockingReason: lifecycleSnapshot.BlockingReason,
+            CanAcceptExecutionRequests: lifecycleSnapshot.CanAcceptExecutionRequests);
         return DaemonStartExecutionResult.Success(output);
     }
 

--- a/src/Ucli/Features/Daemon/Common/CommandContracts/DaemonStartStateCodec.cs
+++ b/src/Ucli/Features/Daemon/Common/CommandContracts/DaemonStartStateCodec.cs
@@ -10,6 +10,8 @@ internal static class DaemonStartStateCodec
 
     public const string AlreadyRunning = "alreadyRunning";
 
+    public const string Failed = "failed";
+
     public static bool TryToValue (
         DaemonStartStatus status,
         [NotNullWhen(true)]
@@ -19,6 +21,7 @@ internal static class DaemonStartStateCodec
         {
             DaemonStartStatus.Started => Started,
             DaemonStartStatus.AlreadyRunning => AlreadyRunning,
+            DaemonStartStatus.Failed => Failed,
             _ => null,
         };
         return value is not null;

--- a/src/Ucli/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbe.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbe.cs
@@ -1,17 +1,17 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Logs;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Timing;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.Timeout;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Application.Shared.Foundation;
-using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Infrastructure.Execution;
 using MackySoft.Ucli.Shared.Unity.ProjectLock;
 
 namespace MackySoft.Ucli.Features.Daemon.Lifecycle.Process.Startup;
 
-/// <summary> Implements daemon startup readiness probing via repeated ping attempts. </summary>
+/// <summary> Implements daemon startup endpoint probing via repeated ping attempts. </summary>
 internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
 {
     private readonly IDaemonPingInfoClient daemonPingInfoClient;
@@ -98,24 +98,12 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
                         attemptTimeout,
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
-                if (pingResponse.CanAcceptExecutionRequests
-                    && string.Equals(pingResponse.LifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal))
+                if (!DaemonStartLifecycleSnapshot.TryCreate(pingResponse, out var lifecycleSnapshot, out var lifecycleError))
                 {
-                    return DaemonStartupReadinessProbeResult.Ready();
+                    return DaemonStartupReadinessProbeResult.Failure(lifecycleError!);
                 }
 
-                if (TryResolveNonRetryableLifecycleFailure(pingResponse, out var startupLifecycleError))
-                {
-                    return DaemonStartupReadinessProbeResult.Failure(startupLifecycleError!);
-                }
-
-                if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
-                {
-                    return DaemonStartupReadinessProbeResult.Failure(ExecutionError.Timeout(
-                        $"Timed out while waiting for daemon startup. Timeout={timeout.TotalMilliseconds:0}ms."));
-                }
-
-                await Task.Delay(GetRetryDelay(remainingTimeout), cancellationToken).ConfigureAwait(false);
+                return DaemonStartupReadinessProbeResult.Ready(lifecycleSnapshot!);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -168,74 +156,6 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             DaemonTimeouts.StartupProbeRetryDelayMilliseconds,
             Math.Max(1, (int)Math.Ceiling(remainingTimeout.TotalMilliseconds)));
         return TimeSpan.FromMilliseconds(retryDelayMilliseconds);
-    }
-
-    private static bool TryResolveNonRetryableLifecycleFailure (
-        IpcPingResponse pingResponse,
-        out ExecutionError? error)
-    {
-        ArgumentNullException.ThrowIfNull(pingResponse);
-
-        if (!IpcEditorLifecycleStateCodec.TryParse(pingResponse.LifecycleState, out var lifecycleState))
-        {
-            error = ExecutionError.InternalError(
-                $"Unity daemon startup probe returned unsupported lifecycleState '{pingResponse.LifecycleState}'.");
-            return true;
-        }
-
-        if (string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal))
-        {
-            error = ExecutionError.InternalError(
-                "Unity daemon startup probe returned lifecycleState=ready while canAcceptExecutionRequests=false.");
-            return true;
-        }
-
-        if (IsWaitableLifecycleState(lifecycleState!))
-        {
-            error = null;
-            return false;
-        }
-
-        var blockingReason = IpcEditorBlockingReasonCodec.TryParse(pingResponse.BlockingReason, out var normalizedBlockingReason)
-            ? normalizedBlockingReason
-            : null;
-        error = ExecutionError.InternalError(CreateNonWaitableLifecycleMessage(lifecycleState!, blockingReason));
-        return true;
-    }
-
-    private static string CreateNonWaitableLifecycleMessage (
-        string lifecycleState,
-        string? blockingReason)
-    {
-        var lifecycleDetails = blockingReason is null
-            ? $"lifecycleState={lifecycleState}"
-            : $"lifecycleState={lifecycleState}, blockingReason={blockingReason}";
-
-        return lifecycleState switch
-        {
-            IpcEditorLifecycleStateCodec.DomainReloading =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}. Retry after lifecycleState=ready.",
-            IpcEditorLifecycleStateCodec.Playmode =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}. Exit Play Mode and retry after lifecycleState=ready.",
-            IpcEditorLifecycleStateCodec.ModalBlocked =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}. Resolve the modal dialog and retry after lifecycleState=ready.",
-            IpcEditorLifecycleStateCodec.SafeMode =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}. Resolve compiler errors and retry after lifecycleState=ready.",
-            IpcEditorLifecycleStateCodec.ShuttingDown =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}. Start a new daemon after shutdown finishes.",
-            _ =>
-                $"Unity daemon startup cannot continue while {lifecycleDetails}.",
-        };
-    }
-
-    private static bool IsWaitableLifecycleState (string lifecycleState)
-    {
-        return string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Starting, StringComparison.Ordinal)
-            || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Recovering, StringComparison.Ordinal)
-            || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Busy, StringComparison.Ordinal)
-            || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Compiling, StringComparison.Ordinal)
-            || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.DomainReloading, StringComparison.Ordinal)
-            || string.Equals(lifecycleState, IpcEditorLifecycleStateCodec.Reimporting, StringComparison.Ordinal);
     }
 
     private async ValueTask<ExecutionError?> TryClassifyStartupFailureAsync (

--- a/src/Ucli/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbe.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbe.cs
@@ -66,14 +66,16 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
                         unityProject,
                         cancellationToken)
                     .ConfigureAwait(false);
-                var startupFailureError = await TryClassifyStartupFailureAsync(
+                var startupFailure = await TryClassifyStartupFailureAsync(
                         unityProject,
                         includeProjectLockFile: false,
                         cancellationToken)
                     .ConfigureAwait(false);
-                if (startupFailureError is not null)
+                if (startupFailure.Error is not null)
                 {
-                    return DaemonStartupReadinessProbeResult.Failure(AppendDiagnostic(startupFailureError, postExitLockDiagnostic));
+                    return DaemonStartupReadinessProbeResult.Failure(
+                        AppendDiagnostic(startupFailure.Error, postExitLockDiagnostic),
+                        startupFailure.Classification);
                 }
 
                 return DaemonStartupReadinessProbeResult.Failure(ExecutionError.InternalError(
@@ -124,14 +126,16 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
                 // NOTE:
                 // A Unity process launched by uCLI creates Temp/UnityLockfile before its IPC server
                 // is ready. Treat that lock as external only when no launched process id is known.
-                var startupFailureError = await TryClassifyStartupFailureAsync(
+                var startupFailure = await TryClassifyStartupFailureAsync(
                         unityProject,
                         includeProjectLockFile: daemonProcessId is null,
                         cancellationToken)
                     .ConfigureAwait(false);
-                if (startupFailureError is not null)
+                if (startupFailure.Error is not null)
                 {
-                    return DaemonStartupReadinessProbeResult.Failure(startupFailureError);
+                    return DaemonStartupReadinessProbeResult.Failure(
+                        startupFailure.Error,
+                        startupFailure.Classification);
                 }
 
                 if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
@@ -158,7 +162,7 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
         return TimeSpan.FromMilliseconds(retryDelayMilliseconds);
     }
 
-    private async ValueTask<ExecutionError?> TryClassifyStartupFailureAsync (
+    private async ValueTask<StartupFailureClassificationResult> TryClassifyStartupFailureAsync (
         ResolvedUnityProjectContext unityProject,
         bool includeProjectLockFile,
         CancellationToken cancellationToken)
@@ -174,7 +178,7 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
                 projectLockPreflightResult);
             if (projectLockError != null)
             {
-                return projectLockError;
+                return new StartupFailureClassificationResult(projectLockError, null);
             }
         }
 
@@ -185,16 +189,21 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             .ConfigureAwait(false);
         if (!logReadResult.IsSuccess || string.IsNullOrWhiteSpace(logReadResult.Text))
         {
-            return null;
+            return new StartupFailureClassificationResult(null, null);
         }
 
         var latestStartupLogText = DaemonStartupFailureLogClassifier.GetLatestStartupLogText(logReadResult.Text);
-        return DaemonStartupFailureLogClassifier.TryClassify(
+        if (!DaemonStartupFailureLogClassifier.TryClassifyFailure(
                 latestStartupLogText,
                 DaemonStartupFailureClassificationContext.Batchmode,
-                out var error)
-            ? error
-            : null;
+                out var classification))
+        {
+            return new StartupFailureClassificationResult(null, null);
+        }
+
+        return new StartupFailureClassificationResult(
+            ExecutionError.InternalError(classification!.Message, DaemonErrorCodes.DaemonStartupBlocked),
+            classification);
     }
 
     private async ValueTask<string?> CreatePostExitLockDiagnosticAsync (
@@ -226,4 +235,8 @@ internal sealed class DaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
             ? message
             : $"{message} {diagnostic}";
     }
+
+    private readonly record struct StartupFailureClassificationResult (
+        ExecutionError? Error,
+        DaemonStartupFailureClassification? Classification);
 }

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiStartupObserver.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiStartupObserver.cs
@@ -76,7 +76,9 @@ internal sealed class DaemonGuiStartupObserver : IDaemonGuiStartupObserver
                 .ConfigureAwait(false);
             if (sessionResult.IsSuccess)
             {
-                return DaemonGuiStartupObservationResult.Success(sessionResult.Session!);
+                return DaemonGuiStartupObservationResult.Success(
+                    sessionResult.Session!,
+                    sessionResult.LifecycleSnapshot);
             }
 
             if (sessionResult.Error!.Kind != ExecutionErrorKind.Timeout)

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -244,7 +244,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 .ConfigureAwait(false);
             if (probeResult.IsReady)
             {
-                return DaemonStartResult.Started(session);
+                return DaemonStartResult.Started(session, probeResult.LifecycleSnapshot);
             }
 
             return await CreateFailureWithCompensationAsync(
@@ -352,7 +352,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         }
         if (waitResult.IsSuccess)
         {
-            return DaemonStartResult.Started(waitResult.Session!);
+            return DaemonStartResult.Started(waitResult.Session!, waitResult.LifecycleSnapshot);
         }
 
         if (waitResult.IsBlocked)

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -106,6 +106,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     unityProject,
                     editorMode,
                     deadline,
+                    onStartupBlocked,
                     launchAttemptId,
                     launchStartedAtUtc,
                     cancellationToken)
@@ -127,6 +128,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         ResolvedUnityProjectContext unityProject,
         DaemonEditorMode editorMode,
         ExecutionDeadline deadline,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
         string launchAttemptId,
         DateTimeOffset launchStartedAtUtc,
         CancellationToken cancellationToken)
@@ -245,6 +247,22 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             if (probeResult.IsReady)
             {
                 return DaemonStartResult.Started(session, probeResult.LifecycleSnapshot);
+            }
+
+            if (probeResult.FailureClassification is not null)
+            {
+                return await CreateClassifiedBatchmodeStartupBlockedFailureAsync(
+                        unityProject,
+                        probeResult.FailureClassification,
+                        probeResult.Error!,
+                        onStartupBlocked,
+                        launchedProcessId,
+                        launchedProcessStartedAtUtc,
+                        expectedIssuedAtUtc,
+                        launchAttemptId,
+                        launchStartedAtUtc,
+                        unityLogPath)
+                    .ConfigureAwait(false);
             }
 
             return await CreateFailureWithCompensationAsync(
@@ -428,12 +446,20 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 CancellationToken.None)
             .ConfigureAwait(false);
         var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
-        var startup = new DaemonStartupObservation(
-            StartupStatus: startupStatus,
-            StartupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
-            LaunchAttemptId: launchAttemptId,
-            ProcessAction: processAction,
-            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);
+        var startup = CreateStartupObservation(
+            startupStatus,
+            DaemonStartupBlockingReasonValues.Unknown,
+            launchAttemptId,
+            processAction,
+            DaemonStartupRetryDispositionValues.Unknown,
+            editorMode,
+            DaemonSessionOwnerKindValues.Cli,
+            processId is not null,
+            processId,
+            processStartedAtUtc,
+            launchStartedAtUtc,
+            diagnosis.UpdatedAtUtc,
+            CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
         var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
                 unityProject,
                 launchAttemptId,
@@ -531,12 +557,20 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 unityLogPath,
                 diagnosis)
             .ConfigureAwait(false);
-        var startup = new DaemonStartupObservation(
-            StartupStatus: startupStatus,
-            StartupBlockingReason: startupBlockingReason,
-            LaunchAttemptId: launchAttemptId,
-            ProcessAction: processAction,
-            RetryDisposition: retryDisposition);
+        var startup = CreateStartupObservation(
+            startupStatus,
+            startupBlockingReason,
+            launchAttemptId,
+            processAction,
+            retryDisposition,
+            editorMode,
+            DaemonSessionOwnerKindValues.Cli,
+            processId is not null,
+            processId,
+            processStartedAtUtc,
+            launchStartedAtUtc,
+            updatedAtUtc,
+            CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
         if (!launchAttemptWriteResult.IsSuccess)
         {
             return DaemonStartResult.Failure(
@@ -618,6 +652,175 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             ProcessStartedAtUtc: processStartedAtUtc);
     }
 
+    private static string CreateLaunchAttemptArtifactPath (
+        ResolvedUnityProjectContext unityProject,
+        string launchAttemptId)
+    {
+        return UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
+            unityProject.RepositoryRoot,
+            unityProject.ProjectFingerprint,
+            launchAttemptId);
+    }
+
+    private static DaemonStartupObservation CreateStartupObservation (
+        string startupStatus,
+        string startupBlockingReason,
+        string launchAttemptId,
+        string processAction,
+        string retryDisposition,
+        string? editorMode,
+        string? ownerKind,
+        bool? canShutdownProcess,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset launchStartedAtUtc,
+        DateTimeOffset updatedAtUtc,
+        string? artifactPath)
+    {
+        return new DaemonStartupObservation(
+            StartupStatus: startupStatus,
+            StartupBlockingReason: startupBlockingReason,
+            LaunchAttemptId: launchAttemptId,
+            ProcessAction: processAction,
+            RetryDisposition: retryDisposition,
+            EditorMode: editorMode,
+            OwnerKind: ownerKind,
+            CanShutdownProcess: canShutdownProcess,
+            ProcessId: processId,
+            StartedAtUtc: processStartedAtUtc,
+            ElapsedMilliseconds: checked((int)Math.Max(0, (updatedAtUtc - launchStartedAtUtc).TotalMilliseconds)),
+            ArtifactPath: artifactPath);
+    }
+
+    private async ValueTask<DaemonStartResult> CreateClassifiedBatchmodeStartupBlockedFailureAsync (
+        ResolvedUnityProjectContext unityProject,
+        DaemonStartupFailureClassification classification,
+        ExecutionError primaryError,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset sessionIssuedAtUtc,
+        string launchAttemptId,
+        DateTimeOffset launchStartedAtUtc,
+        string? unityLogPath)
+    {
+        var updatedAtUtc = timeProvider.GetUtcNow();
+        var diagnosis = new DaemonDiagnosis(
+            Reason: classification.Reason,
+            Message: primaryError.Message,
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: processId,
+            EditorInstancePath: null,
+            SessionIssuedAtUtc: sessionIssuedAtUtc,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath,
+            StartupPhase: classification.StartupPhase,
+            ActionRequired: classification.ActionRequired,
+            PrimaryDiagnostic: classification.PrimaryDiagnostic);
+        var diagnosisWriteResult = await daemonDiagnosisStore.WriteAsync(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                diagnosis,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var policyResult = await ApplyBatchmodeStartupBlockedProcessPolicyAsync(
+                unityProject,
+                onStartupBlocked,
+                processId,
+                processStartedAtUtc,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        var startup = CreateStartupObservation(
+            DaemonStartupStatusValues.Blocked,
+            classification.StartupBlockingReason,
+            launchAttemptId,
+            policyResult.ProcessAction,
+            classification.RetryDisposition,
+            DaemonEditorModeValues.Batchmode,
+            DaemonSessionOwnerKindValues.Cli,
+            processId is not null,
+            processId,
+            processStartedAtUtc,
+            launchStartedAtUtc,
+            updatedAtUtc,
+            CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                updatedAtUtc,
+                startup.StartupStatus,
+                startup.StartupBlockingReason!,
+                startup.RetryDisposition,
+                policyResult.ProcessAction,
+                DaemonEditorModeValues.Batchmode,
+                processId,
+                processStartedAtUtc,
+                unityLogPath,
+                diagnosis)
+            .ConfigureAwait(false);
+        if (!diagnosisWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked and diagnosis persistence failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"DiagnosisError={diagnosisWriteResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        if (!launchAttemptWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked and launch-attempt artifact persistence failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        if (policyResult.CleanupResult is { IsSuccess: false })
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked and cleanup failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"CleanupError={policyResult.CleanupResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        return DaemonStartResult.Failure(primaryError, diagnosis, startup);
+    }
+
+    private async ValueTask<StartupBlockedProcessPolicyResult> ApplyBatchmodeStartupBlockedProcessPolicyAsync (
+        ResolvedUnityProjectContext unityProject,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (onStartupBlocked == DaemonStartupBlockedProcessPolicy.Keep)
+        {
+            return new StartupBlockedProcessPolicyResult(
+                CleanupResult: null,
+                ProcessAction: processId is null
+                    ? DaemonStartupProcessActionValues.None
+                    : DaemonStartupProcessActionValues.Kept);
+        }
+
+        var cleanupResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                unityProject,
+                CreateTerminationTarget(processId, processStartedAtUtc),
+                DaemonTimeouts.LaunchCompensationTimeout,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return new StartupBlockedProcessPolicyResult(
+            cleanupResult,
+            ResolveCompensatedProcessAction(processId, cleanupResult));
+    }
+
     private static string ResolveCompensatedProcessAction (
         int? processId,
         DaemonSessionStoreOperationResult compensationResult)
@@ -676,17 +879,26 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 CancellationToken.None)
             .ConfigureAwait(false);
         var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
-        var startup = new DaemonStartupObservation(
-            StartupStatus: DaemonStartupStatusValues.Timeout,
-            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
-            LaunchAttemptId: launchAttemptId,
-            ProcessAction: processAction,
-            RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry);
+        var updatedAtUtc = timeProvider.GetUtcNow();
+        var startup = CreateStartupObservation(
+            DaemonStartupStatusValues.Timeout,
+            DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            launchAttemptId,
+            processAction,
+            DaemonStartupRetryDispositionValues.WaitThenRetry,
+            DaemonEditorModeValues.Gui,
+            DaemonSessionOwnerKindValues.Cli,
+            true,
+            processId,
+            processStartedAtUtc,
+            launchStartedAtUtc,
+            updatedAtUtc,
+            CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
         var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
                 unityProject,
                 launchAttemptId,
                 launchStartedAtUtc,
-                timeProvider.GetUtcNow(),
+                updatedAtUtc,
                 startup.StartupStatus,
                 startup.StartupBlockingReason!,
                 startup.RetryDisposition,
@@ -812,7 +1024,10 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         var startup = CreateGuiStartupBlockedObservation(
             blocker,
             launchAttemptId,
-            processPolicyResult.ProcessAction);
+            processPolicyResult.ProcessAction,
+            launchStartedAtUtc,
+            updatedAtUtc,
+            CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
         var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
                 unityProject,
                 launchAttemptId,
@@ -869,7 +1084,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         return DaemonStartResult.Failure(primaryError, diagnosis, startup);
     }
 
-    private async ValueTask<GuiStartupBlockedProcessPolicyResult> ApplyGuiStartupBlockedProcessPolicyAsync (
+    private async ValueTask<StartupBlockedProcessPolicyResult> ApplyGuiStartupBlockedProcessPolicyAsync (
         ResolvedUnityProjectContext unityProject,
         DaemonGuiStartupBlocker blocker,
         DaemonStartupBlockedProcessPolicy onStartupBlocked,
@@ -885,7 +1100,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     DaemonTimeouts.LaunchCompensationTimeout,
                     cancellationToken)
                 .ConfigureAwait(false);
-            return new GuiStartupBlockedProcessPolicyResult(
+            return new StartupBlockedProcessPolicyResult(
                 cleanupResult,
                 DaemonStartupProcessActionValues.None);
         }
@@ -893,7 +1108,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         if (onStartupBlocked != DaemonStartupBlockedProcessPolicy.Terminate)
         {
             // NOTE: GUI blockers are kept by default so users can resolve Safe Mode, modal, or project errors in Unity.
-            return new GuiStartupBlockedProcessPolicyResult(
+            return new StartupBlockedProcessPolicyResult(
                 CleanupResult: null,
                 ProcessAction: DaemonStartupProcessActionValues.Kept);
         }
@@ -905,7 +1120,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 cancellationToken)
             .ConfigureAwait(false);
 
-        return new GuiStartupBlockedProcessPolicyResult(
+        return new StartupBlockedProcessPolicyResult(
             terminationResult,
             terminationResult.IsSuccess
                 ? DaemonStartupProcessActionValues.Terminated
@@ -932,18 +1147,29 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
     private static DaemonStartupObservation CreateGuiStartupBlockedObservation (
         DaemonGuiStartupBlocker blocker,
         string launchAttemptId,
-        string processAction)
+        string processAction,
+        DateTimeOffset launchStartedAtUtc,
+        DateTimeOffset updatedAtUtc,
+        string artifactPath)
     {
         ArgumentNullException.ThrowIfNull(blocker);
         ArgumentException.ThrowIfNullOrWhiteSpace(launchAttemptId);
         ArgumentException.ThrowIfNullOrWhiteSpace(processAction);
 
-        return new DaemonStartupObservation(
-            StartupStatus: DaemonStartupStatusValues.Blocked,
-            StartupBlockingReason: blocker.StartupBlockingReason,
-            LaunchAttemptId: launchAttemptId,
-            ProcessAction: processAction,
-            RetryDisposition: blocker.RetryDisposition);
+        return CreateStartupObservation(
+            DaemonStartupStatusValues.Blocked,
+            blocker.StartupBlockingReason,
+            launchAttemptId,
+            processAction,
+            blocker.RetryDisposition,
+            DaemonEditorModeValues.Gui,
+            DaemonSessionOwnerKindValues.Cli,
+            true,
+            blocker.ProcessId,
+            blocker.ProcessStartedAtUtc,
+            launchStartedAtUtc,
+            updatedAtUtc,
+            artifactPath);
     }
 
     private string CreateUniqueLaunchAttemptId (
@@ -967,7 +1193,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         return launchAttemptIdGenerator.Create(launchStartedAtUtc);
     }
 
-    private sealed record GuiStartupBlockedProcessPolicyResult (
+    private sealed record StartupBlockedProcessPolicyResult (
         DaemonSessionStoreOperationResult? CleanupResult,
         string ProcessAction);
 

--- a/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorClient.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorClient.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Stop;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
@@ -125,7 +126,8 @@ internal sealed class SupervisorClient
                 return DaemonStartResult.Failure(
                     MapResponseFailure(firstError, status),
                     failurePayload?.Diagnosis,
-                    failurePayload?.Startup);
+                    failurePayload?.Startup,
+                    ResolveDaemonStatus(failurePayload?.DaemonStatus));
             }
 
             if (!IpcPayloadCodec.TryDeserialize(
@@ -139,12 +141,12 @@ internal sealed class SupervisorClient
 
             if (string.Equals(payload.StartStatus, DaemonStartStateCodec.Started, StringComparison.Ordinal))
             {
-                return DaemonStartResult.Started(payload.Session);
+                return DaemonStartResult.Started(payload.Session, payload.LifecycleSnapshot);
             }
 
             if (string.Equals(payload.StartStatus, DaemonStartStateCodec.AlreadyRunning, StringComparison.Ordinal))
             {
-                return DaemonStartResult.AlreadyRunning(payload.Session);
+                return DaemonStartResult.AlreadyRunning(payload.Session, payload.LifecycleSnapshot);
             }
 
             return DaemonStartResult.Failure(ExecutionError.InternalError(
@@ -316,5 +318,12 @@ internal sealed class SupervisorClient
             out _)
             ? payload
             : null;
+    }
+
+    private static DaemonStatusKind ResolveDaemonStatus (string? daemonStatus)
+    {
+        return string.Equals(daemonStatus, DaemonStatusStateCodec.Stale, StringComparison.Ordinal)
+            ? DaemonStatusKind.Stale
+            : DaemonStatusKind.NotRunning;
     }
 }

--- a/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorIpcContracts.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorIpcContracts.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
 
 namespace MackySoft.Ucli.Features.Daemon.Supervisor.Client;
@@ -45,15 +46,19 @@ internal static class SupervisorIpcContracts
     /// <param name="StartStatus"> The daemon start-status literal. </param>
     /// <param name="DaemonStatus"> The daemon status literal. </param>
     /// <param name="Session"> The active daemon session. </param>
+    /// <param name="LifecycleSnapshot"> The endpoint-registered lifecycle snapshot when available. </param>
     internal sealed record EnsureRunningResponse (
         string StartStatus,
         string DaemonStatus,
-        DaemonSession Session);
+        DaemonSession Session,
+        DaemonStartLifecycleSnapshot? LifecycleSnapshot = null);
 
     /// <summary> Represents the payload returned when ensure-running fails with optional startup metadata. </summary>
+    /// <param name="DaemonStatus"> The daemon status after the failed start attempt. </param>
     /// <param name="Diagnosis"> The daemon diagnosis attached to the start failure when available. </param>
     /// <param name="Startup"> The startup observation attached to the start failure when available. </param>
     internal sealed record EnsureRunningFailureResponse (
+        string? DaemonStatus,
         DaemonDiagnosis? Diagnosis,
         DaemonStartupObservation? Startup = null);
 

--- a/src/Ucli/Features/Daemon/Supervisor/Host/SupervisorProjectCoordinator.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Host/SupervisorProjectCoordinator.cs
@@ -137,7 +137,7 @@ internal sealed class SupervisorProjectCoordinator
             if (startResult.Status == DaemonStartStatus.AlreadyRunning)
             {
                 _ = TryRegisterManagedProcess(slot, unityProject, startResult.Session!);
-                return DaemonStartResult.AlreadyRunning(startResult.Session!);
+                return DaemonStartResult.AlreadyRunning(startResult.Session!, startResult.LifecycleSnapshot);
             }
 
             // NOTE:
@@ -145,7 +145,7 @@ internal sealed class SupervisorProjectCoordinator
             // verification failure cannot leave a supervisor-owned process outside supervisor ownership.
             if (!TryRegisterManagedProcess(slot, unityProject, startResult.Session!))
             {
-                return DaemonStartResult.Started(startResult.Session!);
+                return DaemonStartResult.Started(startResult.Session!, startResult.LifecycleSnapshot);
             }
 
             if (!deadline.TryGetRemainingTimeout(out var stabilityTimeout))
@@ -177,7 +177,7 @@ internal sealed class SupervisorProjectCoordinator
                 return DaemonStartResult.Failure(stabilityResult.Error!);
             }
 
-            return DaemonStartResult.Started(startResult.Session!);
+            return DaemonStartResult.Started(startResult.Session!, startResult.LifecycleSnapshot);
         }
         finally
         {

--- a/src/Ucli/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcher.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcher.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Stop;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
@@ -197,7 +198,12 @@ internal sealed class SupervisorRequestDispatcher
 
         if (!startResult.IsSuccess)
         {
-            return CreateExecutionErrorResponse(request, startResult.Error!, startResult.Diagnosis, startResult.Startup);
+            return CreateExecutionErrorResponse(
+                request,
+                startResult.Error!,
+                startResult.DaemonStatus,
+                startResult.Diagnosis,
+                startResult.Startup);
         }
 
         if (!DaemonStartStateCodec.TryToValue(startResult.Status, out var startStatus))
@@ -213,7 +219,8 @@ internal sealed class SupervisorRequestDispatcher
             new SupervisorIpcContracts.EnsureRunningResponse(
                 StartStatus: startStatus!,
                 DaemonStatus: DaemonStatusStateCodec.Running,
-                Session: startResult.Session!));
+                Session: startResult.Session!,
+                LifecycleSnapshot: startResult.LifecycleSnapshot));
     }
 
     private async ValueTask<IpcResponse> HandleStopProjectAsync (
@@ -366,14 +373,18 @@ internal sealed class SupervisorRequestDispatcher
     private static IpcResponse CreateExecutionErrorResponse (
         IpcRequest request,
         ExecutionError error,
+        DaemonStatusKind daemonStatus,
         DaemonDiagnosis? diagnosis,
         DaemonStartupObservation? startup)
     {
+        var daemonStatusValue = DaemonStatusStateCodec.TryToValue(daemonStatus, out var value)
+            ? value
+            : DaemonStatusStateCodec.NotRunning;
         return SupervisorIpcResponseFactory.CreateErrorResponse(
             request,
             ExecutionErrorCodeMapper.ToCode(error),
             error.Message,
-            new SupervisorIpcContracts.EnsureRunningFailureResponse(diagnosis, startup));
+            new SupervisorIpcContracts.EnsureRunningFailureResponse(daemonStatusValue, diagnosis, startup));
     }
 
     private sealed record ProjectContextResult (

--- a/src/Ucli/Hosting/Cli/Daemon/DaemonStartCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/DaemonStartCommand.cs
@@ -104,22 +104,33 @@ internal sealed class DaemonStartCommand
                 {
                     startStatus = DaemonCommandOutputProjector.ToStartStatus(output.StartStatus),
                     daemonStatus = DaemonCommandOutputProjector.ToStatus(output.DaemonStatus),
+                    lifecycleState = output.LifecycleState,
+                    blockingReason = output.BlockingReason,
+                    canAcceptExecutionRequests = output.CanAcceptExecutionRequests,
                     timeoutMilliseconds = output.TimeoutMilliseconds,
                     session = output.Session,
                 });
         }
 
-        if (executionResult.Diagnosis is null)
+        if (executionResult.FailureOutput is null)
         {
             return CommandResultFactory.FromExecutionError(UcliCommandNames.DaemonStart, executionResult.Error!);
         }
 
+        var failureOutput = executionResult.FailureOutput;
         return CommandFailureProjector.Create(
             UcliCommandNames.DaemonStart,
             ApplicationFailure.FromExecutionError(executionResult.Error!),
             payload: new
             {
-                diagnosis = executionResult.Diagnosis,
+                startStatus = DaemonStartStateCodec.Failed,
+                daemonStatus = DaemonCommandOutputProjector.ToStatus(failureOutput.DaemonStatus),
+                timeoutMilliseconds = failureOutput.TimeoutMilliseconds,
+                session = (object?)null,
+                startup = failureOutput.Startup,
+                diagnosis = failureOutput.Diagnosis,
+                retryDisposition = failureOutput.RetryDisposition,
+                safeToRetryImmediately = failureOutput.SafeToRetryImmediately,
             });
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateServiceTests.cs
@@ -17,7 +17,7 @@ public sealed class DaemonExistingSessionGateServiceTests
     {
         var session = CreateSession(processId: 4001);
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.CompletedTask),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.CompletedTask),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
             daemonSessionCleanupService: new StubDaemonSessionCleanupService(),
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -33,6 +33,38 @@ public sealed class DaemonExistingSessionGateServiceTests
         Assert.NotNull(result);
         Assert.Equal(DaemonStartStatus.AlreadyRunning, result!.Status);
         Assert.Equal(session, result.Session);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Ready, result.LifecycleSnapshot!.LifecycleState);
+        Assert.True(result.LifecycleSnapshot.CanAcceptExecutionRequests);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task TryHandleExistingSession_WhenPingReportsCompiling_ReturnsAlreadyRunningWithLifecycleSnapshot ()
+    {
+        var session = CreateSession(processId: 4010);
+        var service = new DaemonExistingSessionGateService(
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.CompletedTask)
+            {
+                Response = CreatePingResponse(IpcEditorLifecycleStateCodec.Compiling, IpcEditorBlockingReasonCodec.Compile, false),
+            },
+            reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
+            daemonSessionCleanupService: new StubDaemonSessionCleanupService(),
+            daemonLifecycleStore: new StubDaemonLifecycleStore(),
+            processIdentityAssessor: new StubDaemonProcessIdentityAssessor());
+
+        var result = await service.TryHandleExistingSessionAsync(
+            CreateContext("fingerprint-existing-running-compiling"),
+            session,
+            TimeSpan.FromMilliseconds(500),
+            editorMode: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(DaemonStartStatus.AlreadyRunning, result!.Status);
+        Assert.Equal(session, result.Session);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Compiling, result.LifecycleSnapshot!.LifecycleState);
+        Assert.Equal(IpcEditorBlockingReasonCodec.Compile, result.LifecycleSnapshot.BlockingReason);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
     }
 
     [Fact]
@@ -41,7 +73,7 @@ public sealed class DaemonExistingSessionGateServiceTests
     {
         var session = CreateSession(processId: 4008);
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.CompletedTask),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.CompletedTask),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
             daemonSessionCleanupService: new StubDaemonSessionCleanupService(),
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -66,7 +98,7 @@ public sealed class DaemonExistingSessionGateServiceTests
     public async Task TryHandleExistingSession_WhenPingTimesOut_ReturnsTimeoutFailure ()
     {
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new TimeoutException("timeout"))),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new TimeoutException("timeout"))),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
             daemonSessionCleanupService: new StubDaemonSessionCleanupService(),
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -113,7 +145,7 @@ public sealed class DaemonExistingSessionGateServiceTests
                 Error: null),
         };
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: pingClient,
+            daemonPingInfoClient: pingClient,
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
             daemonSessionCleanupService: cleanupService,
             daemonLifecycleStore: lifecycleStore,
@@ -143,7 +175,7 @@ public sealed class DaemonExistingSessionGateServiceTests
         };
         var session = CreateSession(processId: 4003);
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("stale"))),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("stale"))),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => true),
             daemonSessionCleanupService: cleanupService,
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -171,7 +203,7 @@ public sealed class DaemonExistingSessionGateServiceTests
             CleanupStaleSessionArtifactsResult = DaemonSessionStoreOperationResult.Success(),
         };
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(timeout =>
+            daemonPingInfoClient: new StubDaemonPingClient(timeout =>
             {
                 timeProvider.Advance(TimeSpan.FromMilliseconds(120));
                 return ValueTask.FromException(new InvalidOperationException("stale"));
@@ -201,7 +233,7 @@ public sealed class DaemonExistingSessionGateServiceTests
         var timeProvider = new ManualTimeProvider();
         var cleanupService = new StubDaemonSessionCleanupService();
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(timeout =>
+            daemonPingInfoClient: new StubDaemonPingClient(timeout =>
             {
                 timeProvider.Advance(TimeSpan.FromMilliseconds(80));
                 return ValueTask.FromException(new InvalidOperationException("stale"));
@@ -236,7 +268,7 @@ public sealed class DaemonExistingSessionGateServiceTests
             CleanupStaleSessionArtifactsResult = DaemonSessionStoreOperationResult.Failure(expectedError),
         };
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("stale"))),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("stale"))),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => true),
             daemonSessionCleanupService: cleanupService,
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -259,7 +291,7 @@ public sealed class DaemonExistingSessionGateServiceTests
     public async Task TryHandleExistingSession_WhenPingThrowsUnexpectedError_ReturnsInternalFailure ()
     {
         var service = new DaemonExistingSessionGateService(
-            daemonPingClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("unexpected"))),
+            daemonPingInfoClient: new StubDaemonPingClient(static _ => ValueTask.FromException(new InvalidOperationException("unexpected"))),
             reachabilityClassifier: new StubDaemonReachabilityClassifier(static _ => false),
             daemonSessionCleanupService: new StubDaemonSessionCleanupService(),
             daemonLifecycleStore: new StubDaemonLifecycleStore(),
@@ -322,7 +354,25 @@ public sealed class DaemonExistingSessionGateServiceTests
             PrimaryDiagnostic: null);
     }
 
-    private sealed class StubDaemonPingClient : IDaemonPingClient
+    private static IpcPingResponse CreatePingResponse (
+        string lifecycleState,
+        string? blockingReason,
+        bool canAcceptExecutionRequests)
+    {
+        return new IpcPingResponse(
+            ServerVersion: "1.0.0",
+            EditorMode: DaemonEditorModeValues.Batchmode,
+            UnityVersion: "2022.3.0f1",
+            ProjectFingerprint: "fingerprint",
+            CompileState: IpcCompileStateCodec.Ready,
+            LifecycleState: lifecycleState,
+            BlockingReason: blockingReason,
+            CompileGeneration: "1",
+            DomainReloadGeneration: "2",
+            CanAcceptExecutionRequests: canAcceptExecutionRequests);
+    }
+
+    private sealed class StubDaemonPingClient : IDaemonPingInfoClient
     {
         private readonly Func<TimeSpan, ValueTask> handler;
 
@@ -333,21 +383,29 @@ public sealed class DaemonExistingSessionGateServiceTests
 
         public Func<int, ValueTask>? Handler { get; set; }
 
+        public IpcPingResponse Response { get; set; } = CreatePingResponse(
+            IpcEditorLifecycleStateCodec.Ready,
+            null,
+            true);
+
         public int CallCount { get; private set; }
 
-        public ValueTask PingAsync (
+        public async ValueTask<IpcPingResponse> PingAndReadAsync (
             ResolvedUnityProjectContext unityProject,
             TimeSpan timeout,
             string? sessionToken = null,
+            bool validateProjectFingerprint = true,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
             if (Handler is not null)
             {
-                return Handler(CallCount);
+                await Handler(CallCount).ConfigureAwait(false);
+                return Response;
             }
 
-            return handler(timeout);
+            await handler(timeout).ConfigureAwait(false);
+            return Response;
         }
     }
 

--- a/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Start/DaemonStartServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Start/DaemonStartServiceTests.cs
@@ -1,6 +1,8 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandExecution;
 using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 using MackySoft.Ucli.Application.Shared.Foundation;
@@ -214,7 +216,60 @@ public sealed class DaemonStartServiceTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(ExecutionErrorCodes.IpcTimeout, result.Error!.Code);
-        Assert.Equal(diagnosisOutputMapper.Output, result.Diagnosis);
+        var failureOutput = Assert.IsType<DaemonStartFailureExecutionOutput>(result.FailureOutput);
+        Assert.Equal(DaemonStatusKind.NotRunning, failureOutput.DaemonStatus);
+        Assert.Equal(1600, failureOutput.TimeoutMilliseconds);
+        Assert.Equal(diagnosisOutputMapper.Output, failureOutput.Diagnosis);
+        Assert.Equal(1, diagnosisOutputMapper.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Start_WhenSupervisorReturnsFailureWithStartup_PreservesFailurePayloadFields ()
+    {
+        var context = DaemonServiceTestContext.CreateExecutionContext(
+            timeoutMilliseconds: 1600,
+            repositoryRoot: "/tmp/repo-root");
+        var resolver = new DaemonServiceTestContext.StubDaemonCommandExecutionContextResolver(
+            DaemonCommandExecutionContextResolutionResult.Success(context));
+        var mapper = new DaemonServiceTestContext.StubDaemonSessionOutputMapper();
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Blocked,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            LaunchAttemptId: "20260312_040500Z_00abcdef",
+            ProcessAction: DaemonStartupProcessActionValues.Kept,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix);
+        var supervisorProjectGateway = new DaemonServiceTestContext.StubSupervisorProjectGateway
+        {
+            EnsureRunningResult = DaemonStartResult.Failure(
+                ExecutionError.InternalError("startup blocked", DaemonErrorCodes.DaemonStartupBlocked),
+                DaemonServiceTestContext.CreateDiagnosis(),
+                startup,
+                DaemonStatusKind.Stale),
+        };
+        var diagnosisOutputMapper = new DaemonServiceTestContext.StubDaemonDiagnosisOutputMapper();
+        var service = CreateService(
+            resolver,
+            supervisorProjectGateway,
+            mapper,
+            daemonDiagnosisOutputMapper: diagnosisOutputMapper);
+
+        var result = await service.StartAsync(
+            projectPath: null,
+            timeoutMilliseconds: null,
+            editorMode: null,
+            onStartupBlocked: DaemonStartupBlockedProcessPolicy.Auto,
+            cancellationToken: CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.Error!.Code);
+        var failureOutput = Assert.IsType<DaemonStartFailureExecutionOutput>(result.FailureOutput);
+        Assert.Equal(DaemonStatusKind.Stale, failureOutput.DaemonStatus);
+        Assert.Equal(1600, failureOutput.TimeoutMilliseconds);
+        Assert.Equal(startup, failureOutput.Startup);
+        Assert.Equal(diagnosisOutputMapper.Output, failureOutput.Diagnosis);
+        Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, failureOutput.RetryDisposition);
+        Assert.False(failureOutput.SafeToRetryImmediately);
         Assert.Equal(1, diagnosisOutputMapper.CallCount);
     }
 

--- a/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Start/DaemonStartServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/UseCases/Start/DaemonStartServiceTests.cs
@@ -6,6 +6,7 @@ using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 
 namespace MackySoft.Ucli.Application.Tests.Daemon;
@@ -28,9 +29,13 @@ public sealed class DaemonStartServiceTests
             Output = DaemonServiceTestContext.CreateSessionOutput(),
         };
         var session = DaemonServiceTestContext.CreateSession();
+        var lifecycleSnapshot = new DaemonStartLifecycleSnapshot(
+            IpcEditorLifecycleStateCodec.Compiling,
+            IpcEditorBlockingReasonCodec.Compile,
+            CanAcceptExecutionRequests: false);
         var supervisorProjectGateway = new DaemonServiceTestContext.StubSupervisorProjectGateway
         {
-            EnsureRunningResult = DaemonStartResult.Started(session),
+            EnsureRunningResult = DaemonStartResult.Started(session, lifecycleSnapshot),
         };
         var service = CreateService(resolver, supervisorProjectGateway, mapper);
 
@@ -42,6 +47,9 @@ public sealed class DaemonStartServiceTests
         Assert.Equal(DaemonStatusKind.Running, output.DaemonStatus);
         Assert.Equal(1200, output.TimeoutMilliseconds);
         Assert.Equal(mapper.Output, output.Session);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Compiling, output.LifecycleState);
+        Assert.Equal(IpcEditorBlockingReasonCodec.Compile, output.BlockingReason);
+        Assert.False(output.CanAcceptExecutionRequests);
         Assert.Equal(1, supervisorProjectGateway.EnsureRunningCallCount);
         Assert.Equal(context.Context.UnityProject, supervisorProjectGateway.LastEnsureRunningUnityProject);
         Assert.True(supervisorProjectGateway.LastEnsureRunningTimeout > TimeSpan.Zero);
@@ -266,7 +274,8 @@ public sealed class DaemonStartServiceTests
         var failureOutput = Assert.IsType<DaemonStartFailureExecutionOutput>(result.FailureOutput);
         Assert.Equal(DaemonStatusKind.Stale, failureOutput.DaemonStatus);
         Assert.Equal(1600, failureOutput.TimeoutMilliseconds);
-        Assert.Equal(startup, failureOutput.Startup);
+        Assert.Equal(startup.StartupBlockingReason, failureOutput.Startup!.StartupBlockingReason);
+        Assert.Equal(startup.RetryDisposition, failureOutput.Startup.RetryDisposition);
         Assert.Equal(diagnosisOutputMapper.Output, failureOutput.Diagnosis);
         Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, failureOutput.RetryDisposition);
         Assert.False(failureOutput.SafeToRetryImmediately);

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeTests.cs
@@ -1,9 +1,11 @@
 namespace MackySoft.Ucli.Tests.Daemon;
 
 using System.Net.Sockets;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Shared.Unity.ProjectLock;
 using MackySoft.Ucli.Tests.Helpers.Ipc;
@@ -176,8 +178,11 @@ public sealed class DaemonStartupReadinessProbeTests
         Assert.False(result.IsReady);
         var error = Assert.IsType<ExecutionError>(result.Error);
         Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
         Assert.Contains("scripts have compiler errors", error.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Marker=Scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Equal(DaemonStartupBlockingReasonValues.Compile, result.FailureClassification!.StartupBlockingReason);
+        Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, result.FailureClassification.RetryDisposition);
         Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(1, logReader.CallCount);
     }
@@ -235,8 +240,11 @@ public sealed class DaemonStartupReadinessProbeTests
         Assert.False(result.IsReady);
         var error = Assert.IsType<ExecutionError>(result.Error);
         Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
         Assert.Contains("package resolution failed", error.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("FirstError=com.unity.test-framework: Package [com.unity.test-framework@1.6.0] cannot be found", error.Message, StringComparison.Ordinal);
+        Assert.Equal(DaemonStartupBlockingReasonValues.PackageResolution, result.FailureClassification!.StartupBlockingReason);
+        Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, result.FailureClassification.RetryDisposition);
         Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(1, logReader.CallCount);
     }

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Process/Startup/DaemonStartupReadinessProbeTests.cs
@@ -28,6 +28,8 @@ public sealed class DaemonStartupReadinessProbeTests
 
         Assert.True(result.IsReady);
         Assert.Null(result.Error);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Ready, result.LifecycleSnapshot!.LifecycleState);
+        Assert.True(result.LifecycleSnapshot.CanAcceptExecutionRequests);
         Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(0, logReader.CallCount);
     }
@@ -57,7 +59,9 @@ public sealed class DaemonStartupReadinessProbeTests
 
         Assert.True(result.IsReady);
         Assert.Null(result.Error);
-        Assert.Equal(2, pingClient.CallCount);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Starting, result.LifecycleSnapshot!.LifecycleState);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
+        Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(0, logReader.CallCount);
     }
 
@@ -86,20 +90,47 @@ public sealed class DaemonStartupReadinessProbeTests
 
         Assert.True(result.IsReady);
         Assert.Null(result.Error);
-        Assert.Equal(2, pingClient.CallCount);
+        Assert.Equal(IpcEditorLifecycleStateCodec.DomainReloading, result.LifecycleSnapshot!.LifecycleState);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
+        Assert.Equal(1, pingClient.CallCount);
+        Assert.Equal(0, logReader.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task WaitUntilReady_WhenPingReportsCompiling_ReturnsReadyWithLifecycleSnapshot ()
+    {
+        var pingClient = new StubDaemonPingInfoClient(static () => ValueTask.FromResult(CreatePingPayload(
+            lifecycleState: IpcEditorLifecycleStateCodec.Compiling,
+            canAcceptExecutionRequests: false)));
+        var logReader = new StubUnityLogReader
+        {
+            NextResult = UnityLogReadResult.Success(string.Empty, false, "/tmp/unity.log", 0),
+        };
+        var probe = CreateProbe(pingClient, logReader);
+
+        var result = await probe.WaitUntilReadyAsync(
+            CreateContext("fingerprint-readiness-compiling"),
+            TimeSpan.FromMilliseconds(500),
+            cancellationToken: CancellationToken.None);
+
+        Assert.True(result.IsReady);
+        Assert.Null(result.Error);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Compiling, result.LifecycleSnapshot!.LifecycleState);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
+        Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(0, logReader.CallCount);
     }
 
     [Theory]
     [Trait("Size", "Small")]
-    [InlineData(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, "Exit Play Mode and retry after lifecycleState=ready.")]
-    [InlineData(IpcEditorLifecycleStateCodec.ModalBlocked, IpcEditorBlockingReasonCodec.ModalDialog, "Resolve the modal dialog and retry after lifecycleState=ready.")]
-    [InlineData(IpcEditorLifecycleStateCodec.SafeMode, IpcEditorBlockingReasonCodec.SafeMode, "Resolve compiler errors and retry after lifecycleState=ready.")]
-    [InlineData(IpcEditorLifecycleStateCodec.ShuttingDown, IpcEditorBlockingReasonCodec.Shutdown, "Start a new daemon after shutdown finishes.")]
-    public async Task WaitUntilReady_WhenPingReportsNonWaitableLifecycleState_ReturnsInternalErrorImmediately (
+    [InlineData(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode)]
+    [InlineData(IpcEditorLifecycleStateCodec.ModalBlocked, IpcEditorBlockingReasonCodec.ModalDialog)]
+    [InlineData(IpcEditorLifecycleStateCodec.SafeMode, IpcEditorBlockingReasonCodec.SafeMode)]
+    [InlineData(IpcEditorLifecycleStateCodec.ShuttingDown, IpcEditorBlockingReasonCodec.Shutdown)]
+    public async Task WaitUntilReady_WhenPingReportsNonReadyLifecycleState_ReturnsReadyWithLifecycleSnapshot (
         string lifecycleState,
-        string blockingReason,
-        string expectedMessageSuffix)
+        string blockingReason)
     {
         var pingClient = new StubDaemonPingInfoClient(staticLifecycleState: lifecycleState, staticBlockingReason: blockingReason);
         var logReader = new StubUnityLogReader
@@ -113,11 +144,11 @@ public sealed class DaemonStartupReadinessProbeTests
             TimeSpan.FromSeconds(5),
             cancellationToken: CancellationToken.None);
 
-        Assert.False(result.IsReady);
-        var error = Assert.IsType<ExecutionError>(result.Error);
-        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
-        Assert.Contains($"lifecycleState={lifecycleState}", error.Message, StringComparison.Ordinal);
-        Assert.Contains(expectedMessageSuffix, error.Message, StringComparison.Ordinal);
+        Assert.True(result.IsReady);
+        Assert.Null(result.Error);
+        Assert.Equal(lifecycleState, result.LifecycleSnapshot!.LifecycleState);
+        Assert.Equal(blockingReason, result.LifecycleSnapshot.BlockingReason);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
         Assert.Equal(1, pingClient.CallCount);
         Assert.Equal(0, logReader.CallCount);
     }

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -7,6 +7,7 @@ namespace MackySoft.Ucli.Tests.Daemon;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Infrastructure.Storage;
 
@@ -845,6 +846,130 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
         Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
         Assert.Equal(processStartedAtUtc, launchAttemptStore.LastLaunchAttempt.ProcessStartedAtUtc);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenReadinessProbeReturnsClassifiedBlocker_PreservesStartupClassification ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7778 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var launcher = new StubUnityDaemonProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(7778, processStartedAtUtc),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            NextResult = DaemonSessionStoreOperationResult.Success(),
+        };
+        var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            launchSessionService,
+            launcher,
+            readinessProbe,
+            compensationService,
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.Error!.Code);
+        Assert.Equal(DaemonStartupStatusValues.Blocked, result.Startup!.StartupStatus);
+        Assert.Equal(DaemonStartupBlockingReasonValues.Compile, result.Startup.StartupBlockingReason);
+        Assert.Equal(DaemonStartupRetryDispositionValues.RetryAfterFix, result.Startup.RetryDisposition);
+        Assert.Equal(DaemonEditorModeValues.Batchmode, result.Startup.EditorMode);
+        Assert.Equal(DaemonSessionOwnerKindValues.Cli, result.Startup.OwnerKind);
+        Assert.Equal(7778, result.Startup.ProcessId);
+        Assert.Equal(processStartedAtUtc, result.Startup.StartedAtUtc);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup.ProcessAction);
+        Assert.NotNull(result.Startup.ArtifactPath);
+        Assert.Equal(DaemonDiagnosisReasonValues.UnityScriptCompilationFailed, result.Diagnosis!.Reason);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.Equal(DaemonStartupStatusValues.Blocked, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupBlockingReasonValues.Compile, launchAttemptStore.LastLaunchAttempt.StartupBlockingReason);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenReadinessProbeReturnsClassifiedBlockerAndKeepPolicy_PreservesProcess ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-keep");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7779 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var launcher = new StubUnityDaemonProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(7779, processStartedAtUtc),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService();
+        var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            launchSessionService,
+            launcher,
+            readinessProbe,
+            compensationService,
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Keep,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.Equal(DaemonStartupProcessActionValues.Kept, result.Startup!.ProcessAction);
+        Assert.Equal(0, compensationService.CallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Kept, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class DaemonLaunchServiceTests
         };
         var readinessProbe = new StubDaemonStartupReadinessProbe
         {
-            NextResult = DaemonStartupReadinessProbeResult.Ready(),
+            NextResult = DaemonStartupReadinessProbeResult.Ready(DaemonStartLifecycleSnapshot.Ready()),
         };
         var compensationService = new StubDaemonLaunchCompensationService();
         var diagnosisStore = new StubDaemonDiagnosisStore();
@@ -1473,7 +1473,7 @@ public sealed class DaemonLaunchServiceTests
 
     private sealed class StubDaemonStartupReadinessProbe : IDaemonStartupReadinessProbe
     {
-        public DaemonStartupReadinessProbeResult NextResult { get; set; } = DaemonStartupReadinessProbeResult.Ready();
+        public DaemonStartupReadinessProbeResult NextResult { get; set; } = DaemonStartupReadinessProbeResult.Ready(DaemonStartLifecycleSnapshot.Ready());
 
         public Action? OnWaitUntilReady { get; set; }
 

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Client/SupervisorClientTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Client/SupervisorClientTests.cs
@@ -79,11 +79,15 @@ public sealed class SupervisorClientTests
                     ProtocolVersion: request.ProtocolVersion,
                     RequestId: request.RequestId,
                     Status: IpcProtocol.StatusOk,
-                    Payload: IpcPayloadCodec.SerializeToElement(
-                        new SupervisorIpcContracts.EnsureRunningResponse(
-                            StartStatus: "started",
-                            DaemonStatus: "running",
-                            Session: CreateSession())),
+                Payload: IpcPayloadCodec.SerializeToElement(
+                    new SupervisorIpcContracts.EnsureRunningResponse(
+                        StartStatus: "started",
+                        DaemonStatus: "running",
+                        Session: CreateSession(),
+                        LifecycleSnapshot: new DaemonStartLifecycleSnapshot(
+                            IpcEditorLifecycleStateCodec.Compiling,
+                            IpcEditorBlockingReasonCodec.Compile,
+                            CanAcceptExecutionRequests: false))),
                     Errors: []));
             },
         };
@@ -99,6 +103,9 @@ public sealed class SupervisorClientTests
             cancellationToken: CancellationToken.None);
 
         Assert.True(result.IsSuccess);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Compiling, result.LifecycleSnapshot!.LifecycleState);
+        Assert.Equal(IpcEditorBlockingReasonCodec.Compile, result.LifecycleSnapshot.BlockingReason);
+        Assert.False(result.LifecycleSnapshot.CanAcceptExecutionRequests);
         var call = Assert.Single(transportClient.Calls);
         Assert.True(call.UsesUnboundedResponseWait);
         Assert.Equal(requestedTimeout, call.Timeout);

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Client/SupervisorClientTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Client/SupervisorClientTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.UnityIntegration.Ipc.Transport;
@@ -118,7 +119,7 @@ public sealed class SupervisorClientTests
                 RequestId: request.RequestId,
                 Status: IpcProtocol.StatusError,
                 Payload: IpcPayloadCodec.SerializeToElement(
-                    new SupervisorIpcContracts.EnsureRunningFailureResponse(diagnosis, startup)),
+                    new SupervisorIpcContracts.EnsureRunningFailureResponse("stale", diagnosis, startup)),
                 Errors:
                 [
                     new IpcError(ExecutionErrorCodes.IpcTimeout, "endpoint registration timed out", null),
@@ -138,6 +139,7 @@ public sealed class SupervisorClientTests
         Assert.Equal(ExecutionErrorCodes.IpcTimeout, result.Error!.Code);
         Assert.Equal(diagnosis, result.Diagnosis);
         Assert.Equal(startup, result.Startup);
+        Assert.Equal(DaemonStatusKind.Stale, result.DaemonStatus);
     }
 
     private static SupervisorInstanceManifest CreateManifest ()

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcherTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Host/SupervisorRequestDispatcherTests.cs
@@ -2,11 +2,13 @@ using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Cleanup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Stop;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Probe;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Infrastructure.Ipc;
 using MackySoft.Ucli.Infrastructure.Project;
 
@@ -136,7 +138,14 @@ public sealed class SupervisorRequestDispatcherTests
     [Trait("Size", "Small")]
     public async Task HandleConnection_WhenEditorModeIsSpecified_PassesNormalizedValueToStartOperation ()
     {
-        var startOperation = new StubDaemonStartOperation();
+        var lifecycleSnapshot = new DaemonStartLifecycleSnapshot(
+            IpcEditorLifecycleStateCodec.Compiling,
+            IpcEditorBlockingReasonCodec.Compile,
+            CanAcceptExecutionRequests: false);
+        var startOperation = new StubDaemonStartOperation
+        {
+            StartResult = DaemonStartResult.AlreadyRunning(CreateSession(), lifecycleSnapshot),
+        };
         var dispatcher = CreateDispatcher(startOperation);
         var runtimeContext = CreateRuntimeContext();
         var unityProjectRoot = Path.Combine(runtimeContext.StorageRoot, "UnityProject");
@@ -163,6 +172,11 @@ public sealed class SupervisorRequestDispatcherTests
             string.Join(Environment.NewLine, response.Errors.Select(error => $"{error.Code.Value}: {error.Message}")));
         Assert.Equal(DaemonEditorMode.Gui, startOperation.LastEditorMode);
         Assert.Equal(DaemonStartupBlockedProcessPolicy.Terminate, startOperation.LastOnStartupBlocked);
+        Assert.True(IpcPayloadCodec.TryDeserialize(
+            response.Payload,
+            out SupervisorIpcContracts.EnsureRunningResponse payload,
+            out _));
+        Assert.Equal(lifecycleSnapshot, payload.LifecycleSnapshot);
     }
 
     [Fact]
@@ -240,7 +254,8 @@ public sealed class SupervisorRequestDispatcherTests
             StartResult = DaemonStartResult.Failure(
                 ExecutionError.Timeout("endpoint registration timed out", ExecutionErrorCodes.IpcTimeout),
                 diagnosis,
-                startup),
+                startup,
+                DaemonStatusKind.Stale),
         };
         var dispatcher = CreateDispatcher(startOperation);
         var runtimeContext = CreateRuntimeContext();
@@ -272,6 +287,7 @@ public sealed class SupervisorRequestDispatcherTests
             out _));
         Assert.Equal(diagnosis, payload.Diagnosis);
         Assert.Equal(startup, payload.Startup);
+        Assert.Equal(DaemonStatusStateCodec.Stale, payload.DaemonStatus);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
@@ -66,6 +66,31 @@ public sealed class DaemonStartCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Start_WhenServiceSucceedsWithCompilingLifecycle_EmitsLifecycleSnapshotPayload ()
+    {
+        var service = new StubDaemonStartService(DaemonStartExecutionResult.Success(CreateSuccessOutput(
+            lifecycleState: IpcEditorLifecycleStateCodec.Compiling,
+            blockingReason: IpcEditorBlockingReasonCodec.Compile,
+            canAcceptExecutionRequests: false)));
+        var command = new DaemonStartCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.StartAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        JsonAssert.For(outputJson.RootElement.GetProperty("payload"))
+            .HasString("startStatus", "started")
+            .HasString("daemonStatus", "running")
+            .HasString("lifecycleState", IpcEditorLifecycleStateCodec.Compiling)
+            .HasString("blockingReason", IpcEditorBlockingReasonCodec.Compile)
+            .HasBoolean("canAcceptExecutionRequests", false);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Start_WhenEditorModeIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
     {
         var service = new StubDaemonStartService(DaemonStartExecutionResult.Success(CreateSuccessOutput()));
@@ -185,7 +210,14 @@ public sealed class DaemonStartCommandTests
             StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
             LaunchAttemptId: "20260312_040500Z_00abcdef",
             ProcessAction: DaemonStartupProcessActionValues.Kept,
-            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix);
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            EditorMode: DaemonEditorModeValues.Batchmode,
+            OwnerKind: DaemonSessionOwnerKindValues.Cli,
+            CanShutdownProcess: true,
+            ProcessId: 4321,
+            StartedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 1, TimeSpan.Zero),
+            ElapsedMilliseconds: 2500,
+            ArtifactPath: "/repo/.ucli/local/fingerprints/fp/launchAttempts/20260312_040500Z_00abcdef/startup-diagnosis.json");
         var service = new StubDaemonStartService(DaemonStartExecutionResult.Failure(
             ExecutionError.InternalError("Unity startup is blocked.", DaemonErrorCodes.DaemonStartupBlocked),
             DaemonStartFailureExecutionOutput.Create(
@@ -221,7 +253,15 @@ public sealed class DaemonStartCommandTests
                 .HasString("startupStatus", DaemonStartupStatusValues.Blocked)
                 .HasString("startupBlockingReason", DaemonStartupBlockingReasonValues.Compile)
                 .HasString("launchAttemptId", "20260312_040500Z_00abcdef")
+                .HasString("editorMode", DaemonEditorModeValues.Batchmode)
+                .HasString("ownerKind", DaemonSessionOwnerKindValues.Cli)
+                .HasBoolean("canShutdownProcess", true)
+                .HasInt32("processId", 4321)
+                .HasString("startedAtUtc", "2026-03-12T04:05:01+00:00")
+                .HasInt32("elapsedMilliseconds", 2500)
                 .HasString("processAction", DaemonStartupProcessActionValues.Kept)
+                .IsNull("processTermination")
+                .HasString("artifactPath", "/repo/.ucli/local/fingerprints/fp/launchAttempts/20260312_040500Z_00abcdef/startup-diagnosis.json")
                 .HasString("retryDisposition", DaemonStartupRetryDispositionValues.RetryAfterFix))
             .HasProperty("diagnosis", diagnosisJson => diagnosisJson
                 .HasString("reason", DaemonDiagnosisReasonValues.UnityScriptCompilationFailed));
@@ -266,10 +306,46 @@ public sealed class DaemonStartCommandTests
             .HasProperty("startup", startupJson => startupJson
                 .HasString("startupStatus", DaemonStartupStatusValues.Timeout)
                 .HasString("startupBlockingReason", DaemonStartupBlockingReasonValues.EndpointNotRegistered)
-                .HasString("retryDisposition", DaemonStartupRetryDispositionValues.WaitThenRetry));
+                .HasString("retryDisposition", DaemonStartupRetryDispositionValues.Unknown));
     }
 
-    private static DaemonStartExecutionOutput CreateSuccessOutput ()
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Start_WhenFailureCanRetryImmediately_EmitsSafeToRetryImmediately ()
+    {
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Failed,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Unknown,
+            LaunchAttemptId: "20260312_040500Z_00abcdef",
+            ProcessAction: DaemonStartupProcessActionValues.None,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryImmediately);
+        var service = new StubDaemonStartService(DaemonStartExecutionResult.Failure(
+            ExecutionError.InternalError("transient startup failure", DaemonErrorCodes.DaemonStartupBlocked),
+            DaemonStartFailureExecutionOutput.Create(
+                DaemonStatusKind.NotRunning,
+                1234,
+                startup,
+                diagnosis: null)));
+        var command = new DaemonStartCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.StartAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.ToolError, exitCode);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        JsonAssert.For(outputJson.RootElement.GetProperty("payload"))
+            .HasString("retryDisposition", DaemonStartupRetryDispositionValues.RetryImmediately)
+            .HasBoolean("safeToRetryImmediately", true)
+            .HasProperty("startup", startupJson => startupJson
+                .HasString("retryDisposition", DaemonStartupRetryDispositionValues.RetryImmediately));
+    }
+
+    private static DaemonStartExecutionOutput CreateSuccessOutput (
+        string lifecycleState = IpcEditorLifecycleStateCodec.Ready,
+        string? blockingReason = null,
+        bool canAcceptExecutionRequests = true)
     {
         return new DaemonStartExecutionOutput(
             StartStatus: DaemonStartStatus.Started,
@@ -285,7 +361,10 @@ public sealed class DaemonStartCommandTests
                 EndpointAddress: "ucli-daemon-endpoint",
                 ProcessId: 1234,
                 ProcessStartedAtUtc: DateTimeOffset.UtcNow,
-                OwnerProcessId: 5678));
+                OwnerProcessId: 5678),
+            LifecycleState: lifecycleState,
+            BlockingReason: blockingReason,
+            CanAcceptExecutionRequests: canAcceptExecutionRequests);
     }
 
     private static DaemonDiagnosisOutput CreateDiagnosis (string reason)

--- a/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
@@ -1,5 +1,6 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Daemon.UseCases.Start;
 using MackySoft.Ucli.Application.Shared.Foundation;
@@ -136,7 +137,11 @@ public sealed class DaemonStartCommandTests
                 Message: "The name 'MissingType' does not exist in the current context"));
         var service = new StubDaemonStartService(DaemonStartExecutionResult.Failure(
             ExecutionError.Timeout("registration timeout", ExecutionErrorCodes.IpcTimeout),
-            diagnosis));
+            DaemonStartFailureExecutionOutput.Create(
+                DaemonStatusKind.NotRunning,
+                1234,
+                startup: null,
+                diagnosis)));
         var command = new DaemonStartCommand(service, CommandResultTestWriter.Create());
 
         CommandExecutionState.Reset();
@@ -170,6 +175,100 @@ public sealed class DaemonStartCommandTests
         Assert.Equal("The name 'MissingType' does not exist in the current context", primaryDiagnosticJson.GetProperty("message").GetString());
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Start_WhenServiceFailureHasStartupBlocker_EmitsStartupFailurePayload ()
+    {
+        var diagnosis = CreateDiagnosis(DaemonDiagnosisReasonValues.UnityScriptCompilationFailed);
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Blocked,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            LaunchAttemptId: "20260312_040500Z_00abcdef",
+            ProcessAction: DaemonStartupProcessActionValues.Kept,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix);
+        var service = new StubDaemonStartService(DaemonStartExecutionResult.Failure(
+            ExecutionError.InternalError("Unity startup is blocked.", DaemonErrorCodes.DaemonStartupBlocked),
+            DaemonStartFailureExecutionOutput.Create(
+                DaemonStatusKind.NotRunning,
+                1234,
+                startup,
+                diagnosis)));
+        var command = new DaemonStartCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.StartAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.ToolError, exitCode);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.DaemonStart,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, DaemonErrorCodes.DaemonStartupBlocked);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        JsonAssert.For(payload)
+            .HasString("startStatus", "failed")
+            .HasString("daemonStatus", "notRunning")
+            .HasInt32("timeoutMilliseconds", 1234)
+            .IsNull("session")
+            .HasString("retryDisposition", DaemonStartupRetryDispositionValues.RetryAfterFix)
+            .HasBoolean("safeToRetryImmediately", false)
+            .HasProperty("startup", startupJson => startupJson
+                .HasString("startupStatus", DaemonStartupStatusValues.Blocked)
+                .HasString("startupBlockingReason", DaemonStartupBlockingReasonValues.Compile)
+                .HasString("launchAttemptId", "20260312_040500Z_00abcdef")
+                .HasString("processAction", DaemonStartupProcessActionValues.Kept)
+                .HasString("retryDisposition", DaemonStartupRetryDispositionValues.RetryAfterFix))
+            .HasProperty("diagnosis", diagnosisJson => diagnosisJson
+                .HasString("reason", DaemonDiagnosisReasonValues.UnityScriptCompilationFailed));
+        Assert.False(payload.TryGetProperty("lifecycleState", out _));
+        Assert.False(payload.TryGetProperty("blockingReason", out _));
+        Assert.False(payload.TryGetProperty("canAcceptExecutionRequests", out _));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Start_WhenEndpointRegistrationTimesOut_NormalizesFinalWaitThenRetryToUnknown ()
+    {
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Timeout,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            LaunchAttemptId: "20260312_040500Z_00abcdef",
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry);
+        var service = new StubDaemonStartService(DaemonStartExecutionResult.Failure(
+            ExecutionError.Timeout("endpoint registration timeout", ExecutionErrorCodes.IpcTimeout),
+            DaemonStartFailureExecutionOutput.Create(
+                DaemonStatusKind.NotRunning,
+                1234,
+                startup,
+                diagnosis: null)));
+        var command = new DaemonStartCommand(service, CommandResultTestWriter.Create());
+
+        CommandExecutionState.Reset();
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.StartAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.ToolError, exitCode);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, ExecutionErrorCodes.IpcTimeout);
+        JsonAssert.For(outputJson.RootElement.GetProperty("payload"))
+            .HasString("startStatus", "failed")
+            .HasString("daemonStatus", "notRunning")
+            .IsNull("session")
+            .HasString("retryDisposition", DaemonStartupRetryDispositionValues.Unknown)
+            .HasBoolean("safeToRetryImmediately", false)
+            .HasProperty("startup", startupJson => startupJson
+                .HasString("startupStatus", DaemonStartupStatusValues.Timeout)
+                .HasString("startupBlockingReason", DaemonStartupBlockingReasonValues.EndpointNotRegistered)
+                .HasString("retryDisposition", DaemonStartupRetryDispositionValues.WaitThenRetry));
+    }
+
     private static DaemonStartExecutionOutput CreateSuccessOutput ()
     {
         return new DaemonStartExecutionOutput(
@@ -187,6 +286,18 @@ public sealed class DaemonStartCommandTests
                 ProcessId: 1234,
                 ProcessStartedAtUtc: DateTimeOffset.UtcNow,
                 OwnerProcessId: 5678));
+    }
+
+    private static DaemonDiagnosisOutput CreateDiagnosis (string reason)
+    {
+        return new DaemonDiagnosisOutput(
+            Reason: reason,
+            Message: "startup diagnosis",
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: new DateTimeOffset(2026, 03, 12, 4, 5, 6, TimeSpan.Zero),
+            ProcessId: 1234,
+            EditorInstancePath: "/repo/UnityProject/Library/EditorInstance.json");
     }
 
     private sealed class StubDaemonStartService : IDaemonStartService


### PR DESCRIPTION
## Summary
- `daemon start` の失敗時 JSON を、session 未成立の startup failure 契約として返すようにしました。
- failure payload に `daemonStatus`、`startup`、`diagnosis`、`retryDisposition`、`safeToRetryImmediately` を投影し、success payload には lifecycle snapshot を追加しました。
- endpoint 登録済みで `lifecycleState=compiling` の場合は、起動失敗ではなく success path として扱います。

## Scope
- `DaemonStartResult`、`DaemonStartExecutionResult`、supervisor IPC に failure daemon status と lifecycle snapshot の伝搬を追加。
- CLI の `daemon start` 出力を startup failure 契約へ整形し、final failure の `waitThenRetry` を `unknown` に正規化。
- startup probe、launch service、supervisor client/host、start command の契約テストを更新・追加。

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh verify --include <changed paths>`)
- Tests: PASS (`bash scripts/test-dotnet.sh`)
- Coverage: N/A（受け入れ条件に無いため未実行）

## Risks / Rollback
- `daemon start` と supervisor 内部 IPC の payload 形状に関わるため、JSON 契約利用側の回帰が主な確認点です。
- 問題があれば、この PR のコミットを revert して既存 payload 投影へ戻します。

## Checklist
- [x] Issue #266 の受け入れ条件をテストで確認
- [x] Unity 側ファイル変更なし、Unity test と `.meta` 更新は不要

Closes #266