### PR TITLE
Implement startup blocker process policy

### DIFF
--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartOperation.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/DaemonStartOperation.cs
@@ -228,6 +228,7 @@ internal sealed class DaemonStartOperation : IDaemonStartOperation
                 unityProject,
                 attachTimeout,
                 editorMode,
+                onStartupBlocked,
                 cancellationToken)
             .ConfigureAwait(false);
         if (attachResult is not null)

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachService.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.GuiEndpoint;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
 using MackySoft.Ucli.Application.Shared.Foundation;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.GuiAttach;
@@ -37,6 +38,7 @@ internal sealed class DaemonGuiEditorAttachService : IDaemonGuiEditorAttachServi
         ResolvedUnityProjectContext unityProject,
         TimeSpan timeout,
         DaemonEditorMode? editorMode,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -74,6 +76,8 @@ internal sealed class DaemonGuiEditorAttachService : IDaemonGuiEditorAttachServi
             return await CreateGuiEndpointNotRegisteredFailureAsync(
                     unityProject,
                     marker,
+                    probeResult.ProcessStartedAtUtc,
+                    onStartupBlocked,
                     CreateTimeoutError($"Timed out before waiting for existing GUI Editor endpoint registration. ProcessId={marker.ProcessId}."))
                 .ConfigureAwait(false);
         }
@@ -95,23 +99,52 @@ internal sealed class DaemonGuiEditorAttachService : IDaemonGuiEditorAttachServi
             return DaemonStartResult.Failure(waitResult.Error);
         }
 
-        return await CreateGuiEndpointNotRegisteredFailureAsync(unityProject, marker, waitResult.Error).ConfigureAwait(false);
+        return await CreateGuiEndpointNotRegisteredFailureAsync(
+                unityProject,
+                marker,
+                probeResult.ProcessStartedAtUtc,
+                onStartupBlocked,
+                waitResult.Error)
+            .ConfigureAwait(false);
     }
 
     private async ValueTask<DaemonStartResult> CreateGuiEndpointNotRegisteredFailureAsync (
         ResolvedUnityProjectContext unityProject,
         UnityEditorInstanceMarker marker,
+        DateTimeOffset? processStartedAtUtc,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
         ExecutionError waitError)
     {
-        return await DaemonGuiEndpointNotRegisteredFailureFactory.CreateFailureAsync(
+        var result = await DaemonGuiEndpointNotRegisteredFailureFactory.CreateFailureAsync(
                 unityProject,
                 daemonDiagnosisStore,
                 timeProvider,
                 "existing GUI Editor",
                 marker.MarkerPath,
                 marker.ProcessId,
-                waitError)
+                waitError,
+                processStartedAtUtc)
             .ConfigureAwait(false);
+        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            onStartupBlocked,
+            DaemonEditorModeValues.Gui,
+            DaemonSessionOwnerKindValues.User,
+            canShutdownProcess: false,
+            marker.ProcessId);
+        var startup = new DaemonStartupObservation(
+            StartupStatus: DaemonStartupStatusValues.Timeout,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            LaunchAttemptId: null,
+            ProcessAction: policyResolution.ProcessActionWhenNotTerminated,
+            RetryDisposition: DaemonStartupRetryDispositionValues.WaitThenRetry,
+            EditorMode: DaemonEditorModeValues.Gui,
+            OwnerKind: DaemonSessionOwnerKindValues.User,
+            CanShutdownProcess: false,
+            ProcessId: marker.ProcessId,
+            StartedAtUtc: processStartedAtUtc,
+            ElapsedMilliseconds: null,
+            ArtifactPath: null);
+        return DaemonStartResult.Failure(result.Error!, result.Diagnosis, startup);
     }
 
     private static ExecutionError CreateTimeoutError (string message)

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/IDaemonGuiEditorAttachService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiAttach/IDaemonGuiEditorAttachService.cs
@@ -11,5 +11,6 @@ internal interface IDaemonGuiEditorAttachService
         ResolvedUnityProjectContext unityProject,
         TimeSpan timeout,
         DaemonEditorMode? editorMode,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolution.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolution.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+
+/// <summary> Represents the resolved process handling for one startup-blocked daemon process. </summary>
+/// <param name="ShouldTerminateProcess"> Whether uCLI should try to terminate the process. </param>
+/// <param name="ProcessActionWhenNotTerminated"> The process action to report when no termination is attempted. </param>
+internal sealed record DaemonStartupBlockedProcessPolicyResolution (
+    bool ShouldTerminateProcess,
+    string ProcessActionWhenNotTerminated);

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolver.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolver.cs
@@ -1,0 +1,73 @@
+namespace MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+
+/// <summary> Resolves process handling for endpoint-registration startup blockers. </summary>
+internal static class DaemonStartupBlockedProcessPolicyResolver
+{
+    /// <summary> Resolves whether the blocked process should be terminated and how a kept process should be reported. </summary>
+    /// <param name="policy"> The startup-blocked process policy requested by the caller. </param>
+    /// <param name="editorMode"> The normalized daemon Editor mode. </param>
+    /// <param name="ownerKind"> The normalized daemon session owner kind. </param>
+    /// <param name="canShutdownProcess"> Whether uCLI owns enough process authority to terminate the process. </param>
+    /// <param name="processId"> The observed Unity process identifier when available. </param>
+    /// <returns> The resolved process policy. </returns>
+    public static DaemonStartupBlockedProcessPolicyResolution Resolve (
+        DaemonStartupBlockedProcessPolicy policy,
+        string editorMode,
+        string ownerKind,
+        bool canShutdownProcess,
+        int? processId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(editorMode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ownerKind);
+
+        if (processId is null)
+        {
+            return new DaemonStartupBlockedProcessPolicyResolution(
+                ShouldTerminateProcess: false,
+                ProcessActionWhenNotTerminated: DaemonStartupProcessActionValues.None);
+        }
+
+        if (!canShutdownProcess || string.Equals(ownerKind, DaemonSessionOwnerKindValues.User, StringComparison.Ordinal))
+        {
+            return Keep();
+        }
+
+        if (!string.Equals(ownerKind, DaemonSessionOwnerKindValues.Cli, StringComparison.Ordinal))
+        {
+            return Keep();
+        }
+
+        return editorMode switch
+        {
+            DaemonEditorModeValues.Batchmode => ResolveCliOwnedBatchmode(policy),
+            DaemonEditorModeValues.Gui => ResolveCliOwnedGui(policy),
+            _ => Keep(),
+        };
+    }
+
+    private static DaemonStartupBlockedProcessPolicyResolution ResolveCliOwnedBatchmode (
+        DaemonStartupBlockedProcessPolicy policy)
+    {
+        return policy == DaemonStartupBlockedProcessPolicy.Keep ? Keep() : Terminate();
+    }
+
+    private static DaemonStartupBlockedProcessPolicyResolution ResolveCliOwnedGui (
+        DaemonStartupBlockedProcessPolicy policy)
+    {
+        return policy == DaemonStartupBlockedProcessPolicy.Terminate ? Terminate() : Keep();
+    }
+
+    private static DaemonStartupBlockedProcessPolicyResolution Keep ()
+    {
+        return new DaemonStartupBlockedProcessPolicyResolution(
+            ShouldTerminateProcess: false,
+            ProcessActionWhenNotTerminated: DaemonStartupProcessActionValues.Kept);
+    }
+
+    private static DaemonStartupBlockedProcessPolicyResolution Terminate ()
+    {
+        return new DaemonStartupBlockedProcessPolicyResolution(
+            ShouldTerminateProcess: true,
+            ProcessActionWhenNotTerminated: DaemonStartupProcessActionValues.Unknown);
+    }
+}

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -340,6 +340,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     unityLogPath,
                     launchAttemptId,
                     launchStartedAtUtc,
+                    onStartupBlocked,
                     ExecutionError.Timeout(
                         "Timed out before GUI daemon session registration wait could begin.",
                         ExecutionErrorCodes.IpcTimeout))
@@ -393,6 +394,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                     unityLogPath,
                     launchAttemptId,
                     launchStartedAtUtc,
+                    onStartupBlocked,
                     waitResult.Error)
                 .ConfigureAwait(false);
         }
@@ -599,7 +601,8 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         int? processId,
         DateTimeOffset? processStartedAtUtc,
         string? unityLogPath,
-        DaemonDiagnosis diagnosis)
+        DaemonDiagnosis diagnosis,
+        bool pruneAfterWrite = true)
     {
         var artifactPath = UcliStoragePathResolver.ResolveLaunchAttemptStartupDiagnosisPath(
             unityProject.RepositoryRoot,
@@ -628,6 +631,11 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         if (!writeResult.IsSuccess)
         {
             return writeResult;
+        }
+
+        if (!pruneAfterWrite)
+        {
+            return DaemonLaunchAttemptStoreOperationResult.Success();
         }
 
         return await launchAttemptStore.PruneAsync(
@@ -725,6 +733,31 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 diagnosis,
                 CancellationToken.None)
             .ConfigureAwait(false);
+        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            onStartupBlocked,
+            DaemonEditorModeValues.Batchmode,
+            DaemonSessionOwnerKindValues.Cli,
+            canShutdownProcess: true,
+            processId);
+        var initialProcessAction = policyResolution.ShouldTerminateProcess
+            ? DaemonStartupProcessActionValues.Unknown
+            : policyResolution.ProcessActionWhenNotTerminated;
+        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                unityProject,
+                launchAttemptId,
+                launchStartedAtUtc,
+                updatedAtUtc,
+                DaemonStartupStatusValues.Blocked,
+                classification.StartupBlockingReason,
+                classification.RetryDisposition,
+                initialProcessAction,
+                DaemonEditorModeValues.Batchmode,
+                processId,
+                processStartedAtUtc,
+                unityLogPath,
+                diagnosis,
+                pruneAfterWrite: !policyResolution.ShouldTerminateProcess)
+            .ConfigureAwait(false);
         var policyResult = await ApplyBatchmodeStartupBlockedProcessPolicyAsync(
                 unityProject,
                 onStartupBlocked,
@@ -732,6 +765,29 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 processStartedAtUtc,
                 CancellationToken.None)
             .ConfigureAwait(false);
+        if (policyResolution.ShouldTerminateProcess)
+        {
+            var finalLaunchAttemptWriteResult = await WriteLaunchAttemptAsync(
+                    unityProject,
+                    launchAttemptId,
+                    launchStartedAtUtc,
+                    updatedAtUtc,
+                    DaemonStartupStatusValues.Blocked,
+                    classification.StartupBlockingReason,
+                    classification.RetryDisposition,
+                    policyResult.ProcessAction,
+                    DaemonEditorModeValues.Batchmode,
+                    processId,
+                    processStartedAtUtc,
+                    unityLogPath,
+                    diagnosis)
+                .ConfigureAwait(false);
+            if (launchAttemptWriteResult.IsSuccess)
+            {
+                launchAttemptWriteResult = finalLaunchAttemptWriteResult;
+            }
+        }
+
         var startup = CreateStartupObservation(
             DaemonStartupStatusValues.Blocked,
             classification.StartupBlockingReason,
@@ -746,21 +802,6 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             launchStartedAtUtc,
             updatedAtUtc,
             CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
-        var launchAttemptWriteResult = await WriteLaunchAttemptAsync(
-                unityProject,
-                launchAttemptId,
-                launchStartedAtUtc,
-                updatedAtUtc,
-                startup.StartupStatus,
-                startup.StartupBlockingReason!,
-                startup.RetryDisposition,
-                policyResult.ProcessAction,
-                DaemonEditorModeValues.Batchmode,
-                processId,
-                processStartedAtUtc,
-                unityLogPath,
-                diagnosis)
-            .ConfigureAwait(false);
         if (!diagnosisWriteResult.IsSuccess)
         {
             return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
@@ -800,13 +841,17 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (onStartupBlocked == DaemonStartupBlockedProcessPolicy.Keep)
+        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            onStartupBlocked,
+            DaemonEditorModeValues.Batchmode,
+            DaemonSessionOwnerKindValues.Cli,
+            canShutdownProcess: true,
+            processId);
+        if (!policyResolution.ShouldTerminateProcess)
         {
             return new StartupBlockedProcessPolicyResult(
                 CleanupResult: null,
-                ProcessAction: processId is null
-                    ? DaemonStartupProcessActionValues.None
-                    : DaemonStartupProcessActionValues.Kept);
+                ProcessAction: policyResolution.ProcessActionWhenNotTerminated);
         }
 
         var cleanupResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
@@ -863,6 +908,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
         string unityLogPath,
         string launchAttemptId,
         DateTimeOffset launchStartedAtUtc,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked,
         ExecutionError waitError)
     {
         var startResult = await CreateGuiEndpointNotRegisteredFailureAsync(
@@ -872,13 +918,23 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 unityLogPath,
                 waitError)
             .ConfigureAwait(false);
-        var compensationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
-                unityProject,
-                CreateTerminationTarget(processId, processStartedAtUtc),
-                DaemonTimeouts.LaunchCompensationTimeout,
-                CancellationToken.None)
-            .ConfigureAwait(false);
-        var processAction = ResolveCompensatedProcessAction(processId, compensationResult);
+        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            onStartupBlocked,
+            DaemonEditorModeValues.Gui,
+            DaemonSessionOwnerKindValues.Cli,
+            canShutdownProcess: true,
+            processId);
+        var compensationResult = policyResolution.ShouldTerminateProcess
+            ? await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
+                    unityProject,
+                    CreateTerminationTarget(processId, processStartedAtUtc),
+                    DaemonTimeouts.LaunchCompensationTimeout,
+                    CancellationToken.None)
+                .ConfigureAwait(false)
+            : null;
+        var processAction = compensationResult is null
+            ? policyResolution.ProcessActionWhenNotTerminated
+            : ResolveCompensatedProcessAction(processId, compensationResult);
         var updatedAtUtc = timeProvider.GetUtcNow();
         var startup = CreateStartupObservation(
             DaemonStartupStatusValues.Timeout,
@@ -921,7 +977,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 startup);
         }
 
-        if (compensationResult.IsSuccess)
+        if (compensationResult is null || compensationResult.IsSuccess)
         {
             return DaemonStartResult.Failure(startResult.Error!, startResult.Diagnosis, startup);
         }
@@ -1105,12 +1161,18 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 DaemonStartupProcessActionValues.None);
         }
 
-        if (onStartupBlocked != DaemonStartupBlockedProcessPolicy.Terminate)
+        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            onStartupBlocked,
+            DaemonEditorModeValues.Gui,
+            DaemonSessionOwnerKindValues.Cli,
+            canShutdownProcess: true,
+            blocker.ProcessId);
+        if (!policyResolution.ShouldTerminateProcess)
         {
             // NOTE: GUI blockers are kept by default so users can resolve Safe Mode, modal, or project errors in Unity.
             return new StartupBlockedProcessPolicyResult(
                 CleanupResult: null,
-                ProcessAction: DaemonStartupProcessActionValues.Kept);
+                ProcessAction: policyResolution.ProcessActionWhenNotTerminated);
         }
 
         var terminationResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -758,9 +758,11 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 diagnosis,
                 pruneAfterWrite: !policyResolution.ShouldTerminateProcess)
             .ConfigureAwait(false);
+        // NOTE: Classified batchmode blockers are hard blockers. Persistence failures are reported as secondary
+        // errors, but they do not disable termination after both persistence operations have been attempted.
         var policyResult = await ApplyBatchmodeStartupBlockedProcessPolicyAsync(
                 unityProject,
-                onStartupBlocked,
+                policyResolution,
                 processId,
                 processStartedAtUtc,
                 CancellationToken.None)
@@ -802,13 +804,35 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
             launchStartedAtUtc,
             updatedAtUtc,
             CreateLaunchAttemptArtifactPath(unityProject, launchAttemptId));
-        if (!diagnosisWriteResult.IsSuccess)
+        if (!diagnosisWriteResult.IsSuccess && !launchAttemptWriteResult.IsSuccess && policyResult.CleanupResult is { IsSuccess: false })
         {
             return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
                 primaryError,
-                "Batchmode startup is blocked and diagnosis persistence failed. " +
+                "Batchmode startup is blocked, diagnosis persistence failed, launch-attempt artifact persistence failed, and cleanup failed. " +
                 $"StartupError={primaryError.Message} " +
-                $"DiagnosisError={diagnosisWriteResult.Error!.Message}"), diagnosis, startup);
+                $"DiagnosisError={diagnosisWriteResult.Error!.Message} " +
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message} " +
+                $"CleanupError={policyResult.CleanupResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        if (!diagnosisWriteResult.IsSuccess && policyResult.CleanupResult is { IsSuccess: false })
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked, diagnosis persistence failed, and cleanup failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"DiagnosisError={diagnosisWriteResult.Error!.Message} " +
+                $"CleanupError={policyResult.CleanupResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        if (!launchAttemptWriteResult.IsSuccess && policyResult.CleanupResult is { IsSuccess: false })
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked, launch-attempt artifact persistence failed, and cleanup failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"ArtifactError={launchAttemptWriteResult.Error!.Message} " +
+                $"CleanupError={policyResult.CleanupResult.Error!.Message}"), diagnosis, startup);
         }
 
         if (!launchAttemptWriteResult.IsSuccess)
@@ -818,6 +842,15 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 "Batchmode startup is blocked and launch-attempt artifact persistence failed. " +
                 $"StartupError={primaryError.Message} " +
                 $"ArtifactError={launchAttemptWriteResult.Error!.Message}"), diagnosis, startup);
+        }
+
+        if (!diagnosisWriteResult.IsSuccess)
+        {
+            return DaemonStartResult.Failure(CreateAugmentedPrimaryError(
+                primaryError,
+                "Batchmode startup is blocked and diagnosis persistence failed. " +
+                $"StartupError={primaryError.Message} " +
+                $"DiagnosisError={diagnosisWriteResult.Error!.Message}"), diagnosis, startup);
         }
 
         if (policyResult.CleanupResult is { IsSuccess: false })
@@ -834,19 +867,13 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
 
     private async ValueTask<StartupBlockedProcessPolicyResult> ApplyBatchmodeStartupBlockedProcessPolicyAsync (
         ResolvedUnityProjectContext unityProject,
-        DaemonStartupBlockedProcessPolicy onStartupBlocked,
+        DaemonStartupBlockedProcessPolicyResolution policyResolution,
         int? processId,
         DateTimeOffset? processStartedAtUtc,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var policyResolution = DaemonStartupBlockedProcessPolicyResolver.Resolve(
-            onStartupBlocked,
-            DaemonEditorModeValues.Batchmode,
-            DaemonSessionOwnerKindValues.Cli,
-            canShutdownProcess: true,
-            processId);
         if (!policyResolution.ShouldTerminateProcess)
         {
             return new StartupBlockedProcessPolicyResult(

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
@@ -860,6 +860,7 @@ public sealed class DaemonStartOperationTests
             ResolvedUnityProjectContext unityProject,
             TimeSpan timeout,
             DaemonEditorMode? editorMode,
+            DaemonStartupBlockedProcessPolicy onStartupBlocked,
             CancellationToken cancellationToken = default)
         {
             CallCount++;

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/DaemonStartOperationTests.cs
@@ -555,6 +555,7 @@ public sealed class DaemonStartOperationTests
         Assert.Equal(DaemonStartStatus.Started, result.Status);
         Assert.Equal(1, guiAttachService.CallCount);
         Assert.Equal(DaemonEditorMode.Gui, guiAttachService.LastEditorMode);
+        Assert.Equal(DaemonStartupBlockedProcessPolicy.Terminate, guiAttachService.LastOnStartupBlocked);
         Assert.Equal(1, launchService.CallCount);
         Assert.Equal(DaemonEditorMode.Gui, launchService.LastEditorMode);
         Assert.Equal(DaemonStartupBlockedProcessPolicy.Terminate, launchService.LastOnStartupBlocked);
@@ -856,6 +857,8 @@ public sealed class DaemonStartOperationTests
 
         public DaemonEditorMode? LastEditorMode { get; private set; }
 
+        public DaemonStartupBlockedProcessPolicy LastOnStartupBlocked { get; private set; }
+
         public ValueTask<DaemonStartResult?> TryAttachExistingGuiEditorAsync (
             ResolvedUnityProjectContext unityProject,
             TimeSpan timeout,
@@ -865,6 +868,7 @@ public sealed class DaemonStartOperationTests
         {
             CallCount++;
             LastEditorMode = editorMode;
+            LastOnStartupBlocked = onStartupBlocked;
             return ValueTask.FromResult(NextResult);
         }
     }

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/GuiAttach/DaemonGuiEditorAttachServiceTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Storage;
 
@@ -36,6 +37,7 @@ public sealed class DaemonGuiEditorAttachServiceTests
             context,
             TimeSpan.FromMilliseconds(500),
             editorMode: null,
+            DaemonStartupBlockedProcessPolicy.Auto,
             CancellationToken.None);
 
         Assert.NotNull(result);
@@ -72,6 +74,7 @@ public sealed class DaemonGuiEditorAttachServiceTests
             CreateContext(),
             TimeSpan.FromMilliseconds(500),
             DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
             CancellationToken.None);
 
         Assert.NotNull(result);
@@ -106,6 +109,7 @@ public sealed class DaemonGuiEditorAttachServiceTests
             CreateContext(),
             TimeSpan.FromMilliseconds(500),
             editorMode: null,
+            DaemonStartupBlockedProcessPolicy.Terminate,
             CancellationToken.None);
 
         Assert.NotNull(result);
@@ -120,6 +124,13 @@ public sealed class DaemonGuiEditorAttachServiceTests
         Assert.True(diagnosisStore.LastDiagnosis.IsInferred);
         Assert.Equal(marker.ProcessId, diagnosisStore.LastDiagnosis.ProcessId);
         Assert.Equal(marker.MarkerPath, diagnosisStore.LastDiagnosis.EditorInstancePath);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonEditorModeValues.Gui, result.Startup!.EditorMode);
+        Assert.Equal(DaemonSessionOwnerKindValues.User, result.Startup.OwnerKind);
+        Assert.False(result.Startup.CanShutdownProcess);
+        Assert.Equal(marker.ProcessId, result.Startup.ProcessId);
+        Assert.Equal(ProbeProcessStartedAtUtc, result.Startup.StartedAtUtc);
+        Assert.Equal(DaemonStartupProcessActionValues.Kept, result.Startup.ProcessAction);
     }
 
     [Fact]
@@ -149,6 +160,7 @@ public sealed class DaemonGuiEditorAttachServiceTests
             CreateContext(),
             TimeSpan.FromMilliseconds(1000),
             editorMode: null,
+            DaemonStartupBlockedProcessPolicy.Auto,
             CancellationToken.None);
 
         Assert.NotNull(result);
@@ -179,6 +191,7 @@ public sealed class DaemonGuiEditorAttachServiceTests
             CreateContext(),
             TimeSpan.FromMilliseconds(500),
             editorMode: null,
+            DaemonStartupBlockedProcessPolicy.Auto,
             CancellationToken.None);
 
         Assert.Null(result);

--- a/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolverTests.cs
@@ -1,0 +1,36 @@
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
+
+namespace MackySoft.Ucli.Application.Tests.Daemon;
+
+public sealed class DaemonStartupBlockedProcessPolicyResolverTests
+{
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Terminate, DaemonEditorModeValues.Gui, DaemonSessionOwnerKindValues.User, false, 1234, false, DaemonStartupProcessActionValues.Kept)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Auto, DaemonEditorModeValues.Gui, DaemonSessionOwnerKindValues.Cli, true, 1234, false, DaemonStartupProcessActionValues.Kept)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Keep, DaemonEditorModeValues.Gui, DaemonSessionOwnerKindValues.Cli, true, 1234, false, DaemonStartupProcessActionValues.Kept)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Terminate, DaemonEditorModeValues.Gui, DaemonSessionOwnerKindValues.Cli, true, 1234, true, DaemonStartupProcessActionValues.Unknown)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Terminate, DaemonEditorModeValues.Gui, DaemonSessionOwnerKindValues.Cli, false, 1234, false, DaemonStartupProcessActionValues.Kept)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Auto, DaemonEditorModeValues.Batchmode, DaemonSessionOwnerKindValues.Cli, true, 1234, true, DaemonStartupProcessActionValues.Unknown)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Terminate, DaemonEditorModeValues.Batchmode, DaemonSessionOwnerKindValues.Cli, true, 1234, true, DaemonStartupProcessActionValues.Unknown)]
+    [InlineData(DaemonStartupBlockedProcessPolicy.Auto, DaemonEditorModeValues.Batchmode, DaemonSessionOwnerKindValues.Cli, true, null, false, DaemonStartupProcessActionValues.None)]
+    public void Resolve_ReturnsExpectedProcessPolicy (
+        DaemonStartupBlockedProcessPolicy policy,
+        string editorMode,
+        string ownerKind,
+        bool canShutdownProcess,
+        int? processId,
+        bool expectedShouldTerminate,
+        string expectedProcessActionWhenNotTerminated)
+    {
+        var result = DaemonStartupBlockedProcessPolicyResolver.Resolve(
+            policy,
+            editorMode,
+            ownerKind,
+            canShutdownProcess,
+            processId);
+
+        Assert.Equal(expectedShouldTerminate, result.ShouldTerminateProcess);
+        Assert.Equal(expectedProcessActionWhenNotTerminated, result.ProcessActionWhenNotTerminated);
+    }
+}

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -167,14 +167,14 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(
             Path.Combine("/tmp/unity-project", "Library", "EditorInstance.json"),
             diagnosisStore.LastDiagnosis.EditorInstancePath);
-        Assert.Equal(1, compensationService.CallCount);
-        Assert.Equal(5432, compensationService.LastProcessId);
-        Assert.Equal(processStartedAtUtc, compensationService.LastProcessStartedAtUtc);
+        Assert.Equal(0, compensationService.CallCount);
+        Assert.Null(compensationService.LastProcessId);
+        Assert.Null(compensationService.LastProcessStartedAtUtc);
         Assert.NotNull(result.Startup);
-        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(DaemonStartupProcessActionValues.Kept, result.Startup!.ProcessAction);
         Assert.Equal(1, launchAttemptStore.WriteCallCount);
         Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
-        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+        Assert.Equal(DaemonStartupProcessActionValues.Kept, launchAttemptStore.LastLaunchAttempt.ProcessAction);
     }
 
     [Fact]
@@ -211,7 +211,7 @@ public sealed class DaemonLaunchServiceTests
             context,
             TimeSpan.FromMilliseconds(500),
             DaemonEditorMode.Gui,
-            DaemonStartupBlockedProcessPolicy.Auto,
+            DaemonStartupBlockedProcessPolicy.Terminate,
             CancellationToken.None);
 
         Assert.Equal(DaemonStartStatus.Failed, result.Status);
@@ -915,6 +915,79 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(1, compensationService.CallCount);
         Assert.Equal(DaemonStartupStatusValues.Blocked, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
         Assert.Equal(DaemonStartupBlockingReasonValues.Compile, launchAttemptStore.LastLaunchAttempt.StartupBlockingReason);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerTerminates_SavesEvidenceBeforeCompensationAndStoresFinalProcessAction ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-order");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7780 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var sequence = new List<string>();
+        var diagnosisStore = new StubDaemonDiagnosisStore
+        {
+            OnWrite = _ => sequence.Add("diagnosis"),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            OnWrite = attempt => sequence.Add($"launchAttempt:{attempt.ProcessAction}"),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            OnCleanup = () => sequence.Add("cleanup"),
+        };
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7780, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(
+            [
+                "diagnosis",
+                $"launchAttempt:{DaemonStartupProcessActionValues.Unknown}",
+                "cleanup",
+                $"launchAttempt:{DaemonStartupProcessActionValues.Terminated}",
+            ],
+            sequence);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(1, launchAttemptStore.PruneCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
     }
 
     [Fact]
@@ -1624,6 +1697,8 @@ public sealed class DaemonLaunchServiceTests
     {
         public DaemonDiagnosisStoreOperationResult WriteResult { get; set; } = DaemonDiagnosisStoreOperationResult.Success();
 
+        public Action<DaemonDiagnosis>? OnWrite { get; set; }
+
         public int WriteCallCount { get; private set; }
 
         public DaemonDiagnosis? LastDiagnosis { get; private set; }
@@ -1644,6 +1719,7 @@ public sealed class DaemonLaunchServiceTests
         {
             WriteCallCount++;
             LastDiagnosis = diagnosis;
+            OnWrite?.Invoke(diagnosis);
             return ValueTask.FromResult(WriteResult);
         }
 
@@ -1669,15 +1745,21 @@ public sealed class DaemonLaunchServiceTests
 
     private sealed class StubDaemonLaunchAttemptStore : IDaemonLaunchAttemptStore
     {
+        private readonly List<DaemonLaunchAttempt> launchAttempts = [];
+
         public DaemonLaunchAttemptStoreOperationResult WriteResult { get; set; } = DaemonLaunchAttemptStoreOperationResult.Success();
 
         public DaemonLaunchAttemptStoreOperationResult PruneResult { get; set; } = DaemonLaunchAttemptStoreOperationResult.Success();
+
+        public Action<DaemonLaunchAttempt>? OnWrite { get; set; }
 
         public int WriteCallCount { get; private set; }
 
         public int PruneCallCount { get; private set; }
 
         public DaemonLaunchAttempt? LastLaunchAttempt { get; private set; }
+
+        public IReadOnlyList<DaemonLaunchAttempt> LaunchAttempts => launchAttempts;
 
         public ValueTask<DaemonLaunchAttemptStoreOperationResult> WriteFailureAsync (
             string storageRoot,
@@ -1687,6 +1769,8 @@ public sealed class DaemonLaunchServiceTests
         {
             WriteCallCount++;
             LastLaunchAttempt = launchAttempt;
+            launchAttempts.Add(launchAttempt);
+            OnWrite?.Invoke(launchAttempt);
             return ValueTask.FromResult(WriteResult);
         }
 
@@ -1713,6 +1797,8 @@ public sealed class DaemonLaunchServiceTests
     {
         public DaemonSessionStoreOperationResult NextResult { get; set; } = DaemonSessionStoreOperationResult.Success();
 
+        public Action? OnCleanup { get; set; }
+
         public int CallCount { get; private set; }
 
         public int? LastProcessId { get; private set; }
@@ -1731,6 +1817,7 @@ public sealed class DaemonLaunchServiceTests
             LastProcessId = target?.ProcessId;
             LastProcessStartedAtUtc = target?.ProcessStartedAtUtc;
             LastTimeout = timeout;
+            OnCleanup?.Invoke();
             return ValueTask.FromResult(NextResult);
         }
     }

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchServiceTests.cs
@@ -179,6 +179,51 @@ public sealed class DaemonLaunchServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Launch_WhenEditorModeGuiRegistrationTimesOutAndTerminatePolicy_CleansFailedProcess ()
+    {
+        var context = CreateContext("fingerprint-gui-launch-timeout-cleanup-success");
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 12, 0, 0, 1, TimeSpan.Zero);
+        var guiLauncher = new StubUnityGuiEditorProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(5434, processStartedAtUtc),
+        };
+        var timeoutError = ExecutionError.Timeout("registration timeout", ExecutionErrorCodes.IpcTimeout);
+        var guiStartupObserver = new StubDaemonGuiStartupObserver
+        {
+            NextResult = DaemonGuiStartupObservationResult.Failure(timeoutError),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            new StubDaemonLaunchSessionService(),
+            new StubUnityDaemonProcessLauncher(),
+            new StubDaemonStartupReadinessProbe(),
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            unityGuiEditorProcessLauncher: guiLauncher,
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Gui,
+            DaemonStartupBlockedProcessPolicy.Terminate,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.Equal(5434, compensationService.LastProcessId);
+        Assert.Equal(processStartedAtUtc, compensationService.LastProcessStartedAtUtc);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupStatusValues.Timeout, launchAttemptStore.LastLaunchAttempt!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Launch_WhenEditorModeGuiRegistrationTimesOutAndCompensationFails_RecordsUnknownProcessAction ()
     {
         var context = CreateContext("fingerprint-gui-launch-timeout-cleanup-fail");
@@ -502,6 +547,81 @@ public sealed class DaemonLaunchServiceTests
         Assert.Equal(processStartedAtUtc, compensationService.LastProcessStartedAtUtc);
         Assert.NotNull(result.Startup);
         Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenEditorModeGuiStartupBlockedAndCleanupFails_PreservesPrimaryBlockerAndRecordsUnknownProcessAction ()
+    {
+        var context = CreateContext("fingerprint-gui-launch-terminate-cleanup-fail");
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 12, 0, 0, 1, TimeSpan.Zero);
+        var primaryDiagnostic = new DaemonPrimaryDiagnostic(
+            Kind: DaemonDiagnosisPrimaryDiagnosticKindValues.Compiler,
+            Code: "CS0103",
+            File: "Assets/Foo.cs",
+            Line: 12,
+            Column: 9,
+            Message: "The name does not exist");
+        var guiLauncher = new StubUnityGuiEditorProcessLauncher
+        {
+            NextResult = UnityDaemonLaunchResult.Success(6545, processStartedAtUtc),
+        };
+        var blocker = new DaemonGuiStartupBlocker(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity Editor startup is blocked because scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            ProcessId: 6545,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: $"/tmp/repo-root/.ucli/local/fingerprints/{context.ProjectFingerprint}/unity.log",
+            PrimaryDiagnostic: primaryDiagnostic);
+        var guiStartupObserver = new StubDaemonGuiStartupObserver
+        {
+            NextResult = DaemonGuiStartupObservationResult.Blocked(blocker),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            NextResult = DaemonSessionStoreOperationResult.Failure(ExecutionError.InternalError("cleanup failed")),
+        };
+        var diagnosisStore = new StubDaemonDiagnosisStore();
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            new StubDaemonLaunchSessionService(),
+            new StubUnityDaemonProcessLauncher(),
+            new StubDaemonStartupReadinessProbe(),
+            compensationService,
+            diagnosisStore,
+            unityGuiEditorProcessLauncher: guiLauncher,
+            guiStartupObserver: guiStartupObserver,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Gui,
+            DaemonStartupBlockedProcessPolicy.Terminate,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity Editor startup is blocked because scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("CleanupError=cleanup failed", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, diagnosisStore.WriteCallCount);
+        Assert.NotNull(result.Diagnosis);
+        Assert.Equal(DaemonDiagnosisReasonValues.UnityScriptCompilationFailed, result.Diagnosis!.Reason);
+        Assert.Equal(DaemonDiagnosisStartupPhaseValues.ScriptCompilation, result.Diagnosis.StartupPhase);
+        Assert.Equal(DaemonDiagnosisActionRequiredValues.FixCompileErrors, result.Diagnosis.ActionRequired);
+        Assert.Equal(primaryDiagnostic, result.Diagnosis.PrimaryDiagnostic);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.Startup!.ProcessAction);
+        Assert.Equal(DaemonStartupBlockingReasonValues.Compile, result.Startup.StartupBlockingReason);
+        Assert.Equal(1, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+        Assert.Equal(result.Diagnosis, launchAttemptStore.LastLaunchAttempt.Diagnosis);
     }
 
     [Fact]
@@ -977,17 +1097,345 @@ public sealed class DaemonLaunchServiceTests
 
         Assert.Equal(DaemonStartStatus.Failed, result.Status);
         Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
-        Assert.Equal(
-            [
-                "diagnosis",
-                $"launchAttempt:{DaemonStartupProcessActionValues.Unknown}",
-                "cleanup",
+        var cleanupIndex = sequence.IndexOf("cleanup");
+        Assert.True(cleanupIndex > sequence.IndexOf("diagnosis"));
+        Assert.Contains(
+            sequence.Take(cleanupIndex),
+            value => value.StartsWith("launchAttempt:", StringComparison.Ordinal));
+        Assert.Contains(
+            sequence.Skip(cleanupIndex + 1),
+            value => string.Equals(
+                value,
                 $"launchAttempt:{DaemonStartupProcessActionValues.Terminated}",
-            ],
-            sequence);
-        Assert.Equal(2, launchAttemptStore.WriteCallCount);
-        Assert.Equal(1, launchAttemptStore.PruneCallCount);
+                StringComparison.Ordinal));
         Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerDiagnosisWriteFails_PreservesPrimaryBlockerAndStillCompensates ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-diagnosis-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7781 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var diagnosisStore = new StubDaemonDiagnosisStore
+        {
+            WriteResult = DaemonDiagnosisStoreOperationResult.Failure(ExecutionError.InternalError("diagnosis failed")),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var compensationService = new StubDaemonLaunchCompensationService();
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7781, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            diagnosisStore,
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("DiagnosisError=diagnosis failed", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerLaunchAttemptWriteFails_PreservesPrimaryBlockerAndStillCompensates ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-artifact-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7782 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore
+        {
+            WriteResult = DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError("artifact failed")),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService();
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7782, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("ArtifactError=artifact failed", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(0, launchAttemptStore.PruneCallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerFinalLaunchAttemptWriteFails_PreservesPrimaryBlockerAndReportsArtifactError ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-final-artifact-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7784 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        launchAttemptStore.WriteResults.Enqueue(DaemonLaunchAttemptStoreOperationResult.Success());
+        launchAttemptStore.WriteResults.Enqueue(
+            DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError("final artifact failed")));
+        var compensationService = new StubDaemonLaunchCompensationService();
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7784, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("ArtifactError=final artifact failed", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, result.Startup!.ProcessAction);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Terminated, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerFinalLaunchAttemptWriteAndCleanupFail_ReportsBothSecondaryErrors ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-final-artifact-cleanup-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7785 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: null);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        launchAttemptStore.WriteResults.Enqueue(DaemonLaunchAttemptStoreOperationResult.Success());
+        launchAttemptStore.WriteResults.Enqueue(
+            DaemonLaunchAttemptStoreOperationResult.Failure(ExecutionError.InternalError("final artifact failed")));
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            NextResult = DaemonSessionStoreOperationResult.Failure(ExecutionError.InternalError("cleanup failed")),
+        };
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7785, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("ArtifactError=final artifact failed", error.Message, StringComparison.Ordinal);
+        Assert.Contains("CleanupError=cleanup failed", error.Message, StringComparison.Ordinal);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.Startup!.ProcessAction);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Launch_WhenBatchmodeClassifiedBlockerCleanupFails_RecordsUnknownProcessAction ()
+    {
+        var context = CreateContext("fingerprint-probe-classified-blocker-cleanup-fail");
+        var initialSession = CreateSession(processId: null, projectFingerprint: context.ProjectFingerprint);
+        var updatedSession = initialSession with { ProcessId = 7783 };
+        var processStartedAtUtc = new DateTimeOffset(2026, 03, 09, 0, 0, 1, TimeSpan.Zero);
+        var primaryDiagnostic = new DaemonPrimaryDiagnostic(
+            Kind: DaemonDiagnosisPrimaryDiagnosticKindValues.Compiler,
+            Code: "CS1002",
+            File: "Assets/Foo.cs",
+            Line: 42,
+            Column: 13,
+            Message: "Semicolon expected");
+        var classification = new DaemonStartupFailureClassification(
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.Compile,
+            Reason: DaemonDiagnosisReasonValues.UnityScriptCompilationFailed,
+            RetryDisposition: DaemonStartupRetryDispositionValues.RetryAfterFix,
+            Message: "Unity scripts have compiler errors.",
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ScriptCompilation,
+            ActionRequired: DaemonDiagnosisActionRequiredValues.FixCompileErrors,
+            PrimaryDiagnostic: primaryDiagnostic);
+        var launchSessionService = new StubDaemonLaunchSessionService
+        {
+            InitializeResult = DaemonLaunchSessionWriteResult.Success(initialSession),
+            UpdateProcessIdResult = DaemonLaunchSessionWriteResult.Success(updatedSession),
+        };
+        var readinessProbe = new StubDaemonStartupReadinessProbe
+        {
+            NextResult = DaemonStartupReadinessProbeResult.Failure(
+                ExecutionError.InternalError(classification.Message, DaemonErrorCodes.DaemonStartupBlocked),
+                classification),
+        };
+        var compensationService = new StubDaemonLaunchCompensationService
+        {
+            NextResult = DaemonSessionStoreOperationResult.Failure(ExecutionError.InternalError("cleanup failed")),
+        };
+        var launchAttemptStore = new StubDaemonLaunchAttemptStore();
+        var service = CreateService(
+            launchSessionService,
+            new StubUnityDaemonProcessLauncher
+            {
+                NextResult = UnityDaemonLaunchResult.Success(7783, processStartedAtUtc),
+            },
+            readinessProbe,
+            compensationService,
+            new StubDaemonDiagnosisStore(),
+            launchAttemptStore: launchAttemptStore);
+
+        var result = await service.LaunchAsync(
+            context,
+            TimeSpan.FromMilliseconds(500),
+            DaemonEditorMode.Batchmode,
+            DaemonStartupBlockedProcessPolicy.Auto,
+            CancellationToken.None);
+
+        Assert.Equal(DaemonStartStatus.Failed, result.Status);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Contains("StartupError=Unity scripts have compiler errors.", error.Message, StringComparison.Ordinal);
+        Assert.Contains("CleanupError=cleanup failed", error.Message, StringComparison.Ordinal);
+        Assert.Equal(1, compensationService.CallCount);
+        Assert.NotNull(result.Diagnosis);
+        Assert.Equal(DaemonDiagnosisReasonValues.UnityScriptCompilationFailed, result.Diagnosis!.Reason);
+        Assert.Equal(DaemonDiagnosisStartupPhaseValues.ScriptCompilation, result.Diagnosis.StartupPhase);
+        Assert.Equal(DaemonDiagnosisActionRequiredValues.FixCompileErrors, result.Diagnosis.ActionRequired);
+        Assert.Equal(primaryDiagnostic, result.Diagnosis.PrimaryDiagnostic);
+        Assert.NotNull(result.Startup);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.Startup!.ProcessAction);
+        Assert.Equal(2, launchAttemptStore.WriteCallCount);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, launchAttemptStore.LastLaunchAttempt!.ProcessAction);
+        Assert.Equal(result.Diagnosis, launchAttemptStore.LastLaunchAttempt.Diagnosis);
     }
 
     [Fact]
@@ -1751,6 +2199,8 @@ public sealed class DaemonLaunchServiceTests
 
         public DaemonLaunchAttemptStoreOperationResult PruneResult { get; set; } = DaemonLaunchAttemptStoreOperationResult.Success();
 
+        public Queue<DaemonLaunchAttemptStoreOperationResult> WriteResults { get; } = new();
+
         public Action<DaemonLaunchAttempt>? OnWrite { get; set; }
 
         public int WriteCallCount { get; private set; }
@@ -1771,7 +2221,7 @@ public sealed class DaemonLaunchServiceTests
             LastLaunchAttempt = launchAttempt;
             launchAttempts.Add(launchAttempt);
             OnWrite?.Invoke(launchAttempt);
-            return ValueTask.FromResult(WriteResult);
+            return ValueTask.FromResult(WriteResults.Count > 0 ? WriteResults.Dequeue() : WriteResult);
         }
 
         public ValueTask<DaemonLaunchAttemptReadResult> ReadLastFailureAsync (


### PR DESCRIPTION
## Summary
- Applies `--onStartupBlocked` to daemon startup failure process handling for user-owned GUI, CLI-owned GUI, and CLI-owned batchmode paths.
- Adds a shared resolver so `auto`, `keep`, and `terminate` produce consistent `processAction` values.
- Preserves batchmode startup diagnosis and launch-attempt evidence before termination compensation, then records the final process action.

## Scope
- Daemon startup orchestration: propagate `onStartupBlocked` through GUI attach and launch startup failure paths.
- Process policy: resolve owner/editor-mode/shutdown-capability behavior and reflect `kept`, `terminated`, `none`, or `unknown` in startup observations and launch attempts.
- Tests: cover resolver matrix, user-owned GUI attach timeout, CLI-owned GUI keep/terminate behavior, and batchmode evidence-before-compensation ordering.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...` and `bash scripts/code-quality.sh verify --include ...`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, 1088 tests)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to daemon startup failure handling before endpoint registration; steady-state `daemon stop`, shutdown IPC protocol, oneshot, and `test.run` behavior are unchanged.
- Rollback by reverting `bfac0edb` if startup process policy regressions appear.

## Checklist
- [x] user-owned GUI remains kept even with `--onStartupBlocked=terminate`
- [x] CLI-owned GUI auto keeps the process
- [x] CLI-owned GUI terminate applies only through shutdown-capable launch ownership
- [x] CLI-owned batchmode classified blocker saves diagnosis and launch attempt before termination compensation
- [x] startup failure `processAction` reflects the actual process handling
- [x] `.NET` verification passed

Closes #267