### PR TITLE
refactor(core): route constructor dependencies through DI

### DIFF
--- a/src/Ucli.Application/Shared/Execution/ReadIndex/Scenes/Access/SceneTreeLiteAccessService.cs
+++ b/src/Ucli.Application/Shared/Execution/ReadIndex/Scenes/Access/SceneTreeLiteAccessService.cs
@@ -22,23 +22,6 @@ internal sealed class SceneTreeLiteAccessService : ISceneTreeLiteAccessService
         IReadIndexFreshnessEvaluator freshnessEvaluator,
         IMutationReadPostconditionStore mutationReadPostconditionStore,
         ISceneTreeLiteSourceRefreshService sourceRefreshService,
-        ISceneTreeLiteSourceProbe sourceProbe)
-        : this(
-            artifactReader,
-            freshnessEvaluator,
-            mutationReadPostconditionStore,
-            sourceRefreshService,
-            sourceProbe,
-            NoOpSceneTreeLiteDirtySourceProbeService.Instance)
-    {
-    }
-
-    /// <summary> Initializes a new instance of the <see cref="SceneTreeLiteAccessService" /> class. </summary>
-    public SceneTreeLiteAccessService (
-        IReadIndexArtifactReader artifactReader,
-        IReadIndexFreshnessEvaluator freshnessEvaluator,
-        IMutationReadPostconditionStore mutationReadPostconditionStore,
-        ISceneTreeLiteSourceRefreshService sourceRefreshService,
         ISceneTreeLiteSourceProbe sourceProbe,
         ISceneTreeLiteDirtySourceProbeService dirtySourceProbeService)
     {
@@ -288,21 +271,4 @@ internal sealed class SceneTreeLiteAccessService : ISceneTreeLiteAccessService
             "Scene-tree-lite read completed.");
     }
 
-    private sealed class NoOpSceneTreeLiteDirtySourceProbeService : ISceneTreeLiteDirtySourceProbeService
-    {
-        public static NoOpSceneTreeLiteDirtySourceProbeService Instance { get; } = new();
-
-        public ValueTask<SceneTreeLiteDirtySourceProbeResult> ProbeAsync (
-            ResolvedUnityProjectContext project,
-            UcliConfig config,
-            UcliCommand command,
-            UnityExecutionModeValue mode,
-            TimeSpan timeout,
-            string scenePath,
-            CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return ValueTask.FromResult(SceneTreeLiteDirtySourceProbeResult.NotAvailable("dirty source probe is not configured."));
-        }
-    }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/CsEval/CsEvalOperation.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/CsEval/CsEvalOperation.cs
@@ -24,16 +24,7 @@ namespace MackySoft.Ucli.Unity.Execution.CsEval
 
         private readonly CsEvalReturnValueSerializer returnValueSerializer;
 
-        public CsEvalOperation ()
-            : this(
-                new CsEvalCompilationService(new CsEvalReferenceResolver(), new CsEvalEntryPointSymbolValidator(), new CsEvalSourcePreparer()),
-                new CsEvalEntryPointReflectionResolver(),
-                new CsEvalReturnValueSerializer())
-        {
-            // NOTE: Operation discovery instantiates [UcliOperation] types through their public parameterless constructor.
-        }
-
-        internal CsEvalOperation (
+        public CsEvalOperation (
             CsEvalCompilationService compilationService,
             CsEvalEntryPointReflectionResolver entryPointResolver,
             CsEvalReturnValueSerializer returnValueSerializer)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Dispatch/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Dispatch/ExecuteRequestDispatcher.cs
@@ -3,7 +3,6 @@ using MackySoft.Ucli.Contracts;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using MackySoft.Ucli.Contracts.Daemon;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Execution.Phases;
 using MackySoft.Ucli.Unity.Execution.RequestIdempotency;
@@ -28,60 +27,6 @@ namespace MackySoft.Ucli.Unity.Execution.Dispatch
         private readonly IExecuteRequestIdempotencyCoordinator requestIdempotencyCoordinator;
         private readonly IUnityEditorReadinessGate readinessGate;
         private readonly IUnityMainThreadRequestExecutor mainThreadRequestExecutor;
-
-        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestDispatcher" /> class. </summary>
-        /// <param name="requestNormalizer"> The execute-request normalizer dependency. </param>
-        /// <param name="operationPhaseExecutor"> The operation-phase executor dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
-        public ExecuteRequestDispatcher (
-            IExecuteRequestNormalizer requestNormalizer,
-            IOperationPhaseExecutor operationPhaseExecutor)
-            : this(
-                requestNormalizer,
-                operationPhaseExecutor,
-                new ExecuteRequestIdempotencyCoordinator(),
-                new PassThroughUnityEditorReadinessGate(),
-                new InlineUnityMainThreadRequestExecutor())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestDispatcher" /> class. </summary>
-        /// <param name="requestNormalizer"> The execute-request normalizer dependency. </param>
-        /// <param name="operationPhaseExecutor"> The operation-phase executor dependency. </param>
-        /// <param name="readinessGate"> The editor-readiness gate dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
-        public ExecuteRequestDispatcher (
-            IExecuteRequestNormalizer requestNormalizer,
-            IOperationPhaseExecutor operationPhaseExecutor,
-            IUnityEditorReadinessGate readinessGate)
-            : this(
-                requestNormalizer,
-                operationPhaseExecutor,
-                new ExecuteRequestIdempotencyCoordinator(),
-                readinessGate,
-                new InlineUnityMainThreadRequestExecutor())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestDispatcher" /> class. </summary>
-        /// <param name="requestNormalizer"> The execute-request normalizer dependency. </param>
-        /// <param name="operationPhaseExecutor"> The operation-phase executor dependency. </param>
-        /// <param name="readinessGate"> The editor-readiness gate dependency. </param>
-        /// <param name="mainThreadRequestExecutor"> The Unity main-thread executor dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
-        public ExecuteRequestDispatcher (
-            IExecuteRequestNormalizer requestNormalizer,
-            IOperationPhaseExecutor operationPhaseExecutor,
-            IUnityEditorReadinessGate readinessGate,
-            IUnityMainThreadRequestExecutor mainThreadRequestExecutor)
-            : this(
-                requestNormalizer,
-                operationPhaseExecutor,
-                new ExecuteRequestIdempotencyCoordinator(),
-                readinessGate,
-                mainThreadRequestExecutor)
-        {
-        }
 
         /// <summary> Initializes a new instance of the <see cref="ExecuteRequestDispatcher" /> class. </summary>
         /// <param name="requestNormalizer"> The execute-request normalizer dependency. </param>
@@ -216,45 +161,6 @@ namespace MackySoft.Ucli.Unity.Execution.Dispatch
                     $"Unexpected error occurred while dispatching execute request. {exception.Message}",
                     null,
                     SerializerOptions);
-            }
-        }
-
-        private sealed class PassThroughUnityEditorReadinessGate : IUnityEditorReadinessGate
-        {
-            public UnityEditorLifecycleSnapshot CaptureSnapshot ()
-            {
-                return new UnityEditorLifecycleSnapshot(
-                    EditorMode: DaemonEditorMode.Batchmode,
-                    LifecycleState: IpcEditorLifecycleStateCodec.Ready,
-                    BlockingReason: null,
-                    CompileState: IpcCompileStateCodec.Ready,
-                    CompileGeneration: "0",
-                    DomainReloadGeneration: "0",
-                    CanAcceptExecutionRequests: true);
-            }
-
-            public Task<UnityEditorExecutionReadinessResult> EnsureExecutionReadyAsync (
-                bool failFast,
-                CancellationToken cancellationToken = default)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                return Task.FromResult(UnityEditorExecutionReadinessResult.Ready(CaptureSnapshot()));
-            }
-        }
-
-        private sealed class InlineUnityMainThreadRequestExecutor : IUnityMainThreadRequestExecutor
-        {
-            public Task<T> ExecuteAsync<T> (
-                Func<Task<T>> workItem,
-                CancellationToken cancellationToken = default)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (workItem == null)
-                {
-                    throw new ArgumentNullException(nameof(workItem));
-                }
-
-                return workItem();
             }
         }
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/DangerousOperationCallAuthorizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/DangerousOperationCallAuthorizer.cs
@@ -16,15 +16,9 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         private readonly IPlanTokenEnvironment environment;
 
         /// <summary> Initializes a new instance of the <see cref="DangerousOperationCallAuthorizer" /> class. </summary>
-        public DangerousOperationCallAuthorizer ()
-            : this(new DefaultPlanTokenEnvironment())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="DangerousOperationCallAuthorizer" /> class. </summary>
         /// <param name="environment"> The runtime environment dependency used to locate project configuration. </param>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="environment" /> is <see langword="null" />. </exception>
-        internal DangerousOperationCallAuthorizer (IPlanTokenEnvironment environment)
+        public DangerousOperationCallAuthorizer (IPlanTokenEnvironment environment)
         {
             this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationExecutionContext.cs
@@ -35,20 +35,11 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
         /// <summary> Initializes a new instance of the <see cref="OperationExecutionContext" /> class. </summary>
         public OperationExecutionContext ()
-            : this(new OperationAliasStore())
         {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="OperationExecutionContext" /> class. </summary>
-        /// <param name="aliasStore"> The alias-store dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="aliasStore" /> is <see langword="null" />. </exception>
-        internal OperationExecutionContext (OperationAliasStore aliasStore)
-        {
-            AliasStore = aliasStore ?? throw new ArgumentNullException(nameof(aliasStore));
         }
 
         /// <summary> Gets the alias store used to share resolved references within one request. </summary>
-        internal OperationAliasStore AliasStore { get; }
+        internal OperationAliasStore AliasStore { get; } = new OperationAliasStore();
 
         /// <summary> Stores or replaces one temporary alias value used during plan execution. </summary>
         /// <param name="alias"> The alias name. </param>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPhaseExecutor.cs
@@ -25,42 +25,11 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         private readonly IDangerousOperationCallAuthorizer dangerousOperationCallAuthorizer;
 
         /// <summary> Initializes a new instance of the <see cref="OperationPhaseExecutor" /> class. </summary>
-        /// <param name="operationRegistry"> The phase-operation registry dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationRegistry" /> is <see langword="null" />. </exception>
-        public OperationPhaseExecutor (IPhaseOperationRegistry operationRegistry)
-            : this(operationRegistry, new PlanTokenCoordinator(), new DangerousOperationCallAuthorizer())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="OperationPhaseExecutor" /> class. </summary>
-        /// <param name="operationRegistry"> The phase-operation registry dependency. </param>
-        /// <param name="planTokenCoordinator"> The plan-token coordination dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
-        public OperationPhaseExecutor (
-            IPhaseOperationRegistry operationRegistry,
-            IPlanTokenCoordinator planTokenCoordinator)
-            : this(operationRegistry, planTokenCoordinator, new DangerousOperationCallAuthorizer())
-        {
-        }
-
-        internal OperationPhaseExecutor (
-            IPhaseOperationRegistry operationRegistry,
-            IPlanTokenCoordinator planTokenCoordinator,
-            IDangerousOperationCallAuthorizer dangerousOperationCallAuthorizer)
-            : this(
-                new OperationPlanPassExecutor(operationRegistry),
-                new OperationCallPassExecutor(),
-                planTokenCoordinator,
-                dangerousOperationCallAuthorizer)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="OperationPhaseExecutor" /> class. </summary>
         /// <param name="planPassExecutor"> The validate/plan pass executor dependency. </param>
         /// <param name="callPassExecutor"> The call pass executor dependency. </param>
         /// <param name="planTokenCoordinator"> The plan-token coordination dependency. </param>
         /// <exception cref="ArgumentNullException"> Thrown when any dependency is <see langword="null" />. </exception>
-        internal OperationPhaseExecutor (
+        public OperationPhaseExecutor (
             IOperationPlanPassExecutor planPassExecutor,
             IOperationCallPassExecutor callPassExecutor,
             IPlanTokenCoordinator planTokenCoordinator,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPlanPassExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/OperationPlanPassExecutor.cs
@@ -15,18 +15,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         private readonly ExecuteRequestCompiler requestCompiler;
 
         /// <summary> Initializes a new instance of the <see cref="OperationPlanPassExecutor" /> class. </summary>
-        /// <param name="operationRegistry"> The phase-operation registry dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="operationRegistry" /> is <see langword="null" />. </exception>
-        public OperationPlanPassExecutor (IPhaseOperationRegistry operationRegistry)
-            : this(new OperationPlanStepRunner(operationRegistry), new ExecuteRequestCompiler())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="OperationPlanPassExecutor" /> class. </summary>
         /// <param name="stepRunner"> The one-operation plan-step runner dependency. </param>
         /// <param name="requestCompiler"> The runtime request compiler dependency. </param>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="stepRunner" /> is <see langword="null" />. </exception>
-        internal OperationPlanPassExecutor (
+        public OperationPlanPassExecutor (
             OperationPlanStepRunner stepRunner,
             ExecuteRequestCompiler requestCompiler)
         {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/UcliOperationCatalogSnapshotBuilder.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/UcliOperationCatalogSnapshotBuilder.cs
@@ -18,6 +18,21 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             return Build(registrations);
         }
 
+        /// <summary> Discovers operations through dependency injection and builds one shared snapshot. </summary>
+        /// <param name="serviceProvider"> The service provider used to activate operation instances. </param>
+        /// <returns> The discovered operation snapshot. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="serviceProvider" /> is <see langword="null" />. </exception>
+        public static UcliOperationCatalogSnapshot Build (IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            var registrations = UcliOperationDiscoverer.Discover(serviceProvider);
+            return Build(registrations);
+        }
+
         /// <summary> Builds one shared snapshot from discovered registrations. </summary>
         /// <param name="registrations"> The discovered registrations. </param>
         /// <returns> The discovered operation snapshot. </returns>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/UcliOperationDiscoverer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/UcliOperationDiscoverer.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using MackySoft.Ucli.Unity.Execution;
+using Microsoft.Extensions.DependencyInjection;
 using UnityEditor.Compilation;
 
 using RuntimeAssembly = System.Reflection.Assembly;
@@ -15,13 +17,26 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
     {
         private const string NUnitFrameworkAssemblyName = "nunit.framework";
 
+        private static readonly Lazy<IServiceProvider> DefaultOperationServiceProvider = new(CreateDefaultOperationServiceProvider);
+
         /// <summary> Discovers operation instances from currently loaded assemblies. </summary>
         /// <returns> The discovered operation registration list. </returns>
         public static IReadOnlyList<UcliOperationRegistration> Discover ()
         {
+            return Discover(DefaultOperationServiceProvider.Value);
+        }
+
+        /// <summary> Discovers operation instances from currently loaded assemblies. </summary>
+        /// <param name="serviceProvider"> The service provider used to activate operation instances. </param>
+        /// <returns> The discovered operation registration list. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="serviceProvider" /> is <see langword="null" />. </exception>
+        internal static IReadOnlyList<UcliOperationRegistration> Discover (IServiceProvider serviceProvider)
+        {
             return Discover(
+                AppDomain.CurrentDomain.GetAssemblies(),
                 includeUcliDefinedAssemblies: true,
-                includeUserDefinedAssemblies: true);
+                includeUserDefinedAssemblies: true,
+                serviceProvider);
         }
 
         /// <summary> Discovers operation instances from currently loaded assemblies with source-kind filtering. </summary>
@@ -35,7 +50,8 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             return Discover(
                 AppDomain.CurrentDomain.GetAssemblies(),
                 includeUcliDefinedAssemblies,
-                includeUserDefinedAssemblies);
+                includeUserDefinedAssemblies,
+                DefaultOperationServiceProvider.Value);
         }
 
         /// <summary> Discovers operation instances from a specified assembly set. </summary>
@@ -50,9 +66,34 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             bool includeUcliDefinedAssemblies,
             bool includeUserDefinedAssemblies)
         {
+            return Discover(
+                assemblies,
+                includeUcliDefinedAssemblies,
+                includeUserDefinedAssemblies,
+                DefaultOperationServiceProvider.Value);
+        }
+
+        /// <summary> Discovers operation instances from a specified assembly set. </summary>
+        /// <param name="assemblies"> The assembly set to inspect. </param>
+        /// <param name="includeUcliDefinedAssemblies"> Whether built-in uCLI operation assemblies should be discovered. </param>
+        /// <param name="includeUserDefinedAssemblies"> Whether user-defined operation assemblies should be discovered. </param>
+        /// <param name="serviceProvider"> The service provider used to activate operation instances. </param>
+        /// <returns> The discovered operation registration list. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="assemblies" /> or <paramref name="serviceProvider" /> is <see langword="null" />. </exception>
+        /// <exception cref="InvalidOperationException"> Thrown when one discovered operation type is invalid. </exception>
+        internal static IReadOnlyList<UcliOperationRegistration> Discover (
+            IReadOnlyList<RuntimeAssembly> assemblies,
+            bool includeUcliDefinedAssemblies,
+            bool includeUserDefinedAssemblies,
+            IServiceProvider serviceProvider)
+        {
             if (assemblies == null)
             {
                 throw new ArgumentNullException(nameof(assemblies));
+            }
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
             var ucliAssemblyName = typeof(UcliOperationDiscoverer).Assembly.GetName().Name;
@@ -85,7 +126,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                 }
 
                 var types = GetLoadableTypes(assembly);
-                var discoveredFromAssembly = DiscoverFromTypes(types);
+                var discoveredFromAssembly = DiscoverFromTypes(types, serviceProvider);
                 for (var operationIndex = 0; operationIndex < discoveredFromAssembly.Count; operationIndex++)
                 {
                     registrations.Add(discoveredFromAssembly[operationIndex]);
@@ -102,9 +143,26 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <exception cref="InvalidOperationException"> Thrown when one discovered operation type is invalid. </exception>
         internal static IReadOnlyList<UcliOperationRegistration> DiscoverFromTypes (IReadOnlyList<Type?> types)
         {
+            return DiscoverFromTypes(types, DefaultOperationServiceProvider.Value);
+        }
+
+        /// <summary> Discovers operation instances from a specified type set. </summary>
+        /// <param name="types"> The candidate type set. </param>
+        /// <param name="serviceProvider"> The service provider used to activate operation instances. </param>
+        /// <returns> The discovered operation registration list. </returns>
+        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="types" /> or <paramref name="serviceProvider" /> is <see langword="null" />. </exception>
+        /// <exception cref="InvalidOperationException"> Thrown when one discovered operation type is invalid. </exception>
+        internal static IReadOnlyList<UcliOperationRegistration> DiscoverFromTypes (
+            IReadOnlyList<Type?> types,
+            IServiceProvider serviceProvider)
+        {
             if (types == null)
             {
                 throw new ArgumentNullException(nameof(types));
+            }
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
             var registrations = new List<UcliOperationRegistration>();
@@ -134,7 +192,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                         $"Type '{type.FullName}' with '{nameof(UcliOperationAttribute)}' must be a non-abstract, non-generic class.");
                 }
 
-                var instance = CreateOperationInstance(type);
+                var instance = CreateOperationInstance(type, serviceProvider);
                 var metadata = instance.Metadata;
                 if (metadata == null)
                 {
@@ -347,15 +405,27 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             return typedOperationInterface;
         }
 
-        /// <summary> Creates one operation instance through parameterless constructor invocation. </summary>
+        /// <summary> Creates the default operation service provider used by discovery-only callers. </summary>
+        /// <returns> The default operation service provider. </returns>
+        private static IServiceProvider CreateDefaultOperationServiceProvider ()
+        {
+            return new ServiceCollection()
+                .AddUnityOperationServices()
+                .BuildServiceProvider();
+        }
+
+        /// <summary> Creates one operation instance through dependency injection. </summary>
         /// <param name="type"> The operation type. </param>
+        /// <param name="serviceProvider"> The service provider used to activate the operation instance. </param>
         /// <returns> The created operation instance. </returns>
         /// <exception cref="InvalidOperationException"> Thrown when type cannot be instantiated. </exception>
-        private static IUcliOperation CreateOperationInstance (Type type)
+        private static IUcliOperation CreateOperationInstance (
+            Type type,
+            IServiceProvider serviceProvider)
         {
             try
             {
-                var created = Activator.CreateInstance(type) as IUcliOperation;
+                var created = ActivatorUtilities.GetServiceOrCreateInstance(serviceProvider, type) as IUcliOperation;
                 if (created == null)
                 {
                     throw new InvalidOperationException(
@@ -364,10 +434,10 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
                 return created;
             }
-            catch (MissingMethodException exception)
+            catch (InvalidOperationException exception)
             {
                 throw new InvalidOperationException(
-                    $"Type '{type.FullName}' with '{nameof(UcliOperationAttribute)}' requires a public parameterless constructor.",
+                    $"Type '{type.FullName}' with '{nameof(UcliOperationAttribute)}' could not be activated through dependency injection.",
                     exception);
             }
             catch (TargetInvocationException exception)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Coordination/PlanTokenCoordinator.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Coordination/PlanTokenCoordinator.cs
@@ -29,11 +29,6 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
             this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
-        /// <summary> Initializes a new instance of the <see cref="PlanTokenCoordinator" /> class with default runtime environment. </summary>
-        public PlanTokenCoordinator () : this(new DefaultPlanTokenEnvironment())
-        {
-        }
-
         /// <summary>
         /// Issues one plan token from a normalized request and its plan-phase primitive traces.
         /// </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/RequestIdempotency/ExecuteRequestIdempotencyCoordinator.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/RequestIdempotency/ExecuteRequestIdempotencyCoordinator.cs
@@ -18,30 +18,10 @@ namespace MackySoft.Ucli.Unity.Execution.RequestIdempotency
 
         private readonly IExecuteRequestIdempotencyStore store;
 
-        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestIdempotencyCoordinator" /> class with default options. </summary>
-        public ExecuteRequestIdempotencyCoordinator ()
-            : this(DefaultCacheTtl, DefaultMaxEntries, static () => DateTimeOffset.UtcNow)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="ExecuteRequestIdempotencyCoordinator" /> class. </summary>
-        /// <param name="cacheTtl"> The cache TTL duration. Must be greater than <see cref="TimeSpan.Zero" />. </param>
-        /// <param name="maxEntries"> The maximum number of completed entries retained in memory. Must be greater than zero. </param>
-        /// <param name="utcNowProvider"> The UTC clock provider. </param>
-        /// <exception cref="ArgumentOutOfRangeException"> Thrown when <paramref name="cacheTtl" /> or <paramref name="maxEntries" /> is invalid. </exception>
-        /// <exception cref="ArgumentNullException"> Thrown when <paramref name="utcNowProvider" /> is <see langword="null" />. </exception>
-        public ExecuteRequestIdempotencyCoordinator (
-            TimeSpan cacheTtl,
-            int maxEntries,
-            Func<DateTimeOffset> utcNowProvider)
-            : this(new InMemoryExecuteRequestIdempotencyStore(cacheTtl, maxEntries, utcNowProvider))
-        {
-        }
-
         /// <summary> Initializes a new instance of the <see cref="ExecuteRequestIdempotencyCoordinator" /> class. </summary>
         /// <param name="store"> The request-id idempotency store dependency. </param>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="store" /> is <see langword="null" />. </exception>
-        internal ExecuteRequestIdempotencyCoordinator (IExecuteRequestIdempotencyStore store)
+        public ExecuteRequestIdempotencyCoordinator (IExecuteRequestIdempotencyStore store)
         {
             this.store = store ?? throw new ArgumentNullException(nameof(store));
         }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityExecutionServiceCollectionExtensions.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/UnityExecutionServiceCollectionExtensions.cs
@@ -1,6 +1,9 @@
 using System;
+using MackySoft.Ucli.Unity.Execution.CsEval;
 using MackySoft.Ucli.Unity.Execution.Dispatch;
 using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.PlanToken;
+using MackySoft.Ucli.Unity.Execution.RequestIdempotency;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using MackySoft.Ucli.Unity.Runtime;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,23 +23,46 @@ namespace MackySoft.Ucli.Unity.Execution
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddSingleton(static _ => UcliOperationCatalogSnapshotBuilder.Build());
-            services.AddSingleton<IExecuteRequestDispatcher>(serviceProvider => CreateExecuteRequestDispatcher(
-                serviceProvider.GetRequiredService<UcliOperationCatalogSnapshot>(),
-                serviceProvider.GetRequiredService<IUnityEditorReadinessGate>(),
-                serviceProvider.GetRequiredService<IUnityMainThreadRequestExecutor>()));
+            services.AddUnityOperationServices();
+            services.AddSingleton(static serviceProvider => UcliOperationCatalogSnapshotBuilder.Build(serviceProvider));
+            services.AddSingleton<IPhaseOperationRegistry>(serviceProvider => new InMemoryPhaseOperationRegistry(
+                serviceProvider.GetRequiredService<UcliOperationCatalogSnapshot>().Registrations));
+            services.AddSingleton<OperationPlanStepRunner>();
+            services.AddSingleton<ExecuteRequestCompiler>();
+            services.AddSingleton<IOperationPlanPassExecutor, OperationPlanPassExecutor>();
+            services.AddSingleton<IOperationCallPassExecutor, OperationCallPassExecutor>();
+            services.AddSingleton<IPlanTokenEnvironment, DefaultPlanTokenEnvironment>();
+            services.AddSingleton<IPlanTokenCoordinator, PlanTokenCoordinator>();
+            services.AddSingleton<IDangerousOperationCallAuthorizer, DangerousOperationCallAuthorizer>();
+            services.AddSingleton<IOperationPhaseExecutor, OperationPhaseExecutor>();
+            services.AddSingleton<IExecuteRequestNormalizer, ExecuteRequestNormalizer>();
+            services.AddSingleton<IExecuteRequestIdempotencyStore>(static _ => new InMemoryExecuteRequestIdempotencyStore(
+                ExecuteRequestIdempotencyCoordinator.DefaultCacheTtl,
+                ExecuteRequestIdempotencyCoordinator.DefaultMaxEntries,
+                static () => DateTimeOffset.UtcNow));
+            services.AddSingleton<IExecuteRequestIdempotencyCoordinator, ExecuteRequestIdempotencyCoordinator>();
+            services.AddSingleton<IExecuteRequestDispatcher, ExecuteRequestDispatcher>();
             return services;
         }
 
-        private static IExecuteRequestDispatcher CreateExecuteRequestDispatcher (
-            UcliOperationCatalogSnapshot snapshot,
-            IUnityEditorReadinessGate readinessGate,
-            IUnityMainThreadRequestExecutor mainThreadRequestExecutor)
+        /// <summary> Registers built-in operation dependencies used by operation discovery. </summary>
+        /// <param name="services"> The target service collection. </param>
+        /// <returns> The updated service collection. </returns>
+        internal static IServiceCollection AddUnityOperationServices (this IServiceCollection services)
         {
-            var normalizer = new ExecuteRequestNormalizer();
-            var operationRegistry = new InMemoryPhaseOperationRegistry(snapshot.Registrations);
-            var phaseExecutor = new OperationPhaseExecutor(operationRegistry);
-            return new ExecuteRequestDispatcher(normalizer, phaseExecutor, readinessGate, mainThreadRequestExecutor);
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddSingleton<CsEvalReferenceResolver>();
+            services.AddSingleton<CsEvalEntryPointSymbolValidator>();
+            services.AddSingleton<CsEvalSourcePreparer>();
+            services.AddSingleton<CsEvalCompilationService>();
+            services.AddSingleton<CsEvalEntryPointReflectionResolver>();
+            services.AddSingleton<CsEvalReturnValueSerializer>();
+            services.AddSingleton<CsEvalOperation>();
+            return services;
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Testing/TestRun/UnityTestRunService.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Testing/TestRun/UnityTestRunService.cs
@@ -27,28 +27,6 @@ namespace MackySoft.Ucli.Unity.Ipc
         /// <param name="unityTestRunner"> The Unity test runner dependency. </param>
         /// <param name="testResultsXmlWriter"> The test-results XML writer dependency. </param>
         /// <param name="editorLogRangeExporter"> The editor-log range exporter dependency. </param>
-        /// <exception cref="ArgumentNullException"> Thrown when one dependency is <see langword="null" />. </exception>
-        public UnityTestRunService (
-            IUnityTestRunRequestContextFactory requestContextFactory,
-            IUnityTestRunner unityTestRunner,
-            IUnityTestResultsXmlWriter testResultsXmlWriter,
-            IEditorLogRangeExporter editorLogRangeExporter,
-            IUnityEditorReadinessGate readinessGate)
-            : this(
-                requestContextFactory,
-                unityTestRunner,
-                testResultsXmlWriter,
-                editorLogRangeExporter,
-                readinessGate,
-                new InlineUnityMainThreadRequestExecutor())
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="UnityTestRunService" /> class. </summary>
-        /// <param name="requestContextFactory"> The request-context factory dependency. </param>
-        /// <param name="unityTestRunner"> The Unity test runner dependency. </param>
-        /// <param name="testResultsXmlWriter"> The test-results XML writer dependency. </param>
-        /// <param name="editorLogRangeExporter"> The editor-log range exporter dependency. </param>
         /// <param name="readinessGate"> The editor-readiness gate dependency. </param>
         /// <param name="mainThreadRequestExecutor"> The Unity main-thread executor dependency. </param>
         /// <exception cref="ArgumentNullException"> Thrown when one dependency is <see langword="null" />. </exception>
@@ -116,22 +94,6 @@ namespace MackySoft.Ucli.Unity.Ipc
         private static long GetFileLengthOrZero (string path)
         {
             return File.Exists(path) ? new FileInfo(path).Length : 0L;
-        }
-
-        private sealed class InlineUnityMainThreadRequestExecutor : IUnityMainThreadRequestExecutor
-        {
-            public Task<T> ExecuteAsync<T> (
-                Func<Task<T>> workItem,
-                CancellationToken cancellationToken = default)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (workItem == null)
-                {
-                    throw new ArgumentNullException(nameof(workItem));
-                }
-
-                return workItem();
-            }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Lifecycle/UnityEditorReadinessGate.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Lifecycle/UnityEditorReadinessGate.cs
@@ -45,134 +45,33 @@ namespace MackySoft.Ucli.Unity.Runtime
         public UnityEditorReadinessGate (DaemonEditorMode editorMode)
             : this(
                 editorMode,
-                sharedLifecycleTelemetryState,
-                static () => EditorApplication.isCompiling,
-                static () => EditorApplication.isUpdating,
-                static () => EditorApplication.isPlayingOrWillChangePlaymode,
+                sharedLifecycleMonitor,
                 static handler => AssemblyReloadEvents.beforeAssemblyReload += handler,
                 static handler => AssemblyReloadEvents.beforeAssemblyReload -= handler,
                 static handler => EditorApplication.quitting += handler,
                 static handler => EditorApplication.quitting -= handler,
-                subscribeToEditorEvents: true)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="UnityEditorReadinessGate" /> class. </summary>
-        /// <param name="lifecycleTelemetryState"> The mutable lifecycle telemetry state to observe. </param>
-        internal UnityEditorReadinessGate (UnityEditorLifecycleTelemetryState lifecycleTelemetryState)
-            : this(
-                DaemonEditorMode.Batchmode,
-                lifecycleTelemetryState,
-                static () => EditorApplication.isCompiling,
-                static () => EditorApplication.isUpdating,
-                static () => EditorApplication.isPlayingOrWillChangePlaymode,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload += handler,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload -= handler,
-                static handler => EditorApplication.quitting += handler,
-                static handler => EditorApplication.quitting -= handler,
-                subscribeToEditorEvents: false)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="UnityEditorReadinessGate" /> class. </summary>
-        /// <param name="lifecycleTelemetryState"> The mutable lifecycle telemetry state to observe. </param>
-        /// <param name="isCompilingProvider"> The compile-state observer. </param>
-        /// <param name="isUpdatingProvider"> The update-state observer. </param>
-        /// <param name="isPlaymodeActiveProvider"> The Play Mode observer. </param>
-        internal UnityEditorReadinessGate (
-            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
-            Func<bool> isCompilingProvider,
-            Func<bool> isUpdatingProvider,
-            Func<bool> isPlaymodeActiveProvider)
-            : this(
-                DaemonEditorMode.Batchmode,
-                lifecycleTelemetryState,
-                isCompilingProvider,
-                isUpdatingProvider,
-                isPlaymodeActiveProvider,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload += handler,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload -= handler,
-                static handler => EditorApplication.quitting += handler,
-                static handler => EditorApplication.quitting -= handler,
-                subscribeToEditorEvents: false)
+            subscribeToEditorEvents: true)
         {
         }
 
         /// <summary> Initializes a new instance of the <see cref="UnityEditorReadinessGate" /> class. </summary>
         /// <param name="editorMode"> The daemon Editor mode reported by lifecycle snapshots. </param>
-        /// <param name="lifecycleTelemetryState"> The mutable lifecycle telemetry state to observe. </param>
-        /// <param name="isCompilingProvider"> The compile-state observer. </param>
-        /// <param name="isUpdatingProvider"> The update-state observer. </param>
-        /// <param name="isPlaymodeActiveProvider"> The Play Mode observer. </param>
-        internal UnityEditorReadinessGate (
-            DaemonEditorMode editorMode,
-            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
-            Func<bool> isCompilingProvider,
-            Func<bool> isUpdatingProvider,
-            Func<bool> isPlaymodeActiveProvider)
-            : this(
-                editorMode,
-                lifecycleTelemetryState,
-                isCompilingProvider,
-                isUpdatingProvider,
-                isPlaymodeActiveProvider,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload += handler,
-                static handler => AssemblyReloadEvents.beforeAssemblyReload -= handler,
-                static handler => EditorApplication.quitting += handler,
-                static handler => EditorApplication.quitting -= handler,
-                subscribeToEditorEvents: false)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="UnityEditorReadinessGate" /> class. </summary>
-        /// <param name="lifecycleTelemetryState"> The mutable lifecycle telemetry state to observe. </param>
-        /// <param name="isCompilingProvider"> The compile-state observer. </param>
-        /// <param name="isUpdatingProvider"> The update-state observer. </param>
-        /// <param name="isPlaymodeActiveProvider"> The Play Mode observer. </param>
+        /// <param name="lifecycleMonitor"> The lifecycle monitor dependency. </param>
         /// <param name="beforeAssemblyReloadSubscriber"> Subscribes one handler to the assembly-reload start event. </param>
         /// <param name="beforeAssemblyReloadUnsubscriber"> Unsubscribes one handler from the assembly-reload start event. </param>
         /// <param name="quittingSubscriber"> Subscribes one handler to the editor-quitting event. </param>
         /// <param name="quittingUnsubscriber"> Unsubscribes one handler from the editor-quitting event. </param>
+        /// <param name="subscribeToEditorEvents"> Whether this instance should subscribe shared Unity editor lifecycle callbacks. </param>
         internal UnityEditorReadinessGate (
-            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
-            Func<bool> isCompilingProvider,
-            Func<bool> isUpdatingProvider,
-            Func<bool> isPlaymodeActiveProvider,
-            Action<AssemblyReloadEvents.AssemblyReloadCallback> beforeAssemblyReloadSubscriber,
-            Action<AssemblyReloadEvents.AssemblyReloadCallback> beforeAssemblyReloadUnsubscriber,
-            Action<Action> quittingSubscriber,
-            Action<Action> quittingUnsubscriber)
-            : this(
-                DaemonEditorMode.Batchmode,
-                lifecycleTelemetryState,
-                isCompilingProvider,
-                isUpdatingProvider,
-                isPlaymodeActiveProvider,
-                beforeAssemblyReloadSubscriber,
-                beforeAssemblyReloadUnsubscriber,
-                quittingSubscriber,
-                quittingUnsubscriber,
-                subscribeToEditorEvents: false)
-        {
-        }
-
-        private UnityEditorReadinessGate (
             DaemonEditorMode editorMode,
-            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
-            Func<bool> isCompilingProvider,
-            Func<bool> isUpdatingProvider,
-            Func<bool> isPlaymodeActiveProvider,
+            UnityEditorLifecycleMonitor lifecycleMonitor,
             Action<AssemblyReloadEvents.AssemblyReloadCallback> beforeAssemblyReloadSubscriber,
             Action<AssemblyReloadEvents.AssemblyReloadCallback> beforeAssemblyReloadUnsubscriber,
             Action<Action> quittingSubscriber,
             Action<Action> quittingUnsubscriber,
             bool subscribeToEditorEvents)
         {
-            this.lifecycleMonitor = new UnityEditorLifecycleMonitor(
-                lifecycleTelemetryState ?? throw new ArgumentNullException(nameof(lifecycleTelemetryState)),
-                isCompilingProvider,
-                isUpdatingProvider,
-                isPlaymodeActiveProvider);
+            this.lifecycleMonitor = lifecycleMonitor ?? throw new ArgumentNullException(nameof(lifecycleMonitor));
             _ = DaemonEditorModeCodec.ToValue(editorMode);
             this.editorMode = editorMode;
             this.beforeAssemblyReloadSubscriber = beforeAssemblyReloadSubscriber ?? throw new ArgumentNullException(nameof(beforeAssemblyReloadSubscriber));

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CsEvalOperationTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Operations/CsEvalOperationTests.cs
@@ -21,7 +21,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public void Metadata_ExposesDangerousMutationAndCodeContract ()
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
 
             Assert.That(operation.Metadata.OperationName, Is.EqualTo(UcliPrimitiveOperationNames.CsEval));
             Assert.That(operation.Metadata.Kind, Is.EqualTo(UcliOperationKind.Mutation));
@@ -53,7 +53,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Plan_WhenSourceIsValid_DoesNotInvokeEntryPoint () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -88,7 +88,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Plan_WhenNullableContextDirectiveIsOmitted_DoesNotWarnForRequiredNullableSignature () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -121,7 +121,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator PlanAndCall_WhenSourceIsSame_ReturnStableDigestValues () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             var source = @"
 context.DeclareNoTouchedResources();
 return new { value = 7 };
@@ -176,7 +176,7 @@ return new { value = 7 };
         [Category("Size.Small")]
         public IEnumerator Call_WhenStatementSnippetReturnsValue_ReturnsSnippetSourceKind () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -201,7 +201,7 @@ return new { count = 2 };
         [Category("Size.Small")]
         public IEnumerator Call_WhenSnippetHasNoReturn_ReturnsNull () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -221,7 +221,7 @@ context.DeclareNoTouchedResources();
         [Category("Size.Small")]
         public IEnumerator Call_WhenSnippetIsSingleExpression_ReturnsExpressionValue () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: "new { ok = true, label = \"expr\" }");
@@ -238,7 +238,7 @@ context.DeclareNoTouchedResources();
         [Category("Size.Small")]
         public IEnumerator Call_WhenSnippetHasLeadingUsing_CompilesWithUsing () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -259,7 +259,7 @@ return new { value = new StringBuilder().Append(""ok"").ToString() };
         [Category("Size.Small")]
         public IEnumerator Plan_WhenSnippetDoesNotCompile_ReturnsSnippetDiagnosticLine () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"context.Log(""first"");
@@ -278,7 +278,7 @@ return missingSymbol;");
         [Category("Size.Small")]
         public IEnumerator Plan_WhenSourceDoesNotCompile_ReturnsDiagnostics () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -310,7 +310,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenSourceReturnsJsonSerializableValue_ReturnsLogsAndTouchedResources () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -357,7 +357,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenNoTouchedResourcesDeclared_ReturnsNoneAndUnchanged () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -396,7 +396,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenTouchedResourcesAreNotDeclared_ReturnsUnknownAndChanged () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -434,7 +434,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenPrefabAndProjectSettingsAreDeclared_ReturnsTypedTouches () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -478,7 +478,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenEntryPointReturnValueCannotBeSerialized_FailsAfterInvocation () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -525,7 +525,7 @@ namespace EvalScripts
                 "new System.Threading.Tasks.ValueTask()",
                 "new System.Threading.Tasks.ValueTask<int>(1)",
             };
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             for (var i = 0; i < cases.Length; i++)
             {
                 using var context = new OperationExecutionContext();
@@ -556,7 +556,7 @@ return " + cases[i] + @";
         [Category("Size.Small")]
         public IEnumerator Call_WhenEntryPointReturnsDerivedTaskObject_FailsAfterInvocation () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -603,7 +603,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenReturnValueGetterThrows_FailsAfterInvocationWithTouchedResources () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -650,7 +650,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenSnippetReturnValueIsTooLarge_FailsBeforeIpcSerialization () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: "return new string('x', 9 * 1024 * 1024);");
@@ -668,7 +668,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Plan_WhenSourceExceedsInternalGuardrail_FailsBeforeCompilation () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(new string('x', CsEvalSafetyLimits.MaxSourceBytes + 1));
 
@@ -683,7 +683,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenLogsExceedInternalGuardrail_TruncatesLogs () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(@"
 for (var i = 0; i < " + (CsEvalSafetyLimits.MaxLogEntries + 1) + @"; i++)
@@ -706,7 +706,7 @@ context.DeclareNoTouchedResources();
         [Category("Size.Small")]
         public IEnumerator Call_WhenTouchedResourcesExceedInternalGuardrail_ReturnsUnknownAuditState () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(@"
 for (var i = 0; i < " + (CsEvalSafetyLimits.MaxTouchedResources + 1) + @"; i++)
@@ -728,7 +728,7 @@ return null;
         [Category("Size.Small")]
         public IEnumerator Call_WhenEntryPointThrows_FailsAfterInvocationWithDeclaredState () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -770,7 +770,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenEntryPointSignatureIsInvalid_FailsBeforeInvocation () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             var cases = new[]
             {
                 new InvalidEntryPointCase(
@@ -953,7 +953,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenMultipleEntryPointsMatch_FailsBeforeInvocationWithCandidates () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -1012,7 +1012,7 @@ namespace EvalScripts
                 "context.DeclareTouchedAsset(\"Assets/Main.unity\");",
                 "context.DeclareTouchedAsset(\"Assets/Widget.prefab\");",
             };
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             for (var i = 0; i < cases.Length; i++)
             {
                 using var context = new OperationExecutionContext();
@@ -1053,7 +1053,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenEntryPointReturnsTask_FailsBeforeInvocation () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -1083,7 +1083,7 @@ namespace EvalScripts
         [Category("Size.Small")]
         public IEnumerator Call_WhenTouchedDeclarationConflicts_FailsWithLogs () => UniTask.ToCoroutine(async () =>
         {
-            var operation = new CsEvalOperation();
+            var operation = CreateCsEvalOperation();
             using var context = new OperationExecutionContext();
             var request = CreateOperation(
                 source: @"
@@ -1113,6 +1113,17 @@ namespace EvalScripts
             Assert.That(payload.GetProperty("logs")[0].GetProperty("message").GetString(), Is.EqualTo("before conflict"));
             Assert.That(payload.GetProperty("touchedResources").GetProperty("state").GetString(), Is.EqualTo(CsEvalTouchedResourceStateValues.None));
         });
+
+        private static CsEvalOperation CreateCsEvalOperation ()
+        {
+            return new CsEvalOperation(
+                new CsEvalCompilationService(
+                    new CsEvalReferenceResolver(),
+                    new CsEvalEntryPointSymbolValidator(),
+                    new CsEvalSourcePreparer()),
+                new CsEvalEntryPointReflectionResolver(),
+                new CsEvalReturnValueSerializer());
+        }
 
         private static NormalizedOperation CreateOperation (
             string source)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Phases/OperationPhaseExecutorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Phases/OperationPhaseExecutorTests.cs
@@ -351,7 +351,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 issueResultFactory: _ => PlanTokenIssueResult.Success("unused"),
                 requestValidationResultFactory: _ => PlanTokenValidationResult.Success(),
                 validationResultFactory: _ => PlanTokenValidationResult.Success());
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry((UcliPrimitiveOperationNames.Resolve, operation)),
                 coordinator);
             var request = CreateRequest("op-1", UcliPrimitiveOperationNames.Resolve);
@@ -439,7 +439,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 policy: OperationPolicy.Dangerous);
-            var executor = new OperationPhaseExecutor(CreateRegistry(("ucli.tests.dangerous", operation)));
+            var executor = CreateExecutor(CreateRegistry(("ucli.tests.dangerous", operation)));
             var request = CreateRequest("op-1", "ucli.tests.dangerous");
 
             var trace = await ExecuteAsync(executor, PhaseExecutionCommand.Call, request, "Dangerous call denied execution");
@@ -464,7 +464,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 policy: OperationPolicy.Dangerous);
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry(("ucli.tests.dangerous", operation)),
                 new PlanTokenCoordinator(environment),
                 new DangerousOperationCallAuthorizer(environment));
@@ -492,7 +492,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 policy: OperationPolicy.Dangerous,
                 exposure: UcliOperationExposure.EditLoweringOnly);
-            var executor = new OperationPhaseExecutor(CreateRegistry(("ucli.tests.edit-lowering-only", operation)));
+            var executor = CreateExecutor(CreateRegistry(("ucli.tests.edit-lowering-only", operation)));
             var request = CreateRequest(
                 operations: new[] { ("op-1", "ucli.tests.edit-lowering-only") },
                 planToken: null,
@@ -519,7 +519,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 policy: OperationPolicy.Dangerous,
                 exposure: UcliOperationExposure.Internal);
-            var executor = new OperationPhaseExecutor(CreateRegistry(("ucli.tests.internal", operation)));
+            var executor = CreateExecutor(CreateRegistry(("ucli.tests.internal", operation)));
             var request = CreateRequest(
                 operations: new[] { ("op-1", "ucli.tests.internal") },
                 planToken: null,
@@ -549,7 +549,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 issueResultFactory: _ => PlanTokenIssueResult.Success("unused-token"),
                 requestValidationResultFactory: _ => PlanTokenValidationResult.Success(),
                 validationResultFactory: _ => PlanTokenValidationResult.Success());
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry(("ucli.tests.edit-lowering-only", operation)),
                 coordinator);
             var request = CreateRequest("op-1", "ucli.tests.edit-lowering-only");
@@ -578,7 +578,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 issueResultFactory: _ => PlanTokenIssueResult.Success("unused-token"),
                 requestValidationResultFactory: _ => PlanTokenValidationResult.Success(),
                 validationResultFactory: _ => PlanTokenValidationResult.Success());
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry(("ucli.tests.internal", operation)),
                 coordinator);
             var request = CreateRequest("op-1", "ucli.tests.internal");
@@ -608,7 +608,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 exposure: UcliOperationExposure.EditLoweringOnly);
-            var executor = new OperationPhaseExecutor(CreateRegistry((UcliPrimitiveOperationNames.CompEnsure, operation)));
+            var executor = CreateExecutor(CreateRegistry((UcliPrimitiveOperationNames.CompEnsure, operation)));
             var request = CreateEditRequest(
                 stepId: "edit-1",
                 stepJson: "{"
@@ -640,7 +640,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: true),
                 policy: OperationPolicy.Dangerous);
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry(("ucli.tests.dangerous", operation)),
                 new PlanTokenCoordinator(environment),
                 new DangerousOperationCallAuthorizer(environment));
@@ -671,7 +671,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 issueResultFactory: _ => PlanTokenIssueResult.Success("issued-token"),
                 requestValidationResultFactory: _ => PlanTokenValidationResult.Success(),
                 validationResultFactory: _ => PlanTokenValidationResult.Success());
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry((UcliPrimitiveOperationNames.Resolve, operation)),
                 coordinator);
             var request = CreateRequest("op-1", UcliPrimitiveOperationNames.Resolve);
@@ -703,7 +703,7 @@ namespace MackySoft.Ucli.Unity.Tests
                     Code: PlanTokenErrorCodes.PlanTokenInvalid,
                     Message: "invalid token",
                     OpId: null)));
-            var executor = new OperationPhaseExecutor(
+            var executor = CreateExecutor(
                 CreateRegistry(
                     (UcliPrimitiveOperationNames.Resolve, firstOperation),
                     (UcliPrimitiveOperationNames.SceneOpen, secondOperation)),
@@ -764,7 +764,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         PlanTokenErrorCodes.StateChangedSincePlan,
                         "Compiled execution changed since plan token issuance.",
                         null))),
-                new DangerousOperationCallAuthorizer());
+                CreateDangerousOperationCallAuthorizer());
 
             var trace = await ExecuteAsync(executor, PhaseExecutionCommand.Call, request, "Call compile failure should map to compiled execution drift");
 
@@ -816,7 +816,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 new StubPlanPassExecutor(planPassResult),
                 new OperationCallPassExecutor(),
                 coordinator,
-                new DangerousOperationCallAuthorizer());
+                CreateDangerousOperationCallAuthorizer());
 
             var trace = await ExecuteAsync(executor, PhaseExecutionCommand.Call, request, "Legacy-compatible token should preserve compile failure");
 
@@ -843,7 +843,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 validateResult: OperationPhaseStepResult.Success(),
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success());
-            var executor = new OperationPhaseExecutor(CreateRegistry(
+            var executor = CreateExecutor(CreateRegistry(
                 (UcliPrimitiveOperationNames.Resolve, failingOperation),
                 (UcliPrimitiveOperationNames.SceneOpen, skippedOperation)));
             var request = CreateRequest(
@@ -874,7 +874,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 validateResult: OperationPhaseStepResult.Success(),
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success());
-            var executor = new OperationPhaseExecutor(CreateRegistry(
+            var executor = CreateExecutor(CreateRegistry(
                 (UcliPrimitiveOperationNames.Resolve, failingOperation),
                 (UcliPrimitiveOperationNames.SceneOpen, skippedOperation)));
             var request = CreateRequest(
@@ -904,7 +904,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 validateResult: OperationPhaseStepResult.Success(),
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success());
-            var executor = new OperationPhaseExecutor(CreateRegistry(
+            var executor = CreateExecutor(CreateRegistry(
                 (UcliPrimitiveOperationNames.Resolve, failingOperation),
                 (UcliPrimitiveOperationNames.SceneOpen, skippedOperation)));
             var request = CreateRequest(
@@ -1254,7 +1254,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 validateResult: OperationPhaseStepResult.Success(),
                 planResult: OperationPhaseStepResult.Success(),
                 callResult: OperationPhaseStepResult.Success(applied: true, changed: false));
-            var executor = new OperationPhaseExecutor(CreateRegistry(
+            var executor = CreateExecutor(CreateRegistry(
                 ("ucli.tests.replay-failing", replayOperation),
                 (UcliPrimitiveOperationNames.Resolve, secondOperation)));
             var request = CreateRequest(
@@ -1281,7 +1281,45 @@ namespace MackySoft.Ucli.Unity.Tests
 
         private static OperationPhaseExecutor CreateExecutor (IUcliOperation operation)
         {
-            return new OperationPhaseExecutor(CreateRegistry((UcliPrimitiveOperationNames.Resolve, operation)));
+            return CreateExecutor(CreateRegistry((UcliPrimitiveOperationNames.Resolve, operation)));
+        }
+
+        private static OperationPhaseExecutor CreateExecutor (IPhaseOperationRegistry operationRegistry)
+        {
+            var environment = new DefaultPlanTokenEnvironment();
+            return CreateExecutor(
+                operationRegistry,
+                new PlanTokenCoordinator(environment),
+                new DangerousOperationCallAuthorizer(environment));
+        }
+
+        private static OperationPhaseExecutor CreateExecutor (
+            IPhaseOperationRegistry operationRegistry,
+            IPlanTokenCoordinator planTokenCoordinator)
+        {
+            return CreateExecutor(
+                operationRegistry,
+                planTokenCoordinator,
+                CreateDangerousOperationCallAuthorizer());
+        }
+
+        private static OperationPhaseExecutor CreateExecutor (
+            IPhaseOperationRegistry operationRegistry,
+            IPlanTokenCoordinator planTokenCoordinator,
+            IDangerousOperationCallAuthorizer dangerousOperationCallAuthorizer)
+        {
+            return new OperationPhaseExecutor(
+                new OperationPlanPassExecutor(
+                    new OperationPlanStepRunner(operationRegistry),
+                    new ExecuteRequestCompiler()),
+                new OperationCallPassExecutor(),
+                planTokenCoordinator,
+                dangerousOperationCallAuthorizer);
+        }
+
+        private static DangerousOperationCallAuthorizer CreateDangerousOperationCallAuthorizer ()
+        {
+            return new DangerousOperationCallAuthorizer(new DefaultPlanTokenEnvironment());
         }
 
         private static UniTask<PhaseExecutionTrace> ExecuteAsync (

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Requests/ExecuteRequestDispatcherTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Requests/ExecuteRequestDispatcherTests.cs
@@ -13,6 +13,8 @@ using MackySoft.Ucli.Contracts.Ipc.ContractReading;
 using MackySoft.Ucli.Unity.Execution;
 using MackySoft.Ucli.Unity.Execution.Dispatch;
 using MackySoft.Ucli.Unity.Execution.Phases;
+using MackySoft.Ucli.Unity.Execution.PlanToken;
+using MackySoft.Ucli.Unity.Execution.RequestIdempotency;
 using MackySoft.Ucli.Unity.Execution.Requests;
 using MackySoft.Ucli.Unity.Ipc;
 using MackySoft.Ucli.Unity.Runtime;
@@ -64,7 +66,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizedRequest = CreateNormalizedRequest();
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest, planToken: "issued-token"));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan);
 
@@ -103,7 +105,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     operationTrace,
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan, operationName: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.GoDescribe);
 
@@ -147,7 +149,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     operationTrace,
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan, operationName: MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.SceneQuery);
 
@@ -193,7 +195,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Array.Empty<OperationTouch>(),
                         null),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -246,7 +248,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Contracts = CreateContractFacts(UcliOperationKind.Mutation, mayDirty: false),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -294,7 +296,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Contracts = CreateContractFacts(UcliOperationKind.Mutation, mayDirty: true, mayPersist: false),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -337,7 +339,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Contracts = CreateContractFacts(UcliOperationKind.Mutation, mayDirty: false),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Plan,
@@ -382,7 +384,7 @@ namespace MackySoft.Ucli.Unity.Tests
                             IpcExecuteTouchedResourceKindNames.Asset),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Query,
@@ -440,7 +442,7 @@ namespace MackySoft.Ucli.Unity.Tests
                             IpcExecuteTouchedResourceKindNames.Scene),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -486,7 +488,7 @@ namespace MackySoft.Ucli.Unity.Tests
                             IpcExecuteTouchedResourceKindNames.Scene),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Plan,
@@ -531,7 +533,7 @@ namespace MackySoft.Ucli.Unity.Tests
                             IpcExecuteTouchedResourceKindNames.Asset),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -571,7 +573,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Contracts = CreateContractFacts(UcliOperationKind.Mutation, mayDirty: true, mayPersist: true),
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -618,7 +620,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         System.Array.Empty<OperationTouch>(),
                         null),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Call, operationName: "edit");
 
@@ -644,7 +646,7 @@ namespace MackySoft.Ucli.Unity.Tests
             _ = new GameObject("GoodRoot");
             _ = new GameObject("Bad/Root");
             EditorSceneManager.SaveScene(scene, scenePath);
-            var dispatcher = new ExecuteRequestDispatcher(new ExecuteRequestNormalizer(), CreateCatalogPhaseExecutor());
+            var dispatcher = CreateDispatcher(new ExecuteRequestNormalizer(), CreateCatalogPhaseExecutor());
             var context = new ExecuteDispatchContext("req-291-diagnostics", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Plan,
@@ -759,7 +761,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     operationTrace,
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -831,7 +833,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         },
                     },
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -868,7 +870,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         System.Array.Empty<OperationTouch>(),
                         null),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan);
 
@@ -889,7 +891,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizedRequest = CreateNormalizedRequest();
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var firstRequest = CreateExecuteRequest(
                 commandName: UcliCommandIds.Plan,
@@ -917,7 +919,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizedRequest = CreateNormalizedRequest();
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var firstRequest = CreateExecuteRequest(
                 commandName: UcliCommandIds.Call,
@@ -949,7 +951,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest));
             var readinessGate = StubUnityEditorReadinessGate.CreatePending();
             var mainThreadRequestExecutor = new SpyUnityMainThreadRequestExecutor();
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor, readinessGate, mainThreadRequestExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor, readinessGate, mainThreadRequestExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan, failFast: false);
 
@@ -977,7 +979,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest));
             var readinessGate = StubUnityEditorReadinessGate.CreatePending();
             var mainThreadRequestExecutor = new SpyUnityMainThreadRequestExecutor();
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor, readinessGate, mainThreadRequestExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor, readinessGate, mainThreadRequestExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Call, failFast: true);
 
@@ -1007,7 +1009,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
                 new ExecuteRequestNormalizationError(UcliCoreErrorCodes.InvalidArgument, "invalid request", "op-1")));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(CreateNormalizedRequest()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan);
 
@@ -1029,7 +1031,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 new ExecuteRequestNormalizationError(UcliCoreErrorCodes.InvalidArgument, "normalizer should not run", null)));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(CreateNormalizedRequest()));
             var readinessGate = StubUnityEditorReadinessGate.CreatePending();
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor, readinessGate);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor, readinessGate);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Refresh);
 
@@ -1051,7 +1053,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 new ExecuteRequestNormalizationError(UcliCoreErrorCodes.InvalidArgument, "invalid request", "op-1")));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(CreateNormalizedRequest()));
             var readinessGate = StubUnityEditorReadinessGate.CreatePending();
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor, readinessGate);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor, readinessGate);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan);
 
@@ -1072,7 +1074,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizer = new SpyExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
                 new ExecuteRequestNormalizationError(UcliCoreErrorCodes.InvalidArgument, "normalizer should not run", null)));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(CreateNormalizedRequest()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = new IpcExecuteRequest(UcliCommandIds.Plan, default);
 
@@ -1123,7 +1125,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     new OperationFailure(UcliCoreErrorCodes.InvalidArgument, "call failed", "op-1"),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(
                 UcliCommandIds.Call,
@@ -1177,7 +1179,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     new OperationFailure(UcliCoreErrorCodes.InvalidArgument, "edit failed", "edit-1"),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Call, operationId: "edit-1", operationName: "edit");
 
@@ -1201,7 +1203,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 requestId: normalizedRequest.RequestId,
                 steps: CreateTraceSteps(normalizedRequest, editPrimitiveCount: 0),
                 operationTraces: Array.Empty<OperationPhaseTrace>()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Call, operationId: "edit-1", operationName: "edit");
 
@@ -1230,7 +1232,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizedRequest = CreateNormalizedRequest();
             var normalizer = new StubExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Success(normalizedRequest));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(normalizedRequest));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(UcliCommandIds.Plan);
             using var cancellationTokenSource = new CancellationTokenSource();
@@ -1267,7 +1269,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         },
                         null),
                 }));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(commandName, operationName: operationName);
 
@@ -1301,7 +1303,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var normalizer = new SpyExecuteRequestNormalizer(ExecuteRequestNormalizationResult.Failure(
                 new ExecuteRequestNormalizationError(UcliCoreErrorCodes.InvalidArgument, "normalizer should not run", null)));
             var phaseExecutor = new SpyOperationPhaseExecutor(CreateSuccessTrace(CreateNormalizedRequest()));
-            var dispatcher = new ExecuteRequestDispatcher(normalizer, phaseExecutor);
+            var dispatcher = CreateDispatcher(normalizer, phaseExecutor);
             var context = new ExecuteDispatchContext("req-1", IpcProtocol.CurrentVersion);
             var request = CreateExecuteRequest(commandName);
 
@@ -1406,10 +1408,39 @@ namespace MackySoft.Ucli.Unity.Tests
             return new IpcExecuteRequest(commandName, JsonSerializer.SerializeToElement(arguments));
         }
 
+        private static ExecuteRequestDispatcher CreateDispatcher (
+            IExecuteRequestNormalizer requestNormalizer,
+            IOperationPhaseExecutor operationPhaseExecutor,
+            IUnityEditorReadinessGate? readinessGate = null,
+            IUnityMainThreadRequestExecutor? mainThreadRequestExecutor = null)
+        {
+            return new ExecuteRequestDispatcher(
+                requestNormalizer,
+                operationPhaseExecutor,
+                new ExecuteRequestIdempotencyCoordinator(new InMemoryExecuteRequestIdempotencyStore(
+                    ExecuteRequestIdempotencyCoordinator.DefaultCacheTtl,
+                    ExecuteRequestIdempotencyCoordinator.DefaultMaxEntries,
+                    static () => DateTimeOffset.UtcNow)),
+                readinessGate ?? new StubUnityEditorReadinessGate(),
+                mainThreadRequestExecutor ?? new SpyUnityMainThreadRequestExecutor());
+        }
+
         private static OperationPhaseExecutor CreateCatalogPhaseExecutor ()
         {
             var snapshot = UcliOperationCatalogSnapshotBuilder.Build();
-            return new OperationPhaseExecutor(new InMemoryPhaseOperationRegistry(snapshot.Registrations));
+            return CreatePhaseExecutor(new InMemoryPhaseOperationRegistry(snapshot.Registrations));
+        }
+
+        private static OperationPhaseExecutor CreatePhaseExecutor (IPhaseOperationRegistry operationRegistry)
+        {
+            var environment = new DefaultPlanTokenEnvironment();
+            return new OperationPhaseExecutor(
+                new OperationPlanPassExecutor(
+                    new OperationPlanStepRunner(operationRegistry),
+                    new ExecuteRequestCompiler()),
+                new OperationCallPassExecutor(),
+                new PlanTokenCoordinator(environment),
+                new DangerousOperationCallAuthorizer(environment));
         }
 
         private static NormalizedExecuteRequest CreateNormalizedRequest (string operationName = MackySoft.Ucli.Contracts.Ipc.UcliPrimitiveOperationNames.Resolve)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Requests/ExecuteRequestIdempotencyCoordinatorTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Execution/Requests/ExecuteRequestIdempotencyCoordinatorTests.cs
@@ -20,7 +20,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Execute_WhenSameRequestIdAndSameFingerprintAfterCompletion_ReusesCachedResponse () => UniTask.ToCoroutine(async () =>
         {
-            var coordinator = new ExecuteRequestIdempotencyCoordinator();
+            var coordinator = CreateCoordinator();
             var executeCount = 0;
             var requestId = "req-1";
             var firstResponse = await coordinator.ExecuteAsync(
@@ -53,7 +53,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Execute_WhenSameRequestIdAndDifferentFingerprintAfterCompletion_ReturnsConflict () => UniTask.ToCoroutine(async () =>
         {
-            var coordinator = new ExecuteRequestIdempotencyCoordinator();
+            var coordinator = CreateCoordinator();
             var executeCount = 0;
             var conflictCount = 0;
             var requestId = "req-1";
@@ -96,7 +96,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Execute_WhenSameRequestIdAndSameFingerprintInFlight_WaitsForOwnerResponse () => UniTask.ToCoroutine(async () =>
         {
-            var coordinator = new ExecuteRequestIdempotencyCoordinator();
+            var coordinator = CreateCoordinator();
             var requestId = "req-1";
             var ownerExecutionCount = 0;
             var waiterExecutionCount = 0;
@@ -150,7 +150,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Execute_WhenWaiterCancellationRequestedDuringInFlight_ThrowsWithoutCancelingOwner () => UniTask.ToCoroutine(async () =>
         {
-            var coordinator = new ExecuteRequestIdempotencyCoordinator();
+            var coordinator = CreateCoordinator();
             var requestId = "req-1";
             var ownerExecutionCount = 0;
             var waiterExecutionCount = 0;
@@ -215,7 +215,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator Execute_WhenSameRequestIdAndDifferentFingerprintInFlight_ReturnsConflictWithoutExecuting () => UniTask.ToCoroutine(async () =>
         {
-            var coordinator = new ExecuteRequestIdempotencyCoordinator();
+            var coordinator = CreateCoordinator();
             var requestId = "req-1";
             var ownerStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var ownerRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -263,10 +263,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator Execute_WhenEntryExpires_ReexecutesRequest () => UniTask.ToCoroutine(async () =>
         {
             var nowUtc = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero);
-            var coordinator = new ExecuteRequestIdempotencyCoordinator(
-                cacheTtl: TimeSpan.FromHours(24),
-                maxEntries: 10_000,
-                utcNowProvider: () => nowUtc);
+            var coordinator = CreateCoordinator(TimeSpan.FromHours(24), 10_000, () => nowUtc);
             var executeCount = 0;
             var requestId = "req-1";
 
@@ -301,10 +298,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator Execute_WhenCacheExceedsMaxEntries_EvictsOldestEntry () => UniTask.ToCoroutine(async () =>
         {
             var nowUtc = new DateTimeOffset(2026, 3, 3, 0, 0, 0, TimeSpan.Zero);
-            var coordinator = new ExecuteRequestIdempotencyCoordinator(
-                cacheTtl: TimeSpan.FromHours(24),
-                maxEntries: 2,
-                utcNowProvider: () => nowUtc);
+            var coordinator = CreateCoordinator(TimeSpan.FromHours(24), 2, () => nowUtc);
             var executeCount = 0;
 
             await ExecuteAsync("req-1", "fingerprint-1", "first-1");
@@ -473,6 +467,25 @@ namespace MackySoft.Ucli.Unity.Tests
         private static string GetMarker (IpcResponse response)
         {
             return response.Payload.GetProperty("marker").GetString() ?? string.Empty;
+        }
+
+        private static ExecuteRequestIdempotencyCoordinator CreateCoordinator ()
+        {
+            return CreateCoordinator(
+                ExecuteRequestIdempotencyCoordinator.DefaultCacheTtl,
+                ExecuteRequestIdempotencyCoordinator.DefaultMaxEntries,
+                static () => DateTimeOffset.UtcNow);
+        }
+
+        private static ExecuteRequestIdempotencyCoordinator CreateCoordinator (
+            TimeSpan cacheTtl,
+            int maxEntries,
+            Func<DateTimeOffset> utcNowProvider)
+        {
+            return new ExecuteRequestIdempotencyCoordinator(new InMemoryExecuteRequestIdempotencyStore(
+                cacheTtl,
+                maxEntries,
+                utcNowProvider));
         }
     }
 }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/UnityIpcMethodHandlersTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/UnityIpcMethodHandlersTests.cs
@@ -88,7 +88,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 isStartupPending: true);
             var handler = new PingUnityIpcMethodHandler(
                 new StubServerVersionProvider("1.2.3"),
-                new UnityEditorReadinessGate(
+                CreateReadinessGate(
                     telemetryState,
                     static () => false,
                     static () => false,
@@ -126,7 +126,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 isStartupPending: false);
             var handler = new PingUnityIpcMethodHandler(
                 new StubServerVersionProvider("1.2.3"),
-                new UnityEditorReadinessGate(
+                CreateReadinessGate(
                     telemetryState,
                     static () => false,
                     static () => false,
@@ -1017,6 +1017,26 @@ namespace MackySoft.Ucli.Unity.Tests
             object payload)
         {
             return CreateRequest(requestId, IpcMethodNames.Ping, payload);
+        }
+
+        private static UnityEditorReadinessGate CreateReadinessGate (
+            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
+            Func<bool> isCompilingProvider,
+            Func<bool> isUpdatingProvider,
+            Func<bool> isPlaymodeActiveProvider)
+        {
+            return new UnityEditorReadinessGate(
+                DaemonEditorMode.Batchmode,
+                new UnityEditorLifecycleMonitor(
+                    lifecycleTelemetryState,
+                    isCompilingProvider,
+                    isUpdatingProvider,
+                    isPlaymodeActiveProvider),
+                static _ => { },
+                static _ => { },
+                static _ => { },
+                static _ => { },
+                subscribeToEditorEvents: false);
         }
 
         private static IpcRequest CreateExecuteRequest (

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/UnityEditorReadinessGateTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/UnityEditorReadinessGateTests.cs
@@ -192,7 +192,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 isShuttingDown: false,
                 isStartupPending: false,
                 isRecoveringPending: true);
-            var gate = new UnityEditorReadinessGate(
+            var gate = CreateGate(
                 DaemonEditorMode.Gui,
                 telemetryState,
                 static () => false,
@@ -223,7 +223,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 isDomainReloading: false,
                 isShuttingDown: false,
                 isStartupPending: false);
-            var gate = new UnityEditorReadinessGate(
+            var gate = CreateGate(
                 DaemonEditorMode.Gui,
                 telemetryState,
                 static () => false,
@@ -568,14 +568,38 @@ namespace MackySoft.Ucli.Unity.Tests
                 isShuttingDown,
                 isStartupPending);
             return new UnityEditorReadinessGate(
-                lifecycleTelemetryState,
-                () => probe.IsCompiling,
-                () => probe.IsUpdating,
-                () => probe.IsPlaymodeActive,
+                DaemonEditorMode.Batchmode,
+                new UnityEditorLifecycleMonitor(
+                    lifecycleTelemetryState,
+                    () => probe.IsCompiling,
+                    () => probe.IsUpdating,
+                    () => probe.IsPlaymodeActive),
                 signalBus.SubscribeBeforeAssemblyReload,
                 signalBus.UnsubscribeBeforeAssemblyReload,
                 signalBus.SubscribeQuitting,
-                signalBus.UnsubscribeQuitting);
+                signalBus.UnsubscribeQuitting,
+                subscribeToEditorEvents: false);
+        }
+
+        private static UnityEditorReadinessGate CreateGate (
+            DaemonEditorMode editorMode,
+            UnityEditorLifecycleTelemetryState lifecycleTelemetryState,
+            Func<bool> isCompilingProvider,
+            Func<bool> isUpdatingProvider,
+            Func<bool> isPlaymodeActiveProvider)
+        {
+            return new UnityEditorReadinessGate(
+                editorMode,
+                new UnityEditorLifecycleMonitor(
+                    lifecycleTelemetryState,
+                    isCompilingProvider,
+                    isUpdatingProvider,
+                    isPlaymodeActiveProvider),
+                static _ => { },
+                static _ => { },
+                static _ => { },
+                static _ => { },
+                subscribeToEditorEvents: false);
         }
 
         private sealed class EditorActivityProbe

--- a/src/Ucli/Features/Daemon/Lifecycle/Session/DaemonSessionStore.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Session/DaemonSessionStore.cs
@@ -13,14 +13,6 @@ internal sealed class DaemonSessionStore : IDaemonSessionStore
 
     private readonly IDaemonSessionValidator sessionValidator;
 
-    /// <summary> Initializes a new instance of the <see cref="DaemonSessionStore" /> class with default dependencies. </summary>
-    public DaemonSessionStore ()
-        : this(
-            new DaemonSessionJsonSerializer(),
-            new DaemonSessionValidator())
-    {
-    }
-
     /// <summary> Initializes a new instance of the <see cref="DaemonSessionStore" /> class. </summary>
     /// <param name="sessionSerializer"> The daemon session serializer dependency. </param>
     /// <param name="sessionValidator"> The daemon session validator dependency. </param>

--- a/src/Ucli/Hosting/Composition/Common/SharedServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Common/SharedServiceCollectionExtensions.cs
@@ -25,6 +25,9 @@ internal static class SharedServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<IEnvironmentVariableReader, ProcessEnvironmentVariableReader>();
+        services.AddSingleton<UcliConfigSchemaValidator>();
+        services.AddSingleton<UcliEffectiveConfigBuilder>();
+        services.AddSingleton<UcliConfigCompiler>();
         services.AddSingleton<IUcliConfigStore, UcliConfigStore>();
         services.AddSingleton<IProjectLifecycleLockProvider, FileSystemProjectLifecycleLockProvider>();
         services.AddSingleton<IUnityProjectLockFileProbe, UnityProjectLockFileProbe>();

--- a/src/Ucli/Hosting/Composition/Common/UnityIntegrationServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Common/UnityIntegrationServiceCollectionExtensions.cs
@@ -42,6 +42,12 @@ internal static class UnityIntegrationServiceCollectionExtensions
         services.AddSingleton<IUnityUcliPluginLocator, UnityUcliPluginLocator>();
         services.AddSingleton<IUnityPluginVerifier, UnityPluginVerifier>();
         services.AddSingleton<IUnityVersionResolver, UnityVersionResolver>();
+        services.AddSingleton<IUnityEditorSearchRootSource, WindowsUnityEditorSearchRootSource>();
+        services.AddSingleton<IUnityEditorSearchRootSource, MacUnityEditorSearchRootSource>();
+        services.AddSingleton<IUnityEditorSearchRootSource, LinuxUnityEditorSearchRootSource>();
+        services.AddSingleton<IUnityPathComparerProvider, UnityPathComparerProvider>();
+        services.AddSingleton<UnityEditorExecutablePathLocator>();
+        services.AddSingleton<UnityEditorVersionConsistencyValidator>();
         services.AddSingleton<IUnityEditorSearchRootProvider, DefaultUnityEditorSearchRootProvider>();
         services.AddSingleton<IUnityEditorPathResolver, UnityEditorPathResolver>();
         services.AddSingleton<IReadIndexArtifactReader, FileReadIndexArtifactReader>();

--- a/src/Ucli/Hosting/Composition/Features/DaemonServiceCollectionExtensions.cs
+++ b/src/Ucli/Hosting/Composition/Features/DaemonServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ internal static class DaemonServiceCollectionExtensions
 
     private static IServiceCollection AddUcliDaemonLifecycleServices (this IServiceCollection services)
     {
+        services.AddSingleton<IDaemonSessionSerializer, DaemonSessionJsonSerializer>();
+        services.AddSingleton<IDaemonSessionValidator, DaemonSessionValidator>();
         services.AddSingleton<IDaemonSessionStore, DaemonSessionStore>();
         services.AddSingleton<IDaemonDiagnosisStore, DaemonDiagnosisStore>();
         services.AddSingleton<IDaemonLaunchAttemptIdGenerator, DaemonLaunchAttemptIdGenerator>();

--- a/src/Ucli/Shared/Configuration/UcliConfigStore.cs
+++ b/src/Ucli/Shared/Configuration/UcliConfigStore.cs
@@ -21,15 +21,9 @@ internal sealed class UcliConfigStore : IUcliConfigStore
     private readonly UcliConfigCompiler compiler;
 
     /// <summary> Initializes a new instance of the <see cref="UcliConfigStore" /> class. </summary>
-    public UcliConfigStore ()
-        : this(UcliConfigCompiler.CreateDefault())
-    {
-    }
-
-    /// <summary> Initializes a new instance of the <see cref="UcliConfigStore" /> class. </summary>
     /// <param name="compiler"> The config compiler dependency. </param>
     /// <exception cref="ArgumentNullException"> Thrown when <paramref name="compiler" /> is <see langword="null" />. </exception>
-    internal UcliConfigStore (UcliConfigCompiler compiler)
+    public UcliConfigStore (UcliConfigCompiler compiler)
     {
         this.compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
     }

--- a/src/Ucli/UnityIntegration/Project/Plugin/UnityUcliPluginLocator.cs
+++ b/src/Ucli/UnityIntegration/Project/Plugin/UnityUcliPluginLocator.cs
@@ -33,28 +33,6 @@ internal sealed class UnityUcliPluginLocator : IUnityUcliPluginLocator
         this.pluginMarkerCacheCoordinator = pluginMarkerCacheCoordinator ?? throw new ArgumentNullException(nameof(pluginMarkerCacheCoordinator));
     }
 
-    /// <summary> Initializes a new instance of the <see cref="UnityUcliPluginLocator" /> class for tests. </summary>
-    internal UnityUcliPluginLocator ()
-        : this(
-            new UnityUcliPluginMarkerDiscovery(),
-            new UnityUcliPluginMarkerValidator(),
-            new UnityUcliPluginMarkerCacheCoordinator(
-                new UnityUcliPluginMarkerCacheStore(),
-                new UnityUcliPluginMarkerValidator()))
-    {
-    }
-
-    /// <summary> Initializes a new instance of the <see cref="UnityUcliPluginLocator" /> class for tests. </summary>
-    internal UnityUcliPluginLocator (UnityUcliPluginMarkerCacheStore pluginMarkerCacheStore)
-        : this(
-            new UnityUcliPluginMarkerDiscovery(),
-            new UnityUcliPluginMarkerValidator(),
-            new UnityUcliPluginMarkerCacheCoordinator(
-                pluginMarkerCacheStore ?? throw new ArgumentNullException(nameof(pluginMarkerCacheStore)),
-                new UnityUcliPluginMarkerValidator()))
-    {
-    }
-
     /// <inheritdoc />
     public async ValueTask<UnityUcliPluginLocateResult> LocateAsync (
         string unityProjectRoot,

--- a/src/Ucli/UnityIntegration/Resolution/DefaultUnityEditorSearchRootProvider.cs
+++ b/src/Ucli/UnityIntegration/Resolution/DefaultUnityEditorSearchRootProvider.cs
@@ -6,42 +6,30 @@ internal sealed class DefaultUnityEditorSearchRootProvider : IUnityEditorSearchR
     private readonly string[] cachedSearchRoots;
 
     /// <summary> Initializes a new instance of the <see cref="DefaultUnityEditorSearchRootProvider" /> class. </summary>
-    public DefaultUnityEditorSearchRootProvider ()
-        : this(
-            new IUnityEditorSearchRootSource[]
-            {
-                new WindowsUnityEditorSearchRootSource(),
-                new MacUnityEditorSearchRootSource(),
-                new LinuxUnityEditorSearchRootSource(),
-            },
-            new UnityPathComparerProvider())
-    {
-    }
-
-    /// <summary> Initializes a new instance of the <see cref="DefaultUnityEditorSearchRootProvider" /> class. </summary>
     /// <param name="searchRootSources"> Search-root sources grouped by platform. </param>
     /// <param name="pathComparerProvider"> Path comparer provider dependency. </param>
     /// <exception cref="ArgumentNullException"> Thrown when one dependency is <see langword="null" />. </exception>
     /// <exception cref="ArgumentException"> Thrown when <paramref name="searchRootSources" /> contains <see langword="null" /> elements. </exception>
-    internal DefaultUnityEditorSearchRootProvider (
-        IReadOnlyList<IUnityEditorSearchRootSource> searchRootSources,
+    public DefaultUnityEditorSearchRootProvider (
+        IEnumerable<IUnityEditorSearchRootSource> searchRootSources,
         IUnityPathComparerProvider pathComparerProvider)
     {
         ArgumentNullException.ThrowIfNull(searchRootSources);
         ArgumentNullException.ThrowIfNull(pathComparerProvider);
 
-        for (var i = 0; i < searchRootSources.Count; i++)
+        var searchRootSourceList = searchRootSources as IReadOnlyList<IUnityEditorSearchRootSource> ?? searchRootSources.ToArray();
+        for (var i = 0; i < searchRootSourceList.Count; i++)
         {
-            if (searchRootSources[i] is null)
+            if (searchRootSourceList[i] is null)
             {
                 throw new ArgumentException("Search root sources must not contain null elements.", nameof(searchRootSources));
             }
         }
 
         var searchRootBuilder = new UnityEditorSearchRootBuilder(pathComparerProvider.GetComparer());
-        for (var i = 0; i < searchRootSources.Count; i++)
+        for (var i = 0; i < searchRootSourceList.Count; i++)
         {
-            var source = searchRootSources[i];
+            var source = searchRootSourceList[i];
             if (!source.IsSupportedCurrentPlatform)
             {
                 continue;

--- a/src/Ucli/UnityIntegration/Resolution/UnityEditorPathResolver.cs
+++ b/src/Ucli/UnityIntegration/Resolution/UnityEditorPathResolver.cs
@@ -14,21 +14,10 @@ internal sealed class UnityEditorPathResolver : IUnityEditorPathResolver
 
     /// <summary> Initializes a new instance of the <see cref="UnityEditorPathResolver" /> class. </summary>
     /// <param name="searchRootProvider"> The search-root provider dependency. </param>
-    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="searchRootProvider" /> is <see langword="null" />. </exception>
-    public UnityEditorPathResolver (IUnityEditorSearchRootProvider searchRootProvider)
-        : this(
-            searchRootProvider,
-            new UnityEditorExecutablePathLocator(),
-            new UnityEditorVersionConsistencyValidator())
-    {
-    }
-
-    /// <summary> Initializes a new instance of the <see cref="UnityEditorPathResolver" /> class. </summary>
-    /// <param name="searchRootProvider"> The search-root provider dependency. </param>
     /// <param name="executablePathLocator"> The executable-path locator dependency. </param>
     /// <param name="versionConsistencyValidator"> The version-consistency validator dependency. </param>
     /// <exception cref="ArgumentNullException"> Thrown when one dependency is <see langword="null" />. </exception>
-    internal UnityEditorPathResolver (
+    public UnityEditorPathResolver (
         IUnityEditorSearchRootProvider searchRootProvider,
         UnityEditorExecutablePathLocator executablePathLocator,
         UnityEditorVersionConsistencyValidator versionConsistencyValidator)

--- a/tests/Ucli.Application.Tests/Shared/Execution/ReadIndex/Scenes/Access/SceneTreeLiteAccessServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Shared/Execution/ReadIndex/Scenes/Access/SceneTreeLiteAccessServiceTests.cs
@@ -31,7 +31,7 @@ public sealed class SceneTreeLiteAccessServiceTests
             Result = IndexFreshnessEvaluationResult.Success(IndexFreshness.Probable),
         };
         var refreshService = new StubSceneTreeLiteSourceRefreshService();
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -89,7 +89,7 @@ public sealed class SceneTreeLiteAccessServiceTests
             Result = SceneTreeLiteDirtySourceProbeResult.DirtySource(dirtyResponse, "Dirty loaded scene is open in Unity daemon."),
         };
         var refreshService = new StubSceneTreeLiteSourceRefreshService();
-        var service = new SceneTreeLiteAccessService(
+        var service = CreateService(
             indexReader,
             new StubSceneTreeLiteFreshnessEvaluator(),
             new TestMutationReadPostconditionStore(),
@@ -143,7 +143,7 @@ public sealed class SceneTreeLiteAccessServiceTests
         {
             Result = SceneTreeLiteDirtySourceProbeResult.NotAvailable("Unity daemon scene is not dirty loaded source."),
         };
-        var service = new SceneTreeLiteAccessService(
+        var service = CreateService(
             indexReader,
             freshnessEvaluator,
             new TestMutationReadPostconditionStore(),
@@ -191,7 +191,7 @@ public sealed class SceneTreeLiteAccessServiceTests
         {
             Result = IndexFreshnessEvaluationResult.Success(IndexFreshness.Fresh),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -229,7 +229,7 @@ public sealed class SceneTreeLiteAccessServiceTests
         {
             Result = IndexFreshnessEvaluationResult.Success(IndexFreshness.Fresh),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -280,7 +280,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     ]),
                 "Existing scene-tree-lite index freshness is 'stale'."),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -346,7 +346,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     ]),
                 "Existing scene-tree-lite index generatedAtUtc is older than mutation read postcondition."),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -407,7 +407,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     ]),
                 "Existing scene-tree-lite index generatedAtUtc is older than mutation read postcondition."),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -460,7 +460,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                 ])),
         };
         var refreshService = new StubSceneTreeLiteSourceRefreshService();
-        var service = new SceneTreeLiteAccessService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, freshnessEvaluator, readPostconditionStore, refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -495,7 +495,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                 "readIndex disabled by mode."),
         };
         var indexReader = new StubReadIndexArtifactReader();
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -533,7 +533,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                 "scene-tree-lite readIndex is unavailable for non-Assets scene paths."),
         };
         var indexReader = new StubReadIndexArtifactReader();
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -569,7 +569,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     SourceInputsHash: "scene-hash",
                     Roots: CreateTree())),
         };
-        var service = new SceneTreeLiteAccessService(
+        var service = CreateService(
             indexReader,
             new StubSceneTreeLiteFreshnessEvaluator(),
             new TestMutationReadPostconditionStore(),
@@ -600,7 +600,7 @@ public sealed class SceneTreeLiteAccessServiceTests
         using var scope = TestDirectories.CreateTempScope("scene-tree-lite-access", "traversal-scene");
         var project = CreateProject(scope);
         var indexReader = new StubReadIndexArtifactReader();
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -629,7 +629,7 @@ public sealed class SceneTreeLiteAccessServiceTests
         using var scope = TestDirectories.CreateTempScope("scene-tree-lite-access", "windows-rooted-scene");
         var project = CreateProject(scope);
         var indexReader = new StubReadIndexArtifactReader();
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), new StubSceneTreeLiteSourceRefreshService(), new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -670,7 +670,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     Roots: CreateTree()),
                 "scene-tree-lite lookup is missing."),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -711,7 +711,7 @@ public sealed class SceneTreeLiteAccessServiceTests
                     Roots: CreateTree()),
                 "Index contract file 'lookups/scene-tree-lite/*.lookup.json' is malformed."),
         };
-        var service = new SceneTreeLiteAccessService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
+        var service = CreateService(indexReader, new StubSceneTreeLiteFreshnessEvaluator(), new TestMutationReadPostconditionStore(), refreshService, new StubSceneTreeLiteSourceProbe());
 
         var result = await service.ReadAsync(
             project,
@@ -728,6 +728,23 @@ public sealed class SceneTreeLiteAccessServiceTests
         Assert.Contains("malformed", result.Output!.AccessInfo.FallbackReason, StringComparison.Ordinal);
         Assert.Equal(SceneTreeLiteSource.Source, result.Output.AccessInfo.Source);
         Assert.Equal(UnityExecutionMode.Auto, refreshService.LastMode);
+    }
+
+    private static SceneTreeLiteAccessService CreateService (
+        IReadIndexArtifactReader artifactReader,
+        IReadIndexFreshnessEvaluator freshnessEvaluator,
+        IMutationReadPostconditionStore mutationReadPostconditionStore,
+        ISceneTreeLiteSourceRefreshService sourceRefreshService,
+        ISceneTreeLiteSourceProbe sourceProbe,
+        ISceneTreeLiteDirtySourceProbeService? dirtySourceProbeService = null)
+    {
+        return new SceneTreeLiteAccessService(
+            artifactReader,
+            freshnessEvaluator,
+            mutationReadPostconditionStore,
+            sourceRefreshService,
+            sourceProbe,
+            dirtySourceProbeService ?? new StubSceneTreeLiteDirtySourceProbeService());
     }
 
     private static ResolvedUnityProjectContext CreateProject (TestDirectoryScope scope)

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionIssuedAtValidationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionIssuedAtValidationTests.cs
@@ -12,7 +12,7 @@ public sealed class DaemonSessionIssuedAtValidationTests
     public async Task Read_WhenIssuedAtUtcIsMissing_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "missing-issued-at");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, "fingerprint-missing-issued-at");
         Directory.CreateDirectory(Path.GetDirectoryName(sessionPath)!);
         await File.WriteAllTextAsync(
@@ -46,7 +46,7 @@ public sealed class DaemonSessionIssuedAtValidationTests
     public async Task Write_WhenIssuedAtUtcIsDefault_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "default-issued-at");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = new DaemonSession(
             SchemaVersion: DaemonSession.CurrentSchemaVersion,
             SessionToken: "token-1",

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionProcessIdValidationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionProcessIdValidationTests.cs
@@ -12,7 +12,7 @@ public sealed class DaemonSessionProcessIdValidationTests
     public async Task Read_WhenProcessIdIsNotPositive_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "invalid-process-id-read");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var projectFingerprint = "fingerprint-invalid-process-id-read";
         var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, projectFingerprint);
         Directory.CreateDirectory(Path.GetDirectoryName(sessionPath)!);
@@ -49,7 +49,7 @@ public sealed class DaemonSessionProcessIdValidationTests
     public async Task Read_WhenProcessStartedAtUtcIsMissingWithProcessId_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "missing-process-started-at-read");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var projectFingerprint = "fingerprint-missing-process-started-at-read";
         var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, projectFingerprint);
         Directory.CreateDirectory(Path.GetDirectoryName(sessionPath)!);
@@ -89,7 +89,7 @@ public sealed class DaemonSessionProcessIdValidationTests
     public async Task Write_WhenProcessIdIsNotPositive_ReturnsInvalidArgument (int processId)
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "invalid-process-id-write");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = new DaemonSession(
             SchemaVersion: DaemonSession.CurrentSchemaVersion,
             SessionToken: "token-1",
@@ -117,7 +117,7 @@ public sealed class DaemonSessionProcessIdValidationTests
     public async Task Write_WhenProcessStartedAtUtcIsMissingWithProcessId_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "missing-process-started-at-write");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = new DaemonSession(
             SchemaVersion: DaemonSession.CurrentSchemaVersion,
             SessionToken: "token-1",

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionShutdownCapabilityValidationTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionShutdownCapabilityValidationTests.cs
@@ -12,7 +12,7 @@ public sealed class DaemonSessionShutdownCapabilityValidationTests
     public async Task Read_WhenCanShutdownProcessIsMissing_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "missing-can-shutdown-process");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var projectFingerprint = "fingerprint-missing-can-shutdown-process";
         var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, projectFingerprint);
         Directory.CreateDirectory(Path.GetDirectoryName(sessionPath)!);
@@ -50,7 +50,7 @@ public sealed class DaemonSessionShutdownCapabilityValidationTests
     public async Task Write_WhenCanShutdownProcessIsFalse_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "can-shutdown-process-false");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = new DaemonSession(
             SchemaVersion: DaemonSession.CurrentSchemaVersion,
             SessionToken: "token-1",

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionStoreTests.cs
@@ -16,7 +16,7 @@ public sealed class DaemonSessionStoreTests
     public async Task WriteReadDelete_RoundTripsSessionJson ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "roundtrip");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(projectFingerprint: "fingerprint-roundtrip", sessionToken: "token-1");
         var gitIgnorePath = Path.Combine(
             scope.FullPath,
@@ -59,7 +59,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenGitIgnoreAlreadyExists_DoesNotOverwriteExistingContents ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "existing-gitignore");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(projectFingerprint: "fingerprint-existing-gitignore", sessionToken: "token-1");
         var relativeGitIgnorePath = Path.Combine(
             UcliStoragePathNames.UcliDirectoryName,
@@ -84,7 +84,7 @@ public sealed class DaemonSessionStoreTests
         }
 
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "owner-only");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(projectFingerprint: "fingerprint-owner-only", sessionToken: "token-1");
 
         var writeResult = await store.WriteAsync(scope.FullPath, session, CancellationToken.None);
@@ -111,7 +111,7 @@ public sealed class DaemonSessionStoreTests
         }
 
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "current-user-only");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(projectFingerprint: "fingerprint-current-user-only", sessionToken: "token-1");
 
         var writeResult = await store.WriteAsync(scope.FullPath, session, CancellationToken.None);
@@ -140,7 +140,7 @@ public sealed class DaemonSessionStoreTests
         Directory.CreateDirectory(Path.GetDirectoryName(blockedPath)!);
         await File.WriteAllTextAsync(blockedPath, "blocked", CancellationToken.None);
 
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(projectFingerprint: "fingerprint-blocked", sessionToken: "token-1");
 
         var writeResult = await store.WriteAsync(scope.FullPath, session, CancellationToken.None);
@@ -156,7 +156,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Read_WhenSessionJsonIsMalformed_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "malformed-json");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var sessionPath = UcliStoragePathResolver.ResolveSessionPath(scope.FullPath, "fingerprint-malformed");
         Directory.CreateDirectory(Path.GetDirectoryName(sessionPath)!);
         await File.WriteAllTextAsync(sessionPath, "{", CancellationToken.None);
@@ -176,7 +176,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenTransportKindIsInvalid_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "invalid-transport");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(
             projectFingerprint: "fingerprint-invalid-transport",
             sessionToken: "token-1") with
@@ -197,7 +197,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenEditorModeIsUnsupported_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "invalid-editor-mode");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(
             projectFingerprint: "fingerprint-invalid-editor-mode",
             sessionToken: "token-1") with
@@ -218,7 +218,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenOwnerKindIsNotCli_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "invalid-owner-kind");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(
             projectFingerprint: "fingerprint-invalid-owner-kind",
             sessionToken: "token-1") with
@@ -239,7 +239,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Read_WhenSessionFingerprintDoesNotMatchRequestedFingerprint_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "fingerprint-mismatch");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var requestedFingerprint = "fingerprint-requested";
         var mismatchedSession = CreateSession(projectFingerprint: "fingerprint-other", sessionToken: "token-1");
 
@@ -266,7 +266,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Read_WhenEditorModeIsUnsupported_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "read-invalid-editor-mode");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var requestedFingerprint = "fingerprint-read-invalid-editor-mode";
         var session = CreateSession(projectFingerprint: requestedFingerprint, sessionToken: "token-1") with
         {
@@ -296,7 +296,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenOwnerKindIsUserAndCanShutdownProcessIsTrue_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "user-owner-can-shutdown-true");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(
             projectFingerprint: "fingerprint-user-owner-can-shutdown-true",
             sessionToken: "token-1") with
@@ -319,7 +319,7 @@ public sealed class DaemonSessionStoreTests
     public async Task Write_WhenGuiUserSessionCannotShutdownProcess_Succeeds ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-store", "gui-user-owner");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var session = CreateSession(
             projectFingerprint: "fingerprint-gui-user-owner",
             sessionToken: "token-1") with

--- a/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionTokenProviderTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Lifecycle/Session/DaemonSessionTokenProviderTests.cs
@@ -12,7 +12,7 @@ public sealed class DaemonSessionTokenProviderTests
     public async Task Resolve_WhenSessionExists_ReturnsToken ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-token-provider", "session-exists");
-        var store = new DaemonSessionStore();
+        var store = new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator());
         var provider = new DaemonSessionTokenProvider(store);
         var context = CreateContext(scope.FullPath, "fingerprint-session-exists");
 
@@ -32,7 +32,7 @@ public sealed class DaemonSessionTokenProviderTests
     public async Task Resolve_WhenSessionDoesNotExist_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("daemon-session-token-provider", "session-missing");
-        var provider = new DaemonSessionTokenProvider(new DaemonSessionStore());
+        var provider = new DaemonSessionTokenProvider(new DaemonSessionStore(new DaemonSessionJsonSerializer(), new DaemonSessionValidator()));
         var context = CreateContext(scope.FullPath, "fingerprint-session-missing");
 
         var resolveResult = await provider.ResolveAsync(context, CancellationToken.None);

--- a/tests/Ucli.Tests/ProjectContextResolverTests.cs
+++ b/tests/Ucli.Tests/ProjectContextResolverTests.cs
@@ -37,7 +37,7 @@ public sealed class ProjectContextResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "file-config");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var saveResult = await configStore.SaveAsync(
             unityProjectPath,
             new UcliConfig(
@@ -89,7 +89,7 @@ public sealed class ProjectContextResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("init-status-context-resolver", "invalid-config");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         scope.WriteFile(relativeConfigPath, "{");
@@ -131,6 +131,6 @@ public sealed class ProjectContextResolverTests
             new ProjectPathInputResolver(new StubEnvironmentVariableReader(
                 environmentVariables ?? new Dictionary<string, string?>(StringComparer.Ordinal))),
             new UnityProjectResolver(),
-            configStore ?? new UcliConfigStore());
+            configStore ?? new UcliConfigStore(UcliConfigCompiler.CreateDefault()));
     }
 }

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -13,7 +13,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "load-default");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
 
         var result = await configStore.LoadAsync(unityProjectPath, CancellationToken.None);
 
@@ -36,7 +36,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "save-round-trip");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var config = new UcliConfig(
             SchemaVersion: 1,
             OperationPolicy: OperationPolicy.Dangerous,
@@ -104,7 +104,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "malformed-json");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         scope.WriteFile(relativeConfigPath, "{");
@@ -124,7 +124,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "multiple-schema-errors");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         scope.WriteFile(relativeConfigPath, """
@@ -154,7 +154,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "schema-version-mismatch");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidSchemaConfigJson = JsonSerializer.Serialize(
@@ -185,7 +185,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-allowlist-load");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidAllowlistConfigJson = JsonSerializer.Serialize(
@@ -215,7 +215,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-allowlist-save");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var invalidConfig = new UcliConfig(
             SchemaVersion: UcliContractConstants.Config.SchemaVersion,
             OperationPolicy: OperationPolicy.Safe,
@@ -241,7 +241,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-read-index-default-mode");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidConfigJson = JsonSerializer.Serialize(
@@ -270,7 +270,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-ipc-timeout-load");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidConfigJson = JsonSerializer.Serialize(
@@ -300,7 +300,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "missing-ipc-timeout-by-command");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var configJson = JsonSerializer.Serialize(
@@ -328,7 +328,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-ipc-timeout-save");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var invalidConfig = new UcliConfig(
             SchemaVersion: UcliContractConstants.Config.SchemaVersion,
             OperationPolicy: OperationPolicy.Safe,
@@ -356,7 +356,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "empty-ipc-timeout-by-command");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var configJson = JsonSerializer.Serialize(
@@ -385,7 +385,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "unsupported-ipc-timeout-command");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidConfigJson = JsonSerializer.Serialize(
@@ -420,7 +420,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "invalid-ipc-timeout-by-command-save");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var invalidConfig = new UcliConfig(
             SchemaVersion: UcliContractConstants.Config.SchemaVersion,
             OperationPolicy: OperationPolicy.Safe,
@@ -452,7 +452,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "unsupported-ipc-timeout-command-save");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var invalidConfig = new UcliConfig(
             SchemaVersion: UcliContractConstants.Config.SchemaVersion,
             OperationPolicy: OperationPolicy.Safe,
@@ -485,7 +485,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "multiple-save-diagnostics");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var invalidConfig = new UcliConfig(
             SchemaVersion: 2,
             OperationPolicy: (OperationPolicy)999,
@@ -526,7 +526,7 @@ public sealed class UcliConfigStoreTests
     {
         using var scope = TestDirectories.CreateTempScope("ucli-config-store", "unknown-property");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var configStore = new UcliConfigStore();
+        var configStore = new UcliConfigStore(UcliConfigCompiler.CreateDefault());
         var configPath = configStore.GetConfigPath(unityProjectPath);
         var relativeConfigPath = Path.GetRelativePath(scope.FullPath, configPath);
         var invalidConfigJson = JsonSerializer.Serialize(

--- a/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityPluginPackageSpecTests.cs
@@ -4,6 +4,7 @@ using System.Xml.Linq;
 using MackySoft.Tests;
 using MackySoft.Ucli.UnityIntegration.Project.Plugin;
 using MackySoft.Ucli.UnityIntegration.Project.Plugin.Cache;
+using MackySoft.Ucli.UnityIntegration.Project.Plugin.Marker;
 
 public sealed class UnityPluginPackageSpecTests
 {
@@ -42,7 +43,7 @@ public sealed class UnityPluginPackageSpecTests
               "protocolVersion": 1
             }
             """);
-        var locator = new UnityUcliPluginLocator(CreateNoOpCacheStore());
+        var locator = CreateLocator(CreateNoOpCacheStore());
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -94,6 +95,15 @@ public sealed class UnityPluginPackageSpecTests
             static (_, _) => ValueTask.FromResult<string?>(null),
             static (_, _, _) => ValueTask.CompletedTask,
             static _ => { });
+    }
+
+    private static UnityUcliPluginLocator CreateLocator (UnityUcliPluginMarkerCacheStore cacheStore)
+    {
+        var markerValidator = new UnityUcliPluginMarkerValidator();
+        return new UnityUcliPluginLocator(
+            new UnityUcliPluginMarkerDiscovery(),
+            markerValidator,
+            new UnityUcliPluginMarkerCacheCoordinator(cacheStore, markerValidator));
     }
 
     private static string ResolveRepositoryRoot ()

--- a/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityUcliPluginLocatorTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Project/Plugin/UnityUcliPluginLocatorTests.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Infrastructure.Project;
 using MackySoft.Ucli.Infrastructure.Storage;
 using MackySoft.Ucli.UnityIntegration.Project.Plugin;
 using MackySoft.Ucli.UnityIntegration.Project.Plugin.Cache;
+using MackySoft.Ucli.UnityIntegration.Project.Plugin.Marker;
 
 namespace MackySoft.Ucli.Tests;
 
@@ -20,7 +21,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -43,7 +44,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Packages", "com.mackysoft.ucli.unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -66,7 +67,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "Packages", "com.mackysoft.ucli.unity.1.0.0"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -89,7 +90,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "Packages", "MackySoft.Ucli.Unity.1.0.0"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -112,7 +113,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -135,7 +136,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var firstResult = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -160,7 +161,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var cacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var firstResult = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -188,7 +189,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         var observedCacheStore = new ObservedPluginMarkerCacheStore();
-        var locator = new UnityUcliPluginLocator(observedCacheStore.CacheStore);
+        var locator = CreateLocator(observedCacheStore.CacheStore);
         var firstCacheWriteTask = observedCacheStore.ExpectWriteAsync();
 
         var firstResult = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
@@ -222,7 +223,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "ThirdParty", "UcliCopy"));
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -237,7 +238,7 @@ public sealed class UnityUcliPluginLocatorTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-ucli-plugin-locator", "not-found");
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -257,7 +258,7 @@ public sealed class UnityUcliPluginLocatorTests
         await scope.WriteFileAsync(
             Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity", UnityUcliPluginLocator.MarkerFileName),
             "{ invalid");
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -283,7 +284,7 @@ public sealed class UnityUcliPluginLocatorTests
               "protocolVersion": 1
             }
             """);
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -309,7 +310,7 @@ public sealed class UnityUcliPluginLocatorTests
               "protocolVersion": 2
             }
             """);
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -338,7 +339,7 @@ public sealed class UnityUcliPluginLocatorTests
                 await releaseWrite.Task.ConfigureAwait(false);
             },
             static path => FileUtilities.DeleteIfExists(path));
-        var locator = new UnityUcliPluginLocator(cacheStore);
+        var locator = CreateLocator(cacheStore);
         using var cancellationTokenSource = new CancellationTokenSource();
 
         var locateTask = locator.LocateAsync(unityProjectPath, cancellationTokenSource.Token).AsTask();
@@ -360,7 +361,7 @@ public sealed class UnityUcliPluginLocatorTests
         var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Assets", "MackySoft", "MackySoft.Ucli.Unity"));
         await WriteMarkerAsync(scope, Path.Combine("UnityProject", "Packages", "com.mackysoft.ucli.unity"));
-        var locator = new UnityUcliPluginLocator();
+        var locator = CreateLocator();
 
         var result = await locator.LocateAsync(unityProjectPath, CancellationToken.None);
 
@@ -409,6 +410,20 @@ public sealed class UnityUcliPluginLocatorTests
                     PropertyNameCaseInsensitive = true,
                 })
             ?? throw new InvalidOperationException("Plugin marker cache JSON was null.");
+    }
+
+    private static UnityUcliPluginLocator CreateLocator ()
+    {
+        return CreateLocator(new UnityUcliPluginMarkerCacheStore());
+    }
+
+    private static UnityUcliPluginLocator CreateLocator (UnityUcliPluginMarkerCacheStore cacheStore)
+    {
+        var markerValidator = new UnityUcliPluginMarkerValidator();
+        return new UnityUcliPluginLocator(
+            new UnityUcliPluginMarkerDiscovery(),
+            markerValidator,
+            new UnityUcliPluginMarkerCacheCoordinator(cacheStore, markerValidator));
     }
 
     private sealed class ObservedPluginMarkerCacheStore

--- a/tests/Ucli.Tests/UnityIntegration/Resolution/UnityEditorPathResolverTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Resolution/UnityEditorPathResolverTests.cs
@@ -12,7 +12,7 @@ public sealed class UnityEditorPathResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "preferred-file");
         var executablePath = EnsureEditorInstallation(scope, "Editors", "6000.1.4f1");
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve("6000.1.4f1", executablePath);
 
@@ -28,7 +28,7 @@ public sealed class UnityEditorPathResolverTests
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "preferred-directory");
         var executablePath = EnsureEditorInstallation(scope, "Editors", "6000.1.4f1");
         var versionDirectoryPath = Path.GetDirectoryName(Path.GetDirectoryName(executablePath)!)!;
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve("6000.1.4f1", versionDirectoryPath);
 
@@ -43,7 +43,7 @@ public sealed class UnityEditorPathResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "missing-preferred-path");
         var missingPath = scope.GetPath(Path.Combine("Missing", "Editor", "Unity.exe"));
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve("6000.1.4f1", missingPath);
 
@@ -60,7 +60,7 @@ public sealed class UnityEditorPathResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "unsupported-executable");
         var filePath = scope.WriteFile(Path.Combine("Editors", "not-unity-binary"), string.Empty);
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve("6000.1.4f1", filePath);
 
@@ -77,7 +77,7 @@ public sealed class UnityEditorPathResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "version-mismatch");
         var executablePath = EnsureEditorInstallation(scope, "Editors", "6000.1.3f1");
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve("6000.1.4f1", executablePath);
 
@@ -95,7 +95,7 @@ public sealed class UnityEditorPathResolverTests
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "c-suffix");
         const string unityVersion = "2022.3.5f1c1";
         var executablePath = EnsureEditorInstallation(scope, "Editors", unityVersion);
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve(unityVersion, executablePath);
 
@@ -111,7 +111,7 @@ public sealed class UnityEditorPathResolverTests
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "search-root-success");
         var searchRootPath = scope.CreateDirectory("SearchRoot");
         var executablePath = EnsureEditorInstallation(scope, "SearchRoot", "6000.1.4f1");
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(searchRootPath));
+        var resolver = CreateResolver(new StubSearchRootProvider(searchRootPath));
 
         var result = resolver.Resolve("6000.1.4f1", null);
 
@@ -126,7 +126,7 @@ public sealed class UnityEditorPathResolverTests
     {
         using var scope = TestDirectories.CreateTempScope("unity-editor-path-resolver", "search-root-missing");
         var searchRootPath = scope.CreateDirectory("SearchRoot");
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(searchRootPath));
+        var resolver = CreateResolver(new StubSearchRootProvider(searchRootPath));
 
         var result = resolver.Resolve("6000.1.4f1", null);
 
@@ -141,7 +141,7 @@ public sealed class UnityEditorPathResolverTests
     [Trait("Size", "Small")]
     public void Resolve_WhenUnityVersionIsWhitespace_ReturnsInvalidArgumentError ()
     {
-        var resolver = new UnityEditorPathResolver(new StubSearchRootProvider(Array.Empty<string>()));
+        var resolver = CreateResolver(new StubSearchRootProvider(Array.Empty<string>()));
 
         var result = resolver.Resolve(" ", null);
 
@@ -159,6 +159,14 @@ public sealed class UnityEditorPathResolverTests
     {
         var versionRelativePath = Path.Combine(rootRelativePath, unityVersion);
         return scope.WriteFile(Path.Combine(versionRelativePath, "Editor", "Unity.exe"), string.Empty);
+    }
+
+    private static UnityEditorPathResolver CreateResolver (IUnityEditorSearchRootProvider searchRootProvider)
+    {
+        return new UnityEditorPathResolver(
+            searchRootProvider,
+            new UnityEditorExecutablePathLocator(),
+            new UnityEditorVersionConsistencyValidator());
     }
 
     private sealed class StubSearchRootProvider : IUnityEditorSearchRootProvider


### PR DESCRIPTION
## Summary
- Remove convenience constructors that instantiate collaborator implementations directly.
- Move affected dependency construction into service collection registrations and explicit test helpers.
- Keep Unity operation discovery compatible by activating operations through DI.

## Scope
- Core and daemon composition now registers config, daemon session, Unity editor resolution, execution, and C# eval collaborators explicitly.
- Unity execution, readiness, test-run, and request idempotency constructors now require their dependencies directly.
- Unit and Unity editor tests were updated to build explicit dependency graphs.

## Verification
- Gate level: Standard
- Format: PASS (bash scripts/code-quality.sh format; bash scripts/code-quality.sh verify; targeted verify after final Unity readiness adjustment)
- Tests: PASS (bash scripts/verify.sh; bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor")
- Coverage: N/A

## Risks / Rollback
- Risk is limited to service composition and test construction paths; runtime behavior should remain unchanged.
- Rollback by reverting the single refactor commit if DI activation or Unity operation discovery regresses.

## Checklist
- [x] Removed constructor-local collaborator creation patterns
- [x] Confirmed targeted anti-pattern searches return no production matches
- [x] Ran .NET and Unity verification

Issue: none (ad-hoc task)
