### PR TITLE
ci(release): use unprefixed package release tags

### DIFF
--- a/.github/workflows/package-publish.yaml
+++ b/.github/workflows/package-publish.yaml
@@ -3,11 +3,11 @@ name: package-publish
 on:
   push:
     tags:
-      - release/*
+      - "[0-9]*.[0-9]*.[0-9]*"
   workflow_dispatch:
     inputs:
-      package_version:
-        description: "SemVer package version (e.g. 1.2.3)"
+      release_tag:
+        description: "Release tag without prefix (e.g. 1.2.3)"
         required: true
         type: string
 
@@ -49,8 +49,8 @@ jobs:
         id: version
         shell: bash
         env:
-          DISPATCH_VERSION: ${{ github.event.inputs.package_version }}
-        run: ./scripts/resolve-release-version.sh --tag-prefix release --dispatch-version "${DISPATCH_VERSION}"
+          DISPATCH_TAG: ${{ github.event.inputs.release_tag }}
+        run: ./scripts/resolve-release-version.sh --dispatch-tag "${DISPATCH_TAG}"
 
       - name: Validate release source
         id: source

--- a/docs/package-operations.md
+++ b/docs/package-operations.md
@@ -53,12 +53,12 @@ NuGetForUnity のUIで導入した場合は依存パッケージも `packages.co
 ```
 
 ## Release Artifact Mirror
-`package-publish` workflow は、nuget.org への公開が成功した後に同じ `.nupkg` を GitHub Releases へミラーし、schema artifact zip も同じ `release/<version>` へ添付する。NuGet パッケージ配布の正は nuget.org とし、GitHub Releases はタグごとの公開成果物を確認する監査場所として扱う。
+`package-publish` workflow は、nuget.org への公開が成功した後に同じ `.nupkg` を GitHub Releases へミラーし、schema artifact zip も同じ `<version>` tag へ添付する。NuGet パッケージ配布の正は nuget.org とし、GitHub Releases はタグごとの公開成果物を確認する監査場所として扱う。
 
-- `release/<version>`: `MackySoft.Ucli.<version>.nupkg`
-- `release/<version>`: `MackySoft.Ucli.Contracts.<version>.nupkg` / `MackySoft.Ucli.Infrastructure.<version>.nupkg`
-- `release/<version>`: `MackySoft.Ucli.Unity.<version>.nupkg`
-- `release/<version>`: `MackySoft.Ucli.Schemas.<version>.zip`
+- `<version>`: `MackySoft.Ucli.<version>.nupkg`
+- `<version>`: `MackySoft.Ucli.Contracts.<version>.nupkg` / `MackySoft.Ucli.Infrastructure.<version>.nupkg`
+- `<version>`: `MackySoft.Ucli.Unity.<version>.nupkg`
+- `<version>`: `MackySoft.Ucli.Schemas.<version>.zip`
 
 ## Agent Skill Distribution
 uCLI 公式 SKILL は agent 向け workflow 配布物であり、operation contract の正本ではない。正本は `Ucli.Contracts`、operation metadata、`ucli ops describe`、[json-request-spec.md](json-request-spec.md) に置く。
@@ -91,7 +91,7 @@ dotnet tool install --global MackySoft.Ucli --version <version>
 dotnet tool update --global MackySoft.Ucli --version <version>
 ```
 
-CLI パッケージは `src/Ucli/Ucli.csproj` と root の `Directory.Build.props` を正として `dotnet pack` で生成する。公開 workflow は `release/<version>` tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。
+CLI パッケージは `src/Ucli/Ucli.csproj` と root の `Directory.Build.props` を正として `dotnet pack` で生成する。公開 workflow は `<version>` tag の version を `Version` / `PackageVersion` に渡し、`ucli --version` が公開 version と一致することを検証してから nuget.org へ公開し、同じ `.nupkg` を GitHub Releases へミラーする。
 
 ```bash
 dotnet pack "src/Ucli/Ucli.csproj" \
@@ -216,11 +216,11 @@ done
 - Unity 検証は `src/Ucli`、`src/Ucli.Application`、`src/Ucli.Unity`、`src/Ucli.Contracts`、`src/Ucli.Infrastructure`、`scripts/test-unity.sh`、`scripts/update-local-shared-packages.sh`、`verify` 自体の変更時に動く。`buildalon/unity-setup` と `buildalon/activate-unity-license` で各 OS の Unity Editor を用意した後、CI とローカル共通の `scripts/test-unity.sh` から `ucli test run --mode oneshot` を使って `EditMode` テストアセンブリを明示指定して実行する。workflow はプロセス終了コードだけでなく `command-result.json` の `status` / `exitCode` / `payload.result` も検証し、`pass` 以外を失敗として扱う。
 - CLI pack 検証は `Directory.Build.props`、`src/Ucli`、`src/Ucli.Contracts`、`src/Ucli.Infrastructure`、`README.md`、`LICENSE`、`package-publish`、`verify` 自体の変更時に動く。`dotnet pack` 後にローカル tool install、`ucli --version`、`ucli --help`、nupkg 内の `DotnetToolSettings.xml` / `README.md` / `LICENSE` を検証する。
 - Unity package pack 検証は `scripts/pack-unity-plugin.sh` で `MackySoft.Ucli.Unity` nupkg を作成し、`scripts/verify-unity-plugin-package.sh` で必須ファイル、依存定義、ローカル復元後の `ucli-plugin.json` 配置を検証する。
-- `package-publish`: `release/<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `package_version` から同名タグを先に作成して push し、その同一 workflow run の中で version sync / pack / package verify / nuget.org publication state check / publish availability wait / GitHub Release mirror / repository version sync PR 作成まで継続する。
+- `package-publish`: `<major>.<minor>.<patch>` タグを公開の起点とする。`workflow_dispatch` は `release_tag` から同名タグを先に作成して push し、その同一 workflow run の中で version sync / pack / package verify / nuget.org publication state check / publish availability wait / GitHub Release mirror / repository version sync PR 作成まで継続する。
 - `package-publish` は公開後に `chore/release-sync-<version>` ブランチを作成し、`Directory.Build.props`、`schemas/v1/schema-manifest.json`、`src/Ucli.Unity/Assets/packages.config`、`src/Ucli.Unity/MackySoft.Ucli.Unity.nuspec` の package version を同一値へ同期する PR を作成する。同期 PR に対しては `verify` workflow を明示的に dispatch する。
-- タグは `v` プレフィックスを付けない（例: `release/x.y.z`）。
+- タグは `v` や `release/` のプレフィックスを付けない（例: `x.y.z`）。
 
 ```bash
-git tag release/x.y.z
-git push origin release/x.y.z
+git tag x.y.z
+git push origin x.y.z
 ```

--- a/scripts/resolve-release-version.sh
+++ b/scripts/resolve-release-version.sh
@@ -3,27 +3,21 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-Usage: scripts/resolve-release-version.sh --tag-prefix <prefix> [--dispatch-version <version>] [--event-name <event>] [--ref-name <ref>]
+Usage: scripts/resolve-release-version.sh [--dispatch-tag <tag>] [--event-name <event>] [--ref-name <ref>]
 
 Resolves a SemVer package version and release tag name for package publish workflows.
 EOF
 }
 
-tag_prefix=""
-dispatch_version="${DISPATCH_VERSION:-}"
+dispatch_tag="${DISPATCH_TAG:-}"
 event_name="${GITHUB_EVENT_NAME:-}"
 ref_name="${GITHUB_REF_NAME:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --tag-prefix)
+    --dispatch-tag)
       [[ $# -ge 2 ]] || { usage; exit 2; }
-      tag_prefix="$2"
-      shift 2
-      ;;
-    --dispatch-version)
-      [[ $# -ge 2 ]] || { usage; exit 2; }
-      dispatch_version="$2"
+      dispatch_tag="$2"
       shift 2
       ;;
     --event-name)
@@ -47,34 +41,34 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${tag_prefix}" || -z "${event_name}" ]]; then
+if [[ -z "${event_name}" ]]; then
   usage
   exit 2
 fi
 
-if [[ ! "${tag_prefix}" =~ ^[A-Za-z0-9._-]+$ ]]; then
-  echo "Tag prefix must not contain path separators or shell pattern characters. Actual: ${tag_prefix}" >&2
-  exit 2
-fi
-
 if [[ "${event_name}" == "workflow_dispatch" ]]; then
-  package_version="${dispatch_version}"
+  release_tag="${dispatch_tag}"
 else
-  expected_prefix="${tag_prefix}/"
-  if [[ -z "${ref_name}" || "${ref_name}" != "${expected_prefix}"* ]]; then
-    echo "Release ref must start with ${expected_prefix}. Actual: ${ref_name}" >&2
+  if [[ -z "${ref_name}" ]]; then
+    echo "Release ref name is required for ${event_name}." >&2
     exit 1
   fi
 
-  package_version="${ref_name#${expected_prefix}}"
+  release_tag="${ref_name}"
 fi
 
-if [[ ! "${package_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Package version must use <major>.<minor>.<patch> format. Actual: ${package_version}" >&2
+if [[ "${release_tag}" == */* ]]; then
+  echo "Release tag must not contain path separators. Use <major>.<minor>.<patch> without release/ prefix. Actual: ${release_tag}" >&2
   exit 1
 fi
 
-tag_name="${tag_prefix}/${package_version}"
+if [[ ! "${release_tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Release tag must use <major>.<minor>.<patch> format without a prefix. Actual: ${release_tag}" >&2
+  exit 1
+fi
+
+package_version="${release_tag}"
+tag_name="${release_tag}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {


### PR DESCRIPTION
## Summary
- Change package release tags from `release/<version>` to plain SemVer tags such as `1.2.3`.
- Keep workflow dispatch and tag push resolution aligned on the same unprefixed tag name.
- Update release operations documentation to match the workflow contract.

## Scope
- `.github/workflows/package-publish.yaml`: accepts `release_tag` input and runs on unprefixed SemVer-shaped tags.
- `scripts/resolve-release-version.sh`: resolves package version and release tag without a prefix, rejecting `release/` and `v` inputs.
- `docs/package-operations.md`: documents the unprefixed tag release flow.

## Verification
- Gate level: Standard
- Format: PASS (`git diff --check origin/master..HEAD`)
- Tests: PASS (`bash -n scripts/resolve-release-version.sh scripts/create-release-tag.sh`, workflow YAML parse, release tag resolver normal/reject cases)
- Coverage: N/A

## Risks / Rollback
- Existing automation that calls `workflow_dispatch` with `package_version` must switch to `release_tag`.
- Rollback is reverting this PR to restore the previous `release/<version>` tag contract.

## Checklist
- [x] Release workflow no longer requires the `release/` tag prefix.
- [x] Documentation matches the workflow input and manual tag commands.

Issue: none (ad-hoc task)
