### PR TITLE
startup observation を oneshot と test.run へ展開する

### DIFF
--- a/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
@@ -1,0 +1,161 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Contracts.Storage;
+
+namespace MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
+
+/// <summary> Creates command-facing startup failure details from daemon startup classification data. </summary>
+internal static class StartupFailureDetailFactory
+{
+    /// <summary> Creates a startup-blocked detail from a classified Unity startup log. </summary>
+    public static StartupFailureDetail CreateClassifiedBatchmodeFailure (
+        DaemonStartupFailureClassification classification,
+        string message,
+        string? unityLogPath,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset updatedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(classification);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        var diagnosis = new DaemonDiagnosisOutput(
+            Reason: classification.Reason,
+            Message: message,
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: processId,
+            EditorInstancePath: null,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath,
+            StartupPhase: classification.StartupPhase,
+            ActionRequired: classification.ActionRequired,
+            PrimaryDiagnostic: ToOutput(classification.PrimaryDiagnostic));
+        var startup = new DaemonStartupObservationOutput(
+            StartupStatus: DaemonStartupStatusValues.Blocked,
+            StartupBlockingReason: classification.StartupBlockingReason,
+            LaunchAttemptId: null,
+            EditorMode: DaemonEditorModeValues.Batchmode,
+            OwnerKind: DaemonSessionOwnerKindValues.Cli,
+            CanShutdownProcess: true,
+            ProcessId: processId,
+            StartedAtUtc: processStartedAtUtc,
+            ElapsedMilliseconds: null,
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessTermination: null,
+            ArtifactPath: null,
+            RetryDisposition: classification.RetryDisposition);
+
+        return new StartupFailureDetail(
+            startup,
+            diagnosis,
+            classification.RetryDisposition,
+            string.Equals(classification.RetryDisposition, DaemonStartupRetryDispositionValues.RetryImmediately, StringComparison.Ordinal));
+    }
+
+    /// <summary> Creates a detail for an endpoint that never became reachable before the command timeout. </summary>
+    public static StartupFailureDetail CreateEndpointNotRegisteredFailure (
+        string message,
+        string? unityLogPath,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset updatedAtUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        var diagnosis = new DaemonDiagnosisOutput(
+            Reason: DaemonDiagnosisReasonValues.StartupFailed,
+            Message: message,
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: processId,
+            EditorInstancePath: null,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath,
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.EndpointRegistration,
+            ActionRequired: null,
+            PrimaryDiagnostic: null);
+        var startup = new DaemonStartupObservationOutput(
+            StartupStatus: DaemonStartupStatusValues.Timeout,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.EndpointNotRegistered,
+            LaunchAttemptId: null,
+            EditorMode: DaemonEditorModeValues.Batchmode,
+            OwnerKind: DaemonSessionOwnerKindValues.Cli,
+            CanShutdownProcess: true,
+            ProcessId: processId,
+            StartedAtUtc: processStartedAtUtc,
+            ElapsedMilliseconds: null,
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessTermination: null,
+            ArtifactPath: null,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);
+
+        return new StartupFailureDetail(
+            startup,
+            diagnosis,
+            DaemonStartupRetryDispositionValues.Unknown,
+            false);
+    }
+
+    /// <summary> Creates a detail for an unclassified Unity process exit before endpoint or test-runner startup completed. </summary>
+    public static StartupFailureDetail CreateProcessExitedFailure (
+        string message,
+        string? unityLogPath,
+        int? processId,
+        DateTimeOffset? processStartedAtUtc,
+        DateTimeOffset updatedAtUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        var diagnosis = new DaemonDiagnosisOutput(
+            Reason: DaemonDiagnosisReasonValues.EditorExitedBeforeBootstrap,
+            Message: message,
+            ReportedBy: DaemonDiagnosisReportedByValues.Cli,
+            IsInferred: true,
+            UpdatedAtUtc: updatedAtUtc,
+            ProcessId: processId,
+            EditorInstancePath: null,
+            ProcessStartedAtUtc: processStartedAtUtc,
+            UnityLogPath: unityLogPath,
+            StartupPhase: DaemonDiagnosisStartupPhaseValues.ProcessExit,
+            ActionRequired: null,
+            PrimaryDiagnostic: null);
+        var startup = new DaemonStartupObservationOutput(
+            StartupStatus: DaemonStartupStatusValues.Failed,
+            StartupBlockingReason: DaemonStartupBlockingReasonValues.ProcessExit,
+            LaunchAttemptId: null,
+            EditorMode: DaemonEditorModeValues.Batchmode,
+            OwnerKind: DaemonSessionOwnerKindValues.Cli,
+            CanShutdownProcess: true,
+            ProcessId: processId,
+            StartedAtUtc: processStartedAtUtc,
+            ElapsedMilliseconds: null,
+            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessTermination: null,
+            ArtifactPath: null,
+            RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);
+
+        return new StartupFailureDetail(
+            startup,
+            diagnosis,
+            DaemonStartupRetryDispositionValues.Unknown,
+            false);
+    }
+
+    private static DaemonPrimaryDiagnosticOutput? ToOutput (DaemonPrimaryDiagnostic? diagnostic)
+    {
+        return diagnostic is null
+            ? null
+            : new DaemonPrimaryDiagnosticOutput(
+                Kind: diagnostic.Kind,
+                Code: diagnostic.Code,
+                File: diagnostic.File,
+                Line: diagnostic.Line,
+                Column: diagnostic.Column,
+                Message: diagnostic.Message);
+    }
+}

--- a/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
@@ -2,6 +2,7 @@ using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Diagnosis;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Startup;
+using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Contracts.Storage;
 
 namespace MackySoft.Ucli.Application.Features.Daemon.Common.Projection;

--- a/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
@@ -44,7 +44,7 @@ internal static class StartupFailureDetailFactory
             ProcessId: processId,
             StartedAtUtc: processStartedAtUtc,
             ElapsedMilliseconds: null,
-            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessAction: DaemonStartupProcessActionValues.Unknown,
             ProcessTermination: null,
             ArtifactPath: null,
             RetryDisposition: classification.RetryDisposition);
@@ -89,7 +89,7 @@ internal static class StartupFailureDetailFactory
             ProcessId: processId,
             StartedAtUtc: processStartedAtUtc,
             ElapsedMilliseconds: null,
-            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessAction: DaemonStartupProcessActionValues.Unknown,
             ProcessTermination: null,
             ArtifactPath: null,
             RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);
@@ -134,7 +134,7 @@ internal static class StartupFailureDetailFactory
             ProcessId: processId,
             StartedAtUtc: processStartedAtUtc,
             ElapsedMilliseconds: null,
-            ProcessAction: DaemonStartupProcessActionValues.Terminated,
+            ProcessAction: DaemonStartupProcessActionValues.Unknown,
             ProcessTermination: null,
             ArtifactPath: null,
             RetryDisposition: DaemonStartupRetryDispositionValues.Unknown);

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessService.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsCatalogAccessService.cs
@@ -199,7 +199,8 @@ internal sealed class OpsCatalogAccessService : IOpsCatalogAccessService
         {
             return OpsListReadResult.Failure(
                 refreshResult.Message,
-                refreshResult.ErrorCode!.Value);
+                refreshResult.ErrorCode!.Value,
+                refreshResult.StartupFailure);
         }
 
         return OpsListReadResult.Success(
@@ -234,7 +235,8 @@ internal sealed class OpsCatalogAccessService : IOpsCatalogAccessService
         {
             return OpsDescribeReadResult.Failure(
                 refreshResult.Message,
-                refreshResult.ErrorCode!.Value);
+                refreshResult.ErrorCode!.Value,
+                refreshResult.StartupFailure);
         }
 
         var operation = refreshResult.Snapshot!.Operations.FirstOrDefault(

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsDescribeReadResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsDescribeReadResult.cs
@@ -4,7 +4,8 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 internal sealed record OpsDescribeReadResult (
     OpsDescribeReadOutput? Output,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether the describe read succeeded. </summary>
     public bool IsSuccess => Output is not null && ErrorCode is null;
@@ -21,8 +22,9 @@ internal sealed record OpsDescribeReadResult (
     /// <summary> Creates a failed describe-read result. </summary>
     public static OpsDescribeReadResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
-        return new OpsDescribeReadResult(null, message, errorCode);
+        return new OpsDescribeReadResult(null, message, errorCode, startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsDescribeReadResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsDescribeReadResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 
 /// <summary> Represents one normalized internal <c>ops describe</c> read result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsListReadResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsListReadResult.cs
@@ -4,7 +4,8 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 internal sealed record OpsListReadResult (
     OpsListReadOutput? Output,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether the list read succeeded. </summary>
     public bool IsSuccess => Output is not null && ErrorCode is null;
@@ -21,8 +22,9 @@ internal sealed record OpsListReadResult (
     /// <summary> Creates a failed list-read result. </summary>
     public static OpsListReadResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
-        return new OpsListReadResult(null, message, errorCode);
+        return new OpsListReadResult(null, message, errorCode, startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsListReadResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Access/OpsListReadResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Access;
 
 /// <summary> Represents one normalized internal <c>ops list</c> read result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
@@ -4,10 +4,12 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 /// <param name="Snapshot"> The validated catalog snapshot on success; otherwise <see langword="null" />. </param>
 /// <param name="Message"> The user-facing result message. </param>
 /// <param name="ErrorCode"> The machine-readable error code on failure; otherwise <see langword="null" />. </param>
+/// <param name="StartupFailure"> The structured startup failure detail when source fetch failed before Unity accepted the request. </param>
 internal sealed record OpsCatalogFetchResult (
     OpsCatalogSnapshot? Snapshot,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether fetch succeeded. </summary>
     public bool IsSuccess => Snapshot is not null && ErrorCode is null;
@@ -30,11 +32,13 @@ internal sealed record OpsCatalogFetchResult (
     /// <returns> The failed result. </returns>
     public static OpsCatalogFetchResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
         return new OpsCatalogFetchResult(
             Snapshot: null,
             Message: message,
-            ErrorCode: errorCode);
+            ErrorCode: errorCode,
+            StartupFailure: startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogFetchResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 
 /// <summary> Represents one operation-catalog fetch result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
@@ -5,7 +5,8 @@ internal sealed record OpsCatalogSourceRefreshResult (
     OpsCatalogSnapshot? Snapshot,
     string? FallbackReason,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether the source refresh succeeded. </summary>
     public bool IsSuccess => Snapshot is not null && ErrorCode is null;
@@ -24,7 +25,8 @@ internal sealed record OpsCatalogSourceRefreshResult (
     /// <summary> Creates a failed source refresh result. </summary>
     public static OpsCatalogSourceRefreshResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
         if (!errorCode.IsValid)
@@ -32,6 +34,6 @@ internal sealed record OpsCatalogSourceRefreshResult (
             throw new ArgumentException("Error code must not be empty.", nameof(errorCode));
         }
 
-        return new OpsCatalogSourceRefreshResult(null, null, message, errorCode);
+        return new OpsCatalogSourceRefreshResult(null, null, message, errorCode, startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Catalog.Source;
 
 /// <summary> Represents one ops-catalog source refresh result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsDescribeServiceResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsDescribeServiceResult.cs
@@ -4,10 +4,12 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Common.Contracts;
 /// <param name="Output"> The successful output; otherwise <see langword="null" />. </param>
 /// <param name="Message"> The user-facing result message. </param>
 /// <param name="ErrorCode"> The machine-readable error code on failure; otherwise <see langword="null" />. </param>
+/// <param name="StartupFailure"> The structured startup failure detail when source fallback failed before Unity accepted the request. </param>
 internal sealed record OpsDescribeServiceResult (
     OpsDescribeExecutionOutput? Output,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether the service execution succeeded. </summary>
     public bool IsSuccess => Output is not null && ErrorCode is null;
@@ -30,8 +32,9 @@ internal sealed record OpsDescribeServiceResult (
     /// <returns> The failed result. </returns>
     public static OpsDescribeServiceResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
-        return new OpsDescribeServiceResult(null, message, errorCode);
+        return new OpsDescribeServiceResult(null, message, errorCode, startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsDescribeServiceResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsDescribeServiceResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Common.Contracts;
 
 /// <summary> Represents one normalized <c>ops describe</c> service result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsListServiceResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsListServiceResult.cs
@@ -4,10 +4,12 @@ namespace MackySoft.Ucli.Application.Features.OperationCatalog.Common.Contracts;
 /// <param name="Output"> The successful output; otherwise <see langword="null" />. </param>
 /// <param name="Message"> The user-facing result message. </param>
 /// <param name="ErrorCode"> The machine-readable error code on failure; otherwise <see langword="null" />. </param>
+/// <param name="StartupFailure"> The structured startup failure detail when source fallback failed before Unity accepted the request. </param>
 internal sealed record OpsListServiceResult (
     OpsListExecutionOutput? Output,
     string Message,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether the service execution succeeded. </summary>
     public bool IsSuccess => Output is not null && ErrorCode is null;
@@ -30,8 +32,9 @@ internal sealed record OpsListServiceResult (
     /// <returns> The failed result. </returns>
     public static OpsListServiceResult Failure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure = null)
     {
-        return new OpsListServiceResult(null, message, errorCode);
+        return new OpsListServiceResult(null, message, errorCode, startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsListServiceResult.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/Common/Contracts/OpsListServiceResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.OperationCatalog.Common.Contracts;
 
 /// <summary> Represents one normalized <c>ops list</c> service result. </summary>

--- a/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/OpsService.cs
+++ b/src/Ucli.Application/Features/OperationCatalog/UseCases/Ops/OpsService.cs
@@ -68,7 +68,8 @@ internal sealed class OpsService : IOpsService
         {
             return OpsListServiceResult.Failure(
                 catalogResult.Message,
-                catalogResult.ErrorCode!.Value);
+                catalogResult.ErrorCode!.Value,
+                catalogResult.StartupFailure);
         }
 
         var filterResult = filter!.Apply(catalogResult.Output!.Snapshot.Operations);
@@ -110,7 +111,8 @@ internal sealed class OpsService : IOpsService
         {
             return OpsDescribeServiceResult.Failure(
                 catalogResult.Message,
-                catalogResult.ErrorCode!.Value);
+                catalogResult.ErrorCode!.Value,
+                catalogResult.StartupFailure);
         }
 
         return describeResultMapper.Map(catalogResult.Output!);

--- a/src/Ucli.Application/Features/Requests/Shared/Execution/Results/RequestFailureNormalizer.cs
+++ b/src/Ucli.Application/Features/Requests/Shared/Execution/Results/RequestFailureNormalizer.cs
@@ -1,5 +1,4 @@
 using MackySoft.Ucli.Application.Features.Requests.Shared.OperationMetadata;
-using MackySoft.Ucli.Application.Shared.Execution;
 
 namespace MackySoft.Ucli.Application.Features.Requests.Shared.Execution.Results;
 
@@ -54,15 +53,15 @@ internal static class RequestFailureNormalizer
 
         if (failure.Code == ExecutionErrorCodes.IpcTimeout)
         {
-            return ApplicationFailure.Timeout(failure.Message, failure.Code);
+            return ApplicationFailure.Timeout(failure.Message, failure.Code, startupFailure: failure.StartupFailure);
         }
 
         if (ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(failure.Code))
         {
-            return ApplicationFailure.InvalidInput(failure.Message, failure.Code);
+            return ApplicationFailure.InvalidInput(failure.Message, failure.Code, startupFailure: failure.StartupFailure);
         }
 
-        return ApplicationFailure.UnityIpcFailure(failure.Message, failure.Code);
+        return ApplicationFailure.UnityIpcFailure(failure.Message, failure.Code, startupFailure: failure.StartupFailure);
     }
 
     /// <summary> Normalizes one operation execution error from an external result boundary. </summary>

--- a/src/Ucli.Application/Features/Requests/Shared/Execution/Results/RequestFailureNormalizer.cs
+++ b/src/Ucli.Application/Features/Requests/Shared/Execution/Results/RequestFailureNormalizer.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Requests.Shared.OperationMetadata;
+using MackySoft.Ucli.Application.Shared.Execution;
 
 namespace MackySoft.Ucli.Application.Features.Requests.Shared.Execution.Results;
 

--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
@@ -163,7 +163,7 @@ internal sealed record TestRunServiceResult
         return new TestRunServiceResult(
             result: null,
             errorKind: TestRunErrorKind.InvalidInput,
-            failure: ApplicationFailure.InvalidInput(message, errorCode),
+            failure: ApplicationFailure.InvalidInput(message, errorCode, startupFailure: startupFailure),
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
@@ -192,7 +192,8 @@ internal sealed record TestRunServiceResult
             failure: ApplicationFailure.ExternalProcessFailure(
                 message,
                 errorCode,
-                outcome: ApplicationOutcome.InfrastructureError),
+                outcome: ApplicationOutcome.InfrastructureError,
+                startupFailure: startupFailure),
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
@@ -218,7 +219,7 @@ internal sealed record TestRunServiceResult
         return new TestRunServiceResult(
             result: null,
             errorKind: TestRunErrorKind.ToolError,
-            failure: CreateToolFailure(message, errorCode),
+            failure: CreateToolFailure(message, errorCode, startupFailure),
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
@@ -228,11 +229,12 @@ internal sealed record TestRunServiceResult
 
     private static ApplicationFailure CreateToolFailure (
         string message,
-        UcliErrorCode errorCode)
+        UcliErrorCode errorCode,
+        StartupFailureDetail? startupFailure)
     {
         if (errorCode == ExecutionErrorCodes.IpcTimeout || errorCode == TestRunErrorCodes.UnityTestExecutionTimeout)
         {
-            return ApplicationFailure.Timeout(message, errorCode);
+            return ApplicationFailure.Timeout(message, errorCode, startupFailure: startupFailure);
         }
 
         if (errorCode == ExecutionErrorCodes.Canceled)
@@ -240,6 +242,6 @@ internal sealed record TestRunServiceResult
             return ApplicationFailure.Canceled(message, errorCode);
         }
 
-        return ApplicationFailure.ExternalProcessFailure(message, errorCode);
+        return ApplicationFailure.ExternalProcessFailure(message, errorCode, startupFailure: startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Represents normalized output returned from test-run core service. </summary>

--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunServiceResult.cs
@@ -1,5 +1,3 @@
-using MackySoft.Ucli.Application.Shared.Execution;
-
 namespace MackySoft.Ucli.Application.Features.Testing.Run.Common.Contracts;
 
 /// <summary> Represents normalized output returned from test-run core service. </summary>
@@ -12,7 +10,8 @@ internal sealed record TestRunServiceResult
         string message,
         string? runId,
         string? artifactsDir,
-        string? summaryJsonPath)
+        string? summaryJsonPath,
+        StartupFailureDetail? startupFailure = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
 
@@ -45,6 +44,7 @@ internal sealed record TestRunServiceResult
         RunId = runId;
         ArtifactsDir = artifactsDir;
         SummaryJsonPath = summaryJsonPath;
+        StartupFailure = startupFailure;
     }
 
     /// <summary> Gets the pass/fail result when execution reaches test result evaluation. </summary>
@@ -75,6 +75,9 @@ internal sealed record TestRunServiceResult
 
     /// <summary> Gets the summary JSON path when available. </summary>
     public string? SummaryJsonPath { get; }
+
+    /// <summary> Gets the structured startup failure detail when Unity did not reach test execution. </summary>
+    public StartupFailureDetail? StartupFailure { get; }
 
     /// <summary> Gets the machine-readable error code when execution fails. </summary>
     public UcliErrorCode? ErrorCode => Failure?.Code;
@@ -154,7 +157,8 @@ internal sealed record TestRunServiceResult
         UcliErrorCode errorCode,
         string? runId = null,
         string? artifactsDir = null,
-        string? summaryJsonPath = null)
+        string? summaryJsonPath = null,
+        StartupFailureDetail? startupFailure = null)
     {
         return new TestRunServiceResult(
             result: null,
@@ -163,7 +167,8 @@ internal sealed record TestRunServiceResult
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
-            summaryJsonPath: summaryJsonPath);
+            summaryJsonPath: summaryJsonPath,
+            startupFailure);
     }
 
     /// <summary> Creates an infrastructure error result. </summary>
@@ -178,7 +183,8 @@ internal sealed record TestRunServiceResult
         UcliErrorCode errorCode,
         string? runId = null,
         string? artifactsDir = null,
-        string? summaryJsonPath = null)
+        string? summaryJsonPath = null,
+        StartupFailureDetail? startupFailure = null)
     {
         return new TestRunServiceResult(
             result: null,
@@ -190,7 +196,8 @@ internal sealed record TestRunServiceResult
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
-            summaryJsonPath: summaryJsonPath);
+            summaryJsonPath: summaryJsonPath,
+            startupFailure);
     }
 
     /// <summary> Creates a tool-error result. </summary>
@@ -205,7 +212,8 @@ internal sealed record TestRunServiceResult
         UcliErrorCode errorCode,
         string? runId = null,
         string? artifactsDir = null,
-        string? summaryJsonPath = null)
+        string? summaryJsonPath = null,
+        StartupFailureDetail? startupFailure = null)
     {
         return new TestRunServiceResult(
             result: null,
@@ -214,7 +222,8 @@ internal sealed record TestRunServiceResult
             message: message,
             runId: runId,
             artifactsDir: artifactsDir,
-            summaryJsonPath: summaryJsonPath);
+            summaryJsonPath: summaryJsonPath,
+            startupFailure);
     }
 
     private static ApplicationFailure CreateToolFailure (

--- a/src/Ucli.Application/Features/Testing/Run/Execution/UnityTestExecutionResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Execution/UnityTestExecutionResult.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
 namespace MackySoft.Ucli.Application.Features.Testing.Run.Execution;
 
 /// <summary> Represents one Unity test-execution result. </summary>

--- a/src/Ucli.Application/Features/Testing/Run/Execution/UnityTestExecutionResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Execution/UnityTestExecutionResult.cs
@@ -5,11 +5,13 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.Execution;
 /// <param name="FailureKind"> The execution failure kind on failure; otherwise <see langword="null" />. </param>
 /// <param name="ErrorMessage"> The user-facing execution error message on failure; otherwise <see langword="null" />. </param>
 /// <param name="ErrorCode"> The machine-readable execution error code on failure; otherwise <see langword="null" />. </param>
+/// <param name="StartupFailure"> The structured startup failure detail when Unity did not reach test execution. </param>
 internal sealed record UnityTestExecutionResult (
     int? ProcessExitCode,
     UnityTestExecutionFailureKind? FailureKind,
     string? ErrorMessage,
-    UcliErrorCode? ErrorCode)
+    UcliErrorCode? ErrorCode,
+    StartupFailureDetail? StartupFailure = null)
 {
     /// <summary> Gets a value indicating whether execution succeeded. </summary>
     public bool IsSuccess => ProcessExitCode.HasValue && FailureKind is null;
@@ -30,7 +32,8 @@ internal sealed record UnityTestExecutionResult (
     public static UnityTestExecutionResult Failure (
         UnityTestExecutionFailureKind failureKind,
         string errorMessage,
-        UcliErrorCode? errorCode = null)
+        UcliErrorCode? errorCode = null,
+        StartupFailureDetail? startupFailure = null)
     {
         return new UnityTestExecutionResult(
             null,
@@ -38,6 +41,7 @@ internal sealed record UnityTestExecutionResult (
             errorMessage,
             errorCode.HasValue && errorCode.Value.IsValid
                 ? errorCode.Value
-                : (UcliErrorCode?)null);
+                : (UcliErrorCode?)null,
+            startupFailure);
     }
 }

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
@@ -83,7 +83,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
                     setupErrorCode,
                     runId: session.RunId,
                     artifactsDir: session.Paths.ArtifactsDir,
-                    summaryJsonPath: session.Paths.SummaryJsonPath);
+                    summaryJsonPath: session.Paths.SummaryJsonPath,
+                    startupFailure: unityExecutionResult.StartupFailure);
             }
 
             UcliErrorCode errorCode = unityExecutionResult.FailureKind switch
@@ -100,7 +101,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
                 errorCode,
                 runId: session.RunId,
                 artifactsDir: session.Paths.ArtifactsDir,
-                summaryJsonPath: session.Paths.SummaryJsonPath);
+                summaryJsonPath: session.Paths.SummaryJsonPath,
+                startupFailure: unityExecutionResult.StartupFailure);
         }
 
         if (!conversionResult.IsSuccess)

--- a/src/Ucli.Application/GlobalUsings.cs
+++ b/src/Ucli.Application/GlobalUsings.cs
@@ -7,7 +7,6 @@ global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Shutdo
 global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Timing;
 global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
 global using MackySoft.Ucli.Application.Shared.Context.Project;
-global using MackySoft.Ucli.Application.Shared.Execution;
 global using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 global using MackySoft.Ucli.Application.Shared.Execution.ReadIndex;
 global using MackySoft.Ucli.Application.Shared.Execution.ReadIndex.Assets;

--- a/src/Ucli.Application/GlobalUsings.cs
+++ b/src/Ucli.Application/GlobalUsings.cs
@@ -7,6 +7,7 @@ global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Shutdo
 global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Timing;
 global using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Start.Startup;
 global using MackySoft.Ucli.Application.Shared.Context.Project;
+global using MackySoft.Ucli.Application.Shared.Execution;
 global using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 global using MackySoft.Ucli.Application.Shared.Execution.ReadIndex;
 global using MackySoft.Ucli.Application.Shared.Execution.ReadIndex.Assets;

--- a/src/Ucli.Application/Shared/Execution/ApplicationFailure.cs
+++ b/src/Ucli.Application/Shared/Execution/ApplicationFailure.cs
@@ -11,12 +11,14 @@ internal sealed record ApplicationFailure
     /// <param name="code"> The machine-readable failure code. </param>
     /// <param name="message"> The user-facing failure message. </param>
     /// <param name="opId"> The operation identifier associated with the failure, or <see langword="null" /> when not applicable. </param>
+    /// <param name="startupFailure"> The structured startup failure detail when this failure occurred before a Unity process accepted the request. </param>
     public ApplicationFailure (
         ApplicationFailureKind kind,
         ApplicationOutcome outcome,
         UcliErrorCode code,
         string message,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
         if (!IsDefinedKind(kind))
         {
@@ -36,6 +38,7 @@ internal sealed record ApplicationFailure
         Code = code;
         Message = message;
         OpId = opId;
+        StartupFailure = startupFailure;
     }
 
     /// <summary> Gets the application failure classification. </summary>
@@ -53,13 +56,17 @@ internal sealed record ApplicationFailure
     /// <summary> Gets the operation identifier associated with the failure, or <see langword="null" /> when not applicable. </summary>
     public string? OpId { get; }
 
+    /// <summary> Gets the structured startup failure detail when this failure occurred before a Unity process accepted the request. </summary>
+    public StartupFailureDetail? StartupFailure { get; }
+
     /// <summary> Creates a classified failure using the default outcome and fallback error code for the specified kind. </summary>
     public static ApplicationFailure Create (
         ApplicationFailureKind kind,
         string message,
         UcliErrorCode? code = null,
         string? opId = null,
-        ApplicationOutcome? outcome = null)
+        ApplicationOutcome? outcome = null,
+        StartupFailureDetail? startupFailure = null)
     {
         var resolvedCode = ResolveCode(kind, code);
         return new ApplicationFailure(
@@ -67,16 +74,18 @@ internal sealed record ApplicationFailure
             outcome ?? ResolveOutcome(kind),
             resolvedCode,
             message,
-            opId);
+            opId,
+            startupFailure);
     }
 
     /// <summary> Creates an invalid-input failure. </summary>
     public static ApplicationFailure InvalidInput (
         string message,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.InvalidInput, message, code, opId);
+        return Create(ApplicationFailureKind.InvalidInput, message, code, opId, startupFailure: startupFailure);
     }
 
     /// <summary> Creates a configuration failure. </summary>
@@ -101,9 +110,10 @@ internal sealed record ApplicationFailure
     public static ApplicationFailure UnityIpcFailure (
         string message,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.UnityIpcFailure, message, code, opId);
+        return Create(ApplicationFailureKind.UnityIpcFailure, message, code, opId, startupFailure: startupFailure);
     }
 
     /// <summary> Creates an external-process failure. </summary>
@@ -111,27 +121,30 @@ internal sealed record ApplicationFailure
         string message,
         UcliErrorCode? code = null,
         string? opId = null,
-        ApplicationOutcome? outcome = null)
+        ApplicationOutcome? outcome = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.ExternalProcessFailure, message, code, opId, outcome);
+        return Create(ApplicationFailureKind.ExternalProcessFailure, message, code, opId, outcome, startupFailure);
     }
 
     /// <summary> Creates a contract-violation failure. </summary>
     public static ApplicationFailure ContractViolation (
         string message,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.ContractViolation, message, code, opId);
+        return Create(ApplicationFailureKind.ContractViolation, message, code, opId, startupFailure: startupFailure);
     }
 
     /// <summary> Creates a timeout failure. </summary>
     public static ApplicationFailure Timeout (
         string message,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.Timeout, message, code, opId);
+        return Create(ApplicationFailureKind.Timeout, message, code, opId, startupFailure: startupFailure);
     }
 
     /// <summary> Creates a canceled failure. </summary>
@@ -147,16 +160,18 @@ internal sealed record ApplicationFailure
     public static ApplicationFailure InternalError (
         string message,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
-        return Create(ApplicationFailureKind.InternalError, message, code, opId);
+        return Create(ApplicationFailureKind.InternalError, message, code, opId, startupFailure: startupFailure);
     }
 
     /// <summary> Creates a failure from a structured execution error. </summary>
     public static ApplicationFailure FromExecutionError (
         ExecutionError error,
         UcliErrorCode? code = null,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
         ArgumentNullException.ThrowIfNull(error);
         var resolvedCode = code.HasValue && code.Value.IsValid
@@ -165,11 +180,11 @@ internal sealed record ApplicationFailure
 
         return error.Kind switch
         {
-            ExecutionErrorKind.InvalidArgument => InvalidInput(error.Message, resolvedCode, opId),
-            ExecutionErrorKind.Timeout when ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(resolvedCode) => InvalidInput(error.Message, resolvedCode, opId),
-            ExecutionErrorKind.Timeout => Timeout(error.Message, resolvedCode, opId),
-            ExecutionErrorKind.InternalError when ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(resolvedCode) => InvalidInput(error.Message, resolvedCode, opId),
-            ExecutionErrorKind.InternalError => InternalError(error.Message, resolvedCode, opId),
+            ExecutionErrorKind.InvalidArgument => InvalidInput(error.Message, resolvedCode, opId, startupFailure),
+            ExecutionErrorKind.Timeout when ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(resolvedCode) => InvalidInput(error.Message, resolvedCode, opId, startupFailure),
+            ExecutionErrorKind.Timeout => Timeout(error.Message, resolvedCode, opId, startupFailure),
+            ExecutionErrorKind.InternalError when ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(resolvedCode) => InvalidInput(error.Message, resolvedCode, opId, startupFailure),
+            ExecutionErrorKind.InternalError => InternalError(error.Message, resolvedCode, opId, startupFailure),
             _ => throw new ArgumentOutOfRangeException(nameof(error), error.Kind, "Execution error kind is not defined."),
         };
     }
@@ -178,7 +193,8 @@ internal sealed record ApplicationFailure
     public static ApplicationFailure FromCode (
         UcliErrorCode? code,
         string message,
-        string? opId = null)
+        string? opId = null,
+        StartupFailureDetail? startupFailure = null)
     {
         var resolvedCode = code.HasValue && code.Value.IsValid
             ? code.Value
@@ -186,7 +202,7 @@ internal sealed record ApplicationFailure
 
         if (resolvedCode == ExecutionErrorCodes.IpcTimeout)
         {
-            return Timeout(message, resolvedCode, opId);
+            return Timeout(message, resolvedCode, opId, startupFailure);
         }
 
         if (resolvedCode == ExecutionErrorCodes.Canceled)
@@ -196,15 +212,15 @@ internal sealed record ApplicationFailure
 
         if (ApplicationFailureOutcomeResolver.IsInvalidArgumentCode(resolvedCode))
         {
-            return InvalidInput(message, resolvedCode, opId);
+            return InvalidInput(message, resolvedCode, opId, startupFailure);
         }
 
         if (resolvedCode == UcliCoreErrorCodes.InternalError)
         {
-            return InternalError(message, resolvedCode, opId);
+            return InternalError(message, resolvedCode, opId, startupFailure);
         }
 
-        return ContractViolation(message, resolvedCode, opId);
+        return ContractViolation(message, resolvedCode, opId, startupFailure);
     }
 
     private static UcliErrorCode ResolveCode (

--- a/src/Ucli.Application/Shared/Execution/StartupFailureDetail.cs
+++ b/src/Ucli.Application/Shared/Execution/StartupFailureDetail.cs
@@ -1,0 +1,14 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+
+namespace MackySoft.Ucli.Application.Shared.Execution;
+
+/// <summary> Represents structured startup failure details projected by commands that start a Unity process. </summary>
+/// <param name="Startup"> The startup observation associated with the failed process startup. </param>
+/// <param name="Diagnosis"> The structured diagnosis associated with the failed process startup when available. </param>
+/// <param name="RetryDisposition"> The normalized retry disposition. </param>
+/// <param name="SafeToRetryImmediately"> Whether the failed command can be retried immediately without external changes. </param>
+internal sealed record StartupFailureDetail (
+    DaemonStartupObservationOutput? Startup,
+    DaemonDiagnosisOutput? Diagnosis,
+    string RetryDisposition,
+    bool SafeToRetryImmediately);

--- a/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestFailure.cs
+++ b/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestFailure.cs
@@ -6,9 +6,11 @@ internal sealed record UnityRequestFailure
     /// <summary> Initializes a new instance of the <see cref="UnityRequestFailure" /> class. </summary>
     /// <param name="code"> The machine-readable failure code. </param>
     /// <param name="message"> The user-facing failure message. </param>
+    /// <param name="startupFailure"> The structured startup failure detail when Unity did not accept the request. </param>
     public UnityRequestFailure (
         UcliErrorCode code,
-        string message)
+        string message,
+        StartupFailureDetail? startupFailure = null)
     {
         if (!code.IsValid)
         {
@@ -19,6 +21,7 @@ internal sealed record UnityRequestFailure
 
         Code = code;
         Message = message;
+        StartupFailure = startupFailure;
     }
 
     /// <summary> Gets the machine-readable failure code. </summary>
@@ -26,4 +29,7 @@ internal sealed record UnityRequestFailure
 
     /// <summary> Gets the user-facing failure message. </summary>
     public string Message { get; }
+
+    /// <summary> Gets the structured startup failure detail when Unity did not accept the request. </summary>
+    public StartupFailureDetail? StartupFailure { get; }
 }

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
@@ -2,6 +2,18 @@ namespace MackySoft.Ucli.Contracts;
 
 internal static class DaemonErrorCodeDescriptors
 {
+    private static IReadOnlyList<UcliCommand> StartupObservationCommands { get; } =
+    [
+        UcliCommandIds.DaemonStart,
+        UcliCommandIds.Plan,
+        UcliCommandIds.Call,
+        UcliCommandIds.Resolve,
+        UcliCommandIds.Query,
+        UcliCommandIds.Refresh,
+        UcliCommandIds.Ops,
+        UcliCommandIds.TestRun,
+    ];
+
     public static IReadOnlyList<UcliErrorCodeDescriptor> All { get; } =
     [
         UcliErrorCodeDescriptorFactory.Create(
@@ -37,7 +49,7 @@ internal static class DaemonErrorCodeDescriptors
             category: "daemon",
             summary: "Unity daemon startup was blocked by a known Unity startup condition.",
             meaning: "The daemon start operation could not complete because Unity reported, or the launcher observed, a terminal startup blocker before the daemon endpoint became available.",
-            appliesTo: [UcliCommandIds.DaemonStart],
+            appliesTo: StartupObservationCommands,
             possiblePhases: ["daemonStartup", "guiBootstrap", "scriptCompilation", "packageResolution", "userAction"],
             impliesNotApplied: true,
             mayBeIndeterminate: false,
@@ -65,7 +77,7 @@ internal static class DaemonErrorCodeDescriptors
             category: "daemon",
             summary: "Unity exited before daemon startup completed.",
             meaning: "The Unity process ended before the daemon endpoint and session registration were established.",
-            appliesTo: [UcliCommandIds.DaemonStart],
+            appliesTo: StartupObservationCommands,
             possiblePhases: ["daemonStartup", "processLaunch", "endpointRegistration"],
             impliesNotApplied: true,
             mayBeIndeterminate: false,
@@ -84,7 +96,7 @@ internal static class DaemonErrorCodeDescriptors
             category: "daemon",
             summary: "Daemon endpoint was not registered before the startup timeout.",
             meaning: "uCLI observed a Unity process but did not receive a daemon endpoint registration before the start budget expired.",
-            appliesTo: [UcliCommandIds.DaemonStart],
+            appliesTo: StartupObservationCommands,
             possiblePhases: ["endpointRegistration", "daemonStartup"],
             impliesNotApplied: true,
             mayBeIndeterminate: false,

--- a/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
+++ b/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogReader.cs
@@ -51,7 +51,8 @@ internal sealed class OpsCatalogReader : IOpsCatalogReader
         {
             return OpsCatalogFetchResult.Failure(
                 executionResult.Message,
-                executionResult.ErrorCode!.Value);
+                executionResult.ErrorCode!.Value,
+                executionResult.FailureInfo!.StartupFailure);
         }
 
         return CreateResultFromResponse(executionResult.Response!, "ops.read");

--- a/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshService.cs
+++ b/src/Ucli/Features/OperationCatalog/Catalog/Source/OpsCatalogSourceRefreshService.cs
@@ -82,7 +82,8 @@ internal sealed class OpsCatalogSourceRefreshService : IOpsCatalogSourceRefreshS
 
                 return OpsCatalogSourceRefreshResult.Failure(
                     attemptResult.FetchResult.Message,
-                    attemptResult.FetchResult.ErrorCode!.Value);
+                    attemptResult.FetchResult.ErrorCode!.Value,
+                    attemptResult.FetchResult.StartupFailure);
             }
 
             snapshot = attemptResult.FetchResult.Snapshot!;

--- a/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
+++ b/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
@@ -15,6 +15,8 @@ namespace MackySoft.Ucli.Features.Testing.Run.Execution;
 /// <summary> Implements Unity test execution through external process invocation and artifact verification. </summary>
 internal sealed class UnityTestExecutor : IUnityTestExecutor
 {
+    private const int MaxStartupLogTailBytes = 65536;
+
     private static readonly TimeSpan ProjectExecutionLockAcquireTimeout = TimeSpan.FromMilliseconds(100);
 
     private readonly IUnityCommandBuilder unityCommandBuilder;
@@ -279,7 +281,7 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
         string logText;
         try
         {
-            logText = await File.ReadAllTextAsync(editorLogPath, cancellationToken).ConfigureAwait(false);
+            logText = await ReadStartupLogTailAsync(editorLogPath, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -311,6 +313,26 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
             processId: null,
             processStartedAtUtc: null,
             DateTimeOffset.UtcNow);
+    }
+
+    private static async ValueTask<string> ReadStartupLogTailAsync (
+        string editorLogPath,
+        CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            editorLogPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete,
+            bufferSize: 4096,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        if (stream.Length > MaxStartupLogTailBytes)
+        {
+            stream.Seek(-MaxStartupLogTailBytes, SeekOrigin.End);
+        }
+
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private static UnityTestExecutionFailureKind ResolveProjectLockFailureKind (UnityProjectLockPreflightResult preflightResult)

--- a/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
+++ b/src/Ucli/Features/Testing/Run/Execution/UnityTestExecutor.cs
@@ -1,7 +1,10 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 using MackySoft.Ucli.Application.Features.Testing.Run.Artifacts;
 using MackySoft.Ucli.Application.Features.Testing.Run.Configuration;
 using MackySoft.Ucli.Application.Features.Testing.Run.Execution;
 using MackySoft.Ucli.Application.Shared.Context.Project;
+using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 using MackySoft.Ucli.Application.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Shared.Unity.Process;
@@ -168,9 +171,16 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
                             processRunResult.ErrorMessage ?? $"Unity process exited with code {processRunResult.ExitCode.Value}.",
                             configuration.UnityProject)
                         .ConfigureAwait(false);
+                    var startupFailure = await TryCreateStartupFailureFromEditorLogAsync(
+                            artifactPaths.EditorLogPath,
+                            abnormalExitMessage,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                     return UnityTestExecutionResult.Failure(
                         UnityTestExecutionFailureKind.AbnormalExit,
-                        abnormalExitMessage);
+                        abnormalExitMessage,
+                        startupFailure is null ? null : DaemonErrorCodes.DaemonStartupBlocked,
+                        startupFailure);
                 }
 
                 break;
@@ -187,9 +197,16 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
                     artifactValidationError!,
                     configuration.UnityProject)
                 .ConfigureAwait(false);
+            var startupFailure = await TryCreateStartupFailureFromEditorLogAsync(
+                    artifactPaths.EditorLogPath,
+                    artifactFailureMessage,
+                    cancellationToken)
+                .ConfigureAwait(false);
             return UnityTestExecutionResult.Failure(
                 UnityTestExecutionFailureKind.ArtifactMissing,
-                artifactFailureMessage);
+                artifactFailureMessage,
+                startupFailure is null ? null : DaemonErrorCodes.DaemonStartupBlocked,
+                startupFailure);
         }
 
         return UnityTestExecutionResult.Success(processRunResult.ExitCode!.Value);
@@ -247,6 +264,53 @@ internal sealed class UnityTestExecutor : IUnityTestExecutor
                 CancellationToken.None)
             .ConfigureAwait(false);
         return UnityProjectLockPreflightErrorFactory.AppendPostExitDiagnostic(message, preflightResult);
+    }
+
+    private static async ValueTask<StartupFailureDetail?> TryCreateStartupFailureFromEditorLogAsync (
+        string editorLogPath,
+        string fallbackMessage,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(editorLogPath) || !File.Exists(editorLogPath))
+        {
+            return null;
+        }
+
+        string logText;
+        try
+        {
+            logText = await File.ReadAllTextAsync(editorLogPath, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(logText))
+        {
+            return null;
+        }
+
+        var latestStartupLogText = DaemonStartupFailureLogClassifier.GetLatestStartupLogText(logText);
+        if (!DaemonStartupFailureLogClassifier.TryClassifyFailure(
+                latestStartupLogText,
+                DaemonStartupFailureClassificationContext.Batchmode,
+                out var classification))
+        {
+            return null;
+        }
+
+        return StartupFailureDetailFactory.CreateClassifiedBatchmodeFailure(
+            classification!,
+            classification!.Message ?? fallbackMessage,
+            editorLogPath,
+            processId: null,
+            processStartedAtUtc: null,
+            DateTimeOffset.UtcNow);
     }
 
     private static UnityTestExecutionFailureKind ResolveProjectLockFailureKind (UnityProjectLockPreflightResult preflightResult)

--- a/src/Ucli/Hosting/Cli/Common/Execution/StartupFailurePayloadProjector.cs
+++ b/src/Ucli/Hosting/Cli/Common/Execution/StartupFailurePayloadProjector.cs
@@ -1,0 +1,55 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+
+namespace MackySoft.Ucli.Hosting.Cli.Common.Execution;
+
+/// <summary> Projects optional Unity startup failure details into command payload dictionaries. </summary>
+internal static class StartupFailurePayloadProjector
+{
+    /// <summary> Appends the first startup failure detail from the supplied failures when one exists. </summary>
+    public static void AppendFromFailures (
+        IDictionary<string, object?> payload,
+        IReadOnlyList<ApplicationFailure> failures)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(failures);
+
+        for (var i = 0; i < failures.Count; i++)
+        {
+            var startupFailure = failures[i]?.StartupFailure;
+            if (startupFailure is not null)
+            {
+                Append(payload, startupFailure);
+                return;
+            }
+        }
+    }
+
+    /// <summary> Appends one startup failure detail to a command payload dictionary. </summary>
+    public static void Append (
+        IDictionary<string, object?> payload,
+        StartupFailureDetail? startupFailure)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        if (startupFailure is null)
+        {
+            return;
+        }
+
+        if (startupFailure.Startup is not null)
+        {
+            payload["startup"] = startupFailure.Startup;
+        }
+
+        if (startupFailure.Diagnosis is not null)
+        {
+            payload["diagnosis"] = startupFailure.Diagnosis;
+        }
+
+        if (!string.IsNullOrWhiteSpace(startupFailure.RetryDisposition))
+        {
+            payload["retryDisposition"] = startupFailure.RetryDisposition;
+        }
+
+        payload["safeToRetryImmediately"] = startupFailure.SafeToRetryImmediately;
+    }
+}

--- a/src/Ucli/Hosting/Cli/Ops/OpsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Ops/OpsCommandResultFactory.cs
@@ -28,7 +28,11 @@ internal static class OpsCommandResultFactory
                 });
         }
 
-        return CreateFailure(UcliCommandNames.OpsList, serviceResult.Message, serviceResult.ErrorCode);
+        return CreateFailure(
+            UcliCommandNames.OpsList,
+            serviceResult.Message,
+            serviceResult.ErrorCode,
+            serviceResult.StartupFailure);
     }
 
     /// <summary> Creates one command result for <c>ops describe</c>. </summary>
@@ -50,14 +54,24 @@ internal static class OpsCommandResultFactory
                 });
         }
 
-        return CreateFailure(UcliCommandNames.OpsDescribe, serviceResult.Message, serviceResult.ErrorCode);
+        return CreateFailure(
+            UcliCommandNames.OpsDescribe,
+            serviceResult.Message,
+            serviceResult.ErrorCode,
+            serviceResult.StartupFailure);
     }
 
     private static CommandResult CreateFailure (
         string command,
         string message,
-        UcliErrorCode? errorCode)
+        UcliErrorCode? errorCode,
+        StartupFailureDetail? startupFailure)
     {
-        return CommandFailureProjector.Create(command, ApplicationFailure.FromCode(errorCode, message), new { });
+        var payload = new Dictionary<string, object?>();
+        StartupFailurePayloadProjector.Append(payload, startupFailure);
+        return CommandFailureProjector.Create(
+            command,
+            ApplicationFailure.FromCode(errorCode, message, startupFailure: startupFailure),
+            payload);
     }
 }

--- a/src/Ucli/Hosting/Cli/Requests/CallCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Requests/CallCommandResultFactory.cs
@@ -14,7 +14,12 @@ internal static class CallCommandResultFactory
     {
         ArgumentNullException.ThrowIfNull(serviceResult);
 
-        object payload = CreatePayload(serviceResult.Output);
+        var payload = CreatePayload(serviceResult.Output);
+        if (!serviceResult.IsSuccess)
+        {
+            StartupFailurePayloadProjector.AppendFromFailures(payload, serviceResult.Errors);
+        }
+
         if (serviceResult.IsSuccess)
         {
             return CommandResult.Success(
@@ -30,11 +35,11 @@ internal static class CallCommandResultFactory
             serviceResult.Errors);
     }
 
-    private static object CreatePayload (CallExecutionOutput? output)
+    private static Dictionary<string, object?> CreatePayload (CallExecutionOutput? output)
     {
         if (output == null)
         {
-            return new { };
+            return new Dictionary<string, object?>();
         }
 
         var payload = new Dictionary<string, object?>

--- a/src/Ucli/Hosting/Cli/Requests/PlanCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Requests/PlanCommandResultFactory.cs
@@ -14,7 +14,11 @@ internal static class PlanCommandResultFactory
     {
         ArgumentNullException.ThrowIfNull(serviceResult);
 
-        object payload = CreatePayload(serviceResult.Output);
+        var payload = CreatePayload(serviceResult.Output);
+        if (!serviceResult.IsSuccess)
+        {
+            StartupFailurePayloadProjector.AppendFromFailures(payload, serviceResult.Errors);
+        }
 
         if (serviceResult.IsSuccess)
         {
@@ -31,29 +35,26 @@ internal static class PlanCommandResultFactory
             serviceResult.Errors);
     }
 
-    private static object CreatePayload (PlanExecutionOutput? output)
+    private static Dictionary<string, object?> CreatePayload (PlanExecutionOutput? output)
     {
         if (output == null)
         {
-            return new { };
+            return new Dictionary<string, object?>();
         }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["requestId"] = output.RequestId,
+            ["opResults"] = output.OpResults,
+            ["readIndex"] = ReadIndexInfoPayloadProjector.Create(output.ReadIndex),
+        };
 
         if (string.IsNullOrWhiteSpace(output.PlanToken))
         {
-            return new
-            {
-                requestId = output.RequestId,
-                opResults = output.OpResults,
-                readIndex = ReadIndexInfoPayloadProjector.Create(output.ReadIndex),
-            };
+            return payload;
         }
 
-        return new
-        {
-            requestId = output.RequestId,
-            opResults = output.OpResults,
-            readIndex = ReadIndexInfoPayloadProjector.Create(output.ReadIndex),
-            planToken = output.PlanToken,
-        };
+        payload["planToken"] = output.PlanToken;
+        return payload;
     }
 }

--- a/src/Ucli/Hosting/Cli/Requests/Query/QueryCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Requests/Query/QueryCommandResultFactory.cs
@@ -13,12 +13,16 @@ internal static class QueryCommandResultFactory
     {
         ArgumentNullException.ThrowIfNull(serviceResult);
 
-        object payload = new
+        var payload = new Dictionary<string, object?>
         {
-            requestId = serviceResult.RequestId,
-            opResults = serviceResult.OpResults,
-            readIndex = ReadIndexInfoPayloadProjector.Create(serviceResult.ReadIndex),
+            ["requestId"] = serviceResult.RequestId,
+            ["opResults"] = serviceResult.OpResults,
+            ["readIndex"] = ReadIndexInfoPayloadProjector.Create(serviceResult.ReadIndex),
         };
+        if (!serviceResult.IsSuccess)
+        {
+            StartupFailurePayloadProjector.AppendFromFailures(payload, serviceResult.Errors);
+        }
 
         if (serviceResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Requests/RefreshCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Requests/RefreshCommandResultFactory.cs
@@ -25,6 +25,11 @@ internal static class RefreshCommandResultFactory
             payload["readPostcondition"] = executionResult.ReadPostcondition;
         }
 
+        if (!executionResult.IsSuccess)
+        {
+            StartupFailurePayloadProjector.AppendFromFailures(payload, executionResult.Errors);
+        }
+
         if (executionResult.IsSuccess)
         {
             return CommandResult.Success(

--- a/src/Ucli/Hosting/Cli/Requests/ResolveCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Requests/ResolveCommandResultFactory.cs
@@ -13,12 +13,16 @@ internal static class ResolveCommandResultFactory
     {
         ArgumentNullException.ThrowIfNull(serviceResult);
 
-        object payload = new
+        var payload = new Dictionary<string, object?>
         {
-            requestId = serviceResult.RequestId,
-            opResults = serviceResult.OpResults,
-            readIndex = ReadIndexInfoPayloadProjector.Create(serviceResult.ReadIndex),
+            ["requestId"] = serviceResult.RequestId,
+            ["opResults"] = serviceResult.OpResults,
+            ["readIndex"] = ReadIndexInfoPayloadProjector.Create(serviceResult.ReadIndex),
         };
+        if (!serviceResult.IsSuccess)
+        {
+            StartupFailurePayloadProjector.AppendFromFailures(payload, serviceResult.Errors);
+        }
 
         if (serviceResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Testing/TestRunCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Testing/TestRunCommandResultFactory.cs
@@ -16,14 +16,18 @@ internal static class TestRunCommandResultFactory
     {
         ArgumentNullException.ThrowIfNull(serviceResult);
 
-        var payload = new
+        var payload = new Dictionary<string, object?>
         {
-            result = serviceResult.ResultValue,
-            errorKind = serviceResult.ErrorKindValue,
-            runId = serviceResult.RunId,
-            artifactsDir = serviceResult.ArtifactsDir,
-            summaryJsonPath = serviceResult.SummaryJsonPath,
+            ["result"] = serviceResult.ResultValue,
+            ["errorKind"] = serviceResult.ErrorKindValue,
+            ["runId"] = serviceResult.RunId,
+            ["artifactsDir"] = serviceResult.ArtifactsDir,
+            ["summaryJsonPath"] = serviceResult.SummaryJsonPath,
         };
+        if (serviceResult.ErrorKind is not null)
+        {
+            StartupFailurePayloadProjector.Append(payload, serviceResult.StartupFailure);
+        }
 
         if (serviceResult.ErrorKind is null)
         {

--- a/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
@@ -562,8 +562,26 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
             DateTimeOffset.UtcNow);
         return UnityIpcFailureClassifier.FromCodeAndMessage(
             DaemonErrorCodes.DaemonStartupBlocked,
-            startupFailure.Diagnosis?.Message ?? fallbackMessage,
+            CombineStartupFailureMessages(startupFailure.Diagnosis?.Message, fallbackMessage),
             startupFailure);
+    }
+
+    private static string CombineStartupFailureMessages (
+        string? primaryMessage,
+        string fallbackMessage)
+    {
+        if (string.IsNullOrWhiteSpace(primaryMessage))
+        {
+            return fallbackMessage;
+        }
+
+        if (string.IsNullOrWhiteSpace(fallbackMessage)
+            || string.Equals(primaryMessage, fallbackMessage, StringComparison.Ordinal))
+        {
+            return primaryMessage;
+        }
+
+        return $"{primaryMessage}{Environment.NewLine}{fallbackMessage}";
     }
 
     /// <summary> Appends a post-exit Unity lock-file cleanup diagnostic after uCLI has terminated a oneshot Unity process. </summary>

--- a/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Clients/UnityOneshotIpcClient.cs
@@ -1,5 +1,9 @@
 using System.Text.Json;
+using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Logs;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Process.Startup;
 using MackySoft.Ucli.Application.Shared.Context.Project;
+using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 using MackySoft.Ucli.Application.Shared.Execution.Lifecycle;
 using MackySoft.Ucli.Application.Shared.Execution.Timeout;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
@@ -40,6 +44,8 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
 
     private readonly IUnityProjectLockPreflightService unityProjectLockPreflightService;
 
+    private readonly IUnityLogReader? unityLogReader;
+
     private readonly TimeSpan cleanupTimeout;
 
     private readonly TimeSpan cleanupRetryDelay;
@@ -55,13 +61,15 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
         IIpcEndpointResolver endpointResolver,
         IUnityIpcTransportClient transportClient,
         IProjectLifecycleLockProvider lifecycleLockProvider,
-        IUnityProjectLockPreflightService unityProjectLockPreflightService)
+        IUnityProjectLockPreflightService unityProjectLockPreflightService,
+        IUnityLogReader? unityLogReader = null)
         : this(
             batchmodeProcessLauncher,
             endpointResolver,
             transportClient,
             lifecycleLockProvider,
             unityProjectLockPreflightService,
+            unityLogReader,
             DefaultCleanupTimeout,
             StartupRetryDelay)
     {
@@ -75,6 +83,27 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
         IUnityProjectLockPreflightService unityProjectLockPreflightService,
         TimeSpan cleanupTimeout,
         TimeSpan cleanupRetryDelay)
+        : this(
+            batchmodeProcessLauncher,
+            endpointResolver,
+            transportClient,
+            lifecycleLockProvider,
+            unityProjectLockPreflightService,
+            unityLogReader: null,
+            cleanupTimeout,
+            cleanupRetryDelay)
+    {
+    }
+
+    internal UnityOneshotIpcClient (
+        IUnityBatchmodeProcessLauncher batchmodeProcessLauncher,
+        IIpcEndpointResolver endpointResolver,
+        IUnityIpcTransportClient transportClient,
+        IProjectLifecycleLockProvider lifecycleLockProvider,
+        IUnityProjectLockPreflightService unityProjectLockPreflightService,
+        IUnityLogReader? unityLogReader,
+        TimeSpan cleanupTimeout,
+        TimeSpan cleanupRetryDelay)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(cleanupTimeout, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(cleanupRetryDelay, TimeSpan.Zero);
@@ -84,6 +113,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
         this.transportClient = transportClient ?? throw new ArgumentNullException(nameof(transportClient));
         this.lifecycleLockProvider = lifecycleLockProvider ?? throw new ArgumentNullException(nameof(lifecycleLockProvider));
         this.unityProjectLockPreflightService = unityProjectLockPreflightService ?? throw new ArgumentNullException(nameof(unityProjectLockPreflightService));
+        this.unityLogReader = unityLogReader;
         this.cleanupTimeout = cleanupTimeout;
         this.cleanupRetryDelay = cleanupRetryDelay;
     }
@@ -163,7 +193,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
             UnityRequestExecutionResult result;
             try
             {
-                var startupProbeError = await WaitUntilReachableAsync(
+                var startupProbeFailure = await WaitUntilReachableAsync(
                         unityProject,
                         sessionToken,
                         ResolveStartupProbeFailFast(dispatchRequest),
@@ -172,10 +202,9 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
                         timeout,
                         cancellationToken)
                     .ConfigureAwait(false);
-                if (startupProbeError != null)
+                if (startupProbeFailure != null)
                 {
-                    result = UnityRequestExecutionResult.Failure(
-                        UnityIpcFailureClassifier.FromExecutionError(startupProbeError));
+                    result = UnityRequestExecutionResult.Failure(startupProbeFailure);
                 }
                 else if (!deadline.TryGetRemainingTimeout(out var requestTimeout))
                 {
@@ -324,7 +353,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
     /// <param name="timeout"> The original request timeout used for diagnostics. Must be greater than <see cref="TimeSpan.Zero" />. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by the caller. </param>
     /// <returns> <see langword="null" /> when startup is reachable; otherwise the startup failure. </returns>
-    private async ValueTask<ExecutionError?> WaitUntilReachableAsync (
+    private async ValueTask<UnityRequestFailure?> WaitUntilReachableAsync (
         ResolvedUnityProjectContext unityProject,
         string sessionToken,
         bool failFast,
@@ -339,8 +368,13 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
 
             if (!deadline.TryGetRemainingTimeout(out var remainingTimeout))
             {
-                return ExecutionError.Timeout(
-                    $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.");
+                var message = $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.";
+                return await CreateStartupTimeoutFailureAsync(
+                        unityProject,
+                        processHandle,
+                        message,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             if (processHandle.HasExited)
@@ -350,7 +384,12 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
                     ? $"Unity oneshot process exited before startup readiness was confirmed. ExitCode={code}."
                     : "Unity oneshot process exited before startup readiness was confirmed.";
                 message = await AppendPostUnityProcessExitLockFileDiagnosticAsync(message, unityProject).ConfigureAwait(false);
-                return ExecutionError.InternalError(message);
+                return await CreateStartupProcessExitFailureAsync(
+                        unityProject,
+                        processHandle,
+                        message,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             var attemptTimeout = remainingTimeout < TimeSpan.FromSeconds(1)
@@ -372,7 +411,7 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
                         out var payload,
                         out var error))
                 {
-                    return ExecutionError.InternalError(
+                    return UnityIpcFailureClassifier.InternalError(
                         $"Unity oneshot startup probe returned an invalid response. {error!.Message}");
                 }
 
@@ -384,15 +423,21 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
 
                 if (readinessDecision.IsFailure)
                 {
-                    return ExecutionError.InternalError(
+                    return UnityIpcFailureClassifier.FromCodeAndMessage(
+                        readinessDecision.ErrorCode ?? UcliCoreErrorCodes.InternalError,
                         readinessDecision.ErrorMessage!,
-                        readinessDecision.ErrorCode);
+                        startupFailure: null);
                 }
 
                 if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
                 {
-                    return ExecutionError.Timeout(
-                        $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.");
+                    var message = $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.";
+                    return await CreateStartupTimeoutFailureAsync(
+                            unityProject,
+                            processHandle,
+                            message,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                 }
 
                 await Task.Delay(GetRetryDelay(remainingTimeout), cancellationToken).ConfigureAwait(false);
@@ -405,13 +450,120 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
             {
                 if (!deadline.TryGetRemainingTimeout(out remainingTimeout))
                 {
-                    return ExecutionError.Timeout(
-                        $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.");
+                    var message = $"Unity oneshot IPC request timed out after {timeout.TotalMilliseconds:0} milliseconds.";
+                    return await CreateStartupTimeoutFailureAsync(
+                            unityProject,
+                            processHandle,
+                            message,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                 }
 
                 await Task.Delay(GetRetryDelay(remainingTimeout), cancellationToken).ConfigureAwait(false);
             }
         }
+    }
+
+    private async ValueTask<UnityRequestFailure> CreateStartupTimeoutFailureAsync (
+        ResolvedUnityProjectContext unityProject,
+        IUnityBatchmodeProcessHandle processHandle,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var classifiedFailure = await TryCreateClassifiedStartupFailureAsync(
+                unityProject,
+                processHandle,
+                message,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (classifiedFailure is not null)
+        {
+            return classifiedFailure;
+        }
+
+        var startupFailure = StartupFailureDetailFactory.CreateEndpointNotRegisteredFailure(
+            message,
+            ResolveUnityLogPath(unityProject),
+            processHandle.ProcessId,
+            processHandle.StartTimeUtc,
+            DateTimeOffset.UtcNow);
+        return UnityIpcFailureClassifier.FromCodeAndMessage(
+            ExecutionErrorCodes.IpcTimeout,
+            message,
+            startupFailure);
+    }
+
+    private async ValueTask<UnityRequestFailure> CreateStartupProcessExitFailureAsync (
+        ResolvedUnityProjectContext unityProject,
+        IUnityBatchmodeProcessHandle processHandle,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var classifiedFailure = await TryCreateClassifiedStartupFailureAsync(
+                unityProject,
+                processHandle,
+                message,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (classifiedFailure is not null)
+        {
+            return classifiedFailure;
+        }
+
+        var startupFailure = StartupFailureDetailFactory.CreateProcessExitedFailure(
+            message,
+            ResolveUnityLogPath(unityProject),
+            processHandle.ProcessId,
+            processHandle.StartTimeUtc,
+            DateTimeOffset.UtcNow);
+        return UnityIpcFailureClassifier.FromCodeAndMessage(
+            DaemonErrorCodes.DaemonStartProcessExited,
+            message,
+            startupFailure);
+    }
+
+    private async ValueTask<UnityRequestFailure?> TryCreateClassifiedStartupFailureAsync (
+        ResolvedUnityProjectContext unityProject,
+        IUnityBatchmodeProcessHandle processHandle,
+        string fallbackMessage,
+        CancellationToken cancellationToken)
+    {
+        if (unityLogReader is null)
+        {
+            return null;
+        }
+
+        var logReadResult = await unityLogReader.ReadTailAsync(
+                unityProject.RepositoryRoot,
+                unityProject.ProjectFingerprint,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (!logReadResult.IsSuccess || string.IsNullOrWhiteSpace(logReadResult.Text))
+        {
+            return null;
+        }
+
+        var latestStartupLogText = DaemonStartupFailureLogClassifier.GetLatestStartupLogText(logReadResult.Text);
+        if (!DaemonStartupFailureLogClassifier.TryClassifyFailure(
+                latestStartupLogText,
+                DaemonStartupFailureClassificationContext.Batchmode,
+                out var classification))
+        {
+            return null;
+        }
+
+        var message = classification!.Message;
+        var startupFailure = StartupFailureDetailFactory.CreateClassifiedBatchmodeFailure(
+            classification,
+            string.IsNullOrWhiteSpace(message) ? fallbackMessage : message,
+            ResolveUnityLogPath(unityProject),
+            processHandle.ProcessId,
+            processHandle.StartTimeUtc,
+            DateTimeOffset.UtcNow);
+        return UnityIpcFailureClassifier.FromCodeAndMessage(
+            DaemonErrorCodes.DaemonStartupBlocked,
+            startupFailure.Diagnosis?.Message ?? fallbackMessage,
+            startupFailure);
     }
 
     /// <summary> Appends a post-exit Unity lock-file cleanup diagnostic after uCLI has terminated a oneshot Unity process. </summary>
@@ -446,7 +598,8 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
         var message = await AppendPostUnityProcessExitLockFileDiagnosticAsync(failure.Message, unityProject).ConfigureAwait(false);
         return UnityRequestExecutionResult.Failure(UnityIpcFailureClassifier.FromCodeAndMessage(
             failure.Code,
-            message));
+            message,
+            failure.StartupFailure));
     }
 
     private async ValueTask<string> AppendPostUnityProcessExitLockFileDiagnosticAsync (
@@ -556,6 +709,13 @@ internal sealed class UnityOneshotIpcClient : IUnityIpcClient
     {
         var payload = IpcPayloadCodec.SerializeToElement(new IpcShutdownRequest(CleanupShutdownRequestedBy));
         return UnityIpcRequestFactory.Create(sessionToken, IpcMethodNames.Shutdown, payload);
+    }
+
+    private static string ResolveUnityLogPath (ResolvedUnityProjectContext unityProject)
+    {
+        return UcliStoragePathResolver.ResolveUnityLogPath(
+            unityProject.RepositoryRoot,
+            unityProject.ProjectFingerprint);
     }
 
     /// <summary> Waits for the launched oneshot Unity process to exit after response handling completes. </summary>

--- a/src/Ucli/UnityIntegration/Ipc/Failures/UnityIpcFailureClassifier.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Failures/UnityIpcFailureClassifier.cs
@@ -1,3 +1,4 @@
+using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Application.Shared.Execution.ErrorCodes;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Application.Shared.Execution.UnityRequest;
@@ -123,10 +124,12 @@ internal static class UnityIpcFailureClassifier
     /// <returns> The classified Unity request failure. </returns>
     public static UnityRequestFailure FromCodeAndMessage (
         UcliErrorCode code,
-        string message)
+        string message,
+        StartupFailureDetail? startupFailure = null)
     {
         return new UnityRequestFailure(
             code,
-            message);
+            message,
+            startupFailure);
     }
 }

--- a/tests/Ucli.Application.Tests/Features/ErrorCatalog/Catalog/ErrorCodeCatalogTests.cs
+++ b/tests/Ucli.Application.Tests/Features/ErrorCatalog/Catalog/ErrorCodeCatalogTests.cs
@@ -239,6 +239,28 @@ public sealed class ErrorCodeCatalogTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Describe_WithDaemonStartupBlocked_IncludesStartupObservationCommands ()
+    {
+        var service = new ErrorCodeCatalogService(CreateCatalog());
+
+        var result = service.Describe(DaemonErrorCodes.DaemonStartupBlocked, requireKnown: true);
+
+        Assert.True(result.IsSuccess);
+        var appliesTo = result.Descriptor!.AppliesTo
+            .Select(static command => command.Name)
+            .ToArray();
+        Assert.Contains(UcliCommandIds.DaemonStart.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Plan.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Call.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Refresh.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Resolve.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Query.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.Ops.Name, appliesTo);
+        Assert.Contains(UcliCommandIds.TestRun.Name, appliesTo);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Describe_WithInvalidCode_ReturnsInvalidArgument ()
     {
         var service = new ErrorCodeCatalogService(CreateCatalog());

--- a/tests/Ucli.Application.Tests/Features/ErrorCatalog/Catalog/ErrorCodeCatalogTests.cs
+++ b/tests/Ucli.Application.Tests/Features/ErrorCatalog/Catalog/ErrorCodeCatalogTests.cs
@@ -237,13 +237,16 @@ public sealed class ErrorCodeCatalogTests
         Assert.Equal(code, result.Descriptor!.Code.Value);
     }
 
-    [Fact]
+    [Theory]
+    [InlineData("DAEMON_STARTUP_BLOCKED")]
+    [InlineData("DAEMON_START_PROCESS_EXITED")]
+    [InlineData("DAEMON_ENDPOINT_NOT_REGISTERED")]
     [Trait("Size", "Small")]
-    public void Describe_WithDaemonStartupBlocked_IncludesStartupObservationCommands ()
+    public void Describe_WithStartupObservationCode_IncludesStartupObservationCommands (string code)
     {
         var service = new ErrorCodeCatalogService(CreateCatalog());
 
-        var result = service.Describe(DaemonErrorCodes.DaemonStartupBlocked, requireKnown: true);
+        var result = service.Describe(new UcliErrorCode(code), requireKnown: true);
 
         Assert.True(result.IsSuccess);
         var appliesTo = result.Descriptor!.AppliesTo

--- a/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
@@ -36,6 +36,32 @@ public sealed class TestRunResultMapperTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Map_WithStartupFailureExecutionFailure_PropagatesStartupDetailToServiceAndApplicationFailure ()
+    {
+        var session = CreateSession();
+        var startupFailure = new StartupFailureDetail(
+            Startup: null,
+            Diagnosis: null,
+            RetryDisposition: "unknown",
+            SafeToRetryImmediately: false);
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Success(
+            session,
+            UnityTestExecutionResult.Failure(
+                UnityTestExecutionFailureKind.ArtifactMissing,
+                "Unity startup is blocked.",
+                DaemonErrorCodes.DaemonStartupBlocked,
+                startupFailure),
+            UnityResultsConversionResult.Success(false)));
+
+        Assert.Equal(TestRunErrorKind.ToolError, result.ErrorKind);
+        Assert.Same(startupFailure, result.StartupFailure);
+        Assert.Same(startupFailure, result.Failure!.StartupFailure);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Map_WithCompletionErrorAfterFailedTests_PrefersFailedTestsOutcome ()
     {
         var session = CreateSession();

--- a/tests/Ucli.Tests/Features/Testing/Run/Execution/UnityTestExecutorTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/Execution/UnityTestExecutorTests.cs
@@ -186,8 +186,79 @@ public sealed class UnityTestExecutorTests
         var startupFailure = result.StartupFailure!;
         Assert.Equal("blocked", startupFailure.Startup!.StartupStatus);
         Assert.Equal("compile", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, startupFailure.Startup.ProcessAction);
         Assert.Equal("unityScriptCompilationFailed", startupFailure.Diagnosis!.Reason);
         Assert.Equal("CS0246", startupFailure.Diagnosis.PrimaryDiagnostic!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenAbnormalExitHasCompileErrorLog_ReturnsStructuredStartupFailure ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-test-executor", "abnormal-exit-compile-error");
+        var configuration = CreateConfiguration(scope);
+        var artifactPaths = CreateArtifactPaths(scope);
+        scope.WriteFile(
+            "run/editor.log",
+            """
+            COMMAND LINE ARGUMENTS:
+            Assets/Scripts/Broken.cs(10,5): error CS0246: The type or namespace name 'MissingType' could not be found
+            Scripts have compiler errors.
+            """);
+
+        var executor = new UnityTestExecutor(
+            new StubUnityCommandBuilder(["-batchmode"]),
+            new StubProcessRunner(ProcessRunResult.Exited(1, "Unity exited.")),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe());
+
+        var result = await executor.ExecuteAsync(
+            configuration,
+            artifactPaths,
+            TimeSpan.FromMilliseconds(3000),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UnityTestExecutionFailureKind.AbnormalExit, result.FailureKind);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.NotNull(result.StartupFailure);
+        Assert.Equal("CS0246", result.StartupFailure!.Diagnosis!.PrimaryDiagnostic!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenEditorLogExceedsTailLimit_ClassifiesStartupFailureFromTail ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-test-executor", "large-editor-log-compile-error");
+        var configuration = CreateConfiguration(scope);
+        var artifactPaths = CreateArtifactPaths(scope);
+        scope.WriteFile(
+            "run/editor.log",
+            new string('x', 70000) +
+            """
+
+            COMMAND LINE ARGUMENTS:
+            Assets/Scripts/Broken.cs(10,5): error CS0246: The type or namespace name 'MissingType' could not be found
+            Scripts have compiler errors.
+            """);
+
+        var executor = new UnityTestExecutor(
+            new StubUnityCommandBuilder(["-batchmode"]),
+            new StubProcessRunner(ProcessRunResult.Exited(0)),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe());
+
+        var result = await executor.ExecuteAsync(
+            configuration,
+            artifactPaths,
+            TimeSpan.FromMilliseconds(3000),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UnityTestExecutionFailureKind.ArtifactMissing, result.FailureKind);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.NotNull(result.StartupFailure);
+        Assert.Equal("compile", result.StartupFailure!.Startup!.StartupBlockingReason);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Features/Testing/Run/Execution/UnityTestExecutorTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/Execution/UnityTestExecutorTests.cs
@@ -154,6 +154,44 @@ public sealed class UnityTestExecutorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Execute_WhenArtifactsAreMissingAndEditorLogHasCompileError_ReturnsStructuredStartupFailure ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-test-executor", "missing-results-compile-error");
+        var configuration = CreateConfiguration(scope);
+        var artifactPaths = CreateArtifactPaths(scope);
+        scope.WriteFile(
+            "run/editor.log",
+            """
+            COMMAND LINE ARGUMENTS:
+            Assets/Scripts/Broken.cs(10,5): error CS0246: The type or namespace name 'MissingType' could not be found
+            Scripts have compiler errors.
+            """);
+
+        var executor = new UnityTestExecutor(
+            new StubUnityCommandBuilder(["-batchmode"]),
+            new StubProcessRunner(ProcessRunResult.Exited(0)),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe());
+
+        var result = await executor.ExecuteAsync(
+            configuration,
+            artifactPaths,
+            TimeSpan.FromMilliseconds(3000),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(UnityTestExecutionFailureKind.ArtifactMissing, result.FailureKind);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.NotNull(result.StartupFailure);
+        var startupFailure = result.StartupFailure!;
+        Assert.Equal("blocked", startupFailure.Startup!.StartupStatus);
+        Assert.Equal("compile", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal("unityScriptCompilationFailed", startupFailure.Diagnosis!.Reason);
+        Assert.Equal("CS0246", startupFailure.Diagnosis.PrimaryDiagnostic!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Execute_WithSubSecondTimeout_PreservesExactTimeout ()
     {
         using var scope = TestDirectories.CreateTempScope("unity-test-executor", "timeout-round-up");

--- a/tests/Ucli.Tests/Hosting/Cli/CallCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/CallCommandResultFactoryTests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Requests.Call.Common.Contracts;
 using MackySoft.Ucli.Application.Features.Requests.Shared.Execution.Results;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Requests;
 
 namespace MackySoft.Ucli.Tests;
@@ -54,6 +56,38 @@ public sealed class CallCommandResultFactoryTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Create_WhenFailureHasStartupDetail_EmitsStartupDiagnosisWithoutChangingEnvelope ()
+    {
+        var startupFailure = CreateStartupFailureDetail();
+        var result = CallCommandResultFactory.Create(CallServiceResult.Failure(
+            "Unity startup is blocked.",
+            [
+                ApplicationFailure.UnityIpcFailure(
+                    "Unity startup is blocked.",
+                    DaemonErrorCodes.DaemonStartupBlocked,
+                    startupFailure: startupFailure),
+            ]));
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(result, SerializerOptions));
+        var root = json.RootElement;
+        JsonAssert.For(root)
+            .HasString("command", UcliCommandNames.Call)
+            .HasString("status", "error")
+            .HasProperty("payload", payload => payload
+                .HasProperty("startup", startup => startup
+                    .HasString("startupStatus", "blocked")
+                    .HasString("startupBlockingReason", "compile"))
+                .HasProperty("diagnosis", diagnosis => diagnosis
+                    .HasString("reason", "unityScriptCompilationFailed")
+                    .HasProperty("primaryDiagnostic", primaryDiagnostic => primaryDiagnostic
+                        .HasString("code", "CS0246")))
+                .HasString("retryDisposition", "retryAfterFix")
+                .HasBoolean("safeToRetryImmediately", false));
+        CommandResultAssert.HasSingleError(root, DaemonErrorCodes.DaemonStartupBlocked);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Create_WhenReadPostconditionExists_EmitsTopLevelPayloadOnly ()
     {
         var readPostcondition = new OperationExecutionReadPostcondition(
@@ -85,5 +119,45 @@ public sealed class CallCommandResultFactoryTests
                     .HasString("surface", IpcExecuteReadPostconditionSurfaceNames.SceneTreeLite)
                     .HasString("scenePath", "Assets/Scenes/Main.unity")));
         Assert.False(payload.GetProperty("plan").TryGetProperty("readPostcondition", out _));
+    }
+
+    private static StartupFailureDetail CreateStartupFailureDetail ()
+    {
+        return new StartupFailureDetail(
+            Startup: new DaemonStartupObservationOutput(
+                StartupStatus: "blocked",
+                StartupBlockingReason: "compile",
+                LaunchAttemptId: null,
+                EditorMode: "batchmode",
+                OwnerKind: "cli",
+                CanShutdownProcess: true,
+                ProcessId: 1234,
+                StartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                ElapsedMilliseconds: null,
+                ProcessAction: "terminated",
+                ProcessTermination: null,
+                ArtifactPath: null,
+                RetryDisposition: "retryAfterFix"),
+            Diagnosis: new DaemonDiagnosisOutput(
+                Reason: "unityScriptCompilationFailed",
+                Message: "Unity startup is blocked.",
+                ReportedBy: "cli",
+                IsInferred: true,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:06+00:00"),
+                ProcessId: 1234,
+                EditorInstancePath: null,
+                ProcessStartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                UnityLogPath: "/repo/.ucli/local/logs/unity.log",
+                StartupPhase: "scriptCompilation",
+                ActionRequired: "fixCompileErrors",
+                PrimaryDiagnostic: new DaemonPrimaryDiagnosticOutput(
+                    Kind: "compiler",
+                    Code: "CS0246",
+                    File: "Assets/Scripts/Broken.cs",
+                    Line: 10,
+                    Column: 5,
+                    Message: "error CS0246")),
+            RetryDisposition: "retryAfterFix",
+            SafeToRetryImmediately: false);
     }
 }

--- a/tests/Ucli.Tests/Hosting/Cli/CommandResultFactoryStartupFailureTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/CommandResultFactoryStartupFailureTests.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.OperationCatalog.Common.Contracts;
+using MackySoft.Ucli.Application.Features.Requests.Plan.Common.Contracts;
+using MackySoft.Ucli.Application.Features.Requests.Query.UseCases.Query;
+using MackySoft.Ucli.Application.Features.Requests.Resolve.UseCases.Resolve;
+using MackySoft.Ucli.Application.Features.Requests.Shared.Execution.OperationExecute;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Ops;
+using MackySoft.Ucli.Hosting.Cli.Requests;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class CommandResultFactoryStartupFailureTests
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public static IEnumerable<object[]> StartupFailureCommandResults
+    {
+        get
+        {
+            yield return
+            [
+                UcliCommandNames.Plan,
+                PlanCommandResultFactory.Create(PlanServiceResult.Failure(
+                    "Unity startup is blocked.",
+                    [CreateStartupFailure()]))
+            ];
+            yield return
+            [
+                UcliCommandNames.Refresh,
+                RefreshCommandResultFactory.Create(OperationExecuteResultFactory.Failure(
+                    "request-id",
+                    [],
+                    [CreateStartupFailure()],
+                    "Unity startup is blocked."))
+            ];
+            yield return
+            [
+                UcliCommandNames.Resolve,
+                ResolveCommandResultFactory.Create(ResolveServiceResult.Failure(
+                    "request-id",
+                    [],
+                    [CreateStartupFailure()],
+                    "Unity startup is blocked.",
+                    CreateReadIndexInfo()))
+            ];
+            yield return
+            [
+                UcliCommandNames.Query,
+                QueryCommandResultFactory.Create(QueryServiceResult.Failure(
+                    UcliCommandNames.Query,
+                    "request-id",
+                    [],
+                    [CreateStartupFailure()],
+                    "Unity startup is blocked.",
+                    CreateReadIndexInfo()))
+            ];
+            yield return
+            [
+                UcliCommandNames.OpsList,
+                OpsCommandResultFactory.CreateList(OpsListServiceResult.Failure(
+                    "Unity startup is blocked.",
+                    DaemonErrorCodes.DaemonStartupBlocked,
+                    CreateStartupFailureDetail()))
+            ];
+            yield return
+            [
+                UcliCommandNames.OpsDescribe,
+                OpsCommandResultFactory.CreateDescribe(OpsDescribeServiceResult.Failure(
+                    "Unity startup is blocked.",
+                    DaemonErrorCodes.DaemonStartupBlocked,
+                    CreateStartupFailureDetail()))
+            ];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(StartupFailureCommandResults))]
+    [Trait("Size", "Small")]
+    public void Create_WhenFailureHasStartupDetail_EmitsStartupDiagnosisWithoutChangingEnvelope (
+        string commandName,
+        object resultObject)
+    {
+        var result = Assert.IsType<CommandResult>(resultObject);
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(result, SerializerOptions));
+        var root = json.RootElement;
+        JsonAssert.For(root)
+            .HasString("command", commandName)
+            .HasString("status", "error")
+            .HasProperty("payload", payload => payload
+                .HasProperty("startup", startup => startup
+                    .HasString("startupStatus", "blocked")
+                    .HasString("startupBlockingReason", "compile"))
+                .HasProperty("diagnosis", diagnosis => diagnosis
+                    .HasString("reason", "unityScriptCompilationFailed")
+                    .HasProperty("primaryDiagnostic", primaryDiagnostic => primaryDiagnostic
+                        .HasString("code", "CS0246")))
+                .HasString("retryDisposition", "retryAfterFix")
+                .HasBoolean("safeToRetryImmediately", false));
+        CommandResultAssert.HasSingleError(root, DaemonErrorCodes.DaemonStartupBlocked);
+    }
+
+    private static ApplicationFailure CreateStartupFailure ()
+    {
+        return ApplicationFailure.UnityIpcFailure(
+            "Unity startup is blocked.",
+            DaemonErrorCodes.DaemonStartupBlocked,
+            startupFailure: CreateStartupFailureDetail());
+    }
+
+    private static StartupFailureDetail CreateStartupFailureDetail ()
+    {
+        return new StartupFailureDetail(
+            Startup: new DaemonStartupObservationOutput(
+                StartupStatus: "blocked",
+                StartupBlockingReason: "compile",
+                LaunchAttemptId: null,
+                EditorMode: "batchmode",
+                OwnerKind: "cli",
+                CanShutdownProcess: true,
+                ProcessId: 1234,
+                StartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                ElapsedMilliseconds: null,
+                ProcessAction: "terminated",
+                ProcessTermination: null,
+                ArtifactPath: null,
+                RetryDisposition: "retryAfterFix"),
+            Diagnosis: new DaemonDiagnosisOutput(
+                Reason: "unityScriptCompilationFailed",
+                Message: "Unity startup is blocked.",
+                ReportedBy: "cli",
+                IsInferred: true,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:06+00:00"),
+                ProcessId: 1234,
+                EditorInstancePath: null,
+                ProcessStartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                UnityLogPath: "/repo/.ucli/local/logs/unity.log",
+                StartupPhase: "scriptCompilation",
+                ActionRequired: "fixCompileErrors",
+                PrimaryDiagnostic: new DaemonPrimaryDiagnosticOutput(
+                    Kind: "compiler",
+                    Code: "CS0246",
+                    File: "Assets/Scripts/Broken.cs",
+                    Line: 10,
+                    Column: 5,
+                    Message: "error CS0246")),
+            RetryDisposition: "retryAfterFix",
+            SafeToRetryImmediately: false);
+    }
+
+    private static ReadIndexInfo CreateReadIndexInfo ()
+    {
+        return new ReadIndexInfo(
+            Used: false,
+            Hit: false,
+            Source: ReadIndexInfoSource.Unity,
+            Freshness: IndexFreshness.Probable,
+            GeneratedAtUtc: null,
+            FallbackReason: null);
+    }
+}

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
@@ -93,6 +93,7 @@ public sealed class TestRunCommandResultFactoryTests
         Assert.Equal("error", result.Status);
         Assert.Single(result.Errors);
         Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.Errors[0].Code);
+        Assert.NotNull(serviceResult.Failure!.StartupFailure);
 
         var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
         JsonAssert.For(payload)

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandResultFactoryTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Features.Testing.Run.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Testing;
@@ -8,6 +9,11 @@ namespace MackySoft.Ucli.Tests;
 
 public sealed class TestRunCommandResultFactoryTests
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
     [Fact]
     [Trait("Size", "Small")]
     public void Create_WithFailResult_ReturnsOkEnvelopeWithPayload ()
@@ -27,7 +33,7 @@ public sealed class TestRunCommandResultFactoryTests
         Assert.Equal(serviceResult.Message, result.Message);
         Assert.Empty(result.Errors);
 
-        var payload = JsonSerializer.SerializeToElement(result.Payload);
+        var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
         JsonAssert.For(payload)
             .HasString("result", "fail")
             .IsNull("errorKind")
@@ -60,13 +66,45 @@ public sealed class TestRunCommandResultFactoryTests
         Assert.Equal(message, result.Errors[0].Message);
         Assert.Null(result.Errors[0].OpId);
 
-        var payload = JsonSerializer.SerializeToElement(result.Payload);
+        var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
         JsonAssert.For(payload)
             .IsNull("result")
             .HasString("errorKind", "toolError")
             .HasString("runId", "run-id")
             .HasString("artifactsDir", "/tmp/artifacts")
             .HasString("summaryJsonPath", "/tmp/artifacts/summary.json");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Create_WithStartupFailure_EmitsStartupDiagnosisInErrorPayload ()
+    {
+        var serviceResult = TestRunServiceResult.ToolError(
+            message: "Unity startup is blocked.",
+            errorCode: DaemonErrorCodes.DaemonStartupBlocked,
+            runId: "run-id",
+            artifactsDir: "/tmp/artifacts",
+            summaryJsonPath: "/tmp/artifacts/summary.json",
+            startupFailure: CreateStartupFailureDetail());
+
+        var result = TestRunCommandResultFactory.Create(serviceResult);
+
+        Assert.Equal(UcliCommandNames.TestRun, result.Command);
+        Assert.Equal("error", result.Status);
+        Assert.Single(result.Errors);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.Errors[0].Code);
+
+        var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
+        JsonAssert.For(payload)
+            .IsNull("result")
+            .HasString("errorKind", "toolError")
+            .HasProperty("startup", startup => startup
+                .HasString("startupStatus", "blocked")
+                .HasString("startupBlockingReason", "compile"))
+            .HasProperty("diagnosis", diagnosis => diagnosis
+                .HasString("reason", "unityScriptCompilationFailed"))
+            .HasString("retryDisposition", "retryAfterFix")
+            .HasBoolean("safeToRetryImmediately", false);
     }
 
     [Fact]
@@ -84,7 +122,7 @@ public sealed class TestRunCommandResultFactoryTests
         Assert.Single(result.Errors);
         Assert.Equal(UcliCoreErrorCodes.InternalError, result.Errors[0].Code);
 
-        var payload = JsonSerializer.SerializeToElement(result.Payload);
+        var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
         JsonAssert.For(payload)
             .IsNull("result")
             .HasString("errorKind", "infraError")
@@ -113,12 +151,46 @@ public sealed class TestRunCommandResultFactoryTests
         Assert.Equal(UcliCoreErrorCodes.InvalidArgument, error.Code);
         Assert.Equal(message, error.Message);
 
-        var payload = JsonSerializer.SerializeToElement(result.Payload);
+        var payload = JsonSerializer.SerializeToElement(result.Payload, SerializerOptions);
         JsonAssert.For(payload)
             .IsNull("result")
             .HasString("errorKind", "infraError")
             .HasString("runId", "run-id")
             .HasString("artifactsDir", "/tmp/artifacts")
             .HasString("summaryJsonPath", "/tmp/artifacts/summary.json");
+    }
+
+    private static StartupFailureDetail CreateStartupFailureDetail ()
+    {
+        return new StartupFailureDetail(
+            Startup: new DaemonStartupObservationOutput(
+                StartupStatus: "blocked",
+                StartupBlockingReason: "compile",
+                LaunchAttemptId: null,
+                EditorMode: "batchmode",
+                OwnerKind: "cli",
+                CanShutdownProcess: true,
+                ProcessId: null,
+                StartedAtUtc: null,
+                ElapsedMilliseconds: null,
+                ProcessAction: "terminated",
+                ProcessTermination: null,
+                ArtifactPath: null,
+                RetryDisposition: "retryAfterFix"),
+            Diagnosis: new DaemonDiagnosisOutput(
+                Reason: "unityScriptCompilationFailed",
+                Message: "Unity startup is blocked.",
+                ReportedBy: "cli",
+                IsInferred: true,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:06+00:00"),
+                ProcessId: null,
+                EditorInstancePath: null,
+                ProcessStartedAtUtc: null,
+                UnityLogPath: "/tmp/artifacts/editor.log",
+                StartupPhase: "scriptCompilation",
+                ActionRequired: "fixCompileErrors",
+                PrimaryDiagnostic: null),
+            RetryDisposition: "retryAfterFix",
+            SafeToRetryImmediately: false);
     }
 }

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
@@ -374,6 +374,52 @@ public sealed class UnityOneshotIpcClientTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task SendAsync_WhenUnityExitsWithPackageResolutionLog_ReturnsClassifiedStartupFailure ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "exit-package-resolution");
+        var unityProject = CreateUnityProject(scope);
+        var unityLogPath = scope.GetPath("UnityProject/Logs/Editor.log");
+        var processHandle = new StubUnityBatchmodeProcessHandle(hasExited: true, exitCode: 1);
+        var launcher = new StubUnityBatchmodeProcessLauncher(UnityBatchmodeProcessLaunchResult.Success(processHandle));
+        var logReader = new StubUnityLogReader(UnityLogReadResult.Success(
+            """
+            COMMAND LINE ARGUMENTS:
+            An error occurred while resolving packages:
+            Project has invalid dependencies:
+              com.example.missing: No package found for com.example.missing.
+            """,
+            truncated: false,
+            path: unityLogPath,
+            sizeBytes: 224));
+        var client = new UnityOneshotIpcClient(
+            launcher,
+            new StubIpcEndpointResolver(new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock")),
+            new StubUnityIpcTransportClient(_ => throw new Xunit.Sdk.XunitException("Transport should not be called.")),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe(
+                UnityProjectLockFileProbeResult.Unlocked(scope.GetPath("UnityProject/Temp/UnityLockfile"))),
+            logReader);
+
+        var result = await client.SendAsync(
+            unityProject,
+            CreateDispatchRequest(),
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.Equal(1, logReader.CallCount);
+        Assert.NotNull(result.FailureInfo!.StartupFailure);
+        var startupFailure = result.FailureInfo.StartupFailure!;
+        Assert.Equal("blocked", startupFailure.Startup!.StartupStatus);
+        Assert.Equal("packageResolution", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, startupFailure.Startup.ProcessAction);
+        Assert.Equal("unityPackageResolutionFailed", startupFailure.Diagnosis!.Reason);
+        Assert.Equal("packageResolution", startupFailure.Diagnosis.PrimaryDiagnostic!.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task SendAsync_WhenClassifiedProcessExitHasStaleLockDiagnostic_PreservesCleanupMessage ()
     {
         using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "exit-compile-error-stale-lock");

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
@@ -293,6 +293,7 @@ public sealed class UnityOneshotIpcClientTests
         Assert.Contains("Stale Unity project lock file was removed", result.Message, StringComparison.Ordinal);
         Assert.NotNull(result.FailureInfo!.StartupFailure);
         Assert.Equal("failed", result.FailureInfo.StartupFailure!.Startup!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.FailureInfo.StartupFailure.Startup.ProcessAction);
         Assert.Equal(0, processHandle.TerminateCallCount);
     }
 
@@ -323,6 +324,7 @@ public sealed class UnityOneshotIpcClientTests
         Assert.Contains("exited before startup readiness", result.Message, StringComparison.Ordinal);
         Assert.NotNull(result.FailureInfo!.StartupFailure);
         Assert.Equal("failed", result.FailureInfo.StartupFailure!.Startup!.StartupStatus);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, result.FailureInfo.StartupFailure.Startup.ProcessAction);
     }
 
     [Fact]
@@ -365,8 +367,49 @@ public sealed class UnityOneshotIpcClientTests
         var startupFailure = result.FailureInfo.StartupFailure!;
         Assert.Equal("blocked", startupFailure.Startup!.StartupStatus);
         Assert.Equal("compile", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, startupFailure.Startup.ProcessAction);
         Assert.Equal("unityScriptCompilationFailed", startupFailure.Diagnosis!.Reason);
         Assert.Equal("CS0246", startupFailure.Diagnosis.PrimaryDiagnostic!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenClassifiedProcessExitHasStaleLockDiagnostic_PreservesCleanupMessage ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "exit-compile-error-stale-lock");
+        var unityProject = CreateUnityProject(scope);
+        var unityLogPath = scope.GetPath("UnityProject/Logs/Editor.log");
+        var lockFilePath = scope.GetPath("UnityProject/Temp/UnityLockfile");
+        var processHandle = new StubUnityBatchmodeProcessHandle(hasExited: true, exitCode: 1);
+        var launcher = new StubUnityBatchmodeProcessLauncher(UnityBatchmodeProcessLaunchResult.Success(processHandle));
+        var logReader = new StubUnityLogReader(UnityLogReadResult.Success(
+            """
+            COMMAND LINE ARGUMENTS:
+            Assets/Scripts/Broken.cs(10,5): error CS0246: The type or namespace name 'MissingType' could not be found
+            Scripts have compiler errors.
+            """,
+            truncated: false,
+            path: unityLogPath,
+            sizeBytes: 192));
+        var client = new UnityOneshotIpcClient(
+            launcher,
+            new StubIpcEndpointResolver(new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock")),
+            new StubUnityIpcTransportClient(_ => throw new Xunit.Sdk.XunitException("Transport should not be called.")),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe(
+                UnityProjectLockFileProbeResult.Locked(lockFilePath)),
+            logReader);
+
+        var result = await client.SendAsync(
+            unityProject,
+            CreateDispatchRequest(),
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.Contains("CS0246", result.Message, StringComparison.Ordinal);
+        Assert.Contains("Stale Unity project lock file was removed", result.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -450,6 +493,7 @@ public sealed class UnityOneshotIpcClientTests
         var startupFailure = result.FailureInfo.StartupFailure!;
         Assert.Equal("timeout", startupFailure.Startup!.StartupStatus);
         Assert.Equal("endpointNotRegistered", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal(DaemonStartupProcessActionValues.Unknown, startupFailure.Startup.ProcessAction);
         Assert.Equal("startupFailed", startupFailure.Diagnosis!.Reason);
         Assert.Contains(transportClient.Requests, request => string.Equals(request.Method, IpcMethodNames.Shutdown, StringComparison.Ordinal));
         var bootstrapArguments = Assert.IsType<IpcOneshotBootstrapArguments>(launcher.LastBootstrapArguments);

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityOneshotIpcClientTests.cs
@@ -288,9 +288,11 @@ public sealed class UnityOneshotIpcClientTests
             CancellationToken.None);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal(UcliCoreErrorCodes.InternalError, result.ErrorCode);
+        Assert.Equal(DaemonErrorCodes.DaemonStartProcessExited, result.ErrorCode);
         Assert.Contains("exited before startup readiness", result.Message, StringComparison.Ordinal);
         Assert.Contains("Stale Unity project lock file was removed", result.Message, StringComparison.Ordinal);
+        Assert.NotNull(result.FailureInfo!.StartupFailure);
+        Assert.Equal("failed", result.FailureInfo.StartupFailure!.Startup!.StartupStatus);
         Assert.Equal(0, processHandle.TerminateCallCount);
     }
 
@@ -317,8 +319,54 @@ public sealed class UnityOneshotIpcClientTests
             CancellationToken.None);
 
         Assert.False(result.IsSuccess);
-        Assert.Equal(UcliCoreErrorCodes.InternalError, result.ErrorCode);
+        Assert.Equal(DaemonErrorCodes.DaemonStartProcessExited, result.ErrorCode);
         Assert.Contains("exited before startup readiness", result.Message, StringComparison.Ordinal);
+        Assert.NotNull(result.FailureInfo!.StartupFailure);
+        Assert.Equal("failed", result.FailureInfo.StartupFailure!.Startup!.StartupStatus);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenUnityExitsWithCompileErrorLog_ReturnsClassifiedStartupFailure ()
+    {
+        using var scope = TestDirectories.CreateTempScope("unity-oneshot-ipc-client", "exit-compile-error");
+        var unityProject = CreateUnityProject(scope);
+        var unityLogPath = scope.GetPath("UnityProject/Logs/Editor.log");
+        var processHandle = new StubUnityBatchmodeProcessHandle(hasExited: true, exitCode: 1);
+        var launcher = new StubUnityBatchmodeProcessLauncher(UnityBatchmodeProcessLaunchResult.Success(processHandle));
+        var logReader = new StubUnityLogReader(UnityLogReadResult.Success(
+            """
+            COMMAND LINE ARGUMENTS:
+            Assets/Scripts/Broken.cs(10,5): error CS0246: The type or namespace name 'MissingType' could not be found
+            Scripts have compiler errors.
+            """,
+            truncated: false,
+            path: unityLogPath,
+            sizeBytes: 192));
+        var client = new UnityOneshotIpcClient(
+            launcher,
+            new StubIpcEndpointResolver(new IpcEndpoint(IpcTransportKind.UnixDomainSocket, "/tmp/ucli-oneshot.sock")),
+            new StubUnityIpcTransportClient(_ => throw new Xunit.Sdk.XunitException("Transport should not be called.")),
+            new StubProjectLifecycleLockProvider(),
+            new StubUnityProjectLockFileProbe(
+                UnityProjectLockFileProbeResult.Unlocked(scope.GetPath("UnityProject/Temp/UnityLockfile"))),
+            logReader);
+
+        var result = await client.SendAsync(
+            unityProject,
+            CreateDispatchRequest(),
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, result.ErrorCode);
+        Assert.Equal(1, logReader.CallCount);
+        Assert.NotNull(result.FailureInfo!.StartupFailure);
+        var startupFailure = result.FailureInfo.StartupFailure!;
+        Assert.Equal("blocked", startupFailure.Startup!.StartupStatus);
+        Assert.Equal("compile", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal("unityScriptCompilationFailed", startupFailure.Diagnosis!.Reason);
+        Assert.Equal("CS0246", startupFailure.Diagnosis.PrimaryDiagnostic!.Code);
     }
 
     [Fact]
@@ -398,6 +446,11 @@ public sealed class UnityOneshotIpcClientTests
 
         Assert.False(result.IsSuccess);
         Assert.Equal(ExecutionErrorCodes.IpcTimeout, result.ErrorCode);
+        Assert.NotNull(result.FailureInfo!.StartupFailure);
+        var startupFailure = result.FailureInfo.StartupFailure!;
+        Assert.Equal("timeout", startupFailure.Startup!.StartupStatus);
+        Assert.Equal("endpointNotRegistered", startupFailure.Startup.StartupBlockingReason);
+        Assert.Equal("startupFailed", startupFailure.Diagnosis!.Reason);
         Assert.Contains(transportClient.Requests, request => string.Equals(request.Method, IpcMethodNames.Shutdown, StringComparison.Ordinal));
         var bootstrapArguments = Assert.IsType<IpcOneshotBootstrapArguments>(launcher.LastBootstrapArguments);
         Assert.All(
@@ -766,6 +819,29 @@ public sealed class UnityOneshotIpcClientTests
             string projectFingerprint)
         {
             return endpoint;
+        }
+    }
+
+    private sealed class StubUnityLogReader : IUnityLogReader
+    {
+        private readonly UnityLogReadResult result;
+
+        public StubUnityLogReader (UnityLogReadResult result)
+        {
+            this.result = result;
+        }
+
+        public int CallCount { get; private set; }
+
+        public ValueTask<UnityLogReadResult> ReadTailAsync (
+            string storageRoot,
+            string projectFingerprint,
+            int maxBytes = IUnityLogReader.DefaultMaxBytes,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CallCount++;
+            return ValueTask.FromResult(result);
         }
     }
 


### PR DESCRIPTION
## Summary
- `daemon start` で確立済みの startup observation / classifier / diagnosis payload を、oneshot IPC 経路と `test.run` の direct Unity 実行へ展開しました。
- 失敗 payload に利用可能な startup detail を追加しつつ、成功 payload と通常の入力不正 payload は変更していません。
- `errors[].code` は command outcome の代表 code、`payload.diagnosis.primaryDiagnostic.code` は詳細診断 code として分離しています。

## Scope
- Application failure / Unity request / test execution / ops result に `StartupFailureDetail` を伝搬する共有モデルを追加。
- `UnityOneshotIpcClient` で Unity log tail を batchmode context の startup classifier に通し、endpoint 未成立 timeout と process exit も structured startup detail に投影。
- `UnityTestExecutor` で test artifact 未生成の startup failure を editor log から分類。
- Plan / Call / Refresh / Resolve / Query / Ops / TestRun の command result factory で失敗時のみ startup detail を payload に追加。
- startup 系 error descriptor の `appliesTo` を対象 command へ拡張し、contract tests を追加。

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, 1099 tests)
- Coverage: N/A

## Risks / Rollback
- Startup failure payload の追加は失敗時 optional field に限定しています。問題が出た場合は `StartupFailureDetail` 伝搬と payload projector の追加分を戻すことで、既存 envelope 形状へ復帰できます。
- Unity 側ファイルは追加していないため、Unity `.meta` 生成と Unity test は対象外です。

## Checklist
- [x] oneshot の endpoint 未成立 failure が structured startup diagnosis を持つ
- [x] `test.run` の Unity process startup failure が structured startup diagnosis を持つ
- [x] stdout は各 command の JSON envelope 1件を維持する
- [x] stderr を機械判定の正本にしない
- [x] 自動 package restore / 自動修復を行わない
- [x] startup classifier の主要分類を oneshot / `test.run` でも再利用する
- [x] 対象 contract tests が追加される
- [x] `bash scripts/test-dotnet.sh` が成功する
- [x] Unity 側変更なしのため Unity test と `.meta` 生成は不要

Closes #269
