### PR TITLE
Add public CLI schema artifacts and assurance invariants

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 
 # Generated SKILL packages must compare byte-for-byte with generator output.
 skills/** text eol=lf
+
+# Generated schema artifacts must compare byte-for-byte with generator output.
+schemas/** text eol=lf

--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -88,14 +88,17 @@ jobs:
           --output artifacts/packages
 
       - name: Pack schema artifacts
-        run: |
-          set -euo pipefail
-          (cd . && zip -r "artifacts/packages/MackySoft.Ucli.Schemas.${{ needs.prepare-release.outputs.package_version }}.zip" schemas)
+        run: ./scripts/pack-schema-artifacts.sh --version "${{ needs.prepare-release.outputs.package_version }}" --output artifacts/packages
 
       - name: Smoke test CLI tool package
         env:
           PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
         run: ./scripts/verify-cli-package.sh artifacts/packages "${PACKAGE_VERSION}"
+
+      - name: Verify schema artifacts
+        env:
+          PACKAGE_VERSION: ${{ needs.prepare-release.outputs.package_version }}
+        run: ./scripts/verify-schema-artifacts.sh artifacts/packages "${PACKAGE_VERSION}"
 
       - name: Publish to nuget.org
         uses: ./.github/actions/publish-nuget-package
@@ -146,6 +149,7 @@ jobs:
             --sync-branch "${sync_branch}" \
             --commit-message "chore(cli): sync package version to ${PACKAGE_VERSION}" \
             --pr-title "chore(cli): sync package version to ${PACKAGE_VERSION}" \
-            --pr-body "Sync \`MackySoft.Ucli\` package version to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
+            --pr-body "Sync \`MackySoft.Ucli\` package version and generated schema manifest to \`${PACKAGE_VERSION}\` after \`${RELEASE_TAG}\` publish. The \`cli-package-publish\` workflow packed, smoke-tested, published, and released the package before creating this PR, then dispatched \`verify.yaml\` for \`${sync_branch}\`." \
             --verify-workflow verify.yaml \
-            --changed-path "Directory.Build.props"
+            --changed-path "Directory.Build.props" \
+            --changed-path "schemas/v1/schema-manifest.json"

--- a/.github/workflows/cli-package-publish.yaml
+++ b/.github/workflows/cli-package-publish.yaml
@@ -75,6 +75,9 @@ jobs:
       - name: Verify generated skills
         run: bash scripts/verify-skills.sh
 
+      - name: Generate release schemas
+        run: bash scripts/generate-schemas.sh --package-version "${{ needs.prepare-release.outputs.package_version }}"
+
       - name: Pack CLI tool
         run: >-
           dotnet pack src/Ucli/Ucli.csproj
@@ -83,6 +86,11 @@ jobs:
           -p:Version=${{ needs.prepare-release.outputs.package_version }}
           -p:PackageVersion=${{ needs.prepare-release.outputs.package_version }}
           --output artifacts/packages
+
+      - name: Pack schema artifacts
+        run: |
+          set -euo pipefail
+          (cd . && zip -r "artifacts/packages/MackySoft.Ucli.Schemas.${{ needs.prepare-release.outputs.package_version }}.zip" schemas)
 
       - name: Smoke test CLI tool package
         env:
@@ -105,6 +113,14 @@ jobs:
           release-title: uCLI ${{ needs.prepare-release.outputs.package_version }}
           release-notes: CLI global tool package for ${{ needs.prepare-release.outputs.tag_name }}.
           repository: ${{ github.repository }}
+
+      - name: Mirror schema artifacts to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+          SCHEMA_ARCHIVE: artifacts/packages/MackySoft.Ucli.Schemas.${{ needs.prepare-release.outputs.package_version }}.zip
+        run: gh release upload "${RELEASE_TAG}" "${SCHEMA_ARCHIVE}" --repo "${REPOSITORY}" --clobber
 
       - name: Create CLI package version sync pull request
         env:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -340,6 +340,9 @@ jobs:
       - name: Verify generated skills
         run: bash scripts/verify-skills.sh
 
+      - name: Generate CI schemas
+        run: bash scripts/generate-schemas.sh --package-version 0.0.0-ci
+
       - name: Pack CLI tool
         run: >-
           dotnet pack src/Ucli/Ucli.csproj
@@ -349,8 +352,14 @@ jobs:
           -p:PackageVersion=0.0.0-ci
           --output artifacts/packages
 
+      - name: Pack schema artifacts
+        run: ./scripts/pack-schema-artifacts.sh --version 0.0.0-ci --output artifacts/packages
+
       - name: Smoke test CLI tool package
         run: ./scripts/verify-cli-package.sh artifacts/packages 0.0.0-ci
+
+      - name: Verify schema artifacts
+        run: ./scripts/verify-schema-artifacts.sh artifacts/packages 0.0.0-ci
 
       - name: Upload CLI package
         if: always()

--- a/Ucli.slnx
+++ b/Ucli.slnx
@@ -16,6 +16,7 @@
     <Project Path="tests/Ucli.Tests/Ucli.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">
+    <Project Path="tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj" />
     <Project Path="tools/Ucli.SkillGenerator/Ucli.SkillGenerator.csproj" />
   </Folder>
 </Solution>

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -218,7 +218,7 @@ done
 - `shared-package-publish`: `shared/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `shared-package-publish` は公開後に `chore/shared-sync-<version>` ブランチを作成し、`Directory.Build.props`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の shared package version を同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `cli-package-publish`: `cli/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / smoke test / nuget.org publish / GitHub Release mirror まで継続する。
-- `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`Directory.Build.props` の `MackySoft.Ucli` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
+- `cli-package-publish` は公開後に `chore/cli-sync-<version>` ブランチを作成し、`Directory.Build.props` の `MackySoft.Ucli` バージョンと `schemas/v1/schema-manifest.json` の schema artifact version を公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - `unity-package-publish`: `unity/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、同一 workflow run の中で pack / package verify / nuget.org publish / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `unity-package-publish` は公開後に `chore/unity-sync-<version>` ブランチを作成し、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の `MackySoft.Ucli.Unity` バージョンを公開 version へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
 - タグは `v` プレフィックスを付けない（例: `shared/x.y.z`、`cli/x.y.z`、`unity/x.y.z`）。

--- a/schemas/v1/cli-output/defs/assurance-claim.schema.json
+++ b/schemas/v1/cli-output/defs/assurance-claim.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/assurance-claim.schema.json",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "coverage": {
+      "type": "string"
+    },
+    "required": {
+      "type": "boolean"
+    },
+    "verifierRef": {
+      "type": "string"
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/evidence.schema.json"
+      }
+    },
+    "residualRisks": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/residual-risk.schema.json"
+      }
+    }
+  },
+  "required": [
+    "id",
+    "status",
+    "coverage",
+    "required",
+    "verifierRef"
+  ]
+}

--- a/schemas/v1/cli-output/defs/diagnostic.schema.json
+++ b/schemas/v1/cli-output/defs/diagnostic.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/diagnostic.schema.json",
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "message": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "severity": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/schemas/v1/cli-output/defs/evidence.schema.json
+++ b/schemas/v1/cli-output/defs/evidence.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/evidence.schema.json",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string"
+    },
+    "evidenceRef": {
+      "type": "string"
+    },
+    "data": {}
+  },
+  "required": [
+    "kind"
+  ]
+}

--- a/schemas/v1/cli-output/defs/op-result.schema.json
+++ b/schemas/v1/cli-output/defs/op-result.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/op-result.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "opId": {
+      "type": "string"
+    },
+    "op": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "applied": {
+      "type": "boolean"
+    },
+    "changed": {
+      "type": "boolean"
+    },
+    "touched": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/touched.schema.json"
+      }
+    },
+    "diagnostics": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/diagnostic.schema.json"
+      }
+    },
+    "result": {},
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "opId",
+    "op",
+    "phase",
+    "applied",
+    "changed",
+    "touched",
+    "diagnostics"
+  ]
+}

--- a/schemas/v1/cli-output/defs/project.schema.json
+++ b/schemas/v1/cli-output/defs/project.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/project.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "projectPath": {
+      "type": "string"
+    },
+    "projectFingerprint": {
+      "type": "string"
+    },
+    "unityVersion": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "projectPath",
+    "projectFingerprint",
+    "unityVersion"
+  ]
+}

--- a/schemas/v1/cli-output/defs/read-index.schema.json
+++ b/schemas/v1/cli-output/defs/read-index.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/read-index.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "used": {
+      "type": "boolean"
+    },
+    "hit": {
+      "type": "boolean"
+    },
+    "source": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "freshness": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "generatedAtUtc": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "fallbackReason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "used",
+    "hit",
+    "source",
+    "freshness",
+    "generatedAtUtc",
+    "fallbackReason"
+  ]
+}

--- a/schemas/v1/cli-output/defs/report-ref.schema.json
+++ b/schemas/v1/cli-output/defs/report-ref.schema.json
@@ -1,23 +1,44 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/report-ref.schema.json",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "kind": {
-      "type": "string"
+  "oneOf": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "path"
+      ]
     },
-    "path": {
-      "type": "string"
-    },
-    "uri": {
-      "type": "string"
-    },
-    "digest": {
-      "type": "string"
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "digest": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "uri"
+      ]
     }
-  },
-  "required": [
-    "kind"
   ]
 }

--- a/schemas/v1/cli-output/defs/report-ref.schema.json
+++ b/schemas/v1/cli-output/defs/report-ref.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/report-ref.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "uri": {
+      "type": "string"
+    },
+    "digest": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "kind"
+  ]
+}

--- a/schemas/v1/cli-output/defs/residual-risk.schema.json
+++ b/schemas/v1/cli-output/defs/residual-risk.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/residual-risk.schema.json",
+  "type": "object",
+  "properties": {
+    "code": {
+      "type": "string"
+    },
+    "blocking": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "code",
+    "blocking"
+  ]
+}

--- a/schemas/v1/cli-output/defs/touched.schema.json
+++ b/schemas/v1/cli-output/defs/touched.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/touched.schema.json",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "uri": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "state": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/schemas/v1/cli-output/defs/verifier.schema.json
+++ b/schemas/v1/cli-output/defs/verifier.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/verifier.schema.json",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "deterministic": {
+      "type": "boolean"
+    },
+    "required": {
+      "type": "boolean"
+    },
+    "primaryClaims": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "effects": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reportRef": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "kind",
+    "deterministic",
+    "required",
+    "primaryClaims"
+  ]
+}

--- a/schemas/v1/cli-output/defs/window.schema.json
+++ b/schemas/v1/cli-output/defs/window.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/window.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "limit": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "cursor": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nextCursor": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "isComplete": {
+      "type": "boolean"
+    },
+    "totalCount": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "limit",
+    "cursor",
+    "nextCursor",
+    "isComplete",
+    "totalCount"
+  ]
+}

--- a/schemas/v1/cli-output/envelope.schema.json
+++ b/schemas/v1/cli-output/envelope.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/envelope.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "protocolVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "command": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "error"
+      ]
+    },
+    "exitCode": {
+      "type": "integer"
+    },
+    "message": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "opId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "opId"
+        ]
+      }
+    }
+  },
+  "required": [
+    "protocolVersion",
+    "command",
+    "status",
+    "exitCode",
+    "message",
+    "payload",
+    "errors"
+  ]
+}

--- a/schemas/v1/cli-output/payload/call.schema.json
+++ b/schemas/v1/cli-output/payload/call.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/call.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "plan": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/codes.describe.schema.json
+++ b/schemas/v1/cli-output/payload/codes.describe.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/codes.describe.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "code": {
+      "type": "string"
+    },
+    "known": {
+      "type": "boolean"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "meaning": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "appearsIn": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "appliesTo": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "coverageImpact": {
+      "type": "object"
+    },
+    "verdictSemantics": {
+      "type": "object"
+    },
+    "executionSemantics": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "inspect": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "relatedCodes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "code",
+    "known",
+    "kind",
+    "category",
+    "summary",
+    "meaning",
+    "appearsIn",
+    "appliesTo",
+    "executionSemantics",
+    "inspect",
+    "relatedCodes"
+  ]
+}

--- a/schemas/v1/cli-output/payload/codes.list.schema.json
+++ b/schemas/v1/cli-output/payload/codes.list.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/codes.list.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "catalogVersion": {
+      "type": "integer"
+    },
+    "source": {
+      "type": "string"
+    },
+    "kinds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "codes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "kind",
+          "category",
+          "summary"
+        ]
+      }
+    }
+  },
+  "required": [
+    "catalogVersion",
+    "source",
+    "kinds",
+    "codes"
+  ]
+}

--- a/schemas/v1/cli-output/payload/daemon.start.schema.json
+++ b/schemas/v1/cli-output/payload/daemon.start.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/daemon.start.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "startStatus": {
+      "type": "string"
+    },
+    "daemonStatus": {
+      "type": "string"
+    },
+    "lifecycleState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "blockingReason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "canAcceptExecutionRequests": {
+      "type": "boolean"
+    },
+    "timeoutMilliseconds": {
+      "type": "integer"
+    },
+    "session": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "startup": {
+      "type": "object"
+    },
+    "diagnosis": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "retryDisposition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "safeToRetryImmediately": {
+      "type": "boolean"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/daemon.status.schema.json
+++ b/schemas/v1/cli-output/payload/daemon.status.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/daemon.status.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "daemonStatus": {
+      "type": "string"
+    },
+    "serverVersion": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "editorMode": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lifecycleState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "blockingReason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "compileState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "compileGeneration": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "domainReloadGeneration": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "canAcceptExecutionRequests": {
+      "type": "boolean"
+    },
+    "observedAtUtc": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "actionRequired": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "primaryDiagnostic": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "timeoutMilliseconds": {
+      "type": "integer"
+    },
+    "session": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "diagnosis": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "lastLaunchAttempt": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/init.schema.json
+++ b/schemas/v1/cli-output/payload/init.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/init.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "configPath": {
+      "type": "string"
+    },
+    "gitignorePath": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/ops.list.schema.json
+++ b/schemas/v1/cli-output/payload/ops.list.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/ops.list.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "operations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "policy": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "kind",
+          "policy",
+          "description"
+        ]
+      }
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/plan.schema.json
+++ b/schemas/v1/cli-output/payload/plan.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/plan.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    },
+    "planToken": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/query.asset.schema.schema.json
+++ b/schemas/v1/cli-output/payload/query.asset.schema.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.asset.schema.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/query.assets.find.schema.json
+++ b/schemas/v1/cli-output/payload/query.assets.find.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.assets.find.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/query.comp.schema.schema.json
+++ b/schemas/v1/cli-output/payload/query.comp.schema.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.comp.schema.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/query.go.describe.schema.json
+++ b/schemas/v1/cli-output/payload/query.go.describe.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.go.describe.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/query.scene.tree.schema.json
+++ b/schemas/v1/cli-output/payload/query.scene.tree.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.scene.tree.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/refresh.schema.json
+++ b/schemas/v1/cli-output/payload/refresh.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/refresh.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/resolve.schema.json
+++ b/schemas/v1/cli-output/payload/resolve.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/resolve.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "requestId": {
+      "type": "string"
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "opResults": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/op-result.schema.json"
+      }
+    },
+    "readPostcondition": {
+      "type": "object"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/status.schema.json
+++ b/schemas/v1/cli-output/payload/status.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/status.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "daemonStatus": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "unityVersion": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "serverVersion": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lifecycleState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "blockingReason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "compileState": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "compileGeneration": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "domainReloadGeneration": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "canAcceptExecutionRequests": {
+      "type": "boolean"
+    },
+    "editorMode": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "observedAtUtc": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "actionRequired": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "primaryDiagnostic": {
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "timeoutMilliseconds": {
+      "type": "integer"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/test.profile.init.schema.json
+++ b/schemas/v1/cli-output/payload/test.profile.init.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/test.profile.init.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "profilePath": {
+      "type": "string"
+    }
+  }
+}

--- a/schemas/v1/cli-output/payload/test.run.schema.json
+++ b/schemas/v1/cli-output/payload/test.run.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/test.run.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "result": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "errorKind": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "runId": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "artifactsDir": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "summaryJsonPath": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "result",
+    "errorKind",
+    "runId",
+    "artifactsDir",
+    "summaryJsonPath"
+  ]
+}

--- a/schemas/v1/cli-output/payload/validate.schema.json
+++ b/schemas/v1/cli-output/payload/validate.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/validate.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "readIndex": {
+      "$ref": "../defs/read-index.schema.json"
+    }
+  }
+}

--- a/schemas/v1/request/edit-dsl.schema.json
+++ b/schemas/v1/request/edit-dsl.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/request/edit-dsl.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "kind": {
+      "type": "string",
+      "const": "edit"
+    },
+    "id": {
+      "type": "string"
+    },
+    "on": {
+      "type": "object"
+    },
+    "select": {
+      "type": "object"
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "commit": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "kind",
+    "id",
+    "on",
+    "select",
+    "actions",
+    "commit"
+  ]
+}

--- a/schemas/v1/request/request-envelope.schema.json
+++ b/schemas/v1/request/request-envelope.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/request/request-envelope.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "steps": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "op"
+              },
+              "id": {
+                "type": "string"
+              },
+              "op": {
+                "type": "string"
+              },
+              "args": {
+                "type": "object"
+              }
+            },
+            "required": [
+              "kind",
+              "id",
+              "op",
+              "args"
+            ]
+          },
+          {
+            "$ref": "edit-dsl.schema.json"
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "steps"
+  ]
+}

--- a/schemas/v1/schema-manifest.json
+++ b/schemas/v1/schema-manifest.json
@@ -1,0 +1,193 @@
+{
+  "schemaSet": "ucli",
+  "schemaSetVersion": "v1",
+  "protocolVersion": 1,
+  "packageVersion": "0.0.0",
+  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+  "schemas": [
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/envelope.schema.json",
+      "path": "cli-output/envelope.schema.json",
+      "kind": "cli-output-envelope"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/project.schema.json",
+      "path": "cli-output/defs/project.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/read-index.schema.json",
+      "path": "cli-output/defs/read-index.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/op-result.schema.json",
+      "path": "cli-output/defs/op-result.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/diagnostic.schema.json",
+      "path": "cli-output/defs/diagnostic.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/touched.schema.json",
+      "path": "cli-output/defs/touched.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/window.schema.json",
+      "path": "cli-output/defs/window.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/verifier.schema.json",
+      "path": "cli-output/defs/verifier.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/assurance-claim.schema.json",
+      "path": "cli-output/defs/assurance-claim.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/evidence.schema.json",
+      "path": "cli-output/defs/evidence.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/report-ref.schema.json",
+      "path": "cli-output/defs/report-ref.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/defs/residual-risk.schema.json",
+      "path": "cli-output/defs/residual-risk.schema.json",
+      "kind": "cli-output-def"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/status.schema.json",
+      "path": "cli-output/payload/status.schema.json",
+      "kind": "cli-output-payload",
+      "command": "status"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/init.schema.json",
+      "path": "cli-output/payload/init.schema.json",
+      "kind": "cli-output-payload",
+      "command": "init"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/validate.schema.json",
+      "path": "cli-output/payload/validate.schema.json",
+      "kind": "cli-output-payload",
+      "command": "validate"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/plan.schema.json",
+      "path": "cli-output/payload/plan.schema.json",
+      "kind": "cli-output-payload",
+      "command": "plan"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/call.schema.json",
+      "path": "cli-output/payload/call.schema.json",
+      "kind": "cli-output-payload",
+      "command": "call"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/refresh.schema.json",
+      "path": "cli-output/payload/refresh.schema.json",
+      "kind": "cli-output-payload",
+      "command": "refresh"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/resolve.schema.json",
+      "path": "cli-output/payload/resolve.schema.json",
+      "kind": "cli-output-payload",
+      "command": "resolve"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.assets.find.schema.json",
+      "path": "cli-output/payload/query.assets.find.schema.json",
+      "kind": "cli-output-payload",
+      "command": "query.assets.find"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.scene.tree.schema.json",
+      "path": "cli-output/payload/query.scene.tree.schema.json",
+      "kind": "cli-output-payload",
+      "command": "query.scene.tree"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.go.describe.schema.json",
+      "path": "cli-output/payload/query.go.describe.schema.json",
+      "kind": "cli-output-payload",
+      "command": "query.go.describe"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.comp.schema.schema.json",
+      "path": "cli-output/payload/query.comp.schema.schema.json",
+      "kind": "cli-output-payload",
+      "command": "query.comp.schema"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/query.asset.schema.schema.json",
+      "path": "cli-output/payload/query.asset.schema.schema.json",
+      "kind": "cli-output-payload",
+      "command": "query.asset.schema"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/ops.list.schema.json",
+      "path": "cli-output/payload/ops.list.schema.json",
+      "kind": "cli-output-payload",
+      "command": "ops.list"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/codes.list.schema.json",
+      "path": "cli-output/payload/codes.list.schema.json",
+      "kind": "cli-output-payload",
+      "command": "codes.list"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/codes.describe.schema.json",
+      "path": "cli-output/payload/codes.describe.schema.json",
+      "kind": "cli-output-payload",
+      "command": "codes.describe"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/daemon.start.schema.json",
+      "path": "cli-output/payload/daemon.start.schema.json",
+      "kind": "cli-output-payload",
+      "command": "daemon.start"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/daemon.status.schema.json",
+      "path": "cli-output/payload/daemon.status.schema.json",
+      "kind": "cli-output-payload",
+      "command": "daemon.status"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/test.profile.init.schema.json",
+      "path": "cli-output/payload/test.profile.init.schema.json",
+      "kind": "cli-output-payload",
+      "command": "test.profile.init"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/test.run.schema.json",
+      "path": "cli-output/payload/test.run.schema.json",
+      "kind": "cli-output-payload",
+      "command": "test.run"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/request/request-envelope.schema.json",
+      "path": "request/request-envelope.schema.json",
+      "kind": "request-envelope"
+    },
+    {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/request/edit-dsl.schema.json",
+      "path": "request/edit-dsl.schema.json",
+      "kind": "request-edit-dsl"
+    }
+  ]
+}

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -69,7 +69,7 @@ is_dotnet_input() {
 
   case "${file}" in
     # Changes to this detector can alter every downstream job decision.
-    .editorconfig|.gitattributes|Directory.Build.props|Ucli.slnx|.github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|.github/workflows/cli-package-publish.yaml|scripts/code-quality.sh|scripts/detect-verify-scopes.sh|scripts/dotnet-common.sh|scripts/generate-skills.sh|scripts/test-dotnet.sh|scripts/verify-skills.sh|scripts/verify.sh|skills/*|src/Ucli.Skills/SkillDefinitions/*|tools/*)
+    .editorconfig|.gitattributes|Directory.Build.props|Ucli.slnx|.github/workflows/verify.yaml|.github/workflows/shared-package-publish.yaml|.github/workflows/cli-package-publish.yaml|scripts/code-quality.sh|scripts/detect-verify-scopes.sh|scripts/dotnet-common.sh|scripts/generate-schemas.sh|scripts/generate-skills.sh|scripts/test-dotnet.sh|scripts/verify-schemas.sh|scripts/verify-skills.sh|scripts/verify.sh|schemas/*|skills/*|src/Ucli.Skills/SkillDefinitions/*|tools/*)
       return 0
       ;;
   esac
@@ -159,7 +159,7 @@ is_cli_pack_input() {
   fi
 
   case "${file}" in
-    README.md|LICENSE|.gitattributes|Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/generate-skills.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|scripts/verify-skills.sh|skills/*|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*|src/Ucli.Skills/*|tools/*)
+    README.md|LICENSE|.gitattributes|Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/generate-schemas.sh|scripts/generate-skills.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|scripts/verify-schemas.sh|scripts/verify-skills.sh|schemas/*|skills/*|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*|src/Ucli.Skills/*|tools/*)
       return 0
       ;;
     *)

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -159,7 +159,7 @@ is_cli_pack_input() {
   fi
 
   case "${file}" in
-    README.md|LICENSE|.gitattributes|Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/generate-schemas.sh|scripts/generate-skills.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|scripts/verify-schemas.sh|scripts/verify-skills.sh|schemas/*|skills/*|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*|src/Ucli.Skills/*|tools/*)
+    README.md|LICENSE|.gitattributes|Directory.Build.props|.github/workflows/verify.yaml|.github/workflows/cli-package-publish.yaml|scripts/detect-verify-scopes.sh|scripts/generate-schemas.sh|scripts/generate-skills.sh|scripts/pack-schema-artifacts.sh|scripts/schema-artifact-common.sh|scripts/sync-cli-package-version.sh|scripts/verify-cli-package.sh|scripts/verify-schema-artifacts.sh|scripts/verify-schemas.sh|scripts/verify-skills.sh|schemas/*|skills/*|src/Ucli/*|src/Ucli.Application/*|src/Ucli.Contracts/*|src/Ucli.Infrastructure/*|src/Ucli.Skills/*|tools/*)
       return 0
       ;;
     *)

--- a/scripts/generate-schemas.sh
+++ b/scripts/generate-schemas.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/dotnet-common.sh
+source "$script_dir/dotnet-common.sh"
+
+usage() {
+  echo "usage: bash scripts/generate-schemas.sh [--output <schemas-dir>] [--package-version <version>]" >&2
+}
+
+output_root="$DOTNET_REPO_ROOT/schemas"
+package_version=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      if [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+
+      output_root="$2"
+      shift 2
+      ;;
+    --output=*)
+      output_root="${1#--output=}"
+      shift
+      ;;
+    --package-version)
+      if [ "$#" -lt 2 ]; then
+        usage
+        exit 2
+      fi
+
+      package_version="$2"
+      shift 2
+      ;;
+    --package-version=*)
+      package_version="${1#--package-version=}"
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+output_root="$(dotnet_to_bash_path "$output_root")"
+
+case "$output_root" in
+  /*)
+    ;;
+  *)
+    output_root="$DOTNET_REPO_ROOT/$output_root"
+    ;;
+esac
+
+generator_project="$DOTNET_REPO_ROOT/tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"
+runtime_generator_project="$generator_project"
+runtime_repository_root="$DOTNET_REPO_ROOT"
+runtime_output_root="$output_root"
+
+if command -v cygpath >/dev/null 2>&1; then
+  runtime_generator_project="$(cygpath -w "$generator_project")"
+  runtime_repository_root="$(cygpath -w "$DOTNET_REPO_ROOT")"
+  runtime_output_root="$(cygpath -w "$output_root")"
+fi
+
+generator_args=(
+  --project "$runtime_generator_project"
+  --configuration Release
+  --
+  --repository-root "$runtime_repository_root"
+  --output "$runtime_output_root"
+)
+
+if [ -n "$package_version" ]; then
+  generator_args+=(--package-version "$package_version")
+fi
+
+dotnet run "${generator_args[@]}"

--- a/scripts/pack-schema-artifacts.sh
+++ b/scripts/pack-schema-artifacts.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/pack-schema-artifacts.sh --version <version> [--repo-root <path>] [--output <dir>]
+
+Creates MackySoft.Ucli.Schemas.<version>.zip with schemas/v1 as the archive root.
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/schema-artifact-common.sh
+source "${script_dir}/schema-artifact-common.sh"
+
+repository_root="$(cd "${script_dir}/.." && pwd)"
+package_version=""
+output_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      repository_root="$(cd "$2" && pwd)"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      package_version="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      output_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${package_version}" ]]; then
+  usage
+  exit 2
+fi
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "Required tool is missing: zip" >&2
+  exit 1
+fi
+
+if [[ -z "${output_dir}" ]]; then
+  output_dir="${repository_root}/artifacts/packages"
+fi
+
+schema_root="${repository_root}/schemas"
+schema_manifest="${schema_root}/v1/schema-manifest.json"
+if [[ ! -f "${schema_manifest}" ]]; then
+  echo "Schema manifest does not exist: ${schema_manifest}" >&2
+  exit 1
+fi
+
+reject_unsafe_schema_tree_entries "${schema_root}" "source tree"
+assert_json_manifest_package_version "${schema_manifest}" "${package_version}" "Schema manifest"
+
+mkdir -p "${output_dir}"
+output_dir="$(cd "${output_dir}" && pwd)"
+archive_path="${output_dir}/MackySoft.Ucli.Schemas.${package_version}.zip"
+file_list="$(mktemp)"
+trap 'rm -f "${file_list}"' EXIT
+
+while IFS= read -r schema_file; do
+  printf '%s\n' "${schema_file#"${repository_root}/"}"
+done < <(find "${schema_root}" -type f | sort) > "${file_list}"
+
+rm -f "${archive_path}"
+(
+  cd "${repository_root}"
+  zip -q -X "${archive_path}" -@ < "${file_list}"
+)
+
+echo "Packed schema artifacts: ${archive_path}"

--- a/scripts/schema-artifact-common.sh
+++ b/scripts/schema-artifact-common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+require_python3() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Required tool is missing: python3" >&2
+    return 1
+  fi
+}
+
+assert_json_manifest_package_version() {
+  local manifest_path="$1"
+  local expected_version="$2"
+  local label="$3"
+
+  require_python3
+
+  python3 - "${manifest_path}" "${expected_version}" "${label}" <<'PY'
+import json
+import sys
+
+manifest_path = sys.argv[1]
+expected_version = sys.argv[2]
+label = sys.argv[3]
+
+try:
+    with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+except Exception as exception:
+    print(f"{label} could not be parsed as JSON: {exception}", file=sys.stderr)
+    sys.exit(1)
+
+if not isinstance(manifest, dict):
+    print(f"{label} must be a JSON object.", file=sys.stderr)
+    sys.exit(1)
+
+actual_version = manifest.get("packageVersion")
+if actual_version != expected_version:
+    print(
+        f"{label} has an unexpected packageVersion. "
+        f"Expected: {expected_version}. Actual: {actual_version}",
+        file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+reject_unsafe_schema_tree_entries() {
+  local schema_root="$1"
+  local label="$2"
+  local entry
+
+  if [[ ! -d "${schema_root}" ]]; then
+    echo "Generated schemas ${label} does not exist: ${schema_root}" >&2
+    return 1
+  fi
+
+  while IFS= read -r -d '' entry; do
+    case "${entry}" in
+      *$'\n'*|*$'\r'*)
+        echo "Generated schemas ${label} contains a path with a newline: ${entry}" >&2
+        return 1
+        ;;
+    esac
+  done < <(find "${schema_root}" -print0)
+
+  while IFS= read -r entry; do
+    echo "Generated schemas ${label} contains unsupported non-regular path: ${entry}" >&2
+    return 1
+  done < <(find "${schema_root}" ! -type f ! -type d -print | sort)
+}

--- a/scripts/sync-cli-package-version.sh
+++ b/scripts/sync-cli-package-version.sh
@@ -16,3 +16,4 @@ package_version="$(parse_package_version_arg usage "$@")"
 props_path="Directory.Build.props"
 
 update_xml_element_value "${props_path}" "Version" "${package_version}" "central package version"
+bash "${script_dir}/generate-schemas.sh" --package-version "${package_version}"

--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -7,6 +7,8 @@ if [[ "$#" -ne 2 ]]; then
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/schema-artifact-common.sh
+source "${script_dir}/schema-artifact-common.sh"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 package_dir="$1"
 expected_version="$2"
@@ -57,6 +59,10 @@ for entry in README.md LICENSE tools/net8.0/any/DotnetToolSettings.xml tools/net
   fi
 done
 
+package_schema_manifest_path="${tool_path}/package-schema-manifest.json"
+unzip -p "${package_path}" tools/net8.0/any/schemas/v1/schema-manifest.json > "${package_schema_manifest_path}"
+assert_json_manifest_package_version "${package_schema_manifest_path}" "${expected_version}" "CLI package schema manifest"
+
 while IFS= read -r skill_file; do
   relative_path="${skill_file#"${repo_root}/"}"
   entry="tools/net8.0/any/${relative_path}"
@@ -75,10 +81,13 @@ while IFS= read -r schema_file; do
   fi
 done < <(find "${repo_root}/schemas" -type f | sort)
 
-if ! find "${tool_path}" -path "*/schemas/v1/schema-manifest.json" -type f | grep -F "schema-manifest.json" >/dev/null; then
+installed_schema_manifest="$(find "${tool_path}" -path "*/schemas/v1/schema-manifest.json" -type f | head -n 1)"
+if [[ -z "${installed_schema_manifest}" ]]; then
   echo "Installed CLI tool package did not materialize schemas/v1/schema-manifest.json." >&2
   exit 1
 fi
+
+assert_json_manifest_package_version "${installed_schema_manifest}" "${expected_version}" "Installed CLI tool schema manifest"
 
 list_host_independent_skill_files() {
   local relative_path

--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -50,7 +50,7 @@ if ! "${tool_path}/ucli" --help | grep -F "Commands:" >/dev/null; then
 fi
 
 package_entries="$(unzip -Z1 "${package_path}")"
-for entry in README.md LICENSE tools/net8.0/any/DotnetToolSettings.xml; do
+for entry in README.md LICENSE tools/net8.0/any/DotnetToolSettings.xml tools/net8.0/any/schemas/v1/schema-manifest.json; do
   if ! grep -Fx "${entry}" <<< "${package_entries}" >/dev/null; then
     echo "CLI package is missing required entry: ${entry}" >&2
     exit 1
@@ -65,6 +65,20 @@ while IFS= read -r skill_file; do
     exit 1
   fi
 done < <(find "${repo_root}/skills" -type f | sort)
+
+while IFS= read -r schema_file; do
+  relative_path="${schema_file#"${repo_root}/"}"
+  entry="tools/net8.0/any/${relative_path}"
+  if ! grep -Fx "${entry}" <<< "${package_entries}" >/dev/null; then
+    echo "CLI package is missing required schema entry: ${entry}" >&2
+    exit 1
+  fi
+done < <(find "${repo_root}/schemas" -type f | sort)
+
+if ! find "${tool_path}" -path "*/schemas/v1/schema-manifest.json" -type f | grep -F "schema-manifest.json" >/dev/null; then
+  echo "Installed CLI tool package did not materialize schemas/v1/schema-manifest.json." >&2
+  exit 1
+fi
 
 list_host_independent_skill_files() {
   local relative_path

--- a/scripts/verify-schema-artifacts.sh
+++ b/scripts/verify-schema-artifacts.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: $0 <package-dir> <expected-version>" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/schema-artifact-common.sh
+source "${script_dir}/schema-artifact-common.sh"
+
+repository_root="$(cd "${script_dir}/.." && pwd)"
+package_dir="$1"
+expected_version="$2"
+
+if [[ ! -d "${package_dir}" ]]; then
+  echo "Schema artifact package directory does not exist: ${package_dir}" >&2
+  exit 1
+fi
+
+require_python3
+reject_unsafe_schema_tree_entries "${repository_root}/schemas" "source tree"
+
+package_dir="$(cd "${package_dir}" && pwd)"
+archive_path="${package_dir}/MackySoft.Ucli.Schemas.${expected_version}.zip"
+if [[ ! -f "${archive_path}" ]]; then
+  echo "Schema artifact archive was not created: ${archive_path}" >&2
+  exit 1
+fi
+
+python3 - "${repository_root}" "${archive_path}" "${expected_version}" <<'PY'
+import json
+import os
+import posixpath
+import stat
+import sys
+import zipfile
+
+repository_root = sys.argv[1]
+archive_path = sys.argv[2]
+expected_version = sys.argv[3]
+schema_root = os.path.join(repository_root, "schemas")
+
+expected_entries = []
+for root, _, files in os.walk(schema_root):
+    for file_name in files:
+        full_path = os.path.join(root, file_name)
+        relative_path = os.path.relpath(full_path, repository_root).replace(os.sep, "/")
+        expected_entries.append(relative_path)
+
+expected_entries.sort()
+expected_entry_set = set(expected_entries)
+
+with zipfile.ZipFile(archive_path) as archive:
+    infos = archive.infolist()
+    actual_entries = [info.filename for info in infos]
+
+    if not actual_entries:
+        print(f"Schema artifact archive is empty: {archive_path}", file=sys.stderr)
+        sys.exit(1)
+
+    actual_entry_set = set(actual_entries)
+    if actual_entry_set != expected_entry_set:
+        missing = sorted(expected_entry_set - actual_entry_set)
+        unexpected = sorted(actual_entry_set - expected_entry_set)
+        if missing:
+            print("Schema artifact archive is missing entries:", file=sys.stderr)
+            for entry in missing:
+                print(entry, file=sys.stderr)
+        if unexpected:
+            print("Schema artifact archive contains unexpected entries:", file=sys.stderr)
+            for entry in unexpected:
+                print(entry, file=sys.stderr)
+        sys.exit(1)
+
+    for info in infos:
+        name = info.filename
+        if "\n" in name or "\r" in name:
+            print(f"Schema artifact archive contains a path with a newline: {name!r}", file=sys.stderr)
+            sys.exit(1)
+
+        if name.startswith("/") or name.endswith("/") or not name.startswith("schemas/v1/"):
+            print(f"Schema artifact archive contains an invalid entry path: {name}", file=sys.stderr)
+            sys.exit(1)
+
+        normalized_name = posixpath.normpath(name)
+        if normalized_name != name or normalized_name.startswith("../") or "/../" in normalized_name:
+            print(f"Schema artifact archive contains a traversing entry path: {name}", file=sys.stderr)
+            sys.exit(1)
+
+        file_type = (info.external_attr >> 16) & 0o170000
+        if file_type and file_type != stat.S_IFREG:
+            print(f"Schema artifact archive contains a non-regular entry: {name}", file=sys.stderr)
+            sys.exit(1)
+
+    manifest_entry = "schemas/v1/schema-manifest.json"
+    if manifest_entry not in actual_entry_set:
+        print(f"Schema artifact archive is missing required entry: {manifest_entry}", file=sys.stderr)
+        sys.exit(1)
+
+    manifest = json.loads(archive.read(manifest_entry))
+    if not isinstance(manifest, dict):
+        print("Schema artifact manifest must be a JSON object.", file=sys.stderr)
+        sys.exit(1)
+
+    actual_version = manifest.get("packageVersion")
+    if actual_version != expected_version:
+        print(
+            f"Schema artifact manifest has an unexpected packageVersion. "
+            f"Expected: {expected_version}. Actual: {actual_version}",
+            file=sys.stderr)
+        sys.exit(1)
+PY
+
+echo "Schema artifact archive verified: ${archive_path}"

--- a/scripts/verify-schemas.sh
+++ b/scripts/verify-schemas.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/dotnet-common.sh
+source "$script_dir/dotnet-common.sh"
+
+temp_root="$(dotnet_to_bash_path "${RUNNER_TEMP:-${TMPDIR:-/tmp}}")"
+mkdir -p "$temp_root"
+work_dir="$(mktemp -d "${temp_root%/}/ucli-schemas-verify.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+
+reject_non_regular_entries() {
+  local root="$1"
+  local label="$2"
+  local entry
+
+  while IFS= read -r entry; do
+    echo "Generated schemas ${label} contains unsupported non-regular path: ${entry}" >&2
+    return 1
+  done < <(find "$root" ! -type f ! -type d -print | sort)
+}
+
+expected_root="$work_dir/schemas"
+bash "$script_dir/generate-schemas.sh" --output "$expected_root" >/dev/null
+
+reject_non_regular_entries "$DOTNET_REPO_ROOT/schemas" "source tree"
+reject_non_regular_entries "$expected_root" "expected tree"
+
+if ! diff -ruN "$DOTNET_REPO_ROOT/schemas" "$expected_root"; then
+  echo "Generated schema drift detected. Run: bash scripts/generate-schemas.sh" >&2
+  exit 1
+fi
+
+echo "Generated schemas are up to date."

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -79,6 +79,7 @@ if [ "$restore" = true ]; then
 fi
 
 bash scripts/verify-skills.sh
+bash scripts/verify-schemas.sh
 bash scripts/code-quality.sh --no-restore --solution "$solution" verify
 dotnet build "$solution" --configuration "$configuration" --no-restore
 test_dotnet_args=(

--- a/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidationResult.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidationResult.cs
@@ -1,0 +1,9 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Semantics;
+
+/// <summary> Represents semantic invariant validation output for one assurance payload. </summary>
+/// <param name="Violations"> The detected semantic invariant violations. </param>
+internal sealed record AssuranceSemanticInvariantValidationResult (IReadOnlyList<AssuranceSemanticInvariantViolation> Violations)
+{
+    /// <summary> Gets a value indicating whether no semantic invariant violations were found. </summary>
+    public bool IsValid => Violations.Count == 0;
+}

--- a/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
@@ -1,0 +1,520 @@
+using System.Text.Json;
+using MackySoft.Ucli.Application.Features.CodeCatalog.Catalog;
+
+namespace MackySoft.Ucli.Application.Features.Assurance.Semantics;
+
+/// <summary> Validates cross-field semantic invariants in assurance command payloads. </summary>
+internal sealed class AssuranceSemanticInvariantValidator
+{
+    private const string VerdictPass = "pass";
+    private const string VerdictFail = "fail";
+    private const string VerdictIncomplete = "incomplete";
+
+    private readonly ICodeCatalog codeCatalog;
+
+    /// <summary> Initializes a new instance of the <see cref="AssuranceSemanticInvariantValidator" /> class. </summary>
+    /// <param name="codeCatalog"> The code catalog used to resolve claim and risk codes. </param>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="codeCatalog" /> is <see langword="null" />. </exception>
+    public AssuranceSemanticInvariantValidator (ICodeCatalog codeCatalog)
+    {
+        this.codeCatalog = codeCatalog ?? throw new ArgumentNullException(nameof(codeCatalog));
+    }
+
+    /// <summary> Validates one assurance payload object. </summary>
+    /// <param name="payload"> The assurance payload root. </param>
+    /// <returns> The semantic invariant validation result. </returns>
+    public AssuranceSemanticInvariantValidationResult Validate (JsonElement payload)
+    {
+        var violations = new List<AssuranceSemanticInvariantViolation>();
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$", "Assurance payload must be an object.");
+            return new AssuranceSemanticInvariantValidationResult(violations);
+        }
+
+        var reports = ReadReports(payload, violations);
+        var verifiers = ReadVerifiers(payload, reports, violations);
+        var claims = ReadClaims(payload, reports, violations);
+        var payloadResidualRisks = ReadResidualRisks(payload, "$.residualRisks", violations);
+
+        ValidateClaimVerifierReferences(claims, verifiers, violations);
+        ValidatePrimaryClaims(verifiers, claims, violations);
+        ValidateVerdict(payload, claims, payloadResidualRisks, violations);
+
+        return new AssuranceSemanticInvariantValidationResult(violations);
+    }
+
+    private Dictionary<string, ReportInfo> ReadReports (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var reports = new Dictionary<string, ReportInfo>(StringComparer.Ordinal);
+        if (!payload.TryGetProperty("reports", out var reportsElement) || reportsElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.reports", "Assurance payload reports must be an object.");
+            return reports;
+        }
+
+        foreach (var reportProperty in reportsElement.EnumerateObject())
+        {
+            var reportPath = BuildPropertyPath("$.reports", reportProperty.Name);
+            if (reportProperty.Value.ValueKind != JsonValueKind.Object)
+            {
+                AddViolation(violations, reportPath, "Report entry must be an object.");
+                continue;
+            }
+
+            if (!TryReadRequiredString(reportProperty.Value, "kind", reportPath, violations, out var kind))
+            {
+                continue;
+            }
+
+            var hasPath = TryReadOptionalString(reportProperty.Value, "path", reportPath, violations, out var path);
+            var hasUri = TryReadOptionalString(reportProperty.Value, "uri", reportPath, violations, out var uri);
+            if (hasPath == hasUri)
+            {
+                AddViolation(violations, reportPath, "Report entry must contain exactly one locator: path or uri.");
+            }
+
+            reports[reportProperty.Name] = new ReportInfo(kind, path, uri);
+        }
+
+        return reports;
+    }
+
+    private List<VerifierInfo> ReadVerifiers (
+        JsonElement payload,
+        IReadOnlyDictionary<string, ReportInfo> reports,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var verifiers = new List<VerifierInfo>();
+        if (!payload.TryGetProperty("verifiers", out var verifiersElement) || verifiersElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, "$.verifiers", "Assurance payload verifiers must be an array.");
+            return verifiers;
+        }
+
+        var index = 0;
+        foreach (var verifierElement in verifiersElement.EnumerateArray())
+        {
+            var verifierPath = $"$.verifiers[{index}]";
+            if (verifierElement.ValueKind != JsonValueKind.Object)
+            {
+                AddViolation(violations, verifierPath, "Verifier entry must be an object.");
+                index++;
+                continue;
+            }
+
+            var id = TryReadRequiredString(verifierElement, "id", verifierPath, violations, out var readId)
+                ? readId
+                : string.Empty;
+            var required = TryReadBoolean(verifierElement, "required", defaultValue: false);
+            var primaryClaims = ReadStringArray(verifierElement, "primaryClaims", verifierPath, violations);
+
+            if (required && primaryClaims.Count == 0)
+            {
+                AddViolation(violations, BuildPropertyPath(verifierPath, "primaryClaims"), "Required verifier must declare at least one primary claim.");
+            }
+
+            if (TryReadOptionalString(verifierElement, "reportRef", verifierPath, violations, out var reportRef)
+                && !reports.ContainsKey(reportRef!))
+            {
+                AddViolation(violations, BuildPropertyPath(verifierPath, "reportRef"), $"Verifier reportRef '{reportRef}' does not resolve to payload.reports.");
+            }
+
+            verifiers.Add(new VerifierInfo(index, verifierPath, id, required, primaryClaims));
+            index++;
+        }
+
+        return verifiers;
+    }
+
+    private List<ClaimInfo> ReadClaims (
+        JsonElement payload,
+        IReadOnlyDictionary<string, ReportInfo> reports,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var claims = new List<ClaimInfo>();
+        if (!payload.TryGetProperty("claims", out var claimsElement) || claimsElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, "$.claims", "Assurance payload claims must be an array.");
+            return claims;
+        }
+
+        var index = 0;
+        foreach (var claimElement in claimsElement.EnumerateArray())
+        {
+            var claimPath = $"$.claims[{index}]";
+            if (claimElement.ValueKind != JsonValueKind.Object)
+            {
+                AddViolation(violations, claimPath, "Claim entry must be an object.");
+                index++;
+                continue;
+            }
+
+            var id = TryReadRequiredString(claimElement, "id", claimPath, violations, out var readId)
+                ? readId
+                : string.Empty;
+            ValidateCatalogCode(id, CodeCatalogKindValues.Claim, BuildPropertyPath(claimPath, "id"), violations);
+
+            var verifierRef = TryReadRequiredString(claimElement, "verifierRef", claimPath, violations, out var readVerifierRef)
+                ? readVerifierRef
+                : string.Empty;
+            var status = TryReadRequiredString(claimElement, "status", claimPath, violations, out var readStatus)
+                ? readStatus
+                : string.Empty;
+            var coverage = TryReadRequiredString(claimElement, "coverage", claimPath, violations, out var readCoverage)
+                ? readCoverage
+                : string.Empty;
+            var required = TryReadBoolean(claimElement, "required", defaultValue: false);
+
+            ResolveEvidenceReferences(claimElement, claimPath, reports, violations);
+            var residualRisks = ReadResidualRisks(claimElement, BuildPropertyPath(claimPath, "residualRisks"), violations);
+
+            claims.Add(new ClaimInfo(index, claimPath, id, verifierRef, status, coverage, required, residualRisks));
+            index++;
+        }
+
+        return claims;
+    }
+
+    private List<ResidualRiskInfo> ReadResidualRisks (
+        JsonElement owner,
+        string residualRisksPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var risks = new List<ResidualRiskInfo>();
+        var propertyName = GetLastPropertyName(residualRisksPath);
+        if (!owner.TryGetProperty(propertyName, out var residualRisksElement))
+        {
+            return risks;
+        }
+
+        if (residualRisksElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, residualRisksPath, "Residual risks must be an array.");
+            return risks;
+        }
+
+        var index = 0;
+        foreach (var riskElement in residualRisksElement.EnumerateArray())
+        {
+            var riskPath = $"{residualRisksPath}[{index}]";
+            if (riskElement.ValueKind != JsonValueKind.Object)
+            {
+                AddViolation(violations, riskPath, "Residual risk entry must be an object.");
+                index++;
+                continue;
+            }
+
+            if (TryReadRequiredString(riskElement, "code", riskPath, violations, out var code))
+            {
+                ValidateCatalogCode(code, CodeCatalogKindValues.Risk, BuildPropertyPath(riskPath, "code"), violations);
+            }
+
+            risks.Add(new ResidualRiskInfo(TryReadBoolean(riskElement, "blocking", defaultValue: false)));
+            index++;
+        }
+
+        return risks;
+    }
+
+    private static void ValidateClaimVerifierReferences (
+        IReadOnlyList<ClaimInfo> claims,
+        IReadOnlyList<VerifierInfo> verifiers,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var verifierById = verifiers
+            .Where(static verifier => !string.IsNullOrWhiteSpace(verifier.Id))
+            .ToDictionary(static verifier => verifier.Id, static verifier => verifier, StringComparer.Ordinal);
+
+        for (var i = 0; i < claims.Count; i++)
+        {
+            var claim = claims[i];
+            if (!verifierById.TryGetValue(claim.VerifierRef, out var verifier))
+            {
+                AddViolation(violations, BuildPropertyPath(claim.Path, "verifierRef"), $"Claim verifierRef '{claim.VerifierRef}' does not resolve to payload.verifiers.");
+                continue;
+            }
+
+            if (claim.Required && !verifier.Required)
+            {
+                AddViolation(violations, BuildPropertyPath(claim.Path, "required"), "Required claim must reference a required verifier.");
+            }
+        }
+    }
+
+    private static void ValidatePrimaryClaims (
+        IReadOnlyList<VerifierInfo> verifiers,
+        IReadOnlyList<ClaimInfo> claims,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var claimsById = claims
+            .Where(static claim => !string.IsNullOrWhiteSpace(claim.Id))
+            .ToDictionary(static claim => claim.Id, static claim => claim, StringComparer.Ordinal);
+
+        for (var i = 0; i < verifiers.Count; i++)
+        {
+            var verifier = verifiers[i];
+            for (var j = 0; j < verifier.PrimaryClaims.Count; j++)
+            {
+                var claimId = verifier.PrimaryClaims[j];
+                var claimPath = $"{BuildPropertyPath(verifier.Path, "primaryClaims")}[{j}]";
+                if (!claimsById.TryGetValue(claimId, out var claim))
+                {
+                    AddViolation(violations, claimPath, $"Verifier primary claim '{claimId}' does not resolve to payload.claims.");
+                    continue;
+                }
+
+                if (!string.Equals(claim.VerifierRef, verifier.Id, StringComparison.Ordinal))
+                {
+                    AddViolation(violations, claimPath, $"Verifier primary claim '{claimId}' is owned by verifierRef '{claim.VerifierRef}'.");
+                }
+            }
+        }
+    }
+
+    private static void ValidateVerdict (
+        JsonElement payload,
+        IReadOnlyList<ClaimInfo> claims,
+        IReadOnlyList<ResidualRiskInfo> payloadResidualRisks,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadRequiredString(payload, "verdict", "$", violations, out var actualVerdict))
+        {
+            return;
+        }
+
+        var expectedVerdict = RecalculateVerdict(claims, payloadResidualRisks);
+        if (!string.Equals(actualVerdict, expectedVerdict, StringComparison.Ordinal))
+        {
+            AddViolation(violations, "$.verdict", $"Verdict must be '{expectedVerdict}' when recalculated from claims and residual risks.");
+        }
+    }
+
+    private void ValidateCatalogCode (
+        string code,
+        string expectedKind,
+        string path,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return;
+        }
+
+        if (!codeCatalog.TryFind(code, out var descriptor))
+        {
+            AddViolation(violations, path, $"Code '{code}' is not registered in the code catalog.");
+            return;
+        }
+
+        if (!string.Equals(descriptor.Kind, expectedKind, StringComparison.Ordinal))
+        {
+            AddViolation(violations, path, $"Code '{code}' must be registered as kind '{expectedKind}'.");
+        }
+    }
+
+    private static void ResolveEvidenceReferences (
+        JsonElement claimElement,
+        string claimPath,
+        IReadOnlyDictionary<string, ReportInfo> reports,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!claimElement.TryGetProperty("evidence", out var evidenceElement))
+        {
+            return;
+        }
+
+        if (evidenceElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, BuildPropertyPath(claimPath, "evidence"), "Claim evidence must be an array.");
+            return;
+        }
+
+        var index = 0;
+        foreach (var evidenceItem in evidenceElement.EnumerateArray())
+        {
+            var evidencePath = $"{BuildPropertyPath(claimPath, "evidence")}[{index}]";
+            if (evidenceItem.ValueKind != JsonValueKind.Object)
+            {
+                AddViolation(violations, evidencePath, "Evidence entry must be an object.");
+                index++;
+                continue;
+            }
+
+            if (TryReadOptionalString(evidenceItem, "evidenceRef", evidencePath, violations, out var evidenceRef)
+                && !reports.ContainsKey(evidenceRef!))
+            {
+                AddViolation(violations, BuildPropertyPath(evidencePath, "evidenceRef"), $"Evidence reference '{evidenceRef}' does not resolve to payload.reports.");
+            }
+
+            index++;
+        }
+    }
+
+    private static string RecalculateVerdict (
+        IReadOnlyList<ClaimInfo> claims,
+        IReadOnlyList<ResidualRiskInfo> payloadResidualRisks)
+    {
+        if (payloadResidualRisks.Any(static risk => risk.Blocking)
+            || claims.Any(static claim => claim.ResidualRisks.Any(static risk => risk.Blocking)))
+        {
+            return VerdictFail;
+        }
+
+        var requiredClaims = claims.Where(static claim => claim.Required).ToArray();
+        if (requiredClaims.Any(static claim => string.Equals(claim.Status, "failed", StringComparison.Ordinal)))
+        {
+            return VerdictFail;
+        }
+
+        if (requiredClaims.Any(static claim =>
+                !string.Equals(claim.Status, "passed", StringComparison.Ordinal)
+                || !string.Equals(claim.Coverage, "full", StringComparison.Ordinal)))
+        {
+            return VerdictIncomplete;
+        }
+
+        return VerdictPass;
+    }
+
+    private static bool TryReadRequiredString (
+        JsonElement owner,
+        string propertyName,
+        string ownerPath,
+        List<AssuranceSemanticInvariantViolation> violations,
+        out string value)
+    {
+        value = string.Empty;
+        if (!owner.TryGetProperty(propertyName, out var propertyElement) || propertyElement.ValueKind != JsonValueKind.String)
+        {
+            AddViolation(violations, BuildPropertyPath(ownerPath, propertyName), "Required string property is missing or invalid.");
+            return false;
+        }
+
+        value = propertyElement.GetString() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            AddViolation(violations, BuildPropertyPath(ownerPath, propertyName), "Required string property must not be empty.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadOptionalString (
+        JsonElement owner,
+        string propertyName,
+        string ownerPath,
+        List<AssuranceSemanticInvariantViolation> violations,
+        out string? value)
+    {
+        value = null;
+        if (!owner.TryGetProperty(propertyName, out var propertyElement) || propertyElement.ValueKind == JsonValueKind.Null)
+        {
+            return false;
+        }
+
+        if (propertyElement.ValueKind != JsonValueKind.String)
+        {
+            AddViolation(violations, BuildPropertyPath(ownerPath, propertyName), "Optional string property must be a string when present.");
+            return false;
+        }
+
+        value = propertyElement.GetString();
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryReadBoolean (
+        JsonElement owner,
+        string propertyName,
+        bool defaultValue)
+    {
+        return owner.TryGetProperty(propertyName, out var propertyElement)
+            && (propertyElement.ValueKind == JsonValueKind.True || propertyElement.ValueKind == JsonValueKind.False)
+            ? propertyElement.GetBoolean()
+            : defaultValue;
+    }
+
+    private static IReadOnlyList<string> ReadStringArray (
+        JsonElement owner,
+        string propertyName,
+        string ownerPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!owner.TryGetProperty(propertyName, out var arrayElement))
+        {
+            return Array.Empty<string>();
+        }
+
+        if (arrayElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, BuildPropertyPath(ownerPath, propertyName), "Property must be an array.");
+            return Array.Empty<string>();
+        }
+
+        var values = new List<string>();
+        var index = 0;
+        foreach (var item in arrayElement.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                AddViolation(violations, $"{BuildPropertyPath(ownerPath, propertyName)}[{index}]", "Array item must be a string.");
+            }
+            else
+            {
+                values.Add(item.GetString() ?? string.Empty);
+            }
+
+            index++;
+        }
+
+        return values;
+    }
+
+    private static string GetLastPropertyName (string path)
+    {
+        var index = path.LastIndexOf(".", StringComparison.Ordinal);
+        return index >= 0 ? path[(index + 1)..] : path;
+    }
+
+    private static string BuildPropertyPath (
+        string parentPath,
+        string propertyName)
+    {
+        return $"{parentPath}.{propertyName}";
+    }
+
+    private static void AddViolation (
+        List<AssuranceSemanticInvariantViolation> violations,
+        string path,
+        string message)
+    {
+        violations.Add(new AssuranceSemanticInvariantViolation(path, message));
+    }
+
+    private sealed record ReportInfo (
+        string Kind,
+        string? Path,
+        string? Uri);
+
+    private sealed record VerifierInfo (
+        int Index,
+        string Path,
+        string Id,
+        bool Required,
+        IReadOnlyList<string> PrimaryClaims);
+
+    private sealed record ClaimInfo (
+        int Index,
+        string Path,
+        string Id,
+        string VerifierRef,
+        string Status,
+        string Coverage,
+        bool Required,
+        IReadOnlyList<ResidualRiskInfo> ResidualRisks);
+
+    private sealed record ResidualRiskInfo (bool Blocking);
+}

--- a/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
@@ -224,9 +224,7 @@ internal sealed class AssuranceSemanticInvariantValidator
         IReadOnlyList<VerifierInfo> verifiers,
         List<AssuranceSemanticInvariantViolation> violations)
     {
-        var verifierById = verifiers
-            .Where(static verifier => !string.IsNullOrWhiteSpace(verifier.Id))
-            .ToDictionary(static verifier => verifier.Id, static verifier => verifier, StringComparer.Ordinal);
+        var verifierById = BuildVerifierIndex(verifiers, violations);
 
         for (var i = 0; i < claims.Count; i++)
         {
@@ -249,9 +247,7 @@ internal sealed class AssuranceSemanticInvariantValidator
         IReadOnlyList<ClaimInfo> claims,
         List<AssuranceSemanticInvariantViolation> violations)
     {
-        var claimsById = claims
-            .Where(static claim => !string.IsNullOrWhiteSpace(claim.Id))
-            .ToDictionary(static claim => claim.Id, static claim => claim, StringComparer.Ordinal);
+        var claimsById = BuildClaimIndex(claims, violations);
 
         for (var i = 0; i < verifiers.Count; i++)
         {
@@ -270,8 +266,57 @@ internal sealed class AssuranceSemanticInvariantValidator
                 {
                     AddViolation(violations, claimPath, $"Verifier primary claim '{claimId}' is owned by verifierRef '{claim.VerifierRef}'.");
                 }
+
+                if (verifier.Required && !claim.Required)
+                {
+                    AddViolation(violations, claimPath, $"Required verifier primary claim '{claimId}' must be required.");
+                }
             }
         }
+    }
+
+    private static Dictionary<string, VerifierInfo> BuildVerifierIndex (
+        IReadOnlyList<VerifierInfo> verifiers,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var verifierById = new Dictionary<string, VerifierInfo>(StringComparer.Ordinal);
+        for (var i = 0; i < verifiers.Count; i++)
+        {
+            var verifier = verifiers[i];
+            if (string.IsNullOrWhiteSpace(verifier.Id))
+            {
+                continue;
+            }
+
+            if (!verifierById.TryAdd(verifier.Id, verifier))
+            {
+                AddViolation(violations, BuildPropertyPath(verifier.Path, "id"), $"Verifier id '{verifier.Id}' must be unique.");
+            }
+        }
+
+        return verifierById;
+    }
+
+    private static Dictionary<string, ClaimInfo> BuildClaimIndex (
+        IReadOnlyList<ClaimInfo> claims,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        var claimById = new Dictionary<string, ClaimInfo>(StringComparer.Ordinal);
+        for (var i = 0; i < claims.Count; i++)
+        {
+            var claim = claims[i];
+            if (string.IsNullOrWhiteSpace(claim.Id))
+            {
+                continue;
+            }
+
+            if (!claimById.TryAdd(claim.Id, claim))
+            {
+                AddViolation(violations, BuildPropertyPath(claim.Path, "id"), $"Claim id '{claim.Id}' must be unique.");
+            }
+        }
+
+        return claimById;
     }
 
     private static void ValidateVerdict (

--- a/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantViolation.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantViolation.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Semantics;
+
+/// <summary> Represents one semantic invariant violation in an assurance payload. </summary>
+/// <param name="Path"> The JSON path of the violating value. </param>
+/// <param name="Message"> The invariant violation message. </param>
+internal sealed record AssuranceSemanticInvariantViolation (
+    string Path,
+    string Message);

--- a/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
+++ b/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ public static class UcliApplicationServiceCollectionExtensions
 
         services.AddUcliApplicationSharedServices();
         services.AddUcliApplicationCodeCatalogServices();
+        services.AddUcliApplicationAssuranceServices();
         services.AddUcliApplicationRequestServices();
         services.AddUcliApplicationOperationCatalogServices();
         services.AddUcliApplicationDaemonServices();
@@ -92,6 +93,11 @@ public static class UcliApplicationServiceCollectionExtensions
         services.AddSingleton<ICodeCatalogContributor, ApplicationCodeCatalogContributor>();
         services.AddSingleton<ICodeCatalog, CodeCatalog>();
         services.AddSingleton<ICodeCatalogService, CodeCatalogService>();
+        return services;
+    }
+
+    private static IServiceCollection AddUcliApplicationAssuranceServices (this IServiceCollection services)
+    {
         services.AddSingleton<AssuranceSemanticInvariantValidator>();
         return services;
     }

--- a/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
+++ b/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using MackySoft.Ucli.Application.Features.Assurance.Semantics;
 using MackySoft.Ucli.Application.Features.CodeCatalog.Catalog;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandExecution;
 using MackySoft.Ucli.Application.Features.Daemon.Common.Projection;
@@ -91,6 +92,7 @@ public static class UcliApplicationServiceCollectionExtensions
         services.AddSingleton<ICodeCatalogContributor, ApplicationCodeCatalogContributor>();
         services.AddSingleton<ICodeCatalog, CodeCatalog>();
         services.AddSingleton<ICodeCatalogService, CodeCatalogService>();
+        services.AddSingleton<AssuranceSemanticInvariantValidator>();
         return services;
     }
 

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -39,6 +39,11 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
 
+    <None Include="../../schemas/**/*" LinkBase="schemas">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+
     <None Include="../../LICENSE" Pack="true" PackagePath="" Link="LICENSE">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
@@ -53,16 +53,29 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
 
         var documentsByPath = new Dictionary<string, JsonDocument>(StringComparer.Ordinal);
         var pathsById = new Dictionary<string, string>(StringComparer.Ordinal);
+        var schemaDefinitionErrors = new List<string>();
         foreach (var schemaPath in Directory.EnumerateFiles(fullVersionRoot, "*.schema.json", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
         {
             var relativePath = NormalizeRelativeSchemaPath(Path.GetRelativePath(fullVersionRoot, schemaPath));
             var document = JsonDocument.Parse(File.ReadAllText(schemaPath));
             documentsByPath.Add(relativePath, document);
+            ValidateSchemaDefinition(document.RootElement, relativePath, "$", schemaDefinitionErrors);
             if (document.RootElement.TryGetProperty("$id", out var idElement)
                 && idElement.ValueKind == JsonValueKind.String)
             {
                 pathsById.Add(idElement.GetString()!, relativePath);
             }
+        }
+
+        if (schemaDefinitionErrors.Count > 0)
+        {
+            foreach (var document in documentsByPath.Values)
+            {
+                document.Dispose();
+            }
+
+            throw new InvalidOperationException(
+                $"Schema artifact set contains unsupported schema definitions:{Environment.NewLine}{string.Join(Environment.NewLine, schemaDefinitionErrors)}");
         }
 
         using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
@@ -78,7 +91,7 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
                 ?? throw new InvalidOperationException("Schema manifest command entry must be a string.");
             var path = schemaEntry.GetProperty("path").GetString()
                 ?? throw new InvalidOperationException("Schema manifest path entry must be a string.");
-            payloadSchemaPathsByCommand.Add(command, path);
+            payloadSchemaPathsByCommand.Add(command, NormalizeRelativeSchemaPath(path));
         }
 
         return new JsonSchemaArtifactSet(
@@ -103,7 +116,12 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         var errors = new List<string>();
-        var normalizedSchemaPath = NormalizeRelativeSchemaPath(schemaPath);
+        if (!TryNormalizeRelativeSchemaPath(schemaPath, out var normalizedSchemaPath, out var normalizationError))
+        {
+            errors.Add(normalizationError!);
+            return errors;
+        }
+
         if (!documentsByPath.TryGetValue(normalizedSchemaPath, out var document))
         {
             errors.Add($"schema '{normalizedSchemaPath}' was not found.");
@@ -382,12 +400,20 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
         }
         else
         {
-            referencePath = NormalizeRelativeSchemaPath(Path.Join(
+            var relativeReferencePath = Path.Join(
                 Path.GetDirectoryName(currentSchemaPath) ?? string.Empty,
-                referencePath));
+                referencePath);
+            if (!TryNormalizeRelativeSchemaPath(relativeReferencePath, out referencePath, out error))
+            {
+                return false;
+            }
         }
 
-        referencePath = NormalizeRelativeSchemaPath(referencePath);
+        if (!TryNormalizeRelativeSchemaPath(referencePath, out referencePath, out error))
+        {
+            return false;
+        }
+
         if (!documentsByPath.TryGetValue(referencePath, out var document))
         {
             error = $"schema reference '{reference}' from '{currentSchemaPath}' resolved to missing schema '{referencePath}'.";
@@ -444,6 +470,87 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
             if (!SupportedKeywords.Contains(property.Name))
             {
                 errors.Add($"schema '{schemaPath}' for path '{path}' uses unsupported keyword '{property.Name}'.");
+            }
+        }
+    }
+
+    private static void ValidateSchemaDefinition (
+        JsonElement schema,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' must be an object.");
+            return;
+        }
+
+        ValidateSupportedKeywords(schema, schemaPath, path, errors);
+
+        if (schema.TryGetProperty("$defs", out var defsElement))
+        {
+            if (defsElement.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' has non-object $defs.");
+            }
+            else
+            {
+                foreach (var definition in defsElement.EnumerateObject())
+                {
+                    ValidateSchemaDefinition(
+                        definition.Value,
+                        schemaPath,
+                        BuildPropertyPath(BuildPropertyPath(path, "$defs"), definition.Name),
+                        errors);
+                }
+            }
+        }
+
+        if (schema.TryGetProperty("properties", out var propertiesElement))
+        {
+            if (propertiesElement.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' has non-object properties.");
+            }
+            else
+            {
+                foreach (var property in propertiesElement.EnumerateObject())
+                {
+                    ValidateSchemaDefinition(
+                        property.Value,
+                        schemaPath,
+                        BuildPropertyPath(BuildPropertyPath(path, "properties"), property.Name),
+                        errors);
+                }
+            }
+        }
+
+        if (schema.TryGetProperty("additionalProperties", out var additionalPropertiesElement)
+            && additionalPropertiesElement.ValueKind != JsonValueKind.False)
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' has unsupported additionalProperties value.");
+        }
+
+        if (schema.TryGetProperty("items", out var itemsElement))
+        {
+            ValidateSchemaDefinition(itemsElement, schemaPath, BuildPropertyPath(path, "items"), errors);
+        }
+
+        if (schema.TryGetProperty("oneOf", out var oneOfElement))
+        {
+            if (oneOfElement.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' has a non-array oneOf.");
+            }
+            else
+            {
+                var index = 0;
+                foreach (var branch in oneOfElement.EnumerateArray())
+                {
+                    ValidateSchemaDefinition(branch, schemaPath, $"{BuildPropertyPath(path, "oneOf")}[{index}]", errors);
+                    index++;
+                }
             }
         }
     }
@@ -562,6 +669,28 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
 
     private static string NormalizeRelativeSchemaPath (string path)
     {
+        if (!TryNormalizeRelativeSchemaPath(path, out var normalizedPath, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+
+        return normalizedPath;
+    }
+
+    private static bool TryNormalizeRelativeSchemaPath (
+        string path,
+        out string normalizedPath,
+        out string? error)
+    {
+        normalizedPath = string.Empty;
+        error = null;
+
+        if (Path.IsPathRooted(path))
+        {
+            error = $"schema path '{path}' must be relative.";
+            return false;
+        }
+
         var normalized = path.Replace('\\', '/');
         var segments = new Stack<string>();
         foreach (var segment in normalized.Split('/', StringSplitOptions.RemoveEmptyEntries))
@@ -573,18 +702,21 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
 
             if (string.Equals(segment, "..", StringComparison.Ordinal))
             {
-                if (segments.Count > 0)
+                if (segments.Count == 0)
                 {
-                    segments.Pop();
+                    error = $"schema path '{path}' escapes the schema root.";
+                    return false;
                 }
 
+                segments.Pop();
                 continue;
             }
 
             segments.Push(segment);
         }
 
-        return string.Join("/", segments.Reverse());
+        normalizedPath = string.Join("/", segments.Reverse());
+        return true;
     }
 
     private void ThrowIfDisposed ()

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
@@ -1,0 +1,594 @@
+namespace MackySoft.Tests;
+
+using System.Text.Json;
+
+internal sealed class JsonSchemaArtifactSet : IDisposable
+{
+    private const string SchemaBaseId = "https://schemas.mackysoft.dev/ucli/v1/";
+
+    private static readonly HashSet<string> SupportedKeywords = new(StringComparer.Ordinal)
+    {
+        "$schema",
+        "$id",
+        "$defs",
+        "$ref",
+        "type",
+        "required",
+        "properties",
+        "items",
+        "additionalProperties",
+        "enum",
+        "const",
+        "oneOf",
+    };
+
+    private readonly Dictionary<string, JsonDocument> documentsByPath;
+
+    private readonly Dictionary<string, string> pathsById;
+
+    private readonly Dictionary<string, string> payloadSchemaPathsByCommand;
+
+    private bool disposed;
+
+    private JsonSchemaArtifactSet (
+        Dictionary<string, JsonDocument> documentsByPath,
+        Dictionary<string, string> pathsById,
+        Dictionary<string, string> payloadSchemaPathsByCommand)
+    {
+        this.documentsByPath = documentsByPath;
+        this.pathsById = pathsById;
+        this.payloadSchemaPathsByCommand = payloadSchemaPathsByCommand;
+    }
+
+    public static JsonSchemaArtifactSet Load (string versionRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionRoot);
+
+        var fullVersionRoot = Path.GetFullPath(versionRoot);
+        var manifestPath = Path.Combine(fullVersionRoot, "schema-manifest.json");
+        if (!File.Exists(manifestPath))
+        {
+            throw new InvalidOperationException($"Schema manifest was not found: {manifestPath}");
+        }
+
+        var documentsByPath = new Dictionary<string, JsonDocument>(StringComparer.Ordinal);
+        var pathsById = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var schemaPath in Directory.EnumerateFiles(fullVersionRoot, "*.schema.json", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+        {
+            var relativePath = NormalizeRelativeSchemaPath(Path.GetRelativePath(fullVersionRoot, schemaPath));
+            var document = JsonDocument.Parse(File.ReadAllText(schemaPath));
+            documentsByPath.Add(relativePath, document);
+            if (document.RootElement.TryGetProperty("$id", out var idElement)
+                && idElement.ValueKind == JsonValueKind.String)
+            {
+                pathsById.Add(idElement.GetString()!, relativePath);
+            }
+        }
+
+        using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var payloadSchemaPathsByCommand = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var schemaEntry in manifest.RootElement.GetProperty("schemas").EnumerateArray())
+        {
+            if (!schemaEntry.TryGetProperty("command", out var commandElement))
+            {
+                continue;
+            }
+
+            var command = commandElement.GetString()
+                ?? throw new InvalidOperationException("Schema manifest command entry must be a string.");
+            var path = schemaEntry.GetProperty("path").GetString()
+                ?? throw new InvalidOperationException("Schema manifest path entry must be a string.");
+            payloadSchemaPathsByCommand.Add(command, path);
+        }
+
+        return new JsonSchemaArtifactSet(
+            documentsByPath,
+            pathsById,
+            payloadSchemaPathsByCommand);
+    }
+
+    public string? FindPayloadSchemaPath (string command)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        return payloadSchemaPathsByCommand.TryGetValue(command, out var schemaPath) ? schemaPath : null;
+    }
+
+    public IReadOnlyList<string> Validate (
+        string schemaPath,
+        JsonElement element,
+        string path = "$")
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var errors = new List<string>();
+        var normalizedSchemaPath = NormalizeRelativeSchemaPath(schemaPath);
+        if (!documentsByPath.TryGetValue(normalizedSchemaPath, out var document))
+        {
+            errors.Add($"schema '{normalizedSchemaPath}' was not found.");
+            return errors;
+        }
+
+        ValidateAgainstSchema(
+            element,
+            document.RootElement,
+            normalizedSchemaPath,
+            path,
+            errors);
+        return errors;
+    }
+
+    public void Dispose ()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        foreach (var document in documentsByPath.Values)
+        {
+            document.Dispose();
+        }
+
+        disposed = true;
+    }
+
+    private void ValidateAgainstSchema (
+        JsonElement element,
+        JsonElement schema,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (schema.ValueKind != JsonValueKind.Object)
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' must be an object.");
+            return;
+        }
+
+        ValidateSupportedKeywords(schema, schemaPath, path, errors);
+
+        if (schema.TryGetProperty("$ref", out var referenceElement))
+        {
+            ValidateReference(element, referenceElement, schemaPath, path, errors);
+            return;
+        }
+
+        if (schema.TryGetProperty("oneOf", out var oneOfElement))
+        {
+            ValidateOneOf(element, oneOfElement, schemaPath, path, errors);
+            return;
+        }
+
+        if (schema.TryGetProperty("type", out var typeElement)
+            && !MatchesAllowedTypes(element, typeElement, out var expectedTypes))
+        {
+            errors.Add($"path '{path}' expected one of [{expectedTypes}] but was {DescribeActualType(element)}.");
+            return;
+        }
+
+        if (schema.TryGetProperty("const", out var constElement)
+            && !JsonLiteralEquals(element, constElement))
+        {
+            errors.Add($"path '{path}' did not match schema const.");
+            return;
+        }
+
+        if (schema.TryGetProperty("enum", out var enumElement)
+            && !MatchesEnum(element, enumElement))
+        {
+            errors.Add($"path '{path}' did not match any schema enum value.");
+            return;
+        }
+
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            ValidateObject(element, schema, schemaPath, path, errors);
+        }
+
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            ValidateArray(element, schema, schemaPath, path, errors);
+        }
+    }
+
+    private void ValidateReference (
+        JsonElement element,
+        JsonElement referenceElement,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (referenceElement.ValueKind != JsonValueKind.String)
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' has a non-string $ref.");
+            return;
+        }
+
+        var reference = referenceElement.GetString();
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' has an empty $ref.");
+            return;
+        }
+
+        if (!TryResolveReference(schemaPath, reference!, out var referencedSchema, out var referencedSchemaPath, out var error))
+        {
+            errors.Add(error ?? $"schema '{schemaPath}' for path '{path}' has an unresolved $ref.");
+            return;
+        }
+
+        ValidateAgainstSchema(element, referencedSchema, referencedSchemaPath, path, errors);
+    }
+
+    private void ValidateOneOf (
+        JsonElement element,
+        JsonElement oneOfElement,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (oneOfElement.ValueKind != JsonValueKind.Array)
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' has a non-array oneOf.");
+            return;
+        }
+
+        var matchCount = 0;
+        foreach (var branchSchema in oneOfElement.EnumerateArray())
+        {
+            var branchErrors = new List<string>();
+            ValidateAgainstSchema(element, branchSchema, schemaPath, path, branchErrors);
+            if (branchErrors.Count == 0)
+            {
+                matchCount++;
+            }
+        }
+
+        if (matchCount != 1)
+        {
+            errors.Add($"path '{path}' matched {matchCount} oneOf branches in schema '{schemaPath}'.");
+        }
+    }
+
+    private void ValidateObject (
+        JsonElement element,
+        JsonElement schema,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (schema.TryGetProperty("required", out var requiredElement))
+        {
+            if (requiredElement.ValueKind != JsonValueKind.Array)
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' has a non-array required.");
+            }
+            else
+            {
+                foreach (var requiredProperty in requiredElement.EnumerateArray())
+                {
+                    if (requiredProperty.ValueKind != JsonValueKind.String)
+                    {
+                        errors.Add($"schema '{schemaPath}' for path '{path}' has a non-string required item.");
+                        continue;
+                    }
+
+                    var propertyName = requiredProperty.GetString()!;
+                    if (!element.TryGetProperty(propertyName, out _))
+                    {
+                        errors.Add($"path '{BuildPropertyPath(path, propertyName)}' is missing.");
+                    }
+                }
+            }
+        }
+
+        var propertySchemas = default(JsonElement);
+        var hasPropertySchemas = false;
+        if (schema.TryGetProperty("properties", out var propertiesElement))
+        {
+            if (propertiesElement.ValueKind != JsonValueKind.Object)
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' has non-object properties.");
+            }
+            else
+            {
+                propertySchemas = propertiesElement;
+                hasPropertySchemas = true;
+                foreach (var propertySchema in propertiesElement.EnumerateObject())
+                {
+                    if (!element.TryGetProperty(propertySchema.Name, out var propertyValue))
+                    {
+                        continue;
+                    }
+
+                    ValidateAgainstSchema(
+                        propertyValue,
+                        propertySchema.Value,
+                        schemaPath,
+                        BuildPropertyPath(path, propertySchema.Name),
+                        errors);
+                }
+            }
+        }
+
+        if (schema.TryGetProperty("additionalProperties", out var additionalPropertiesElement)
+            && additionalPropertiesElement.ValueKind == JsonValueKind.False)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!hasPropertySchemas || !propertySchemas.TryGetProperty(property.Name, out _))
+                {
+                    errors.Add($"path '{BuildPropertyPath(path, property.Name)}' is not allowed by schema.");
+                }
+            }
+        }
+    }
+
+    private void ValidateArray (
+        JsonElement element,
+        JsonElement schema,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        if (!schema.TryGetProperty("items", out var itemSchema))
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var item in element.EnumerateArray())
+        {
+            ValidateAgainstSchema(
+                item,
+                itemSchema,
+                schemaPath,
+                $"{path}[{index}]",
+                errors);
+            index++;
+        }
+    }
+
+    private bool TryResolveReference (
+        string currentSchemaPath,
+        string reference,
+        out JsonElement referencedSchema,
+        out string referencedSchemaPath,
+        out string? error)
+    {
+        referencedSchema = default;
+        referencedSchemaPath = currentSchemaPath;
+        error = null;
+
+        var hashIndex = reference.IndexOf('#', StringComparison.Ordinal);
+        var referencePath = hashIndex >= 0 ? reference[..hashIndex] : reference;
+        var pointer = hashIndex >= 0 ? reference[(hashIndex + 1)..] : string.Empty;
+
+        if (reference.StartsWith("#", StringComparison.Ordinal))
+        {
+            referencePath = currentSchemaPath;
+            pointer = reference[1..];
+        }
+        else if (reference.StartsWith(SchemaBaseId, StringComparison.Ordinal))
+        {
+            var id = hashIndex >= 0 ? reference[..hashIndex] : reference;
+            if (!pathsById.TryGetValue(id, out referencePath!))
+            {
+                error = $"schema id '{id}' referenced by '{currentSchemaPath}' was not found.";
+                return false;
+            }
+        }
+        else
+        {
+            referencePath = NormalizeRelativeSchemaPath(Path.Join(
+                Path.GetDirectoryName(currentSchemaPath) ?? string.Empty,
+                referencePath));
+        }
+
+        referencePath = NormalizeRelativeSchemaPath(referencePath);
+        if (!documentsByPath.TryGetValue(referencePath, out var document))
+        {
+            error = $"schema reference '{reference}' from '{currentSchemaPath}' resolved to missing schema '{referencePath}'.";
+            return false;
+        }
+
+        referencedSchemaPath = referencePath;
+        referencedSchema = document.RootElement;
+        if (string.IsNullOrWhiteSpace(pointer))
+        {
+            return true;
+        }
+
+        return TryResolveJsonPointer(document.RootElement, pointer, out referencedSchema, out error);
+    }
+
+    private static bool TryResolveJsonPointer (
+        JsonElement root,
+        string pointer,
+        out JsonElement element,
+        out string? error)
+    {
+        element = root;
+        error = null;
+        if (!pointer.StartsWith("/", StringComparison.Ordinal))
+        {
+            error = $"Only JSON pointer $ref fragments are supported. Actual: #{pointer}";
+            return false;
+        }
+
+        foreach (var rawSegment in pointer.Split('/').Skip(1))
+        {
+            var segment = rawSegment
+                .Replace("~1", "/", StringComparison.Ordinal)
+                .Replace("~0", "~", StringComparison.Ordinal);
+            if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty(segment, out element))
+            {
+                error = $"JSON pointer segment '{segment}' was not found in schema reference '#{pointer}'.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void ValidateSupportedKeywords (
+        JsonElement schema,
+        string schemaPath,
+        string path,
+        List<string> errors)
+    {
+        foreach (var property in schema.EnumerateObject())
+        {
+            if (!SupportedKeywords.Contains(property.Name))
+            {
+                errors.Add($"schema '{schemaPath}' for path '{path}' uses unsupported keyword '{property.Name}'.");
+            }
+        }
+    }
+
+    private static bool MatchesAllowedTypes (
+        JsonElement element,
+        JsonElement typeElement,
+        out string expectedTypes)
+    {
+        if (typeElement.ValueKind == JsonValueKind.String)
+        {
+            expectedTypes = typeElement.GetString() ?? string.Empty;
+            return MatchesType(element, expectedTypes);
+        }
+
+        if (typeElement.ValueKind != JsonValueKind.Array)
+        {
+            expectedTypes = "<invalid>";
+            return false;
+        }
+
+        var types = new List<string>();
+        foreach (var item in typeElement.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var type = item.GetString() ?? string.Empty;
+            types.Add(type);
+            if (MatchesType(element, type))
+            {
+                expectedTypes = string.Join(", ", types);
+                return true;
+            }
+        }
+
+        expectedTypes = string.Join(", ", types);
+        return false;
+    }
+
+    private static bool MatchesType (
+        JsonElement element,
+        string type)
+    {
+        return type switch
+        {
+            "object" => element.ValueKind == JsonValueKind.Object,
+            "array" => element.ValueKind == JsonValueKind.Array,
+            "string" => element.ValueKind == JsonValueKind.String,
+            "integer" => element.ValueKind == JsonValueKind.Number && element.TryGetInt64(out _),
+            "number" => element.ValueKind == JsonValueKind.Number,
+            "boolean" => element.ValueKind == JsonValueKind.True || element.ValueKind == JsonValueKind.False,
+            "null" => element.ValueKind == JsonValueKind.Null,
+            _ => false,
+        };
+    }
+
+    private static bool MatchesEnum (
+        JsonElement element,
+        JsonElement enumElement)
+    {
+        if (enumElement.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
+
+        foreach (var enumValue in enumElement.EnumerateArray())
+        {
+            if (JsonLiteralEquals(element, enumValue))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool JsonLiteralEquals (
+        JsonElement left,
+        JsonElement right)
+    {
+        if (left.ValueKind != right.ValueKind)
+        {
+            return false;
+        }
+
+        return left.ValueKind switch
+        {
+            JsonValueKind.String => string.Equals(left.GetString(), right.GetString(), StringComparison.Ordinal),
+            JsonValueKind.Number => left.GetRawText() == right.GetRawText(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => true,
+            JsonValueKind.Null => true,
+            _ => left.GetRawText() == right.GetRawText(),
+        };
+    }
+
+    private static string DescribeActualType (JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Number && !element.TryGetInt64(out _))
+        {
+            return "Number(non-integer)";
+        }
+
+        return element.ValueKind.ToString();
+    }
+
+    private static string BuildPropertyPath (
+        string parentPath,
+        string propertyName)
+    {
+        return $"{parentPath}.{propertyName}";
+    }
+
+    private static string NormalizeRelativeSchemaPath (string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        var segments = new Stack<string>();
+        foreach (var segment in normalized.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (string.Equals(segment, ".", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(segment, "..", StringComparison.Ordinal))
+            {
+                if (segments.Count > 0)
+                {
+                    segments.Pop();
+                }
+
+                continue;
+            }
+
+            segments.Push(segment);
+        }
+
+        return string.Join("/", segments.Reverse());
+    }
+
+    private void ThrowIfDisposed ()
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+    }
+}

--- a/tests/Tests.Helper/Tests/JsonAssertions/JsonSchemaArtifactSetTests.cs
+++ b/tests/Tests.Helper/Tests/JsonAssertions/JsonSchemaArtifactSetTests.cs
@@ -1,0 +1,110 @@
+namespace MackySoft.Ucli.Tests;
+
+using System.Text.Json;
+using MackySoft.Tests;
+
+public sealed class JsonSchemaArtifactSetTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithReferenceEscapingSchemaRoot_ReturnsReferenceError ()
+    {
+        using var scope = TestDirectories.CreateTempScope("json-schema-artifact-set", "escaping-reference");
+        WriteManifest(scope, "root.schema.json");
+        scope.WriteFile(
+            "root.schema.json",
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "https://schemas.mackysoft.dev/ucli/v1/root.schema.json",
+              "$ref": "../outside.schema.json"
+            }
+            """);
+
+        using var schemaSet = JsonSchemaArtifactSet.Load(scope.FullPath);
+        using var document = JsonDocument.Parse("{}");
+
+        var errors = schemaSet.Validate("root.schema.json", document.RootElement);
+
+        Assert.Contains(
+            "schema path '../outside.schema.json' escapes the schema root.",
+            errors,
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Load_WithUnsupportedKeywordInUnusedDefinition_Throws ()
+    {
+        using var scope = TestDirectories.CreateTempScope("json-schema-artifact-set", "unused-definition-keyword");
+        WriteManifest(scope, "root.schema.json");
+        scope.WriteFile(
+            "root.schema.json",
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "https://schemas.mackysoft.dev/ucli/v1/root.schema.json",
+              "type": "object",
+              "$defs": {
+                "unused": {
+                  "type": "string",
+                  "pattern": "^ready$"
+                }
+              }
+            }
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => JsonSchemaArtifactSet.Load(scope.FullPath));
+
+        Assert.Contains("unsupported keyword 'pattern'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Load_WithSchemaValuedAdditionalProperties_Throws ()
+    {
+        using var scope = TestDirectories.CreateTempScope("json-schema-artifact-set", "additional-properties-schema");
+        WriteManifest(scope, "root.schema.json");
+        scope.WriteFile(
+            "root.schema.json",
+            """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$id": "https://schemas.mackysoft.dev/ucli/v1/root.schema.json",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+            """);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => JsonSchemaArtifactSet.Load(scope.FullPath));
+
+        Assert.Contains("unsupported additionalProperties value", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static void WriteManifest (
+        TestDirectoryScope scope,
+        string schemaPath)
+    {
+        scope.WriteFile(
+            "schema-manifest.json",
+            $$"""
+            {
+              "schemaSet": "ucli",
+              "schemaSetVersion": "v1",
+              "protocolVersion": 1,
+              "packageVersion": "0.0.0-test",
+              "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+              "schemas": [
+                {
+                  "$id": "https://schemas.mackysoft.dev/ucli/v1/{{schemaPath}}",
+                  "path": "{{schemaPath}}",
+                  "kind": "payload",
+                  "command": "test"
+                }
+              ]
+            }
+            """);
+    }
+}

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -1,0 +1,528 @@
+using System.Text.Json;
+using MackySoft.Ucli.Application.Features.Assurance.Semantics;
+using MackySoft.Ucli.Application.Features.CodeCatalog.Catalog;
+
+namespace MackySoft.Ucli.Application.Tests.Features.Assurance.Semantics;
+
+public sealed class AssuranceSemanticInvariantValidatorTests
+{
+    private const string ReadyClaim = "UNITY_READY_EXECUTION";
+    private const string CompileClaim = "UNITY_COMPILE_NO_ERRORS";
+    private const string LogUnavailableRisk = "UNITY_LOG_UNAVAILABLE";
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithValidAssurancePayload_ReturnsNoViolations ()
+    {
+        using var document = JsonDocument.Parse(ValidPayload());
+        var result = CreateValidator().Validate(document.RootElement);
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithMissingVerifierReference_ReturnsClaimVerifierPath ()
+    {
+        var payload = """
+            {
+              "verdict": "incomplete",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "missing",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.claims[0].verifierRef");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithRequiredClaimOwnedByOptionalVerifier_ReturnsClaimRequiredPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": false,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.claims[0].required");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithPrimaryClaimOwnedByAnotherVerifier_ReturnsPrimaryClaimPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_COMPILE_NO_ERRORS"
+                  ],
+                  "reportRef": "ready-log"
+                },
+                {
+                  "id": "compile",
+                  "kind": "compile",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_COMPILE_NO_ERRORS"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                },
+                {
+                  "id": "UNITY_COMPILE_NO_ERRORS",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "compile",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verifiers[0].primaryClaims[0]");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithVerdictMismatch_ReturnsVerdictPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "failed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verdict");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithUnresolvedReportAndEvidenceReferences_ReturnsReferencePaths ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "missing-report"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "missing-evidence"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verifiers[0].reportRef");
+        AssertViolationPath(result, "$.claims[0].evidence[0].evidenceRef");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithDigestOnlyReport_ReturnsReportEntryPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "digest": "abc123"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.reports.ready-log");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithUnknownClaimAndRiskCodes_ReturnsCodePaths ()
+    {
+        var payload = """
+            {
+              "verdict": "fail",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_UNKNOWN_CLAIM"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_UNKNOWN_CLAIM",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": [
+                    {
+                      "code": "UNITY_UNKNOWN_CLAIM_RISK",
+                      "blocking": true
+                    }
+                  ]
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": [
+                {
+                  "code": "UNITY_UNKNOWN_GLOBAL_RISK",
+                  "blocking": true
+                }
+              ]
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.claims[0].id");
+        AssertViolationPath(result, "$.claims[0].residualRisks[0].code");
+        AssertViolationPath(result, "$.residualRisks[0].code");
+    }
+
+    private static AssuranceSemanticInvariantValidationResult Validate (string payload)
+    {
+        using var document = JsonDocument.Parse(payload);
+        return CreateValidator().Validate(document.RootElement);
+    }
+
+    private static string ValidPayload ()
+    {
+        return """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log",
+                  "digest": "abc123"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+    }
+
+    private static AssuranceSemanticInvariantValidator CreateValidator ()
+    {
+        return new AssuranceSemanticInvariantValidator(new StubCodeCatalog(
+        [
+            CreateDescriptor(ReadyClaim, CodeCatalogKindValues.Claim),
+            CreateDescriptor(CompileClaim, CodeCatalogKindValues.Claim),
+            CreateDescriptor(LogUnavailableRisk, CodeCatalogKindValues.Risk),
+        ]));
+    }
+
+    private static CodeCatalogDescriptor CreateDescriptor (
+        string code,
+        string kind)
+    {
+        return new CodeCatalogDescriptor(
+            code,
+            kind,
+            Category: "test",
+            Summary: code,
+            Meaning: null,
+            AppearsIn: [],
+            AppliesTo: [],
+            CoverageImpact: null,
+            VerdictSemantics: null,
+            ExecutionSemantics: null,
+            Inspect: [],
+            RelatedCodes: []);
+    }
+
+    private static void AssertViolationPath (
+        AssuranceSemanticInvariantValidationResult result,
+        string path)
+    {
+        Assert.Contains(result.Violations, violation => string.Equals(violation.Path, path, StringComparison.Ordinal));
+    }
+
+    private sealed class StubCodeCatalog : ICodeCatalog
+    {
+        private readonly Dictionary<string, CodeCatalogDescriptor> descriptorsByCode;
+
+        public StubCodeCatalog (IEnumerable<CodeCatalogDescriptor> descriptors)
+        {
+            descriptorsByCode = descriptors.ToDictionary(
+                static descriptor => descriptor.Code,
+                static descriptor => descriptor,
+                StringComparer.Ordinal);
+            Descriptors = descriptorsByCode.Values
+                .OrderBy(static descriptor => descriptor.Code, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        public IReadOnlyList<CodeCatalogDescriptor> Descriptors { get; }
+
+        public bool TryFind (
+            string? code,
+            out CodeCatalogDescriptor descriptor)
+        {
+            if (code != null && descriptorsByCode.TryGetValue(code, out descriptor!))
+            {
+                return true;
+            }
+
+            descriptor = null!;
+            return false;
+        }
+    }
+}

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -197,6 +197,56 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Validate_WithOptionalPrimaryClaimOwnedByRequiredVerifier_ReturnsPrimaryClaimPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": false,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verifiers[0].primaryClaims[0]");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Validate_WithVerdictMismatch_ReturnsVerdictPath ()
     {
         var payload = """
@@ -406,6 +456,130 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         AssertViolationPath(result, "$.claims[0].id");
         AssertViolationPath(result, "$.claims[0].residualRisks[0].code");
         AssertViolationPath(result, "$.residualRisks[0].code");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithDuplicateVerifierId_ReturnsDuplicateVerifierPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                },
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verifiers[1].id");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithDuplicateClaimId_ReturnsDuplicateClaimPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [
+                    "UNITY_READY_EXECUTION"
+                  ],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                },
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.claims[1].id");
     }
 
     private static AssuranceSemanticInvariantValidationResult Validate (string payload)

--- a/tests/Ucli.Architecture.Tests/Architecture/PackageReferenceBoundaryTests.cs
+++ b/tests/Ucli.Architecture.Tests/Architecture/PackageReferenceBoundaryTests.cs
@@ -65,6 +65,7 @@ public sealed class PackageReferenceBoundaryTests
     {
         var expectedPackagesByProject = new Dictionary<string, string[]>(StringComparer.Ordinal)
         {
+            ["tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"] = [],
             ["tools/Ucli.SkillGenerator/Ucli.SkillGenerator.csproj"] = [],
         };
 

--- a/tests/Ucli.Architecture.Tests/Architecture/ProjectReferenceBoundaryTests.cs
+++ b/tests/Ucli.Architecture.Tests/Architecture/ProjectReferenceBoundaryTests.cs
@@ -84,6 +84,10 @@ public sealed class ProjectReferenceBoundaryTests
     {
         var expectedReferencesByProject = new Dictionary<string, string[]>(StringComparer.Ordinal)
         {
+            ["tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"] =
+            [
+                "src/Ucli.Contracts/Ucli.Contracts.csproj",
+            ],
             ["tools/Ucli.SkillGenerator/Ucli.SkillGenerator.csproj"] =
             [
                 "src/Ucli.Skills/Ucli.Skills.csproj",

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -244,6 +244,38 @@ public sealed class PackageMetadataTests
         Assert.Equal("true", outputs["needs_unity_pack"]);
     }
 
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Verify_scope_detector_tracks_schema_artifact_changes ()
+    {
+        IReadOnlyDictionary<string, string> outputs = await RunVerifyScopeDetectorForSingleFileChangeAsync(
+            "schemas/v1/schema-manifest.json",
+            """{"schemaSet":"ucli","packageVersion":"0.0.0"}""",
+            """{"schemaSet":"ucli","packageVersion":"0.0.1"}""");
+
+        Assert.Equal("true", outputs["needs_dotnet"]);
+        Assert.Equal("true", outputs["needs_cli_pack"]);
+        Assert.Equal("false", outputs["needs_shared_pack"]);
+        Assert.Equal("false", outputs["needs_unity"]);
+        Assert.Equal("false", outputs["needs_unity_pack"]);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Verify_scope_detector_tracks_schema_generation_script_changes ()
+    {
+        IReadOnlyDictionary<string, string> outputs = await RunVerifyScopeDetectorForSingleFileChangeAsync(
+            "scripts/generate-schemas.sh",
+            "echo old\n",
+            "echo new\n");
+
+        Assert.Equal("true", outputs["needs_dotnet"]);
+        Assert.Equal("true", outputs["needs_cli_pack"]);
+        Assert.Equal("false", outputs["needs_shared_pack"]);
+        Assert.Equal("false", outputs["needs_unity"]);
+        Assert.Equal("false", outputs["needs_unity_pack"]);
+    }
+
     private static async Task<IReadOnlyDictionary<string, string>> RunVerifyScopeDetectorForSingleFileChangeAsync (
         string relativePath,
         string initialContents,

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -132,6 +132,22 @@ public sealed class PackageMetadataTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Cli_tool_project_includes_generated_schema_artifacts ()
+    {
+        XDocument document = XDocument.Load(Path.Combine(RepositoryRoot, "src/Ucli/Ucli.csproj"));
+        var schemaItem = document
+            .Descendants("None")
+            .SingleOrDefault(static element => string.Equals(
+                element.Attribute("Include")?.Value,
+                "../../schemas/**/*",
+                StringComparison.Ordinal));
+
+        Assert.NotNull(schemaItem);
+        Assert.Equal("schemas", schemaItem!.Attribute("LinkBase")?.Value);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Projects_declare_expected_packability ()
     {
         var expectedPackabilityByProject = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -148,6 +164,7 @@ public sealed class PackageMetadataTests
             ["tests/Ucli.Infrastructure.Tests/Ucli.Infrastructure.Tests.csproj"] = "false",
             ["tests/Ucli.Skills.Tests/Ucli.Skills.Tests.csproj"] = "false",
             ["tests/Ucli.Tests/Ucli.Tests.csproj"] = "false",
+            ["tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"] = "false",
             ["tools/Ucli.SkillGenerator/Ucli.SkillGenerator.csproj"] = "false",
         };
 

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using MackySoft.Tests;
+
+namespace MackySoft.Ucli.Tests.Schemas;
+
+public sealed class CliOutputSchemaArtifactTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void SchemaManifest_IndexesGeneratedV1Schemas ()
+    {
+        var schemaRoot = Path.Combine(RepositoryRoot, "schemas", "v1");
+        var manifestPath = Path.Combine(schemaRoot, "schema-manifest.json");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var root = document.RootElement;
+        Assert.Equal("ucli", root.GetProperty("schemaSet").GetString());
+        Assert.Equal("v1", root.GetProperty("schemaSetVersion").GetString());
+        Assert.Equal(1, root.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal("0.0.0", root.GetProperty("packageVersion").GetString());
+        Assert.Equal("https://json-schema.org/draft/2020-12/schema", root.GetProperty("jsonSchemaDialect").GetString());
+
+        var commandEntries = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var schemaEntry in root.GetProperty("schemas").EnumerateArray())
+        {
+            var path = schemaEntry.GetProperty("path").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(path));
+            Assert.True(
+                File.Exists(Path.Combine(schemaRoot, path!)),
+                $"Schema manifest references missing schema path: {path}");
+            Assert.DoesNotContain("v1", Path.GetFileName(path), StringComparison.OrdinalIgnoreCase);
+
+            if (schemaEntry.TryGetProperty("command", out var commandElement))
+            {
+                commandEntries.Add(commandElement.GetString()!, path!);
+            }
+        }
+
+        Assert.Contains("status", commandEntries.Keys);
+        Assert.Contains("plan", commandEntries.Keys);
+        Assert.Contains("codes.describe", commandEntries.Keys);
+        Assert.Contains("test.run", commandEntries.Keys);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCliOutputGoldenFiles))]
+    [Trait("Size", "Small")]
+    public void CliOutputGoldenFile_MatchesEnvelopeAndCommandPayloadSchemas (string repositoryRelativeGoldenPath)
+    {
+        using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepositoryRoot, repositoryRelativeGoldenPath)));
+        var root = document.RootElement;
+
+        Assert.False(root.TryGetProperty("schemaVersion", out _));
+        AssertSchemaValid(schemaSet.Validate("cli-output/envelope.schema.json", root), repositoryRelativeGoldenPath);
+
+        var command = root.GetProperty("command").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(command));
+        var payloadSchemaPath = schemaSet.FindPayloadSchemaPath(command!);
+        Assert.False(
+            string.IsNullOrWhiteSpace(payloadSchemaPath),
+            $"No payload schema is registered for command '{command}' in {repositoryRelativeGoldenPath}.");
+
+        AssertSchemaValid(
+            schemaSet.Validate(payloadSchemaPath!, root.GetProperty("payload"), "$.payload"),
+            repositoryRelativeGoldenPath);
+    }
+
+    public static IEnumerable<object[]> GetCliOutputGoldenFiles ()
+    {
+        var goldenRoot = Path.Combine(RepositoryRoot, "tests", "Ucli.Tests", "GoldenFiles", "Json", "CliOutput");
+        return Directory
+            .EnumerateFiles(goldenRoot, "*.json", SearchOption.AllDirectories)
+            .Order(StringComparer.Ordinal)
+            .Select(path => new object[]
+            {
+                Path.GetRelativePath(RepositoryRoot, path),
+            });
+    }
+
+    private static void AssertSchemaValid (
+        IReadOnlyList<string> errors,
+        string repositoryRelativeGoldenPath)
+    {
+        Assert.True(
+            errors.Count == 0,
+            $"Schema validation failed for {repositoryRelativeGoldenPath}:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
+    }
+
+    private static string FindRepositoryRoot ()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Ucli.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved from test base directory.");
+    }
+}

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -68,6 +68,28 @@ public sealed class CliOutputSchemaArtifactTests
             repositoryRelativeGoldenPath);
     }
 
+    [Theory]
+    [MemberData(nameof(GetReportRefContractCases))]
+    [Trait("Size", "Small")]
+    public void ReportRefSchema_RequiresKindAndExactlyOneLocation (
+        string reportJson,
+        bool expectedValid)
+    {
+        using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
+        using var document = JsonDocument.Parse(reportJson);
+
+        var errors = schemaSet.Validate("cli-output/defs/report-ref.schema.json", document.RootElement);
+
+        if (expectedValid)
+        {
+            Assert.Empty(errors);
+        }
+        else
+        {
+            Assert.NotEmpty(errors);
+        }
+    }
+
     public static IEnumerable<object[]> GetCliOutputGoldenFiles ()
     {
         var goldenRoot = Path.Combine(RepositoryRoot, "tests", "Ucli.Tests", "GoldenFiles", "Json", "CliOutput");
@@ -78,6 +100,51 @@ public sealed class CliOutputSchemaArtifactTests
             {
                 Path.GetRelativePath(RepositoryRoot, path),
             });
+    }
+
+    public static IEnumerable<object[]> GetReportRefContractCases ()
+    {
+        yield return new object[]
+        {
+            """
+            {
+              "kind": "log",
+              "path": "artifacts/ready.log"
+            }
+            """,
+            true,
+        };
+        yield return new object[]
+        {
+            """
+            {
+              "kind": "report",
+              "uri": "https://example.test/report"
+            }
+            """,
+            true,
+        };
+        yield return new object[]
+        {
+            """
+            {
+              "kind": "report",
+              "digest": "sha256:abc"
+            }
+            """,
+            false,
+        };
+        yield return new object[]
+        {
+            """
+            {
+              "kind": "report",
+              "path": "artifacts/ready.log",
+              "uri": "https://example.test/report"
+            }
+            """,
+            false,
+        };
     }
 
     private static void AssertSchemaValid (

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -51,7 +51,7 @@ internal static class Program
         var versionRoot = Path.Combine(outputRoot, SchemaSetVersion);
         if (Directory.Exists(versionRoot))
         {
-            Directory.Delete(versionRoot, recursive: true);
+            DeleteExistingVersionRoot(versionRoot);
         }
 
         Directory.CreateDirectory(versionRoot);
@@ -293,12 +293,22 @@ internal static class Program
 
     private static Dictionary<string, object?> CreateReportRefSchema ()
     {
-        return ObjectSchema(
-            additionalProperties: false,
-            Required("kind", StringSchema()),
-            Optional("path", StringSchema()),
-            Optional("uri", StringSchema()),
-            Optional("digest", StringSchema()));
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["oneOf"] = new object?[]
+            {
+                ObjectSchema(
+                    additionalProperties: false,
+                    Required("kind", StringSchema()),
+                    Required("path", StringSchema()),
+                    Optional("digest", StringSchema())),
+                ObjectSchema(
+                    additionalProperties: false,
+                    Required("kind", StringSchema()),
+                    Required("uri", StringSchema()),
+                    Optional("digest", StringSchema())),
+            },
+        };
     }
 
     private static Dictionary<string, object?> CreateResidualRiskSchema ()
@@ -662,6 +672,27 @@ internal static class Program
             .Replace("\r\n", "\n", StringComparison.Ordinal)
             .Replace("\r", "\n", StringComparison.Ordinal);
         return json.EndsWith('\n') ? json : json + "\n";
+    }
+
+    private static void DeleteExistingVersionRoot (string versionRoot)
+    {
+        var manifestPath = Path.Combine(versionRoot, "schema-manifest.json");
+        if (!File.Exists(manifestPath))
+        {
+            throw new InvalidOperationException($"Refusing to delete schema output directory without a uCLI schema manifest: {versionRoot}");
+        }
+
+        using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+        var root = manifest.RootElement;
+        if (!root.TryGetProperty("schemaSet", out var schemaSetElement)
+            || !string.Equals(schemaSetElement.GetString(), SchemaSet, StringComparison.Ordinal)
+            || !root.TryGetProperty("schemaSetVersion", out var schemaSetVersionElement)
+            || !string.Equals(schemaSetVersionElement.GetString(), SchemaSetVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Refusing to delete schema output directory with an unexpected manifest: {versionRoot}");
+        }
+
+        Directory.Delete(versionRoot, recursive: true);
     }
 
     private static string ReadPackageVersion (string repositoryRoot)

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -1,0 +1,759 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using MackySoft.Ucli.Contracts;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.SchemaGenerator;
+
+internal static class Program
+{
+    private const string JsonSchemaDialect = "https://json-schema.org/draft/2020-12/schema";
+    private const string SchemaSet = "ucli";
+    private const string SchemaSetVersion = "v1";
+    private const string SchemaBaseId = "https://schemas.mackysoft.dev/ucli/v1/";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private static int Main (string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (!TryParseArgs(args, out var outputRoot, out var packageVersion, out var repositoryRoot))
+        {
+            WriteUsage();
+            return 2;
+        }
+
+        try
+        {
+            packageVersion ??= ReadPackageVersion(repositoryRoot);
+            WriteSchemas(outputRoot, packageVersion);
+            Console.WriteLine($"Generated schemas: {Path.GetFullPath(outputRoot)}");
+            return 0;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            Console.Error.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void WriteSchemas (
+        string outputRoot,
+        string packageVersion)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageVersion);
+
+        var versionRoot = Path.Combine(outputRoot, SchemaSetVersion);
+        if (Directory.Exists(versionRoot))
+        {
+            Directory.Delete(versionRoot, recursive: true);
+        }
+
+        Directory.CreateDirectory(versionRoot);
+
+        var schemaFiles = CreateSchemaFiles();
+        foreach (var schemaFile in schemaFiles)
+        {
+            var outputPath = Path.Combine(versionRoot, schemaFile.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? versionRoot);
+            File.WriteAllText(outputPath, SerializeJson(schemaFile.Document));
+        }
+
+        File.WriteAllText(
+            Path.Combine(versionRoot, "schema-manifest.json"),
+            SerializeJson(CreateManifest(packageVersion, schemaFiles)));
+    }
+
+    private static IReadOnlyList<SchemaFile> CreateSchemaFiles ()
+    {
+        var files = new List<SchemaFile>
+        {
+            CreateSchema("cli-output/envelope.schema.json", "cli-output-envelope", null, CreateEnvelopeSchema()),
+            CreateSchema("cli-output/defs/project.schema.json", "cli-output-def", null, CreateProjectSchema()),
+            CreateSchema("cli-output/defs/read-index.schema.json", "cli-output-def", null, CreateReadIndexSchema()),
+            CreateSchema("cli-output/defs/op-result.schema.json", "cli-output-def", null, CreateOperationResultSchema()),
+            CreateSchema("cli-output/defs/diagnostic.schema.json", "cli-output-def", null, CreateDiagnosticSchema()),
+            CreateSchema("cli-output/defs/touched.schema.json", "cli-output-def", null, CreateTouchedSchema()),
+            CreateSchema("cli-output/defs/window.schema.json", "cli-output-def", null, CreateWindowSchema()),
+            CreateSchema("cli-output/defs/verifier.schema.json", "cli-output-def", null, CreateVerifierSchema()),
+            CreateSchema("cli-output/defs/assurance-claim.schema.json", "cli-output-def", null, CreateAssuranceClaimSchema()),
+            CreateSchema("cli-output/defs/evidence.schema.json", "cli-output-def", null, CreateEvidenceSchema()),
+            CreateSchema("cli-output/defs/report-ref.schema.json", "cli-output-def", null, CreateReportRefSchema()),
+            CreateSchema("cli-output/defs/residual-risk.schema.json", "cli-output-def", null, CreateResidualRiskSchema()),
+            CreatePayloadSchema(UcliCommandIds.Status.Name, CreateStatusPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.Init.Name, CreateInitPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.Validate.Name, CreateValidatePayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.Plan.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: true, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.Call.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: false, includePlanToken: false, includePlan: true)),
+            CreatePayloadSchema(UcliCommandIds.Refresh.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: false, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.Resolve.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.QueryAssetsFind.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.QuerySceneTree.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.QueryGoDescribe.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.QueryCompSchema.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.QueryAssetSchema.Name, CreateRequestExecutionPayloadSchema(includeReadIndex: true, includePlanToken: false, includePlan: false)),
+            CreatePayloadSchema(UcliCommandIds.OpsList.Name, CreateOpsListPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.CodesList.Name, CreateCodesListPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.CodesDescribe.Name, CreateCodesDescribePayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.DaemonStart.Name, CreateDaemonStartPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.DaemonStatus.Name, CreateDaemonStatusPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.TestProfileInit.Name, CreateTestProfileInitPayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.TestRun.Name, CreateTestRunPayloadSchema()),
+            CreateSchema("request/request-envelope.schema.json", "request-envelope", null, CreateRequestEnvelopeSchema()),
+            CreateSchema("request/edit-dsl.schema.json", "request-edit-dsl", null, CreateEditDslSchema()),
+        };
+
+        return files;
+    }
+
+    private static SchemaFile CreatePayloadSchema (
+        string command,
+        Dictionary<string, object?> schema)
+    {
+        return CreateSchema(
+            $"cli-output/payload/{command}.schema.json",
+            "cli-output-payload",
+            command,
+            schema);
+    }
+
+    private static SchemaFile CreateSchema (
+        string relativePath,
+        string kind,
+        string? command,
+        Dictionary<string, object?> schema)
+    {
+        var document = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["$schema"] = JsonSchemaDialect,
+            ["$id"] = SchemaBaseId + relativePath,
+        };
+
+        foreach (var (key, value) in schema)
+        {
+            document[key] = value;
+        }
+
+        return new SchemaFile(relativePath, kind, command, document);
+    }
+
+    private static Dictionary<string, object?> CreateManifest (
+        string packageVersion,
+        IReadOnlyList<SchemaFile> schemaFiles)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["schemaSet"] = SchemaSet,
+            ["schemaSetVersion"] = SchemaSetVersion,
+            ["protocolVersion"] = IpcProtocol.CurrentVersion,
+            ["packageVersion"] = packageVersion,
+            ["jsonSchemaDialect"] = JsonSchemaDialect,
+            ["schemas"] = schemaFiles
+                .Select(static schemaFile =>
+                {
+                    var entry = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["$id"] = SchemaBaseId + schemaFile.RelativePath,
+                        ["path"] = schemaFile.RelativePath,
+                        ["kind"] = schemaFile.Kind,
+                    };
+                    if (schemaFile.Command != null)
+                    {
+                        entry["command"] = schemaFile.Command;
+                    }
+
+                    return entry;
+                })
+                .ToArray(),
+        };
+    }
+
+    private static Dictionary<string, object?> CreateEnvelopeSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("protocolVersion", ConstInteger(IpcProtocol.CurrentVersion)),
+            Required("command", StringSchema()),
+            Required("status", EnumSchema(IpcProtocol.StatusOk, IpcProtocol.StatusError)),
+            Required("exitCode", IntegerSchema()),
+            Required("message", StringSchema()),
+            Required("payload", ObjectSchema(additionalProperties: true)),
+            Required("errors", ArraySchema(ObjectSchema(
+                additionalProperties: false,
+                Required("code", NullableStringSchema()),
+                Required("message", NullableStringSchema()),
+                Required("opId", NullableStringSchema())))));
+    }
+
+    private static Dictionary<string, object?> CreateProjectSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("projectPath", StringSchema()),
+            Required("projectFingerprint", StringSchema()),
+            Required("unityVersion", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateReadIndexSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("used", BooleanSchema()),
+            Required("hit", BooleanSchema()),
+            Required("source", NullableStringSchema()),
+            Required("freshness", NullableStringSchema()),
+            Required("generatedAtUtc", NullableStringSchema()),
+            Required("fallbackReason", NullableStringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateOperationResultSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("opId", StringSchema()),
+            Required("op", StringSchema()),
+            Required("phase", StringSchema()),
+            Required("applied", BooleanSchema()),
+            Required("changed", BooleanSchema()),
+            Required("touched", ArraySchema(ReferenceSchema("../defs/touched.schema.json"))),
+            Required("diagnostics", ArraySchema(ReferenceSchema("../defs/diagnostic.schema.json"))),
+            Optional("result", AnySchema()),
+            Optional("errors", ArraySchema(ObjectSchema(additionalProperties: true))));
+    }
+
+    private static Dictionary<string, object?> CreateDiagnosticSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Optional("code", NullableStringSchema()),
+            Optional("message", NullableStringSchema()),
+            Optional("severity", NullableStringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateTouchedSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Optional("kind", NullableStringSchema()),
+            Optional("path", NullableStringSchema()),
+            Optional("uri", NullableStringSchema()),
+            Optional("state", NullableStringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateWindowSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("limit", NullableIntegerSchema()),
+            Required("cursor", NullableStringSchema()),
+            Required("nextCursor", NullableStringSchema()),
+            Required("isComplete", BooleanSchema()),
+            Required("totalCount", NullableIntegerSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateVerifierSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Required("id", StringSchema()),
+            Required("kind", StringSchema()),
+            Required("deterministic", BooleanSchema()),
+            Required("required", BooleanSchema()),
+            Required("primaryClaims", ArraySchema(StringSchema())),
+            Optional("effects", ArraySchema(StringSchema())),
+            Optional("reportRef", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateAssuranceClaimSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Required("id", StringSchema()),
+            Required("status", StringSchema()),
+            Required("coverage", StringSchema()),
+            Required("required", BooleanSchema()),
+            Required("verifierRef", StringSchema()),
+            Optional("evidence", ArraySchema(ReferenceSchema("../defs/evidence.schema.json"))),
+            Optional("residualRisks", ArraySchema(ReferenceSchema("../defs/residual-risk.schema.json"))));
+    }
+
+    private static Dictionary<string, object?> CreateEvidenceSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Required("kind", StringSchema()),
+            Optional("evidenceRef", StringSchema()),
+            Optional("data", AnySchema()));
+    }
+
+    private static Dictionary<string, object?> CreateReportRefSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("kind", StringSchema()),
+            Optional("path", StringSchema()),
+            Optional("uri", StringSchema()),
+            Optional("digest", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateResidualRiskSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Required("code", StringSchema()),
+            Required("blocking", BooleanSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateStatusPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("daemonStatus", NullableStringSchema()),
+            Optional("unityVersion", NullableStringSchema()),
+            Optional("serverVersion", NullableStringSchema()),
+            Optional("lifecycleState", NullableStringSchema()),
+            Optional("blockingReason", NullableStringSchema()),
+            Optional("compileState", NullableStringSchema()),
+            Optional("compileGeneration", NullableStringSchema()),
+            Optional("domainReloadGeneration", NullableStringSchema()),
+            Optional("canAcceptExecutionRequests", BooleanSchema()),
+            Optional("editorMode", NullableStringSchema()),
+            Optional("observedAtUtc", NullableStringSchema()),
+            Optional("actionRequired", NullableStringSchema()),
+            Optional("primaryDiagnostic", NullableObjectSchema()),
+            Optional("timeoutMilliseconds", IntegerSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateInitPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("configPath", StringSchema()),
+            Optional("gitignorePath", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateValidatePayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("project", ReferenceSchema("../defs/project.schema.json")),
+            Optional("readIndex", ReferenceSchema("../defs/read-index.schema.json")));
+    }
+
+    private static Dictionary<string, object?> CreateRequestExecutionPayloadSchema (
+        bool includeReadIndex,
+        bool includePlanToken,
+        bool includePlan)
+    {
+        var properties = new List<SchemaProperty>
+        {
+            Optional("requestId", StringSchema()),
+            Optional("project", ReferenceSchema("../defs/project.schema.json")),
+            Optional("opResults", ArraySchema(ReferenceSchema("../defs/op-result.schema.json"))),
+            Optional("readPostcondition", ObjectSchema(additionalProperties: true)),
+        };
+
+        if (includeReadIndex)
+        {
+            properties.Add(Optional("readIndex", ReferenceSchema("../defs/read-index.schema.json")));
+        }
+
+        if (includePlanToken)
+        {
+            properties.Add(Optional("planToken", StringSchema()));
+        }
+
+        if (includePlan)
+        {
+            properties.Add(Optional("plan", ObjectSchema(additionalProperties: true)));
+        }
+
+        return ObjectSchema(additionalProperties: false, properties.ToArray());
+    }
+
+    private static Dictionary<string, object?> CreateOpsListPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("operations", ArraySchema(ObjectSchema(
+                additionalProperties: false,
+                Required("name", StringSchema()),
+                Required("kind", StringSchema()),
+                Required("policy", StringSchema()),
+                Required("description", StringSchema())))),
+            Optional("readIndex", ReferenceSchema("../defs/read-index.schema.json")));
+    }
+
+    private static Dictionary<string, object?> CreateCodesListPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("catalogVersion", IntegerSchema()),
+            Required("source", StringSchema()),
+            Required("kinds", ArraySchema(StringSchema())),
+            Required("codes", ArraySchema(ObjectSchema(
+                additionalProperties: false,
+                Required("code", StringSchema()),
+                Required("kind", StringSchema()),
+                Required("category", StringSchema()),
+                Required("summary", StringSchema())))));
+    }
+
+    private static Dictionary<string, object?> CreateCodesDescribePayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("code", StringSchema()),
+            Required("known", BooleanSchema()),
+            Required("kind", StringSchema()),
+            Required("category", StringSchema()),
+            Required("summary", StringSchema()),
+            Required("meaning", NullableStringSchema()),
+            Required("appearsIn", ArraySchema(StringSchema())),
+            Required("appliesTo", ArraySchema(StringSchema())),
+            Optional("coverageImpact", ObjectSchema(additionalProperties: true)),
+            Optional("verdictSemantics", ObjectSchema(additionalProperties: true)),
+            Required("executionSemantics", NullableObjectSchema()),
+            Required("inspect", ArraySchema(StringSchema())),
+            Required("relatedCodes", ArraySchema(StringSchema())));
+    }
+
+    private static Dictionary<string, object?> CreateDaemonStartPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("startStatus", StringSchema()),
+            Optional("daemonStatus", StringSchema()),
+            Optional("lifecycleState", NullableStringSchema()),
+            Optional("blockingReason", NullableStringSchema()),
+            Optional("canAcceptExecutionRequests", BooleanSchema()),
+            Optional("timeoutMilliseconds", IntegerSchema()),
+            Optional("session", NullableObjectSchema()),
+            Optional("startup", ObjectSchema(additionalProperties: true)),
+            Optional("diagnosis", NullableObjectSchema()),
+            Optional("retryDisposition", NullableStringSchema()),
+            Optional("safeToRetryImmediately", BooleanSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateDaemonStatusPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("daemonStatus", StringSchema()),
+            Optional("serverVersion", NullableStringSchema()),
+            Optional("editorMode", NullableStringSchema()),
+            Optional("lifecycleState", NullableStringSchema()),
+            Optional("blockingReason", NullableStringSchema()),
+            Optional("compileState", NullableStringSchema()),
+            Optional("compileGeneration", NullableStringSchema()),
+            Optional("domainReloadGeneration", NullableStringSchema()),
+            Optional("canAcceptExecutionRequests", BooleanSchema()),
+            Optional("observedAtUtc", NullableStringSchema()),
+            Optional("actionRequired", NullableStringSchema()),
+            Optional("primaryDiagnostic", NullableObjectSchema()),
+            Optional("timeoutMilliseconds", IntegerSchema()),
+            Optional("session", NullableObjectSchema()),
+            Optional("diagnosis", NullableObjectSchema()),
+            Optional("lastLaunchAttempt", ObjectSchema(additionalProperties: true)));
+    }
+
+    private static Dictionary<string, object?> CreateTestProfileInitPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Optional("profilePath", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateTestRunPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("result", NullableStringSchema()),
+            Required("errorKind", NullableStringSchema()),
+            Required("runId", NullableStringSchema()),
+            Required("artifactsDir", NullableStringSchema()),
+            Required("summaryJsonPath", NullableStringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateRequestEnvelopeSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("steps", ArraySchema(new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["oneOf"] = new object?[]
+                {
+                    ObjectSchema(
+                        additionalProperties: false,
+                        Required("kind", ConstString("op")),
+                        Required("id", StringSchema()),
+                        Required("op", StringSchema()),
+                        Required("args", ObjectSchema(additionalProperties: true))),
+                    ReferenceSchema("edit-dsl.schema.json"),
+                },
+            })));
+    }
+
+    private static Dictionary<string, object?> CreateEditDslSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("kind", ConstString("edit")),
+            Required("id", StringSchema()),
+            Required("on", ObjectSchema(additionalProperties: true)),
+            Required("select", ObjectSchema(additionalProperties: true)),
+            Required("actions", ArraySchema(ObjectSchema(additionalProperties: true))),
+            Required("commit", StringSchema()));
+    }
+
+    private static SchemaProperty Required (
+        string name,
+        Dictionary<string, object?> schema)
+    {
+        return new SchemaProperty(name, schema, true);
+    }
+
+    private static SchemaProperty Optional (
+        string name,
+        Dictionary<string, object?> schema)
+    {
+        return new SchemaProperty(name, schema, false);
+    }
+
+    private static Dictionary<string, object?> ObjectSchema (
+        bool additionalProperties,
+        params SchemaProperty[] properties)
+    {
+        var schema = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "object",
+        };
+
+        if (!additionalProperties)
+        {
+            schema["additionalProperties"] = false;
+        }
+
+        if (properties.Length > 0)
+        {
+            schema["properties"] = properties.ToDictionary(
+                static property => property.Name,
+                static property => (object?)property.Schema,
+                StringComparer.Ordinal);
+
+            var required = properties
+                .Where(static property => property.Required)
+                .Select(static property => property.Name)
+                .ToArray();
+            if (required.Length > 0)
+            {
+                schema["required"] = required;
+            }
+        }
+
+        return schema;
+    }
+
+    private static Dictionary<string, object?> ArraySchema (Dictionary<string, object?> itemSchema)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "array",
+            ["items"] = itemSchema,
+        };
+    }
+
+    private static Dictionary<string, object?> StringSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "string",
+        };
+    }
+
+    private static Dictionary<string, object?> NullableStringSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = new[] { "string", "null" },
+        };
+    }
+
+    private static Dictionary<string, object?> IntegerSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "integer",
+        };
+    }
+
+    private static Dictionary<string, object?> NullableIntegerSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = new[] { "integer", "null" },
+        };
+    }
+
+    private static Dictionary<string, object?> BooleanSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "boolean",
+        };
+    }
+
+    private static Dictionary<string, object?> NullableObjectSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = new[] { "object", "null" },
+        };
+    }
+
+    private static Dictionary<string, object?> AnySchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal);
+    }
+
+    private static Dictionary<string, object?> ReferenceSchema (string reference)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["$ref"] = reference,
+        };
+    }
+
+    private static Dictionary<string, object?> EnumSchema (params string[] values)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "string",
+            ["enum"] = values,
+        };
+    }
+
+    private static Dictionary<string, object?> ConstString (string value)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "string",
+            ["const"] = value,
+        };
+    }
+
+    private static Dictionary<string, object?> ConstInteger (int value)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "integer",
+            ["const"] = value,
+        };
+    }
+
+    private static string SerializeJson (object value)
+    {
+        var json = JsonSerializer.Serialize(value, SerializerOptions)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal);
+        return json.EndsWith('\n') ? json : json + "\n";
+    }
+
+    private static string ReadPackageVersion (string repositoryRoot)
+    {
+        var propsPath = Path.Combine(repositoryRoot, "Directory.Build.props");
+        if (!File.Exists(propsPath))
+        {
+            throw new InvalidOperationException($"Directory.Build.props was not found: {propsPath}");
+        }
+
+        var document = XDocument.Load(propsPath);
+        var version = document.Descendants("Version").SingleOrDefault()?.Value;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            throw new InvalidOperationException($"Version property was not found: {propsPath}");
+        }
+
+        return version;
+    }
+
+    private static bool TryParseArgs (
+        string[] args,
+        out string outputRoot,
+        out string? packageVersion,
+        out string repositoryRoot)
+    {
+        outputRoot = string.Empty;
+        packageVersion = null;
+        repositoryRoot = Directory.GetCurrentDirectory();
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--output":
+                    if (!TryReadOptionValue(args, ref i, out outputRoot))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--package-version":
+                    if (!TryReadOptionValue(args, ref i, out packageVersion))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--repository-root":
+                    if (!TryReadOptionValue(args, ref i, out repositoryRoot))
+                    {
+                        return false;
+                    }
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+
+        return !string.IsNullOrWhiteSpace(outputRoot)
+            && !string.IsNullOrWhiteSpace(repositoryRoot);
+    }
+
+    private static bool TryReadOptionValue (
+        string[] args,
+        ref int optionIndex,
+        out string value)
+    {
+        if (optionIndex >= args.Length - 1)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = args[++optionIndex];
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static void WriteUsage ()
+    {
+        Console.Error.WriteLine("usage: Ucli.SchemaGenerator --output <schemas-dir> [--repository-root <repo-root>] [--package-version <version>]");
+    }
+
+    private sealed record SchemaFile (
+        string RelativePath,
+        string Kind,
+        string? Command,
+        Dictionary<string, object?> Document);
+
+    private sealed record SchemaProperty (
+        string Name,
+        Dictionary<string, object?> Schema,
+        bool Required);
+}

--- a/tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj
+++ b/tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>MackySoft.Ucli.SchemaGenerator</AssemblyName>
+    <RootNamespace>MackySoft.Ucli.SchemaGenerator</RootNamespace>
+    <LangVersion>13.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Ucli.Contracts/Ucli.Contracts.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Add deterministic generation for public `schemas/v1` CLI schema artifacts, including the manifest, CLI JSON envelope, current command payload schemas, request envelope schema, and shared assurance component definitions.
- Add an internal JSON Schema subset validator for generated artifacts and Golden CLI output validation.
- Add the assurance semantic invariant validator for verdict recomputation, verifier ownership, primary claims, report/evidence references, digest-only report rejection, and code catalog resolution.
- Package schemas into the CLI tool and attach a `schemas/...` archive to GitHub Releases.

## Scope
- `tools/Ucli.SchemaGenerator`, `scripts/generate-schemas.sh`, and `scripts/verify-schemas.sh` generate and drift-check the schema tree.
- `schemas/v1/**` contains the generated v1 schema artifact set.
- `src/Ucli.Application/Features/Assurance/Semantics/**` adds semantic invariant validation for assurance payloads.
- `tests/**` adds Golden schema validation, semantic invariant tests, architecture/package checks, and the test-only subset validator.
- `.github/workflows/cli-package-publish.yaml`, `src/Ucli/Ucli.csproj`, and package verification scripts include schemas in release distribution.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk: the initial JSON Schema subset is intentionally narrow, so future schema keywords must be added deliberately to the generator and test validator together.
- Risk: generated schema file names follow command ids directly, including `query.asset.schema.schema.json` and `query.comp.schema.schema.json`.
- Rollback: revert these commits to remove generated schemas, the validator, package wiring, and release archive generation together.

## Checklist
- [x] `schemas/v1/schema-manifest.json` is generated.
- [x] Golden CLI output is validated through manifest-indexed command payload schemas.
- [x] Semantic invariant failures include concrete JSON paths.
- [x] Schema artifacts use the same relative layout in the repository, CLI package, installed tool root, and release zip.

Closes #282
