### PR TITLE
chore(release): reset tracked package versions

### DIFF
--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: "SemVer CLI package version (e.g. 0.18.0)"
+        description: "SemVer CLI package version (e.g. 1.2.3)"
         required: true
         type: string
 

--- a/.github/workflows/unity-package-publish.yaml
+++ b/.github/workflows/unity-package-publish.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       package_version:
-        description: "SemVer Unity package version (e.g. 0.18.0)"
+        description: "SemVer Unity package version (e.g. 1.2.3)"
         required: true
         type: string
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <Version>0.18.0</Version>
+    <Version>0.0.0</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Hiroya Aramaki</Authors>
     <Company>MackySoft</Company>

--- a/src/Ucli.Unity/Assets/packages.config
+++ b/src/Ucli.Unity/Assets/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MackySoft.Ucli.Contracts" version="0.18.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
-  <package id="MackySoft.Ucli.Infrastructure" version="0.18.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Contracts" version="0.0.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
+  <package id="MackySoft.Ucli.Infrastructure" version="0.0.0" manuallyInstalled="true" targetFramework="netstandard2.1" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="5.3.0" targetFramework="netstandard2.0" />
   <package id="Microsoft.CodeAnalysis.Common" version="5.3.0" targetFramework="netstandard2.0" />

--- a/src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec
+++ b/src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>MackySoft.Ucli.Unity</id>
-    <version>0.18.0</version>
+    <version>0.0.0</version>
     <title>uCLI Unity Plugin</title>
     <authors>Hiroya Aramaki</authors>
     <owners>MackySoft</owners>
@@ -14,8 +14,8 @@
     <description>Unity Editor plugin for uCLI IPC and automation.</description>
     <tags>ucli unity editor automation ipc nugetforunity</tags>
     <dependencies>
-      <dependency id="MackySoft.Ucli.Contracts" version="0.18.0" />
-      <dependency id="MackySoft.Ucli.Infrastructure" version="0.18.0" />
+      <dependency id="MackySoft.Ucli.Contracts" version="0.0.0" />
+      <dependency id="MackySoft.Ucli.Infrastructure" version="0.0.0" />
       <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
       <dependency id="Microsoft.CodeAnalysis.Analyzers" version="5.3.0" />
       <dependency id="Microsoft.CodeAnalysis.Common" version="5.3.0" />

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -201,8 +201,8 @@ public sealed class PackageMetadataTests
     {
         IReadOnlyDictionary<string, string> outputs = await RunVerifyScopeDetectorForSingleFileChangeAsync(
             "Directory.Build.props",
-            "<Project><PropertyGroup><Version>0.18.0</Version></PropertyGroup></Project>",
-            "<Project><PropertyGroup><Version>0.18.1</Version></PropertyGroup></Project>");
+            "<Project><PropertyGroup><Version>0.0.0</Version></PropertyGroup></Project>",
+            "<Project><PropertyGroup><Version>0.0.1</Version></PropertyGroup></Project>");
 
         Assert.Equal("true", outputs["needs_dotnet"]);
         Assert.Equal("true", outputs["needs_shared_pack"]);


### PR DESCRIPTION
## Summary
- Reset repository-tracked package versions to `0.0.0` for the pre-release cleanup.
- Keep release workflows publishing and syncing the requested release version through the existing `PACKAGE_VERSION` flow.
- Update package metadata tests and workflow input examples to avoid carrying the previous pre-release version.

## Verification
- `bash scripts/code-quality.sh verify --include Directory.Build.props src/Ucli.Unity/Assets/packages.config src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec .github/workflows/cli-package-publish.yaml .github/workflows/unity-package-publish.yaml tests/Ucli.Tests/Packaging/PackageMetadataTests.cs`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter FullyQualifiedName~MackySoft.Ucli.Tests.Packaging.PackageMetadataTests`

Issueなし運用です。
