### PR TITLE
test(daemon): lock startup CLI contracts

### DIFF
--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-compiling-success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-compiling-success.json
@@ -1,0 +1,28 @@
+{
+  "protocolVersion": 1,
+  "command": "daemon.start",
+  "status": "ok",
+  "exitCode": 0,
+  "message": "uCLI daemon start completed.",
+  "payload": {
+    "startStatus": "started",
+    "daemonStatus": "running",
+    "lifecycleState": "compiling",
+    "blockingReason": "compile",
+    "canAcceptExecutionRequests": false,
+    "timeoutMilliseconds": 1234,
+    "session": {
+      "projectFingerprint": "fingerprint",
+      "issuedAtUtc": "2026-03-12T01:02:03+00:00",
+      "editorMode": "batchmode",
+      "ownerKind": "cli",
+      "canShutdownProcess": true,
+      "endpointTransportKind": "namedPipe",
+      "endpointAddress": "ucli-daemon-endpoint",
+      "processId": 1234,
+      "processStartedAtUtc": "2026-03-12T01:02:00+00:00",
+      "ownerProcessId": 5678
+    }
+  },
+  "errors": []
+}

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-endpoint-timeout.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-endpoint-timeout.json
@@ -1,0 +1,38 @@
+{
+  "protocolVersion": 1,
+  "command": "daemon.start",
+  "status": "error",
+  "exitCode": 4,
+  "message": "endpoint registration timeout",
+  "payload": {
+    "startStatus": "failed",
+    "daemonStatus": "notRunning",
+    "timeoutMilliseconds": 1234,
+    "session": null,
+    "startup": {
+      "startupStatus": "timeout",
+      "startupBlockingReason": "endpointNotRegistered",
+      "launchAttemptId": "20260312_040500Z_00abcdef",
+      "editorMode": null,
+      "ownerKind": null,
+      "canShutdownProcess": null,
+      "processId": null,
+      "startedAtUtc": null,
+      "elapsedMilliseconds": null,
+      "processAction": "terminated",
+      "processTermination": null,
+      "artifactPath": null,
+      "retryDisposition": "unknown"
+    },
+    "diagnosis": null,
+    "retryDisposition": "unknown",
+    "safeToRetryImmediately": false
+  },
+  "errors": [
+    {
+      "code": "IPC_TIMEOUT",
+      "message": "endpoint registration timeout",
+      "opId": null
+    }
+  ]
+}

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-startup-blocked.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/start-startup-blocked.json
@@ -1,0 +1,51 @@
+{
+  "protocolVersion": 1,
+  "command": "daemon.start",
+  "status": "error",
+  "exitCode": 4,
+  "message": "Unity startup is blocked.",
+  "payload": {
+    "startStatus": "failed",
+    "daemonStatus": "notRunning",
+    "timeoutMilliseconds": 1234,
+    "session": null,
+    "startup": {
+      "startupStatus": "blocked",
+      "startupBlockingReason": "compile",
+      "launchAttemptId": "20260312_040500Z_00abcdef",
+      "editorMode": "batchmode",
+      "ownerKind": "cli",
+      "canShutdownProcess": true,
+      "processId": 4321,
+      "startedAtUtc": "2026-03-12T04:05:01+00:00",
+      "elapsedMilliseconds": 2500,
+      "processAction": "kept",
+      "processTermination": null,
+      "artifactPath": "/repo/.ucli/local/fingerprints/fp/launchAttempts/20260312_040500Z_00abcdef/startup-diagnosis.json",
+      "retryDisposition": "retryAfterFix"
+    },
+    "diagnosis": {
+      "reason": "unityScriptCompilationFailed",
+      "message": "startup diagnosis",
+      "reportedBy": "cli",
+      "isInferred": true,
+      "updatedAtUtc": "2026-03-12T04:05:06+00:00",
+      "processId": 1234,
+      "editorInstancePath": "/repo/UnityProject/Library/EditorInstance.json",
+      "processStartedAtUtc": null,
+      "unityLogPath": null,
+      "startupPhase": null,
+      "actionRequired": null,
+      "primaryDiagnostic": null
+    },
+    "retryDisposition": "retryAfterFix",
+    "safeToRetryImmediately": false
+  },
+  "errors": [
+    {
+      "code": "DAEMON_STARTUP_BLOCKED",
+      "message": "Unity startup is blocked.",
+      "opId": null
+    }
+  ]
+}

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/status-last-launch-attempt.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/status-last-launch-attempt.json
@@ -1,0 +1,51 @@
+{
+  "protocolVersion": 1,
+  "command": "daemon.status",
+  "status": "ok",
+  "exitCode": 0,
+  "message": "uCLI daemon status retrieval completed.",
+  "payload": {
+    "daemonStatus": "notRunning",
+    "serverVersion": null,
+    "editorMode": null,
+    "lifecycleState": null,
+    "blockingReason": null,
+    "compileState": null,
+    "compileGeneration": null,
+    "domainReloadGeneration": null,
+    "canAcceptExecutionRequests": false,
+    "observedAtUtc": "2026-03-12T04:06:00+00:00",
+    "actionRequired": null,
+    "primaryDiagnostic": null,
+    "timeoutMilliseconds": 3000,
+    "session": null,
+    "diagnosis": null,
+    "lastLaunchAttempt": {
+      "launchAttemptId": "20260312_040500Z_00abcdef",
+      "startupStatus": "timeout",
+      "startupBlockingReason": "endpointNotRegistered",
+      "retryDisposition": "retryFreshLaunch",
+      "processAction": "keep",
+      "artifactPath": "/repo/.ucli/local/fingerprints/fp/launch-attempts/20260312_040500Z_00abcdef/startup-diagnosis.json",
+      "unityLogPath": "/repo/.ucli/local/fingerprints/fp/unity.log",
+      "updatedAtUtc": "2026-03-12T04:05:06+00:00",
+      "processId": 1234,
+      "processStartedAtUtc": "2026-03-12T04:05:00+00:00",
+      "diagnosis": {
+        "reason": "guiEndpointNotRegistered",
+        "message": "GUI endpoint was not registered.",
+        "reportedBy": "cli",
+        "isInferred": true,
+        "updatedAtUtc": "2026-03-12T04:05:06+00:00",
+        "processId": 1234,
+        "editorInstancePath": null,
+        "processStartedAtUtc": "2026-03-12T04:05:00+00:00",
+        "unityLogPath": "/repo/.ucli/local/fingerprints/fp/unity.log",
+        "startupPhase": "endpointRegistration",
+        "actionRequired": "inspectUnityLog",
+        "primaryDiagnostic": null
+      }
+    }
+  },
+  "errors": []
+}

--- a/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/DaemonStartCommandTests.cs
@@ -87,6 +87,11 @@ public sealed class DaemonStartCommandTests
             .HasString("lifecycleState", IpcEditorLifecycleStateCodec.Compiling)
             .HasString("blockingReason", IpcEditorBlockingReasonCodec.Compile)
             .HasBoolean("canAcceptExecutionRequests", false);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        Assert.False(payload.TryGetProperty("runtimeKind", out _));
+        Assert.False(payload.GetProperty("session").TryGetProperty("runtimeKind", out _));
+        JsonGoldenFileAssert.Matches(CliOutputGoldenFiles.GetPath("daemon", "start-compiling-success.json"), standardOutput);
     }
 
     [Fact]
@@ -268,6 +273,9 @@ public sealed class DaemonStartCommandTests
         Assert.False(payload.TryGetProperty("lifecycleState", out _));
         Assert.False(payload.TryGetProperty("blockingReason", out _));
         Assert.False(payload.TryGetProperty("canAcceptExecutionRequests", out _));
+        Assert.False(payload.TryGetProperty("runtimeKind", out _));
+        Assert.False(payload.GetProperty("startup").TryGetProperty("runtimeKind", out _));
+        JsonGoldenFileAssert.Matches(CliOutputGoldenFiles.GetPath("daemon", "start-startup-blocked.json"), standardOutput);
     }
 
     [Fact]
@@ -297,7 +305,8 @@ public sealed class DaemonStartCommandTests
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
         CommandResultAssert.HasSingleError(outputJson.RootElement, ExecutionErrorCodes.IpcTimeout);
-        JsonAssert.For(outputJson.RootElement.GetProperty("payload"))
+        var payload = outputJson.RootElement.GetProperty("payload");
+        JsonAssert.For(payload)
             .HasString("startStatus", "failed")
             .HasString("daemonStatus", "notRunning")
             .IsNull("session")
@@ -307,6 +316,12 @@ public sealed class DaemonStartCommandTests
                 .HasString("startupStatus", DaemonStartupStatusValues.Timeout)
                 .HasString("startupBlockingReason", DaemonStartupBlockingReasonValues.EndpointNotRegistered)
                 .HasString("retryDisposition", DaemonStartupRetryDispositionValues.Unknown));
+        Assert.False(payload.TryGetProperty("lifecycleState", out _));
+        Assert.False(payload.TryGetProperty("blockingReason", out _));
+        Assert.False(payload.TryGetProperty("canAcceptExecutionRequests", out _));
+        Assert.False(payload.TryGetProperty("runtimeKind", out _));
+        Assert.False(payload.GetProperty("startup").TryGetProperty("runtimeKind", out _));
+        JsonGoldenFileAssert.Matches(CliOutputGoldenFiles.GetPath("daemon", "start-endpoint-timeout.json"), standardOutput);
     }
 
     [Fact]
@@ -360,7 +375,7 @@ public sealed class DaemonStartCommandTests
                 EndpointTransportKind: "namedPipe",
                 EndpointAddress: "ucli-daemon-endpoint",
                 ProcessId: 1234,
-                ProcessStartedAtUtc: DateTimeOffset.UtcNow,
+                ProcessStartedAtUtc: new DateTimeOffset(2026, 03, 12, 1, 2, 0, TimeSpan.Zero),
                 OwnerProcessId: 5678),
             LifecycleState: lifecycleState,
             BlockingReason: blockingReason,

--- a/tests/Ucli.Tests/Hosting/Cli/DaemonStatusCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/DaemonStatusCommandTests.cs
@@ -155,6 +155,11 @@ public sealed class DaemonStatusCommandTests
                         .HasString("unityLogPath", "/repo/.ucli/local/fingerprints/fp/unity.log")
                         .HasString("startupPhase", DaemonDiagnosisStartupPhaseValues.EndpointRegistration)
                         .HasString("actionRequired", DaemonDiagnosisActionRequiredValues.InspectUnityLog))));
+
+        var payloadJson = outputJson.RootElement.GetProperty("payload");
+        Assert.False(payloadJson.TryGetProperty("runtimeKind", out _));
+        Assert.False(payloadJson.GetProperty("lastLaunchAttempt").TryGetProperty("runtimeKind", out _));
+        JsonGoldenFileAssert.Matches(CliOutputGoldenFiles.GetPath("daemon", "status-last-launch-attempt.json"), standardOutput);
     }
 
     private sealed class StubDaemonStatusService : IDaemonStatusService


### PR DESCRIPTION
## Summary
- Adds deterministic CLI JSON contract coverage for daemon startup failure payloads and endpoint-registered lifecycle snapshots.
- Locks classified startup blocker, endpoint timeout, compiling success, and daemon status `lastLaunchAttempt` output with golden files.
- Keeps the change test-only; no runtime behavior or public model changes are introduced.

## Scope
- Updates daemon start command tests to verify startup failure shape, lifecycle success shape, `runtimeKind` omission, and golden output.
- Updates daemon status command tests to verify `lastLaunchAttempt` output and `runtimeKind` omission.
- Adds daemon CLI golden files under `tests/Ucli.Tests/GoldenFiles/Json/CliOutput/daemon/`.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format --include tests/Ucli.Tests`)
- Tests: PASS (`dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter "FullyQualifiedName~DaemonStartCommandTests|FullyQualifiedName~DaemonStatusCommandTests|FullyQualifiedName~DaemonListCommandTests"`, `bash scripts/test-dotnet.sh`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to golden contract expectations becoming intentionally stricter for daemon CLI JSON output.
- Rollback by reverting the test commit if the contract needs to be redesigned.

## Checklist
- [x] classified startup blocker CLI JSON contract is covered
- [x] unclassified endpoint timeout CLI JSON contract is covered
- [x] `daemon status.lastLaunchAttempt` CLI JSON contract is covered
- [x] compiling lifecycle success path is covered
- [x] startup failure payload omits lifecycle fields
- [x] `runtimeKind` omission is maintained

Closes #268