### PR TITLE
feat: implement ucli play exit

### DIFF
--- a/.ucli/config.json
+++ b/.ucli/config.json
@@ -18,6 +18,9 @@
     "ops": 120000,
     "daemon.start": null,
     "daemon.stop": null,
-    "daemon.status": null
+    "daemon.status": null,
+    "play.status": null,
+    "play.enter": 30000,
+    "play.exit": 30000
   }
 }

--- a/schemas/v1/cli-output/payload/play.exit.schema.json
+++ b/schemas/v1/cli-output/payload/play.exit.schema.json
@@ -1,170 +1,291 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/play.exit.schema.json",
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "transition": {
+  "oneOf": [
+    {
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "project": {
+          "$ref": "../defs/project.schema.json"
+        },
+        "daemonStatus": {
+          "type": "string",
+          "const": "running"
+        },
+        "serverVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "editorMode": {
+          "type": "string",
+          "const": "gui"
+        },
+        "lifecycleState": {
+          "type": "string",
+          "const": "ready"
+        },
+        "blockingReason": {
+          "type": "null"
+        },
+        "compileState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "domainReloadGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "canAcceptExecutionRequests": {
+          "type": "boolean",
+          "const": true
+        },
+        "observedAtUtc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "actionRequired": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "primaryDiagnostic": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "line": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "column": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        "playMode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "type": "string",
+              "const": "stopped"
+            },
+            "transition": {
+              "type": "string",
+              "const": "none"
+            },
+            "isPlaying": {
+              "type": "boolean",
+              "const": false
+            },
+            "isPlayingOrWillChangePlaymode": {
+              "type": "boolean",
+              "const": false
+            },
+            "generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "state",
+            "transition",
+            "isPlaying",
+            "isPlayingOrWillChangePlaymode",
+            "generation"
+          ]
+        },
         "transition": {
-          "type": "string",
-          "const": "exit"
-        },
-        "result": {
-          "type": "string",
-          "enum": [
-            "exited",
-            "alreadyExited",
-            "timeout",
-            "blocked"
-          ]
-        },
-        "before": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "serverVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
+            "transition": {
+              "type": "string",
+              "const": "exit"
             },
-            "editorMode": {
-              "type": [
-                "string",
-                "null"
-              ]
+            "result": {
+              "type": "string",
+              "const": "exited"
             },
-            "unityVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "projectFingerprint": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "lifecycleState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "blockingReason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "domainReloadGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "canAcceptExecutionRequests": {
-              "type": "boolean"
-            },
-            "observedAtUtc": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "actionRequired": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "primaryDiagnostic": {
-              "type": [
-                "object",
-                "null"
-              ],
+            "before": {
+              "type": "object",
               "additionalProperties": false,
               "properties": {
-                "kind": {
-                  "type": "string"
-                },
-                "code": {
+                "serverVersion": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "file": {
+                "editorMode": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "line": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "column": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "message": {
+                "unityVersion": {
                   "type": [
                     "string",
                     "null"
                   ]
-                }
-              },
-              "required": [
-                "kind"
-              ]
-            },
-            "playMode": {
-              "oneOf": [
-                {
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": "string",
+                  "const": "playmode"
+                },
+                "blockingReason": {
+                  "type": "string",
+                  "const": "playMode"
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean",
+                  "const": false
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "state": {
                       "type": "string",
-                      "enum": [
-                        "stopped",
-                        "entering",
-                        "playing",
-                        "exiting",
-                        "unknown"
-                      ]
+                      "const": "playing"
                     },
                     "transition": {
                       "type": "string",
-                      "enum": [
-                        "none",
-                        "entering",
-                        "exiting"
-                      ]
+                      "const": "none"
                     },
                     "isPlaying": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "const": true
                     },
                     "isPlayingOrWillChangePlaymode": {
                       "type": "boolean"
@@ -183,177 +304,158 @@
                     "isPlayingOrWillChangePlaymode",
                     "generation"
                   ]
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "required": [
-            "serverVersion",
-            "editorMode",
-            "unityVersion",
-            "projectFingerprint",
-            "lifecycleState",
-            "blockingReason",
-            "compileState",
-            "compileGeneration",
-            "domainReloadGeneration",
-            "canAcceptExecutionRequests",
-            "observedAtUtc",
-            "actionRequired",
-            "primaryDiagnostic",
-            "playMode"
-          ]
-        },
-        "after": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "serverVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "editorMode": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "unityVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "projectFingerprint": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "lifecycleState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "blockingReason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "domainReloadGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "canAcceptExecutionRequests": {
-              "type": "boolean"
-            },
-            "observedAtUtc": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "actionRequired": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "primaryDiagnostic": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "kind": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "file": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "line": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "column": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "message": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
                 }
               },
               "required": [
-                "kind"
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
               ]
             },
-            "playMode": {
-              "oneOf": [
-                {
+            "after": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": "string",
+                  "const": "ready"
+                },
+                "blockingReason": {
+                  "type": "null"
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean",
+                  "const": true
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "state": {
                       "type": "string",
-                      "enum": [
-                        "stopped",
-                        "entering",
-                        "playing",
-                        "exiting",
-                        "unknown"
-                      ]
+                      "const": "stopped"
                     },
                     "transition": {
                       "type": "string",
-                      "enum": [
-                        "none",
-                        "entering",
-                        "exiting"
-                      ]
+                      "const": "none"
                     },
                     "isPlaying": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "const": false
                     },
                     "isPlayingOrWillChangePlaymode": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "const": false
                     },
                     "generation": {
                       "type": [
@@ -369,234 +471,1739 @@
                     "isPlayingOrWillChangePlaymode",
                     "generation"
                   ]
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "required": [
-            "serverVersion",
-            "editorMode",
-            "unityVersion",
-            "projectFingerprint",
-            "lifecycleState",
-            "blockingReason",
-            "compileState",
-            "compileGeneration",
-            "domainReloadGeneration",
-            "canAcceptExecutionRequests",
-            "observedAtUtc",
-            "actionRequired",
-            "primaryDiagnostic",
-            "playMode"
-          ]
-        },
-        "observed": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "serverVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "editorMode": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "unityVersion": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "projectFingerprint": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "lifecycleState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "blockingReason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileState": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "compileGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "domainReloadGeneration": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "canAcceptExecutionRequests": {
-              "type": "boolean"
-            },
-            "observedAtUtc": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "actionRequired": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "primaryDiagnostic": {
-              "type": [
-                "object",
-                "null"
-              ],
-              "additionalProperties": false,
-              "properties": {
-                "kind": {
-                  "type": "string"
-                },
-                "code": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "file": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "line": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "column": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "message": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
                 }
               },
               "required": [
-                "kind"
-              ]
-            },
-            "playMode": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "state": {
-                      "type": "string",
-                      "enum": [
-                        "stopped",
-                        "entering",
-                        "playing",
-                        "exiting",
-                        "unknown"
-                      ]
-                    },
-                    "transition": {
-                      "type": "string",
-                      "enum": [
-                        "none",
-                        "entering",
-                        "exiting"
-                      ]
-                    },
-                    "isPlaying": {
-                      "type": "boolean"
-                    },
-                    "isPlayingOrWillChangePlaymode": {
-                      "type": "boolean"
-                    },
-                    "generation": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "state",
-                    "transition",
-                    "isPlaying",
-                    "isPlayingOrWillChangePlaymode",
-                    "generation"
-                  ]
-                },
-                {
-                  "type": "null"
-                }
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
               ]
             }
           },
           "required": [
-            "serverVersion",
-            "editorMode",
-            "unityVersion",
-            "projectFingerprint",
-            "lifecycleState",
-            "blockingReason",
-            "compileState",
-            "compileGeneration",
-            "domainReloadGeneration",
-            "canAcceptExecutionRequests",
-            "observedAtUtc",
-            "actionRequired",
-            "primaryDiagnostic",
-            "playMode"
+            "transition",
+            "result",
+            "before",
+            "after"
           ]
         },
-        "applicationState": {
-          "type": "string",
-          "enum": [
-            "notApplied",
-            "applied",
-            "indeterminate",
-            "unknown"
-          ]
+        "timeoutMilliseconds": {
+          "type": "integer"
         }
       },
       "required": [
+        "project",
+        "daemonStatus",
+        "serverVersion",
+        "editorMode",
+        "lifecycleState",
+        "blockingReason",
+        "compileState",
+        "compileGeneration",
+        "domainReloadGeneration",
+        "canAcceptExecutionRequests",
+        "observedAtUtc",
+        "actionRequired",
+        "primaryDiagnostic",
+        "playMode",
         "transition",
-        "result",
-        "before"
+        "timeoutMilliseconds"
       ]
     },
-    "timeoutMilliseconds": {
-      "type": "integer"
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "$ref": "../defs/project.schema.json"
+        },
+        "daemonStatus": {
+          "type": "string",
+          "const": "running"
+        },
+        "serverVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "editorMode": {
+          "type": "string",
+          "const": "gui"
+        },
+        "lifecycleState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "blockingReason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "domainReloadGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "canAcceptExecutionRequests": {
+          "type": "boolean"
+        },
+        "observedAtUtc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "actionRequired": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "primaryDiagnostic": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "line": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "column": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        "playMode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "type": "string",
+              "const": "stopped"
+            },
+            "transition": {
+              "type": "string",
+              "const": "none"
+            },
+            "isPlaying": {
+              "type": "boolean",
+              "const": false
+            },
+            "isPlayingOrWillChangePlaymode": {
+              "type": "boolean",
+              "const": false
+            },
+            "generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "state",
+            "transition",
+            "isPlaying",
+            "isPlayingOrWillChangePlaymode",
+            "generation"
+          ]
+        },
+        "transition": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "transition": {
+              "type": "string",
+              "const": "exit"
+            },
+            "result": {
+              "type": "string",
+              "const": "alreadyExited"
+            },
+            "before": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "const": "stopped"
+                    },
+                    "transition": {
+                      "type": "string",
+                      "const": "none"
+                    },
+                    "isPlaying": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "isPlayingOrWillChangePlaymode": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "generation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "state",
+                    "transition",
+                    "isPlaying",
+                    "isPlayingOrWillChangePlaymode",
+                    "generation"
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            },
+            "after": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "const": "stopped"
+                    },
+                    "transition": {
+                      "type": "string",
+                      "const": "none"
+                    },
+                    "isPlaying": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "isPlayingOrWillChangePlaymode": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "generation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "state",
+                    "transition",
+                    "isPlaying",
+                    "isPlayingOrWillChangePlaymode",
+                    "generation"
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            }
+          },
+          "required": [
+            "transition",
+            "result",
+            "before",
+            "after"
+          ]
+        },
+        "timeoutMilliseconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project",
+        "daemonStatus",
+        "serverVersion",
+        "editorMode",
+        "lifecycleState",
+        "blockingReason",
+        "compileState",
+        "compileGeneration",
+        "domainReloadGeneration",
+        "canAcceptExecutionRequests",
+        "observedAtUtc",
+        "actionRequired",
+        "primaryDiagnostic",
+        "playMode",
+        "transition",
+        "timeoutMilliseconds"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "$ref": "../defs/project.schema.json"
+        },
+        "daemonStatus": {
+          "type": "string",
+          "const": "running"
+        },
+        "serverVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "editorMode": {
+          "type": "string",
+          "const": "gui"
+        },
+        "lifecycleState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "blockingReason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "domainReloadGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "canAcceptExecutionRequests": {
+          "type": "boolean"
+        },
+        "observedAtUtc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "actionRequired": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "primaryDiagnostic": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "line": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "column": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        "playMode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": [
+                "stopped",
+                "entering",
+                "playing",
+                "exiting",
+                "unknown"
+              ]
+            },
+            "transition": {
+              "type": "string",
+              "enum": [
+                "none",
+                "entering",
+                "exiting"
+              ]
+            },
+            "isPlaying": {
+              "type": "boolean"
+            },
+            "isPlayingOrWillChangePlaymode": {
+              "type": "boolean"
+            },
+            "generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "state",
+            "transition",
+            "isPlaying",
+            "isPlayingOrWillChangePlaymode",
+            "generation"
+          ]
+        },
+        "transition": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "transition": {
+              "type": "string",
+              "const": "exit"
+            },
+            "result": {
+              "type": "string",
+              "const": "timeout"
+            },
+            "before": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "stopped",
+                            "entering",
+                            "playing",
+                            "exiting",
+                            "unknown"
+                          ]
+                        },
+                        "transition": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "entering",
+                            "exiting"
+                          ]
+                        },
+                        "isPlaying": {
+                          "type": "boolean"
+                        },
+                        "isPlayingOrWillChangePlaymode": {
+                          "type": "boolean"
+                        },
+                        "generation": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "transition",
+                        "isPlaying",
+                        "isPlayingOrWillChangePlaymode",
+                        "generation"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            },
+            "observed": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "stopped",
+                            "entering",
+                            "playing",
+                            "exiting",
+                            "unknown"
+                          ]
+                        },
+                        "transition": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "entering",
+                            "exiting"
+                          ]
+                        },
+                        "isPlaying": {
+                          "type": "boolean"
+                        },
+                        "isPlayingOrWillChangePlaymode": {
+                          "type": "boolean"
+                        },
+                        "generation": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "transition",
+                        "isPlaying",
+                        "isPlayingOrWillChangePlaymode",
+                        "generation"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            },
+            "applicationState": {
+              "type": "string",
+              "const": "indeterminate"
+            }
+          },
+          "required": [
+            "transition",
+            "result",
+            "before",
+            "observed",
+            "applicationState"
+          ]
+        },
+        "timeoutMilliseconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project",
+        "daemonStatus",
+        "serverVersion",
+        "editorMode",
+        "lifecycleState",
+        "blockingReason",
+        "compileState",
+        "compileGeneration",
+        "domainReloadGeneration",
+        "canAcceptExecutionRequests",
+        "observedAtUtc",
+        "actionRequired",
+        "primaryDiagnostic",
+        "playMode",
+        "transition",
+        "timeoutMilliseconds"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "project": {
+          "$ref": "../defs/project.schema.json"
+        },
+        "daemonStatus": {
+          "type": "string",
+          "const": "running"
+        },
+        "serverVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "editorMode": {
+          "type": "string",
+          "const": "gui"
+        },
+        "lifecycleState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "blockingReason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileState": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compileGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "domainReloadGeneration": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "canAcceptExecutionRequests": {
+          "type": "boolean"
+        },
+        "observedAtUtc": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "actionRequired": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "primaryDiagnostic": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "line": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "column": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        "playMode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": [
+                "stopped",
+                "entering",
+                "playing",
+                "exiting",
+                "unknown"
+              ]
+            },
+            "transition": {
+              "type": "string",
+              "enum": [
+                "none",
+                "entering",
+                "exiting"
+              ]
+            },
+            "isPlaying": {
+              "type": "boolean"
+            },
+            "isPlayingOrWillChangePlaymode": {
+              "type": "boolean"
+            },
+            "generation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "state",
+            "transition",
+            "isPlaying",
+            "isPlayingOrWillChangePlaymode",
+            "generation"
+          ]
+        },
+        "transition": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "transition": {
+              "type": "string",
+              "const": "exit"
+            },
+            "result": {
+              "type": "string",
+              "const": "blocked"
+            },
+            "before": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "stopped",
+                            "entering",
+                            "playing",
+                            "exiting",
+                            "unknown"
+                          ]
+                        },
+                        "transition": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "entering",
+                            "exiting"
+                          ]
+                        },
+                        "isPlaying": {
+                          "type": "boolean"
+                        },
+                        "isPlayingOrWillChangePlaymode": {
+                          "type": "boolean"
+                        },
+                        "generation": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "transition",
+                        "isPlaying",
+                        "isPlayingOrWillChangePlaymode",
+                        "generation"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            },
+            "observed": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "serverVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "editorMode": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "unityVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "projectFingerprint": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lifecycleState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blockingReason": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileState": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "compileGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "domainReloadGeneration": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "canAcceptExecutionRequests": {
+                  "type": "boolean"
+                },
+                "observedAtUtc": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "actionRequired": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "primaryDiagnostic": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "file": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "line": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "column": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind"
+                  ]
+                },
+                "playMode": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "stopped",
+                            "entering",
+                            "playing",
+                            "exiting",
+                            "unknown"
+                          ]
+                        },
+                        "transition": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "entering",
+                            "exiting"
+                          ]
+                        },
+                        "isPlaying": {
+                          "type": "boolean"
+                        },
+                        "isPlayingOrWillChangePlaymode": {
+                          "type": "boolean"
+                        },
+                        "generation": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "transition",
+                        "isPlaying",
+                        "isPlayingOrWillChangePlaymode",
+                        "generation"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "serverVersion",
+                "editorMode",
+                "unityVersion",
+                "projectFingerprint",
+                "lifecycleState",
+                "blockingReason",
+                "compileState",
+                "compileGeneration",
+                "domainReloadGeneration",
+                "canAcceptExecutionRequests",
+                "observedAtUtc",
+                "actionRequired",
+                "primaryDiagnostic",
+                "playMode"
+              ]
+            },
+            "applicationState": {
+              "type": "string",
+              "enum": [
+                "notApplied",
+                "applied",
+                "indeterminate",
+                "unknown"
+              ]
+            }
+          },
+          "required": [
+            "transition",
+            "result",
+            "before",
+            "observed",
+            "applicationState"
+          ]
+        },
+        "timeoutMilliseconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "project",
+        "daemonStatus",
+        "serverVersion",
+        "editorMode",
+        "lifecycleState",
+        "blockingReason",
+        "compileState",
+        "compileGeneration",
+        "domainReloadGeneration",
+        "canAcceptExecutionRequests",
+        "observedAtUtc",
+        "actionRequired",
+        "primaryDiagnostic",
+        "playMode",
+        "transition",
+        "timeoutMilliseconds"
+      ]
     }
-  }
+  ]
 }

--- a/src/Ucli.Application/Features/Play/Common/Contracts/PlayOutputProjectionFactory.cs
+++ b/src/Ucli.Application/Features/Play/Common/Contracts/PlayOutputProjectionFactory.cs
@@ -1,0 +1,54 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Shared.CommandContracts.Projection;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+
+/// <summary> Creates public Play Mode command projection values from IPC lifecycle contracts. </summary>
+internal static class PlayOutputProjectionFactory
+{
+    /// <summary> Creates one lifecycle snapshot output from a Unity Play Mode lifecycle snapshot. </summary>
+    /// <param name="snapshot"> The IPC lifecycle snapshot. </param>
+    /// <returns> The public lifecycle snapshot output. </returns>
+    public static PlayLifecycleSnapshotOutput CreateSnapshotOutput (IpcPlayLifecycleSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var lifecycle = LifecycleProjectionFactory.Create(snapshot);
+        return new PlayLifecycleSnapshotOutput(
+            ServerVersion: lifecycle.ServerVersion,
+            EditorMode: lifecycle.EditorMode,
+            UnityVersion: lifecycle.UnityVersion,
+            ProjectFingerprint: snapshot.ProjectFingerprint,
+            LifecycleState: lifecycle.LifecycleState,
+            BlockingReason: lifecycle.BlockingReason,
+            CompileState: lifecycle.CompileState,
+            CompileGeneration: lifecycle.CompileGeneration,
+            DomainReloadGeneration: lifecycle.DomainReloadGeneration,
+            CanAcceptExecutionRequests: lifecycle.CanAcceptExecutionRequests,
+            ObservedAtUtc: lifecycle.ObservedAtUtc,
+            ActionRequired: lifecycle.ActionRequired,
+            PrimaryDiagnostic: CreatePrimaryDiagnosticOutput(lifecycle.PrimaryDiagnostic),
+            PlayMode: lifecycle.PlayMode!);
+    }
+
+    /// <summary> Creates one public primary diagnostic projection. </summary>
+    /// <param name="diagnostic"> The IPC diagnostic contract. </param>
+    /// <returns> The diagnostic output, or <see langword="null" /> when absent or invalid. </returns>
+    public static DaemonPrimaryDiagnosticOutput? CreatePrimaryDiagnosticOutput (IpcPrimaryDiagnostic? diagnostic)
+    {
+        if (diagnostic is null || !StringValueNormalizer.TryTrimToNonEmpty(diagnostic.Kind, out var kind))
+        {
+            return null;
+        }
+
+        return new DaemonPrimaryDiagnosticOutput(
+            Kind: kind,
+            Code: StringValueNormalizer.TrimToNull(diagnostic.Code),
+            File: StringValueNormalizer.TrimToNull(diagnostic.File),
+            Line: diagnostic.Line,
+            Column: diagnostic.Column,
+            Message: StringValueNormalizer.TrimToNull(diagnostic.Message));
+    }
+}

--- a/src/Ucli.Application/Features/Play/Common/Projection/PlayOutputProjectionFactory.cs
+++ b/src/Ucli.Application/Features/Play/Common/Projection/PlayOutputProjectionFactory.cs
@@ -1,9 +1,10 @@
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.Play.Common.Contracts;
 using MackySoft.Ucli.Application.Shared.CommandContracts.Projection;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Text;
 
-namespace MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+namespace MackySoft.Ucli.Application.Features.Play.Common.Projection;
 
 /// <summary> Creates public Play Mode command projection values from IPC lifecycle contracts. </summary>
 internal static class PlayOutputProjectionFactory

--- a/src/Ucli.Application/Features/Play/UseCases/Enter/PlayEnterService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Enter/PlayEnterService.cs
@@ -1,6 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Play.Common;
-using MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+using MackySoft.Ucli.Application.Features.Play.Common.Projection;
 using MackySoft.Ucli.Application.Shared.CommandContracts.Projection;
 using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Contracts.Ipc;

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/IPlayExitService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/IPlayExitService.cs
@@ -1,0 +1,13 @@
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+
+/// <summary> Provides Play Mode exit workflow execution. </summary>
+internal interface IPlayExitService
+{
+    /// <summary> Executes one Play Mode exit workflow. </summary>
+    /// <param name="input"> The normalized command input. </param>
+    /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
+    /// <returns> A task that resolves to the Play Mode exit result. </returns>
+    ValueTask<PlayExitExecutionResult> ExecuteAsync (
+        PlayExitCommandInput input,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitCommandInput.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitCommandInput.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+
+/// <summary> Represents normalized CLI input values for one Play Mode exit execution. </summary>
+/// <param name="ProjectPath"> The optional Unity project path. </param>
+/// <param name="TimeoutMilliseconds"> The optional normalized timeout in milliseconds. </param>
+internal sealed record PlayExitCommandInput (
+    string? ProjectPath,
+    int? TimeoutMilliseconds);

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitExecutionOutput.cs
@@ -1,0 +1,24 @@
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
+using MackySoft.Ucli.Application.Shared.CommandContracts;
+
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+
+/// <summary> Represents normalized output payload values for one Play Mode exit command execution. </summary>
+internal sealed record PlayExitExecutionOutput (
+    ProjectIdentityInfo Project,
+    DaemonStatusKind DaemonStatus,
+    string? ServerVersion,
+    string EditorMode,
+    string? LifecycleState,
+    string? BlockingReason,
+    string? CompileState,
+    string? CompileGeneration,
+    string? DomainReloadGeneration,
+    bool CanAcceptExecutionRequests,
+    DateTimeOffset? ObservedAtUtc,
+    string? ActionRequired,
+    DaemonPrimaryDiagnosticOutput? PrimaryDiagnostic,
+    PlayModeSnapshotOutput PlayMode,
+    PlayExitTransitionOutput Transition,
+    int TimeoutMilliseconds);

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitExecutionResult.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitExecutionResult.cs
@@ -1,0 +1,50 @@
+using MackySoft.Ucli.Application.Shared.Execution;
+using MackySoft.Ucli.Application.Shared.Foundation;
+
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+
+/// <summary> Represents the result of Play Mode exit workflow execution. </summary>
+internal sealed record PlayExitExecutionResult (
+    PlayExitExecutionOutput? Output,
+    ApplicationFailure? Error)
+{
+    private const string SuccessMessage = "uCLI play exit completed.";
+
+    private const string FailureMessage = "uCLI play exit failed.";
+
+    /// <summary> Gets a value indicating whether the workflow succeeded. </summary>
+    public bool IsSuccess => Output is not null && Error is null;
+
+    /// <summary> Gets the user-facing command message. </summary>
+    public string Message => IsSuccess ? SuccessMessage : Error?.Message ?? FailureMessage;
+
+    /// <summary> Creates a successful result. </summary>
+    /// <param name="output"> The normalized output payload values. </param>
+    /// <returns> The successful result. </returns>
+    public static PlayExitExecutionResult Success (PlayExitExecutionOutput output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        return new PlayExitExecutionResult(output, null);
+    }
+
+    /// <summary> Creates a failed result from a structured execution error. </summary>
+    /// <param name="error"> The structured execution error. </param>
+    /// <returns> The failed result. </returns>
+    public static PlayExitExecutionResult Failure (ExecutionError error)
+    {
+        ArgumentNullException.ThrowIfNull(error);
+        return Failure(ApplicationFailure.FromExecutionError(error));
+    }
+
+    /// <summary> Creates a failed result from an application failure. </summary>
+    /// <param name="failure"> The classified application failure. </param>
+    /// <param name="output"> The transition output when Unity returned one before failing. </param>
+    /// <returns> The failed result. </returns>
+    public static PlayExitExecutionResult Failure (
+        ApplicationFailure failure,
+        PlayExitExecutionOutput? output = null)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new PlayExitExecutionResult(output, failure);
+    }
+}

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
@@ -1,6 +1,6 @@
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
 using MackySoft.Ucli.Application.Features.Play.Common;
-using MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+using MackySoft.Ucli.Application.Features.Play.Common.Projection;
 using MackySoft.Ucli.Application.Shared.CommandContracts.Projection;
 using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Contracts.Ipc;

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
@@ -5,23 +5,23 @@ using MackySoft.Ucli.Application.Shared.CommandContracts.Projection;
 using MackySoft.Ucli.Application.Shared.Execution;
 using MackySoft.Ucli.Contracts.Ipc;
 
-namespace MackySoft.Ucli.Application.Features.Play.UseCases.Enter;
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
 
-/// <summary> Executes Play Mode enter against an existing registered GUI daemon session. </summary>
-internal sealed class PlayEnterService : IPlayEnterService
+/// <summary> Executes Play Mode exit against an existing registered GUI daemon session. </summary>
+internal sealed class PlayExitService : IPlayExitService
 {
     private const int ResponseGraceMilliseconds = 1000;
-    private const string SessionNotAvailableMessage = "Registered GUI daemon session is not available for Play Mode enter.";
-    private const string RequiresGuiEditorMessage = "Play Mode enter requires a registered GUI daemon session.";
+    private const string SessionNotAvailableMessage = "Registered GUI daemon session is not available for Play Mode exit.";
+    private const string RequiresGuiEditorMessage = "Play Mode exit requires a registered GUI daemon session.";
 
     private readonly IPlayCommandExecutionContextResolver contextResolver;
 
     private readonly IUnityRequestExecutor unityRequestExecutor;
 
-    /// <summary> Initializes a new instance of the <see cref="PlayEnterService" /> class. </summary>
+    /// <summary> Initializes a new instance of the <see cref="PlayExitService" /> class. </summary>
     /// <param name="contextResolver"> The Play Mode command context resolver dependency. </param>
     /// <param name="unityRequestExecutor"> The Unity IPC request executor dependency. </param>
-    public PlayEnterService (
+    public PlayExitService (
         IPlayCommandExecutionContextResolver contextResolver,
         IUnityRequestExecutor unityRequestExecutor)
     {
@@ -30,8 +30,8 @@ internal sealed class PlayEnterService : IPlayEnterService
     }
 
     /// <inheritdoc />
-    public async ValueTask<PlayEnterExecutionResult> ExecuteAsync (
-        PlayEnterCommandInput input,
+    public async ValueTask<PlayExitExecutionResult> ExecuteAsync (
+        PlayExitCommandInput input,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -40,36 +40,36 @@ internal sealed class PlayEnterService : IPlayEnterService
         var contextResult = await contextResolver.ResolveAsync(
                 input.ProjectPath,
                 input.TimeoutMilliseconds,
-                UcliCommandIds.PlayEnter,
+                UcliCommandIds.PlayExit,
                 SessionNotAvailableMessage,
                 RequiresGuiEditorMessage,
                 cancellationToken)
             .ConfigureAwait(false);
         if (!contextResult.IsSuccess)
         {
-            return PlayEnterExecutionResult.Failure(contextResult.Error!);
+            return PlayExitExecutionResult.Failure(contextResult.Error!);
         }
 
         var context = contextResult.Context!;
         var requestTimeout = context.Timeout + TimeSpan.FromMilliseconds(ResponseGraceMilliseconds);
         var executionResult = await unityRequestExecutor.ExecuteAsync(
-                UcliCommandIds.PlayEnter,
+                UcliCommandIds.PlayExit,
                 UnityExecutionMode.Daemon,
                 requestTimeout,
                 context.ProjectContext.Config,
                 context.ProjectContext.UnityProject,
-                new UnityRequestPayload.PlayEnter(context.TimeoutMilliseconds),
+                new UnityRequestPayload.PlayExit(context.TimeoutMilliseconds),
                 cancellationToken)
             .ConfigureAwait(false);
         if (!executionResult.IsSuccess)
         {
-            return PlayEnterExecutionResult.Failure(CreateErrorFromUnityRequestFailure(executionResult.FailureInfo!));
+            return PlayExitExecutionResult.Failure(CreateErrorFromUnityRequestFailure(executionResult.FailureInfo!));
         }
 
         return CreateResultFromResponse(context, executionResult.Response!);
     }
 
-    private PlayEnterExecutionResult CreateResultFromResponse (
+    private PlayExitExecutionResult CreateResultFromResponse (
         PlayCommandExecutionContext context,
         UnityRequestResponse response)
     {
@@ -77,47 +77,47 @@ internal sealed class PlayEnterService : IPlayEnterService
         {
             if (!TryReadTransitionResponse(response, out var errorTransitionResponse, out _))
             {
-                return PlayEnterExecutionResult.Failure(CreateErrorFromResponse(response));
+                return PlayExitExecutionResult.Failure(CreateErrorFromResponse(response));
             }
 
             var errorOutputResult = CreateOutput(context, errorTransitionResponse!.Transition);
             if (!errorOutputResult.IsSuccess)
             {
-                return PlayEnterExecutionResult.Failure(errorOutputResult.Error!);
+                return PlayExitExecutionResult.Failure(errorOutputResult.Error!);
             }
 
             var errorOutput = errorOutputResult.Output!;
-            return PlayEnterExecutionResult.Failure(CreateErrorFromResponse(response, errorOutput.Transition), errorOutput);
+            return PlayExitExecutionResult.Failure(CreateErrorFromResponse(response, errorOutput.Transition), errorOutput);
         }
 
         if (!TryReadTransitionResponse(response, out var transitionResponse, out var payloadFailure))
         {
-            return PlayEnterExecutionResult.Failure(payloadFailure!);
+            return PlayExitExecutionResult.Failure(payloadFailure!);
         }
 
         var outputResult = CreateOutput(context, transitionResponse!.Transition);
         if (!outputResult.IsSuccess)
         {
-            return PlayEnterExecutionResult.Failure(outputResult.Error!);
+            return PlayExitExecutionResult.Failure(outputResult.Error!);
         }
 
         var output = outputResult.Output!;
         return output.Transition.Result switch
         {
-            IpcPlayTransitionResultNames.Entered or IpcPlayTransitionResultNames.AlreadyEntered
-                => PlayEnterExecutionResult.Success(output),
+            IpcPlayTransitionResultNames.Exited or IpcPlayTransitionResultNames.AlreadyExited
+                => PlayExitExecutionResult.Success(output),
             IpcPlayTransitionResultNames.Timeout
-                => PlayEnterExecutionResult.Failure(CreateTransitionFailure(
+                => PlayExitExecutionResult.Failure(CreateTransitionFailure(
                     PlayModeErrorCodes.PlayModeTransitionTimeout,
-                    $"Unity Play Mode enter timed out after {context.TimeoutMilliseconds} milliseconds."),
+                    $"Unity Play Mode exit timed out after {context.TimeoutMilliseconds} milliseconds."),
                     output),
             IpcPlayTransitionResultNames.Blocked
-                => PlayEnterExecutionResult.Failure(CreateTransitionFailure(
+                => PlayExitExecutionResult.Failure(CreateTransitionFailure(
                     PlayModeErrorCodes.PlayModeTransitionBlocked,
-                    "Unity Play Mode enter was blocked by the current editor lifecycle state."),
+                    "Unity Play Mode exit was blocked by the current editor lifecycle state."),
                     output),
-            _ => PlayEnterExecutionResult.Failure(CreateStateUnknownFailure(
-                $"Unity play enter returned unsupported result '{output.Transition.Result}'.")),
+            _ => PlayExitExecutionResult.Failure(CreateStateUnknownFailure(
+                $"Unity play exit returned unsupported result '{output.Transition.Result}'.")),
         };
     }
 
@@ -134,57 +134,57 @@ internal sealed class PlayEnterService : IPlayEnterService
         }
 
         transitionResponse = null;
-        failure = ApplicationFailure.InternalError($"Unity play enter payload is invalid. {payloadError.Message}");
+        failure = ApplicationFailure.InternalError($"Unity play exit payload is invalid. {payloadError.Message}");
         return false;
     }
 
-    private static PlayEnterOutputCreationResult CreateOutput (
+    private static PlayExitOutputCreationResult CreateOutput (
         PlayCommandExecutionContext context,
         IpcPlayTransitionResult transition)
     {
-        if (!string.Equals(transition.Transition, IpcPlayTransitionCommandNames.Enter, StringComparison.Ordinal))
+        if (!string.Equals(transition.Transition, IpcPlayTransitionCommandNames.Exit, StringComparison.Ordinal))
         {
-            return PlayEnterOutputCreationResult.Failure(ApplicationFailure.InternalError(
-                $"Unity play enter transition mismatch. Actual={transition.Transition}."));
+            return PlayExitOutputCreationResult.Failure(ApplicationFailure.InternalError(
+                $"Unity play exit transition mismatch. Actual={transition.Transition}."));
         }
 
         if (transition.Before is null)
         {
-            return PlayEnterOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play enter transition before snapshot is missing."));
+            return PlayExitOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play exit transition before snapshot is missing."));
         }
 
         var shapeFailure = ValidateTransitionShape(transition);
         if (shapeFailure is not null)
         {
-            return PlayEnterOutputCreationResult.Failure(shapeFailure);
+            return PlayExitOutputCreationResult.Failure(shapeFailure);
         }
 
         var currentSnapshot = ResolveCurrentSnapshot(transition);
         if (currentSnapshot is null)
         {
-            return PlayEnterOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play enter current lifecycle snapshot is missing."));
+            return PlayExitOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play exit current lifecycle snapshot is missing."));
         }
 
         var validationFailure = ValidateTransitionSnapshots(context, transition, currentSnapshot);
         if (validationFailure is not null)
         {
-            return PlayEnterOutputCreationResult.Failure(validationFailure);
+            return PlayExitOutputCreationResult.Failure(validationFailure);
         }
 
         var lifecycle = LifecycleProjectionFactory.Create(currentSnapshot);
         if (!string.Equals(lifecycle.EditorMode, DaemonEditorModeValues.Gui, StringComparison.Ordinal))
         {
-            return PlayEnterOutputCreationResult.Failure(ApplicationFailure.InternalError(
+            return PlayExitOutputCreationResult.Failure(ApplicationFailure.InternalError(
                 RequiresGuiEditorMessage,
                 PlayModeErrorCodes.PlayModeRequiresGuiEditor));
         }
 
         if (lifecycle.PlayMode is null)
         {
-            return PlayEnterOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play enter playMode snapshot is missing or invalid."));
+            return PlayExitOutputCreationResult.Failure(CreateStateUnknownFailure("Unity play exit playMode snapshot is missing or invalid."));
         }
 
-        return PlayEnterOutputCreationResult.Success(new PlayEnterExecutionOutput(
+        return PlayExitOutputCreationResult.Success(new PlayExitExecutionOutput(
             Project: context.Project,
             DaemonStatus: DaemonStatusKind.Running,
             ServerVersion: lifecycle.ServerVersion,
@@ -207,19 +207,19 @@ internal sealed class PlayEnterService : IPlayEnterService
     {
         if (!string.IsNullOrWhiteSpace(transition.Until))
         {
-            return CreateStateUnknownFailure("Unity play enter transition unexpectedly included a wait target.");
+            return CreateStateUnknownFailure("Unity play exit transition unexpectedly included a wait target.");
         }
 
         return transition.Result switch
         {
-            IpcPlayTransitionResultNames.Entered or IpcPlayTransitionResultNames.AlreadyEntered
+            IpcPlayTransitionResultNames.Exited or IpcPlayTransitionResultNames.AlreadyExited
                 => transition.After is null
-                    ? CreateStateUnknownFailure("Unity play enter success omitted the after snapshot.")
+                    ? CreateStateUnknownFailure("Unity play exit success omitted the after snapshot.")
                     : transition.Observed is not null || !string.IsNullOrWhiteSpace(transition.ApplicationState)
-                        ? CreateStateUnknownFailure("Unity play enter success included transition error fields.")
+                        ? CreateStateUnknownFailure("Unity play exit success included transition error fields.")
                         : null,
             IpcPlayTransitionResultNames.Timeout or IpcPlayTransitionResultNames.Blocked => ValidateTransitionErrorShape(transition),
-            _ => CreateStateUnknownFailure($"Unity play enter returned unsupported result '{transition.Result}'."),
+            _ => CreateStateUnknownFailure($"Unity play exit returned unsupported result '{transition.Result}'."),
         };
     }
 
@@ -227,27 +227,27 @@ internal sealed class PlayEnterService : IPlayEnterService
     {
         if (transition.After is not null)
         {
-            return CreateStateUnknownFailure("Unity play enter transition error included the after snapshot.");
+            return CreateStateUnknownFailure("Unity play exit transition error included the after snapshot.");
         }
 
         return IsValidApplicationState(transition.ApplicationState)
             ? null
-            : CreateStateUnknownFailure($"Unity play enter transition error applicationState is invalid. Actual={transition.ApplicationState}.");
+            : CreateStateUnknownFailure($"Unity play exit transition error applicationState is invalid. Actual={transition.ApplicationState}.");
     }
 
     private static IpcPlayLifecycleSnapshot? ResolveCurrentSnapshot (IpcPlayTransitionResult transition)
     {
         return transition.Result switch
         {
-            IpcPlayTransitionResultNames.Entered or IpcPlayTransitionResultNames.AlreadyEntered => transition.After,
+            IpcPlayTransitionResultNames.Exited or IpcPlayTransitionResultNames.AlreadyExited => transition.After,
             IpcPlayTransitionResultNames.Timeout or IpcPlayTransitionResultNames.Blocked => transition.Observed,
             _ => null,
         };
     }
 
-    private static PlayEnterTransitionOutput CreateTransitionOutput (IpcPlayTransitionResult transition)
+    private static PlayExitTransitionOutput CreateTransitionOutput (IpcPlayTransitionResult transition)
     {
-        return new PlayEnterTransitionOutput(
+        return new PlayExitTransitionOutput(
             Transition: transition.Transition,
             Result: transition.Result,
             Before: PlayOutputProjectionFactory.CreateSnapshotOutput(transition.Before),
@@ -275,11 +275,11 @@ internal sealed class PlayEnterService : IPlayEnterService
 
         return transition.Result switch
         {
-            IpcPlayTransitionResultNames.Entered => ValidateEntered(transition.Before, currentSnapshot),
-            IpcPlayTransitionResultNames.AlreadyEntered => ValidateAlreadyEntered(transition.Before, currentSnapshot),
+            IpcPlayTransitionResultNames.Exited => ValidateExited(transition.Before, currentSnapshot),
+            IpcPlayTransitionResultNames.AlreadyExited => ValidateAlreadyExited(transition.Before, currentSnapshot),
             IpcPlayTransitionResultNames.Timeout => ValidateErrorTransition(transition, IpcPlayApplicationStateNames.Indeterminate),
             IpcPlayTransitionResultNames.Blocked => ValidateErrorTransition(transition, expectedApplicationState: null),
-            _ => CreateStateUnknownFailure($"Unity play enter returned unsupported result '{transition.Result}'."),
+            _ => CreateStateUnknownFailure($"Unity play exit returned unsupported result '{transition.Result}'."),
         };
     }
 
@@ -291,48 +291,48 @@ internal sealed class PlayEnterService : IPlayEnterService
         if (!string.Equals(snapshot.ProjectFingerprint, context.Project.ProjectFingerprint, StringComparison.Ordinal))
         {
             return ApplicationFailure.InternalError(
-                $"Unity play enter {label} projectFingerprint mismatch. Requested={context.Project.ProjectFingerprint}, Actual={snapshot.ProjectFingerprint}.");
+                $"Unity play exit {label} projectFingerprint mismatch. Requested={context.Project.ProjectFingerprint}, Actual={snapshot.ProjectFingerprint}.");
         }
 
         return PlayModeSnapshotOutputFactory.Create(snapshot.PlayMode) is null
-            ? CreateStateUnknownFailure($"Unity play enter {label} playMode snapshot is missing or invalid.")
+            ? CreateStateUnknownFailure($"Unity play exit {label} playMode snapshot is missing or invalid.")
             : null;
     }
 
-    private static ApplicationFailure? ValidateEntered (
+    private static ApplicationFailure? ValidateExited (
         IpcPlayLifecycleSnapshot before,
         IpcPlayLifecycleSnapshot after)
     {
-        if (!IsReadyStoppedSnapshot(before))
+        if (!IsEnteredSnapshot(before))
         {
-            return CreateStateUnknownFailure("Unity play enter reported entered without a ready stopped before snapshot.");
+            return CreateStateUnknownFailure("Unity play exit reported exited without a playing before snapshot.");
         }
 
-        if (!IsEnteredSnapshot(after))
+        if (!IsReadyStoppedSnapshot(after))
         {
-            return CreateStateUnknownFailure("Unity play enter reported entered without a playing snapshot.");
+            return CreateStateUnknownFailure("Unity play exit reported exited without a ready stopped snapshot.");
         }
 
         if (string.Equals(before.PlayMode?.Generation, after.PlayMode?.Generation, StringComparison.Ordinal))
         {
-            return CreateStateUnknownFailure("Unity play enter reported entered without changing playMode.generation.");
+            return CreateStateUnknownFailure("Unity play exit reported exited without changing playMode.generation.");
         }
 
         return null;
     }
 
-    private static ApplicationFailure? ValidateAlreadyEntered (
+    private static ApplicationFailure? ValidateAlreadyExited (
         IpcPlayLifecycleSnapshot before,
         IpcPlayLifecycleSnapshot after)
     {
-        if (!IsEnteredSnapshot(before) || !IsEnteredSnapshot(after))
+        if (!IsStoppedPlayModeSnapshot(before) || !IsStoppedPlayModeSnapshot(after))
         {
-            return CreateStateUnknownFailure("Unity play enter reported alreadyEntered without a playing snapshot.");
+            return CreateStateUnknownFailure("Unity play exit reported alreadyExited without a stopped snapshot.");
         }
 
         if (!string.Equals(before.PlayMode?.Generation, after.PlayMode?.Generation, StringComparison.Ordinal))
         {
-            return CreateStateUnknownFailure("Unity play enter reported alreadyEntered after changing playMode.generation.");
+            return CreateStateUnknownFailure("Unity play exit reported alreadyExited after changing playMode.generation.");
         }
 
         return null;
@@ -344,25 +344,25 @@ internal sealed class PlayEnterService : IPlayEnterService
     {
         if (transition.Observed is null)
         {
-            return CreateStateUnknownFailure("Unity play enter transition error omitted the observed snapshot.");
+            return CreateStateUnknownFailure("Unity play exit transition error omitted the observed snapshot.");
         }
 
         if (expectedApplicationState is not null
             && !string.Equals(transition.ApplicationState, expectedApplicationState, StringComparison.Ordinal))
         {
             return CreateStateUnknownFailure(
-                $"Unity play enter transition error applicationState mismatch. Expected={expectedApplicationState}, Actual={transition.ApplicationState}.");
+                $"Unity play exit transition error applicationState mismatch. Expected={expectedApplicationState}, Actual={transition.ApplicationState}.");
         }
 
         if (string.IsNullOrWhiteSpace(transition.ApplicationState))
         {
-            return CreateStateUnknownFailure("Unity play enter transition error omitted applicationState.");
+            return CreateStateUnknownFailure("Unity play exit transition error omitted applicationState.");
         }
 
         if (!IsValidApplicationState(transition.ApplicationState))
         {
             return CreateStateUnknownFailure(
-                $"Unity play enter transition error applicationState is invalid. Actual={transition.ApplicationState}.");
+                $"Unity play exit transition error applicationState is invalid. Actual={transition.ApplicationState}.");
         }
 
         return null;
@@ -378,14 +378,19 @@ internal sealed class PlayEnterService : IPlayEnterService
 
     private static bool IsReadyStoppedSnapshot (IpcPlayLifecycleSnapshot snapshot)
     {
+        return IsStoppedPlayModeSnapshot(snapshot)
+            && string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
+            && string.IsNullOrWhiteSpace(snapshot.BlockingReason)
+            && snapshot.CanAcceptExecutionRequests;
+    }
+
+    private static bool IsStoppedPlayModeSnapshot (IpcPlayLifecycleSnapshot snapshot)
+    {
         return TryReadPlayModeSnapshot(
                 snapshot,
                 out var playMode,
                 out var playModeState,
                 out var playModeTransition)
-            && string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
-            && string.IsNullOrWhiteSpace(snapshot.BlockingReason)
-            && snapshot.CanAcceptExecutionRequests
             && playModeState == IpcPlayModeState.Stopped
             && playModeTransition == IpcPlayModeTransition.None
             && !playMode.IsPlaying
@@ -433,7 +438,7 @@ internal sealed class PlayEnterService : IPlayEnterService
     {
         var firstError = response.Errors.FirstOrDefault();
         var message = string.IsNullOrWhiteSpace(firstError?.Message)
-            ? $"Unity play enter IPC failed with status '{response.FailureStatus}'."
+            ? $"Unity play exit IPC failed with status '{response.FailureStatus}'."
             : firstError!.Message;
         var code = firstError?.Code;
         if (code == PlayModeErrorCodes.PlayModeTransitionTimeout)
@@ -448,7 +453,7 @@ internal sealed class PlayEnterService : IPlayEnterService
 
     private static ApplicationFailure CreateErrorFromResponse (
         UnityRequestResponse response,
-        PlayEnterTransitionOutput transition)
+        PlayExitTransitionOutput transition)
     {
         var responseCode = response.Errors.FirstOrDefault()?.Code;
         var failure = CreateErrorFromResponse(response);
@@ -476,20 +481,20 @@ internal sealed class PlayEnterService : IPlayEnterService
         return ApplicationFailure.InternalError(message, PlayModeErrorCodes.PlayModeStateUnknown);
     }
 
-    private sealed record PlayEnterOutputCreationResult (
-        PlayEnterExecutionOutput? Output,
+    private sealed record PlayExitOutputCreationResult (
+        PlayExitExecutionOutput? Output,
         ApplicationFailure? Error)
     {
         public bool IsSuccess => Output is not null && Error is null;
 
-        public static PlayEnterOutputCreationResult Success (PlayEnterExecutionOutput output)
+        public static PlayExitOutputCreationResult Success (PlayExitExecutionOutput output)
         {
-            return new PlayEnterOutputCreationResult(output, null);
+            return new PlayExitOutputCreationResult(output, null);
         }
 
-        public static PlayEnterOutputCreationResult Failure (ApplicationFailure error)
+        public static PlayExitOutputCreationResult Failure (ApplicationFailure error)
         {
-            return new PlayEnterOutputCreationResult(null, error);
+            return new PlayExitOutputCreationResult(null, error);
         }
     }
 }

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitTransitionOutput.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitTransitionOutput.cs
@@ -1,0 +1,12 @@
+using MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+
+namespace MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+
+/// <summary> Represents the public <c>play.exit</c> transition payload shape. </summary>
+internal sealed record PlayExitTransitionOutput (
+    string Transition,
+    string Result,
+    PlayLifecycleSnapshotOutput Before,
+    PlayLifecycleSnapshotOutput? After,
+    PlayLifecycleSnapshotOutput? Observed,
+    string? ApplicationState);

--- a/src/Ucli.Application/Shared/Configuration/IpcTimeoutDefaults.cs
+++ b/src/Ucli.Application/Shared/Configuration/IpcTimeoutDefaults.cs
@@ -29,6 +29,7 @@ internal static class IpcTimeoutDefaults
         (UcliCommandIds.LogsUnityClear, 3000),
         (UcliCommandIds.PlayStatus, 3000),
         (UcliCommandIds.PlayEnter, 30000),
+        (UcliCommandIds.PlayExit, 30000),
     ];
 
     private static readonly HashSet<UcliCommand> SupportedCommandSet = CreateSupportedCommandSet();

--- a/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
+++ b/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
@@ -26,6 +26,10 @@ internal abstract record UnityRequestPayload
     internal sealed record PlayEnter (
         int TimeoutMilliseconds) : UnityRequestPayload;
 
+    /// <summary> Represents a Play Mode exit request prepared by application orchestration. </summary>
+    internal sealed record PlayExit (
+        int TimeoutMilliseconds) : UnityRequestPayload;
+
     /// <summary> Represents an execute request whose execute-arguments JSON was already prepared. </summary>
     internal sealed record ExecuteJson (
         UcliCommand Command,

--- a/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
+++ b/src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Prefligh
 using MackySoft.Ucli.Application.Features.OperationCatalog.UseCases.Ops.Projection;
 using MackySoft.Ucli.Application.Features.Play.Common;
 using MackySoft.Ucli.Application.Features.Play.UseCases.Enter;
+using MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
 using MackySoft.Ucli.Application.Features.Play.UseCases.Status;
 using MackySoft.Ucli.Application.Features.Requests.Call.UseCases.Call;
 using MackySoft.Ucli.Application.Features.Requests.Plan.UseCases.Plan;
@@ -218,6 +219,7 @@ public static class UcliApplicationServiceCollectionExtensions
     {
         services.AddSingleton<IPlayCommandExecutionContextResolver, PlayCommandExecutionContextResolver>();
         services.AddSingleton<IPlayEnterService, PlayEnterService>();
+        services.AddSingleton<IPlayExitService, PlayExitService>();
         services.AddSingleton<IPlayStatusService, PlayStatusService>();
         return services;
     }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
@@ -62,6 +62,8 @@ namespace MackySoft.Ucli.Unity.Ipc
             services.AddSingleton<IUnityTestResultsXmlWriter, UnityTestResultsXmlWriter>();
             services.AddSingleton<IUnityTestRunService, UnityTestRunService>();
             services.AddSingleton<IServerVersionProvider, AssemblyServerVersionProvider>();
+            services.AddSingleton<IUnityEditorUpdateAwaiter, UnityEditorUpdateAwaiterAdapter>();
+            services.AddSingleton<IUnityPlayModeController, UnityEditorPlayModeController>();
             services.AddSingleton<PlayEnterTransitionRunner>();
             services.AddSingleton<PlayExitTransitionRunner>();
             services.AddSingleton<IUnityIpcMethodHandler>(serviceProvider =>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
@@ -62,6 +62,8 @@ namespace MackySoft.Ucli.Unity.Ipc
             services.AddSingleton<IUnityTestResultsXmlWriter, UnityTestResultsXmlWriter>();
             services.AddSingleton<IUnityTestRunService, UnityTestRunService>();
             services.AddSingleton<IServerVersionProvider, AssemblyServerVersionProvider>();
+            services.AddSingleton<PlayEnterTransitionRunner>();
+            services.AddSingleton<PlayExitTransitionRunner>();
             services.AddSingleton<IUnityIpcMethodHandler>(serviceProvider =>
             {
                 return new PingUnityIpcMethodHandler(
@@ -87,14 +89,8 @@ namespace MackySoft.Ucli.Unity.Ipc
                     serviceProvider.GetRequiredService<IpcProjectIdentity>(),
                     serviceProvider.GetRequiredService<IDaemonLogger>());
             });
-            services.AddSingleton<IUnityIpcMethodHandler>(serviceProvider =>
-            {
-                return new PlayEnterUnityIpcMethodHandler(
-                    serviceProvider.GetRequiredService<IServerVersionProvider>(),
-                    serviceProvider.GetRequiredService<IUnityEditorReadinessGate>(),
-                    serviceProvider.GetRequiredService<IpcProjectIdentity>(),
-                    serviceProvider.GetRequiredService<IDaemonLogger>());
-            });
+            services.AddSingleton<IUnityIpcMethodHandler, PlayEnterUnityIpcMethodHandler>();
+            services.AddSingleton<IUnityIpcMethodHandler, PlayExitUnityIpcMethodHandler>();
             services.AddSingleton<IUnityIpcMethodHandler, TestRunUnityIpcMethodHandler>();
             services.AddSingleton<IUnityIpcMethodHandler, OpsReadUnityIpcMethodHandler>();
             services.AddSingleton<IUnityIpcMethodHandler, IndexAssetsReadUnityIpcMethodHandler>();

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayEnter/PlayEnterTransitionRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayEnter/PlayEnterTransitionRunner.cs
@@ -5,7 +5,6 @@ using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Daemon;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Runtime;
-using UnityEditor;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -17,50 +16,30 @@ namespace MackySoft.Ucli.Unity.Ipc
         private readonly IServerVersionProvider serverVersionProvider;
         private readonly IUnityEditorReadinessGate readinessGate;
         private readonly IpcProjectIdentity projectIdentity;
-        private readonly Func<CancellationToken, Task> editorUpdateAwaiter;
-        private readonly Action enterPlayModeRequester;
+        private readonly IUnityEditorUpdateAwaiter editorUpdateAwaiter;
+        private readonly IUnityPlayModeController playModeController;
         private readonly IDaemonLogger daemonLogger;
 
         /// <summary> Initializes a new instance of the <see cref="PlayEnterTransitionRunner" /> class. </summary>
         /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
         /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
         /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
+        /// <param name="editorUpdateAwaiter"> The editor update awaiter dependency. </param>
+        /// <param name="playModeController"> The Play Mode controller dependency. </param>
         /// <param name="daemonLogger"> The daemon logger dependency. </param>
         public PlayEnterTransitionRunner (
             IServerVersionProvider serverVersionProvider,
             IUnityEditorReadinessGate readinessGate,
             IpcProjectIdentity projectIdentity,
-            IDaemonLogger daemonLogger = null)
-            : this(
-                serverVersionProvider,
-                readinessGate,
-                projectIdentity,
-                UnityEditorUpdateAwaiter.WaitForNextUpdateAsync,
-                static () => EditorApplication.EnterPlaymode(),
-                daemonLogger)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="PlayEnterTransitionRunner" /> class. </summary>
-        /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
-        /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
-        /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
-        /// <param name="editorUpdateAwaiter"> The editor update awaiter dependency. </param>
-        /// <param name="enterPlayModeRequester"> The Unity Play Mode enter requester dependency. </param>
-        /// <param name="daemonLogger"> The daemon logger dependency. </param>
-        internal PlayEnterTransitionRunner (
-            IServerVersionProvider serverVersionProvider,
-            IUnityEditorReadinessGate readinessGate,
-            IpcProjectIdentity projectIdentity,
-            Func<CancellationToken, Task> editorUpdateAwaiter,
-            Action enterPlayModeRequester,
+            IUnityEditorUpdateAwaiter editorUpdateAwaiter,
+            IUnityPlayModeController playModeController,
             IDaemonLogger daemonLogger = null)
         {
             this.serverVersionProvider = serverVersionProvider ?? throw new ArgumentNullException(nameof(serverVersionProvider));
             this.readinessGate = readinessGate ?? throw new ArgumentNullException(nameof(readinessGate));
             this.projectIdentity = projectIdentity ?? throw new ArgumentNullException(nameof(projectIdentity));
             this.editorUpdateAwaiter = editorUpdateAwaiter ?? throw new ArgumentNullException(nameof(editorUpdateAwaiter));
-            this.enterPlayModeRequester = enterPlayModeRequester ?? throw new ArgumentNullException(nameof(enterPlayModeRequester));
+            this.playModeController = playModeController ?? throw new ArgumentNullException(nameof(playModeController));
             this.daemonLogger = daemonLogger ?? NoOpDaemonLogger.Instance;
         }
 
@@ -108,7 +87,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return CreateSuccess(IpcPlayTransitionResultNames.AlreadyEntered, before, before);
             }
 
-            // NOTE: This must be persisted before EditorApplication.EnterPlaymode is called.
+            // NOTE: This must be persisted before Unity is asked to enter Play Mode.
             // Entering Play Mode can trigger domain reload before this daemon can respond.
             var persistFailure = TryPersistPendingEnter(recoverableContext, before);
             if (persistFailure != null)
@@ -118,7 +97,7 @@ namespace MackySoft.Ucli.Unity.Ipc
 
             try
             {
-                enterPlayModeRequester();
+                playModeController.EnterPlayMode();
             }
             catch (Exception exception)
             {
@@ -194,7 +173,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 while (true)
                 {
                     timeoutCancellationTokenSource.Token.ThrowIfCancellationRequested();
-                    await editorUpdateAwaiter(timeoutCancellationTokenSource.Token);
+                    await editorUpdateAwaiter.WaitForNextUpdateAsync(timeoutCancellationTokenSource.Token);
                     observed = CaptureSnapshot();
 
                     if (IsEnteredSnapshot(observed) && HasGenerationChanged(before, observed))

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a372f7561dba466e9888febf30fad2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitRecoveryPayload.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitRecoveryPayload.cs
@@ -1,0 +1,23 @@
+using System;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Captures the snapshot needed to resume a recoverable Play Mode exit request. </summary>
+    internal sealed class PlayExitRecoveryPayload
+    {
+        /// <summary> Initializes a new instance of the <see cref="PlayExitRecoveryPayload" /> class. </summary>
+        public PlayExitRecoveryPayload ()
+        {
+        }
+
+        /// <summary> Initializes a new instance of the <see cref="PlayExitRecoveryPayload" /> class. </summary>
+        public PlayExitRecoveryPayload (IpcPlayLifecycleSnapshot before)
+        {
+            Before = before ?? throw new ArgumentNullException(nameof(before));
+        }
+
+        /// <summary> Gets or sets the lifecycle snapshot captured before requesting Play Mode exit. </summary>
+        public IpcPlayLifecycleSnapshot Before { get; set; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitRecoveryPayload.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitRecoveryPayload.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ccf18bae5870433ab5a550d244e3e29

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionExecutionResult.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionExecutionResult.cs
@@ -1,0 +1,32 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Represents a Unity-side Play Mode exit transition response and optional structured error. </summary>
+    internal sealed record PlayExitTransitionExecutionResult (
+        IpcPlayTransitionResponse Response,
+        IpcError Error)
+    {
+        /// <summary> Gets a value indicating whether the transition request succeeded. </summary>
+        public bool IsSuccess => Error == null;
+
+        /// <summary> Creates a successful transition result. </summary>
+        /// <param name="response"> The structured transition response. </param>
+        /// <returns> The successful result. </returns>
+        public static PlayExitTransitionExecutionResult Success (IpcPlayTransitionResponse response)
+        {
+            return new PlayExitTransitionExecutionResult(response, null);
+        }
+
+        /// <summary> Creates a failed transition result. </summary>
+        /// <param name="response"> The structured transition response. </param>
+        /// <param name="error"> The structured transition error. </param>
+        /// <returns> The failed result. </returns>
+        public static PlayExitTransitionExecutionResult Failure (
+            IpcPlayTransitionResponse response,
+            IpcError error)
+        {
+            return new PlayExitTransitionExecutionResult(response, error);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionExecutionResult.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionExecutionResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4c033ca3583a4c12a052631882a2755

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
@@ -5,7 +5,6 @@ using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Daemon;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Unity.Runtime;
-using UnityEditor;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -18,50 +17,30 @@ namespace MackySoft.Ucli.Unity.Ipc
         private readonly IServerVersionProvider serverVersionProvider;
         private readonly IUnityEditorReadinessGate readinessGate;
         private readonly IpcProjectIdentity projectIdentity;
-        private readonly Func<CancellationToken, Task> editorUpdateAwaiter;
-        private readonly Action exitPlayModeRequester;
+        private readonly IUnityEditorUpdateAwaiter editorUpdateAwaiter;
+        private readonly IUnityPlayModeController playModeController;
         private readonly IDaemonLogger daemonLogger;
 
         /// <summary> Initializes a new instance of the <see cref="PlayExitTransitionRunner" /> class. </summary>
         /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
         /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
         /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
+        /// <param name="editorUpdateAwaiter"> The editor update awaiter dependency. </param>
+        /// <param name="playModeController"> The Play Mode controller dependency. </param>
         /// <param name="daemonLogger"> The daemon logger dependency. </param>
         public PlayExitTransitionRunner (
             IServerVersionProvider serverVersionProvider,
             IUnityEditorReadinessGate readinessGate,
             IpcProjectIdentity projectIdentity,
-            IDaemonLogger daemonLogger = null)
-            : this(
-                serverVersionProvider,
-                readinessGate,
-                projectIdentity,
-                UnityEditorUpdateAwaiter.WaitForNextUpdateAsync,
-                static () => EditorApplication.ExitPlaymode(),
-                daemonLogger)
-        {
-        }
-
-        /// <summary> Initializes a new instance of the <see cref="PlayExitTransitionRunner" /> class. </summary>
-        /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
-        /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
-        /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
-        /// <param name="editorUpdateAwaiter"> The editor update awaiter dependency. </param>
-        /// <param name="exitPlayModeRequester"> The Unity Play Mode exit requester dependency. </param>
-        /// <param name="daemonLogger"> The daemon logger dependency. </param>
-        internal PlayExitTransitionRunner (
-            IServerVersionProvider serverVersionProvider,
-            IUnityEditorReadinessGate readinessGate,
-            IpcProjectIdentity projectIdentity,
-            Func<CancellationToken, Task> editorUpdateAwaiter,
-            Action exitPlayModeRequester,
+            IUnityEditorUpdateAwaiter editorUpdateAwaiter,
+            IUnityPlayModeController playModeController,
             IDaemonLogger daemonLogger = null)
         {
             this.serverVersionProvider = serverVersionProvider ?? throw new ArgumentNullException(nameof(serverVersionProvider));
             this.readinessGate = readinessGate ?? throw new ArgumentNullException(nameof(readinessGate));
             this.projectIdentity = projectIdentity ?? throw new ArgumentNullException(nameof(projectIdentity));
             this.editorUpdateAwaiter = editorUpdateAwaiter ?? throw new ArgumentNullException(nameof(editorUpdateAwaiter));
-            this.exitPlayModeRequester = exitPlayModeRequester ?? throw new ArgumentNullException(nameof(exitPlayModeRequester));
+            this.playModeController = playModeController ?? throw new ArgumentNullException(nameof(playModeController));
             this.daemonLogger = daemonLogger ?? NoOpDaemonLogger.Instance;
         }
 
@@ -109,7 +88,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return CreateSuccess(IpcPlayTransitionResultNames.AlreadyExited, before, before);
             }
 
-            // NOTE: This must be persisted before EditorApplication.ExitPlaymode is called.
+            // NOTE: This must be persisted before Unity is asked to exit Play Mode.
             // Leaving Play Mode can trigger domain reload before this daemon can respond.
             var persistFailure = TryPersistPendingExit(recoverableContext, before);
             if (persistFailure != null)
@@ -119,7 +98,7 @@ namespace MackySoft.Ucli.Unity.Ipc
 
             try
             {
-                exitPlayModeRequester();
+                playModeController.ExitPlayMode();
             }
             catch (Exception exception)
             {
@@ -196,7 +175,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 while (true)
                 {
                     timeoutCancellationTokenSource.Token.ThrowIfCancellationRequested();
-                    await editorUpdateAwaiter(timeoutCancellationTokenSource.Token);
+                    await editorUpdateAwaiter.WaitForNextUpdateAsync(timeoutCancellationTokenSource.Token);
                     observed = CaptureSnapshot();
 
                     if (IsReadyStoppedSnapshot(observed) && HasGenerationChanged(before, observed))

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
@@ -1,0 +1,622 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MackySoft.Ucli.Contracts;
+using MackySoft.Ucli.Contracts.Daemon;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
+using UnityEditor;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Executes and observes a Unity Editor Play Mode exit transition. </summary>
+    internal sealed class PlayExitTransitionRunner
+    {
+        private const int RejectedPlayingObservationThreshold = 2;
+        private const int StoppedWithoutGenerationChangeObservationThreshold = 2;
+
+        private readonly IServerVersionProvider serverVersionProvider;
+        private readonly IUnityEditorReadinessGate readinessGate;
+        private readonly IpcProjectIdentity projectIdentity;
+        private readonly Func<CancellationToken, Task> editorUpdateAwaiter;
+        private readonly Action exitPlayModeRequester;
+        private readonly IDaemonLogger daemonLogger;
+
+        /// <summary> Initializes a new instance of the <see cref="PlayExitTransitionRunner" /> class. </summary>
+        /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
+        /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
+        /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
+        /// <param name="daemonLogger"> The daemon logger dependency. </param>
+        public PlayExitTransitionRunner (
+            IServerVersionProvider serverVersionProvider,
+            IUnityEditorReadinessGate readinessGate,
+            IpcProjectIdentity projectIdentity,
+            IDaemonLogger daemonLogger = null)
+            : this(
+                serverVersionProvider,
+                readinessGate,
+                projectIdentity,
+                UnityEditorUpdateAwaiter.WaitForNextUpdateAsync,
+                static () => EditorApplication.ExitPlaymode(),
+                daemonLogger)
+        {
+        }
+
+        /// <summary> Initializes a new instance of the <see cref="PlayExitTransitionRunner" /> class. </summary>
+        /// <param name="serverVersionProvider"> The server-version provider dependency. </param>
+        /// <param name="readinessGate"> The lifecycle snapshot provider dependency. </param>
+        /// <param name="projectIdentity"> The project identity served by this IPC host. </param>
+        /// <param name="editorUpdateAwaiter"> The editor update awaiter dependency. </param>
+        /// <param name="exitPlayModeRequester"> The Unity Play Mode exit requester dependency. </param>
+        /// <param name="daemonLogger"> The daemon logger dependency. </param>
+        internal PlayExitTransitionRunner (
+            IServerVersionProvider serverVersionProvider,
+            IUnityEditorReadinessGate readinessGate,
+            IpcProjectIdentity projectIdentity,
+            Func<CancellationToken, Task> editorUpdateAwaiter,
+            Action exitPlayModeRequester,
+            IDaemonLogger daemonLogger = null)
+        {
+            this.serverVersionProvider = serverVersionProvider ?? throw new ArgumentNullException(nameof(serverVersionProvider));
+            this.readinessGate = readinessGate ?? throw new ArgumentNullException(nameof(readinessGate));
+            this.projectIdentity = projectIdentity ?? throw new ArgumentNullException(nameof(projectIdentity));
+            this.editorUpdateAwaiter = editorUpdateAwaiter ?? throw new ArgumentNullException(nameof(editorUpdateAwaiter));
+            this.exitPlayModeRequester = exitPlayModeRequester ?? throw new ArgumentNullException(nameof(exitPlayModeRequester));
+            this.daemonLogger = daemonLogger ?? NoOpDaemonLogger.Instance;
+        }
+
+        /// <summary> Executes Play Mode exit and waits until Unity reports a ready edit-mode snapshot. </summary>
+        /// <param name="timeoutMilliseconds"> The transition timeout in milliseconds. </param>
+        /// <param name="recoverableContext"> The persisted operation context used to resume after domain reload. </param>
+        /// <param name="cancellationToken"> The cancellation token propagated by the IPC request. </param>
+        /// <returns> The structured transition result. </returns>
+        public async Task<PlayExitTransitionExecutionResult> ExitAsync (
+            int timeoutMilliseconds,
+            RecoverableIpcOperationContext recoverableContext,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var before = CaptureSnapshot();
+
+            if (recoverableContext != null && recoverableContext.HasOperationRecord)
+            {
+                if (!TryReadPendingExit(recoverableContext, out var pendingBefore, out var pendingReadErrorMessage))
+                {
+                    return CreateFailure(
+                        PlayModeErrorCodes.PlayModeStateUnknown,
+                        $"Recoverable Play Mode exit state is invalid. {pendingReadErrorMessage}",
+                        before,
+                        before,
+                        IpcPlayApplicationStateNames.Unknown);
+                }
+
+                return await ResumePendingExitAsync(
+                    pendingBefore,
+                    before,
+                    recoverableContext,
+                    timeoutMilliseconds,
+                    cancellationToken);
+            }
+
+            var preconditionFailure = ValidatePreconditions(before);
+            if (preconditionFailure != null)
+            {
+                return preconditionFailure;
+            }
+
+            if (IsStoppedPlayModeSnapshot(before))
+            {
+                return CreateSuccess(IpcPlayTransitionResultNames.AlreadyExited, before, before);
+            }
+
+            // NOTE: This must be persisted before EditorApplication.ExitPlaymode is called.
+            // Leaving Play Mode can trigger domain reload before this daemon can respond.
+            var persistFailure = TryPersistPendingExit(recoverableContext, before);
+            if (persistFailure != null)
+            {
+                return persistFailure;
+            }
+
+            try
+            {
+                exitPlayModeRequester();
+            }
+            catch (Exception exception)
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeExitRejected,
+                    $"Unity rejected Play Mode exit. {exception.Message}",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.NotApplied);
+            }
+
+            return await ObserveRequestedExitAsync(
+                before,
+                before,
+                TimeSpan.FromMilliseconds(timeoutMilliseconds),
+                timeoutMilliseconds,
+                classifyInitialObservation: false,
+                cancellationToken);
+        }
+
+        private async Task<PlayExitTransitionExecutionResult> ResumePendingExitAsync (
+            IpcPlayLifecycleSnapshot pendingBefore,
+            IpcPlayLifecycleSnapshot current,
+            RecoverableIpcOperationContext recoverableContext,
+            int timeoutMilliseconds,
+            CancellationToken cancellationToken)
+        {
+            if (IsRecoverablePendingExit(pendingBefore, current))
+            {
+                return CreateSuccess(IpcPlayTransitionResultNames.Exited, pendingBefore, current);
+            }
+
+            var remainingTimeout = ResolveRemainingPendingTimeout(
+                recoverableContext,
+                timeoutMilliseconds);
+            if (remainingTimeout <= TimeSpan.Zero)
+            {
+                return CreateTimeout(pendingBefore, current, timeoutMilliseconds);
+            }
+
+            return await ObserveRequestedExitAsync(
+                pendingBefore,
+                current,
+                remainingTimeout,
+                timeoutMilliseconds,
+                classifyInitialObservation: true,
+                cancellationToken);
+        }
+
+        private async Task<PlayExitTransitionExecutionResult> ObserveRequestedExitAsync (
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot initialObserved,
+            TimeSpan remainingTimeout,
+            int timeoutMilliseconds,
+            bool classifyInitialObservation,
+            CancellationToken cancellationToken)
+        {
+            var observed = initialObserved;
+            var playingObservations = 0;
+            var stoppedWithoutGenerationChangeObservations = 0;
+            using var timeoutCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCancellationTokenSource.CancelAfter(remainingTimeout);
+            try
+            {
+                if (classifyInitialObservation)
+                {
+                    var initialFailure = ClassifyObservedFailure(before, observed, ref playingObservations, ref stoppedWithoutGenerationChangeObservations);
+                    if (initialFailure != null)
+                    {
+                        return initialFailure;
+                    }
+                }
+
+                while (true)
+                {
+                    timeoutCancellationTokenSource.Token.ThrowIfCancellationRequested();
+                    await editorUpdateAwaiter(timeoutCancellationTokenSource.Token);
+                    observed = CaptureSnapshot();
+
+                    if (IsReadyStoppedSnapshot(observed) && HasGenerationChanged(before, observed))
+                    {
+                        return CreateSuccess(IpcPlayTransitionResultNames.Exited, before, observed);
+                    }
+
+                    var observedFailure = ClassifyObservedFailure(before, observed, ref playingObservations, ref stoppedWithoutGenerationChangeObservations);
+                    if (observedFailure != null)
+                    {
+                        return observedFailure;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                return CreateTimeout(before, observed, timeoutMilliseconds);
+            }
+        }
+
+        private bool TryReadPendingExit (
+            RecoverableIpcOperationContext recoverableContext,
+            out IpcPlayLifecycleSnapshot before,
+            out string errorMessage)
+        {
+            before = null;
+            if (recoverableContext == null)
+            {
+                errorMessage = null;
+                return false;
+            }
+
+            if (!recoverableContext.TryReadPendingPayload<PlayExitRecoveryPayload>(out var recoveryPayload, out var pendingPayloadErrorMessage))
+            {
+                errorMessage = string.IsNullOrWhiteSpace(pendingPayloadErrorMessage)
+                    ? "Pending Play Mode exit payload is missing."
+                    : pendingPayloadErrorMessage;
+                if (!string.IsNullOrWhiteSpace(pendingPayloadErrorMessage))
+                {
+                    daemonLogger.Warning(
+                        DaemonLogCategories.Lifecycle,
+                        $"Play Mode exit pending transition read failed. {pendingPayloadErrorMessage}");
+                }
+
+                return false;
+            }
+
+            before = recoveryPayload.Before;
+            if (before == null)
+            {
+                errorMessage = "Pending Play Mode exit before snapshot is missing.";
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
+        private PlayExitTransitionExecutionResult TryPersistPendingExit (
+            RecoverableIpcOperationContext recoverableContext,
+            IpcPlayLifecycleSnapshot before)
+        {
+            if (recoverableContext == null)
+            {
+                return null;
+            }
+
+            return recoverableContext.TryMarkPending(new PlayExitRecoveryPayload(before), out var errorMessage)
+                ? null
+                : CreateFailure(
+                    PlayModeErrorCodes.PlayModeExitRejected,
+                    $"Unity Play Mode exit could not persist transition recovery state. {errorMessage}",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.NotApplied);
+        }
+
+        private static TimeSpan ResolveRemainingPendingTimeout (
+            RecoverableIpcOperationContext recoverableContext,
+            int timeoutMilliseconds)
+        {
+            var totalTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+            if (recoverableContext?.StartedAtUtc == null)
+            {
+                return totalTimeout;
+            }
+
+            var elapsed = DateTimeOffset.UtcNow - recoverableContext.StartedAtUtc.Value;
+            return elapsed >= totalTimeout
+                ? TimeSpan.Zero
+                : totalTimeout - elapsed;
+        }
+
+        private PlayExitTransitionExecutionResult ValidatePreconditions (IpcPlayLifecycleSnapshot before)
+        {
+            if (!string.Equals(before.EditorMode, DaemonEditorModeValues.Gui, StringComparison.Ordinal))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeRequiresGuiEditor,
+                    "Play Mode exit requires a GUI Editor session.",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.NotApplied);
+            }
+
+            if (before.PlayMode == null || IsUnknownPlayMode(before))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeStateUnknown,
+                    "Unity Play Mode state is unknown before exiting Play Mode.",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.Unknown);
+            }
+
+            if (IsPlayModeChanging(before))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeAlreadyChanging,
+                    "Unity Play Mode is already changing.",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.NotApplied);
+            }
+
+            if (IsStoppedPlayModeSnapshot(before))
+            {
+                return null;
+            }
+
+            if (!IsEnteredSnapshot(before))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeTransitionBlocked,
+                    $"Unity Play Mode exit is blocked by lifecycleState={before.LifecycleState ?? "null"}.",
+                    before,
+                    before,
+                    IpcPlayApplicationStateNames.NotApplied);
+            }
+
+            return null;
+        }
+
+        private PlayExitTransitionExecutionResult ClassifyObservedFailure (
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot observed,
+            ref int playingObservations,
+            ref int stoppedWithoutGenerationChangeObservations)
+        {
+            if (observed.PlayMode == null || IsUnknownPlayMode(observed))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeStateUnknown,
+                    "Unity Play Mode state became unknown while exiting Play Mode.",
+                    before,
+                    observed,
+                    IpcPlayApplicationStateNames.Unknown);
+            }
+
+            TryReadPlayModeSnapshot(
+                observed,
+                out _,
+                out var observedPlayModeState,
+                out var observedPlayModeTransition);
+
+            if (observedPlayModeState == IpcPlayModeState.Exiting
+                || observedPlayModeTransition == IpcPlayModeTransition.Exiting)
+            {
+                playingObservations = 0;
+                stoppedWithoutGenerationChangeObservations = 0;
+                return null;
+            }
+
+            if (observedPlayModeState == IpcPlayModeState.Entering
+                || observedPlayModeTransition == IpcPlayModeTransition.Entering)
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeAlreadyChanging,
+                    "Unity Play Mode started entering while exit was requested.",
+                    before,
+                    observed,
+                    IpcPlayApplicationStateNames.Unknown);
+            }
+
+            if (IsStoppedPlayModeSnapshot(observed) && HasGenerationChanged(before, observed))
+            {
+                if (IsExitWaitLifecycle(observed))
+                {
+                    playingObservations = 0;
+                    stoppedWithoutGenerationChangeObservations = 0;
+                    return null;
+                }
+
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeTransitionBlocked,
+                    $"Unity Play Mode exit completed but lifecycleState={observed.LifecycleState ?? "null"} blocked readiness.",
+                    before,
+                    observed,
+                    IpcPlayApplicationStateNames.Applied);
+            }
+
+            if (!IsExitWaitLifecycle(observed))
+            {
+                return CreateFailure(
+                    PlayModeErrorCodes.PlayModeTransitionBlocked,
+                    $"Unity Play Mode exit was blocked by lifecycleState={observed.LifecycleState ?? "null"}.",
+                    before,
+                    observed,
+                    IpcPlayApplicationStateNames.Unknown);
+            }
+
+            if (IsEnteredSnapshot(observed))
+            {
+                playingObservations++;
+                if (playingObservations >= RejectedPlayingObservationThreshold)
+                {
+                    return CreateFailure(
+                        PlayModeErrorCodes.PlayModeExitRejected,
+                        "Unity did not accept the Play Mode exit request.",
+                        before,
+                        observed,
+                        IpcPlayApplicationStateNames.NotApplied);
+                }
+            }
+            else
+            {
+                playingObservations = 0;
+            }
+
+            if (IsStoppedPlayModeSnapshot(observed) && !HasGenerationChanged(before, observed))
+            {
+                stoppedWithoutGenerationChangeObservations++;
+                if (stoppedWithoutGenerationChangeObservations >= StoppedWithoutGenerationChangeObservationThreshold)
+                {
+                    return CreateFailure(
+                        PlayModeErrorCodes.PlayModeStateUnknown,
+                        "Unity Play Mode stopped without advancing playMode.generation.",
+                        before,
+                        observed,
+                        IpcPlayApplicationStateNames.Unknown);
+                }
+            }
+            else
+            {
+                stoppedWithoutGenerationChangeObservations = 0;
+            }
+
+            return null;
+        }
+
+        private IpcPlayLifecycleSnapshot CaptureSnapshot ()
+        {
+            return UnityLifecycleResponseCodec.CreatePlayLifecycleSnapshot(
+                projectIdentity.UnityVersion,
+                serverVersionProvider.GetVersion(),
+                projectIdentity.ProjectFingerprint,
+                readinessGate.CaptureSnapshot());
+        }
+
+        private static PlayExitTransitionExecutionResult CreateSuccess (
+            string result,
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot after)
+        {
+            return PlayExitTransitionExecutionResult.Success(new IpcPlayTransitionResponse(
+                new IpcPlayTransitionResult(
+                    Transition: IpcPlayTransitionCommandNames.Exit,
+                    Result: result,
+                    Before: before)
+                {
+                    After = after,
+                }));
+        }
+
+        private static PlayExitTransitionExecutionResult CreateFailure (
+            UcliCode code,
+            string message,
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot observed,
+            string applicationState)
+        {
+            var response = new IpcPlayTransitionResponse(
+                new IpcPlayTransitionResult(
+                    Transition: IpcPlayTransitionCommandNames.Exit,
+                    Result: IpcPlayTransitionResultNames.Blocked,
+                    Before: before)
+                {
+                    Observed = observed,
+                    ApplicationState = applicationState,
+                });
+            return PlayExitTransitionExecutionResult.Failure(response, new IpcError(code, message, null));
+        }
+
+        private static PlayExitTransitionExecutionResult CreateTimeout (
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot observed,
+            int timeoutMilliseconds)
+        {
+            var response = new IpcPlayTransitionResponse(
+                new IpcPlayTransitionResult(
+                    Transition: IpcPlayTransitionCommandNames.Exit,
+                    Result: IpcPlayTransitionResultNames.Timeout,
+                    Before: before)
+                {
+                    Observed = observed,
+                    ApplicationState = IpcPlayApplicationStateNames.Indeterminate,
+                });
+            return PlayExitTransitionExecutionResult.Failure(
+                response,
+                new IpcError(
+                    PlayModeErrorCodes.PlayModeTransitionTimeout,
+                    $"Unity Play Mode exit timed out after {timeoutMilliseconds} milliseconds.",
+                    null));
+        }
+
+        private static bool IsEnteredSnapshot (IpcPlayLifecycleSnapshot snapshot)
+        {
+            return TryReadPlayModeSnapshot(
+                    snapshot,
+                    out var playMode,
+                    out var playModeState,
+                    out var playModeTransition)
+                && string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Playmode, StringComparison.Ordinal)
+                && playModeState == IpcPlayModeState.Playing
+                && playModeTransition == IpcPlayModeTransition.None
+                && playMode.IsPlaying
+                && !snapshot.CanAcceptExecutionRequests;
+        }
+
+        private static bool HasGenerationChanged (
+            IpcPlayLifecycleSnapshot before,
+            IpcPlayLifecycleSnapshot after)
+        {
+            return !string.Equals(before.PlayMode?.Generation, after.PlayMode?.Generation, StringComparison.Ordinal);
+        }
+
+        private static bool IsReadyStoppedSnapshot (IpcPlayLifecycleSnapshot snapshot)
+        {
+            return IsStoppedPlayModeSnapshot(snapshot)
+                && string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
+                && string.IsNullOrWhiteSpace(snapshot.BlockingReason)
+                && snapshot.CanAcceptExecutionRequests;
+        }
+
+        private static bool IsStoppedPlayModeSnapshot (IpcPlayLifecycleSnapshot snapshot)
+        {
+            return TryReadPlayModeSnapshot(
+                    snapshot,
+                    out var playMode,
+                    out var playModeState,
+                    out var playModeTransition)
+                && playModeState == IpcPlayModeState.Stopped
+                && playModeTransition == IpcPlayModeTransition.None
+                && !playMode.IsPlaying
+                && !playMode.IsPlayingOrWillChangePlaymode;
+        }
+
+        private static bool IsPlayModeChanging (IpcPlayLifecycleSnapshot snapshot)
+        {
+            return TryReadPlayModeSnapshot(
+                    snapshot,
+                    out _,
+                    out var playModeState,
+                    out var playModeTransition)
+                && (playModeState == IpcPlayModeState.Entering
+                    || playModeState == IpcPlayModeState.Exiting
+                    || playModeTransition == IpcPlayModeTransition.Entering
+                    || playModeTransition == IpcPlayModeTransition.Exiting);
+        }
+
+        private static bool IsUnknownPlayMode (IpcPlayLifecycleSnapshot snapshot)
+        {
+            if (!TryReadPlayModeSnapshot(
+                    snapshot,
+                    out _,
+                    out var playModeState,
+                    out _))
+            {
+                return true;
+            }
+
+            return playModeState == IpcPlayModeState.Unknown;
+        }
+
+        private static bool IsExitWaitLifecycle (IpcPlayLifecycleSnapshot snapshot)
+        {
+            return string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Ready, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Playmode, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Starting, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Recovering, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Busy, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Compiling, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.DomainReloading, StringComparison.Ordinal)
+                || string.Equals(snapshot.LifecycleState, IpcEditorLifecycleStateCodec.Reimporting, StringComparison.Ordinal);
+        }
+
+        private static bool IsRecoverablePendingExit (
+            IpcPlayLifecycleSnapshot pendingBefore,
+            IpcPlayLifecycleSnapshot current)
+        {
+            return pendingBefore != null
+                && current != null
+                && IsEnteredSnapshot(pendingBefore)
+                && IsReadyStoppedSnapshot(current)
+                && string.Equals(pendingBefore.ProjectFingerprint, current.ProjectFingerprint, StringComparison.Ordinal)
+                && HasGenerationChanged(pendingBefore, current);
+        }
+
+        private static bool TryReadPlayModeSnapshot (
+            IpcPlayLifecycleSnapshot snapshot,
+            out IpcPlayModeSnapshot playMode,
+            out IpcPlayModeState state,
+            out IpcPlayModeTransition transition)
+        {
+            playMode = snapshot.PlayMode;
+            state = default;
+            transition = default;
+            return playMode != null
+                && IpcPlayModeStateCodec.TryParse(playMode.State, out state)
+                && IpcPlayModeTransitionCodec.TryParse(playMode.Transition, out transition);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99fc7176bb37f4977ad463cc1b1331d5

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitUnityIpcMethodHandler.cs
@@ -9,17 +9,17 @@ using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
-    /// <summary> Handles <c>play.enter</c> IPC method requests. </summary>
-    internal sealed class PlayEnterUnityIpcMethodHandler : IRecoverableUnityIpcMethodHandler
+    /// <summary> Handles <c>play.exit</c> IPC method requests. </summary>
+    internal sealed class PlayExitUnityIpcMethodHandler : IRecoverableUnityIpcMethodHandler
     {
-        private readonly PlayEnterTransitionRunner transitionRunner;
+        private readonly PlayExitTransitionRunner transitionRunner;
         private readonly IDaemonLogger daemonLogger;
 
-        /// <summary> Initializes a new instance of the <see cref="PlayEnterUnityIpcMethodHandler" /> class. </summary>
+        /// <summary> Initializes a new instance of the <see cref="PlayExitUnityIpcMethodHandler" /> class. </summary>
         /// <param name="transitionRunner"> The transition runner dependency. </param>
         /// <param name="daemonLogger"> The daemon logger dependency. </param>
-        public PlayEnterUnityIpcMethodHandler (
-            PlayEnterTransitionRunner transitionRunner,
+        public PlayExitUnityIpcMethodHandler (
+            PlayExitTransitionRunner transitionRunner,
             IDaemonLogger daemonLogger = null)
         {
             this.transitionRunner = transitionRunner ?? throw new ArgumentNullException(nameof(transitionRunner));
@@ -27,7 +27,7 @@ namespace MackySoft.Ucli.Unity.Ipc
         }
 
         /// <inheritdoc />
-        public string Method => IpcMethodNames.PlayEnter;
+        public string Method => IpcMethodNames.PlayExit;
 
         /// <inheritdoc />
         public bool TryCreateRecoverableRequestPayloadHash (
@@ -35,17 +35,17 @@ namespace MackySoft.Ucli.Unity.Ipc
             out string requestPayloadHash,
             out IpcResponse errorResponse)
         {
-            if (!TryReadPlayEnterRequest(
+            if (!TryReadPlayExitRequest(
                     request,
                     logDecodeFailure: false,
-                    out IpcPlayEnterRequest enterRequest,
+                    out IpcPlayExitRequest exitRequest,
                     out errorResponse))
             {
                 requestPayloadHash = null;
                 return false;
             }
 
-            var stablePayload = IpcPayloadCodec.SerializeToElement(enterRequest);
+            var stablePayload = IpcPayloadCodec.SerializeToElement(exitRequest);
             requestPayloadHash = Sha256LowerHex.Compute(Encoding.UTF8.GetBytes(stablePayload.GetRawText()));
             return true;
         }
@@ -78,17 +78,17 @@ namespace MackySoft.Ucli.Unity.Ipc
                 throw new ArgumentNullException(nameof(request));
             }
 
-            if (!TryReadPlayEnterRequest(
+            if (!TryReadPlayExitRequest(
                     request,
                     logDecodeFailure: true,
-                    out IpcPlayEnterRequest enterRequest,
+                    out IpcPlayExitRequest exitRequest,
                     out var errorResponse))
             {
                 return errorResponse!;
             }
 
-            var result = await transitionRunner.EnterAsync(
-                enterRequest.TimeoutMilliseconds!.Value,
+            var result = await transitionRunner.ExitAsync(
+                exitRequest.TimeoutMilliseconds!.Value,
                 recoverableContext,
                 cancellationToken);
             if (result.IsSuccess)
@@ -104,28 +104,28 @@ namespace MackySoft.Ucli.Unity.Ipc
                 result.Response);
         }
 
-        private bool TryReadPlayEnterRequest (
+        private bool TryReadPlayExitRequest (
             IpcRequest request,
             bool logDecodeFailure,
-            out IpcPlayEnterRequest enterRequest,
+            out IpcPlayExitRequest exitRequest,
             out IpcResponse errorResponse)
         {
-            if (!UnityIpcRequestCodec.TryDecodePlayEnterRequest(
+            if (!UnityIpcRequestCodec.TryDecodePlayExitRequest(
                     request,
-                    out enterRequest,
+                    out exitRequest,
                     out errorResponse))
             {
                 if (logDecodeFailure)
                 {
                     daemonLogger.Warning(
                         DaemonLogCategories.Health,
-                        "Play enter payload decode failed.");
+                        "Play exit payload decode failed.");
                 }
 
                 return false;
             }
 
-            if (!TryValidateTimeoutMilliseconds(enterRequest!.TimeoutMilliseconds, out var timeoutErrorMessage))
+            if (!TryValidateTimeoutMilliseconds(exitRequest!.TimeoutMilliseconds, out var timeoutErrorMessage))
             {
                 errorResponse = UnityIpcResponseFactory.CreateErrorResponse(
                     request,
@@ -145,13 +145,13 @@ namespace MackySoft.Ucli.Unity.Ipc
         {
             if (!timeoutMilliseconds.HasValue)
             {
-                errorMessage = "PlayEnter timeoutMilliseconds is required.";
+                errorMessage = "PlayExit timeoutMilliseconds is required.";
                 return false;
             }
 
             if (timeoutMilliseconds.Value <= 0)
             {
-                errorMessage = "PlayEnter timeoutMilliseconds must be greater than zero.";
+                errorMessage = "PlayExit timeoutMilliseconds must be greater than zero.";
                 return false;
             }
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitUnityIpcMethodHandler.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitUnityIpcMethodHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ca58276ee7ed4b0083947922f101dc9

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Server/UnityIpcRequestCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Server/UnityIpcRequestCodec.cs
@@ -85,6 +85,19 @@ namespace MackySoft.Ucli.Unity.Ipc
             return TryDecodePayload(request, "PlayEnter", out payload, out errorResponse);
         }
 
+        /// <summary> Tries to decode one Play Mode exit request payload. </summary>
+        /// <param name="request"> The incoming request envelope. </param>
+        /// <param name="payload"> The decoded payload when successful. </param>
+        /// <param name="errorResponse"> The invalid-argument response when decoding fails. </param>
+        /// <returns> <see langword="true" /> when decoding succeeded; otherwise <see langword="false" />. </returns>
+        public static bool TryDecodePlayExitRequest (
+            IpcRequest request,
+            out IpcPlayExitRequest? payload,
+            out IpcResponse? errorResponse)
+        {
+            return TryDecodePayload(request, "PlayExit", out payload, out errorResponse);
+        }
+
         /// <summary> Tries to decode one ops-read request payload. </summary>
         /// <param name="request"> The incoming request envelope. </param>
         /// <param name="payload"> The decoded payload when successful. </param>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/IUnityEditorUpdateAwaiter.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/IUnityEditorUpdateAwaiter.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MackySoft.Ucli.Unity.Runtime
+{
+    /// <summary> Waits for Unity Editor update callbacks. </summary>
+    internal interface IUnityEditorUpdateAwaiter
+    {
+        /// <summary> Completes after one Editor update callback. </summary>
+        /// <param name="cancellationToken"> The cancellation token propagated by the caller. </param>
+        /// <returns> A task that completes on the next Editor update. </returns>
+        Task WaitForNextUpdateAsync (CancellationToken cancellationToken);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/IUnityEditorUpdateAwaiter.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/IUnityEditorUpdateAwaiter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4029cb0dd37f34037aca6c1c946841bf

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/UnityEditorUpdateAwaiterAdapter.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/UnityEditorUpdateAwaiterAdapter.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MackySoft.Ucli.Unity.Runtime
+{
+    /// <summary> Adapts the static Unity Editor update awaiter for dependency injection. </summary>
+    internal sealed class UnityEditorUpdateAwaiterAdapter : IUnityEditorUpdateAwaiter
+    {
+        /// <inheritdoc />
+        public Task WaitForNextUpdateAsync (CancellationToken cancellationToken)
+        {
+            return UnityEditorUpdateAwaiter.WaitForNextUpdateAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/UnityEditorUpdateAwaiterAdapter.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/MainThread/UnityEditorUpdateAwaiterAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32ed78f139a9c4e2c86d902c76065015

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2dc87e2c548ed49368712d8459b92dc1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/IUnityPlayModeController.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/IUnityPlayModeController.cs
@@ -1,0 +1,12 @@
+namespace MackySoft.Ucli.Unity.Runtime
+{
+    /// <summary> Requests Unity Editor Play Mode transitions. </summary>
+    internal interface IUnityPlayModeController
+    {
+        /// <summary> Requests entering Play Mode. </summary>
+        void EnterPlayMode ();
+
+        /// <summary> Requests exiting Play Mode. </summary>
+        void ExitPlayMode ();
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/IUnityPlayModeController.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/IUnityPlayModeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c721c486d1734593b1e14e34bd6e588

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/UnityEditorPlayModeController.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/UnityEditorPlayModeController.cs
@@ -1,0 +1,20 @@
+using UnityEditor;
+
+namespace MackySoft.Ucli.Unity.Runtime
+{
+    /// <summary> Requests Unity Editor Play Mode transitions through UnityEditor APIs. </summary>
+    internal sealed class UnityEditorPlayModeController : IUnityPlayModeController
+    {
+        /// <inheritdoc />
+        public void EnterPlayMode ()
+        {
+            EditorApplication.EnterPlaymode();
+        }
+
+        /// <inheritdoc />
+        public void ExitPlayMode ()
+        {
+            EditorApplication.ExitPlaymode();
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/UnityEditorPlayModeController.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/PlayMode/UnityEditorPlayModeController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 230f9d26475d141e1896b6fa871f8955

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayEnterUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayEnterUnityIpcMethodHandlerTests.cs
@@ -377,8 +377,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 new StubServerVersionProvider("1.2.3"),
                 readinessGate,
                 new IpcProjectIdentity("/repo/UnityProject", "project-fingerprint", "6000.1.4f1"),
-                editorUpdateAwaiter ?? CompleteEditorUpdateAsync,
-                enterPlayModeRequester ?? RequestNoop);
+                new StubUnityEditorUpdateAwaiter(editorUpdateAwaiter ?? CompleteEditorUpdateAsync),
+                new StubUnityPlayModeController(enterPlayModeRequester ?? RequestNoop));
         }
 
         private static RecoverableIpcOperationContext CreateRecoverableContext (
@@ -555,6 +555,41 @@ namespace MackySoft.Ucli.Unity.Tests
             public string GetVersion ()
             {
                 return version;
+            }
+        }
+
+        private sealed class StubUnityEditorUpdateAwaiter : IUnityEditorUpdateAwaiter
+        {
+            private readonly Func<CancellationToken, Task> awaiter;
+
+            public StubUnityEditorUpdateAwaiter (Func<CancellationToken, Task> awaiter)
+            {
+                this.awaiter = awaiter ?? throw new ArgumentNullException(nameof(awaiter));
+            }
+
+            public Task WaitForNextUpdateAsync (CancellationToken cancellationToken)
+            {
+                return awaiter(cancellationToken);
+            }
+        }
+
+        private sealed class StubUnityPlayModeController : IUnityPlayModeController
+        {
+            private readonly Action enterPlayModeRequester;
+
+            public StubUnityPlayModeController (Action enterPlayModeRequester)
+            {
+                this.enterPlayModeRequester = enterPlayModeRequester ?? throw new ArgumentNullException(nameof(enterPlayModeRequester));
+            }
+
+            public void EnterPlayMode ()
+            {
+                enterPlayModeRequester();
+            }
+
+            public void ExitPlayMode ()
+            {
+                throw new NotSupportedException();
             }
         }
 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs
@@ -71,6 +71,38 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [UnityTest]
         [Category("Size.Small")]
+        public IEnumerator Handler_WhenPayloadIsInvalid_ReturnsInvalidArgumentWithoutCapturingSnapshot () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot());
+            var handler = CreateHandler(readinessGate);
+            var request = CreatePlayExitRequest("req-play-exit-invalid", 123);
+
+            var response = await handler.HandleAsync(request, CancellationToken.None);
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
+            Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Handler_WhenTimeoutIsMissing_ReturnsInvalidArgumentWithoutCapturingSnapshot () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot());
+            var handler = CreateHandler(readinessGate);
+            var request = CreatePlayExitRequest("req-play-exit-missing-timeout", new IpcPlayExitRequest());
+
+            var response = await handler.HandleAsync(request, CancellationToken.None);
+
+            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+            Assert.That(response.Errors.Count, Is.EqualTo(1));
+            Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
+            Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
         public IEnumerator Handler_WhenExitSucceeds_ReturnsExitedTransitionPayload () => UniTask.ToCoroutine(async () =>
         {
             var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "10"));
@@ -173,6 +205,82 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [UnityTest]
         [Category("Size.Small")]
+        public IEnumerator Runner_WhenPendingRecordWriteFails_DoesNotRequestExit () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "31"));
+            var recoverableStore = new StubRecoverableIpcOperationStore
+            {
+                PendingWriteResult = false,
+                PendingWriteErrorMessage = "write failed",
+            };
+            var recoverableContext = CreateEmptyRecoverableContext(recoverableStore);
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, recoverableContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeExitRejected));
+            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
+            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenPendingRecordPayloadIsInvalid_DoesNotRequestExitAgain () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "31"));
+            var recoverableStore = new StubRecoverableIpcOperationStore();
+            var recoverableContext = CreateRecoverableContext(recoverableStore, new PlayExitRecoveryPayload());
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, recoverableContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeStateUnknown));
+            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.Unknown));
+            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenPendingExitIsStillChanging_ResumesObservationWithoutRequestingExitAgain () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreateExitingSnapshot(generation: "31"));
+            var recoverableStore = new StubRecoverableIpcOperationStore();
+            var recoverableContext = CreateRecoverableContext(
+                recoverableStore,
+                new PlayExitRecoveryPayload(CreatePlayLifecycleSnapshot(CreatePlayingSnapshot(generation: "31"))));
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                editorUpdateAwaiter: cancellationToken =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    readinessGate.Snapshot = CreateReadyStoppedSnapshot(generation: "32");
+                    return Task.CompletedTask;
+                },
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, recoverableContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Exited));
+            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("31"));
+            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("32"));
+            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
         public IEnumerator Runner_WhenPreconditionIsBlocked_ReturnsBlockedWithoutRequestingExit () => UniTask.ToCoroutine(async () =>
         {
             var readinessGate = new MutableUnityEditorReadinessGate(CreateLifecycleSnapshot(
@@ -191,6 +299,24 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeTransitionBlocked));
             Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Blocked));
+            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenPlayModeIsAlreadyChanging_ReturnsAlreadyChangingWithoutRequestingExit () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreateExitingSnapshot(generation: "41"));
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, null, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeAlreadyChanging));
             Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
             Assert.That(exitRequestCount, Is.EqualTo(0));
         });
@@ -270,8 +396,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 new StubServerVersionProvider("1.2.3"),
                 readinessGate,
                 new IpcProjectIdentity("/repo/UnityProject", "project-fingerprint", "6000.1.4f1"),
-                editorUpdateAwaiter ?? CompleteEditorUpdateAsync,
-                exitPlayModeRequester ?? RequestNoop);
+                new StubUnityEditorUpdateAwaiter(editorUpdateAwaiter ?? CompleteEditorUpdateAsync),
+                new StubUnityPlayModeController(exitPlayModeRequester ?? RequestNoop));
         }
 
         private static RecoverableIpcOperationContext CreateRecoverableContext (
@@ -350,6 +476,21 @@ namespace MackySoft.Ucli.Unity.Tests
                 IpcEditorBlockingReasonCodec.PlayMode,
                 canAcceptExecutionRequests: false,
                 CreatePlayingPlayMode(generation));
+        }
+
+        private static UnityEditorLifecycleSnapshot CreateExitingSnapshot (string generation = "2")
+        {
+            return CreateLifecycleSnapshot(
+                DaemonEditorMode.Gui,
+                IpcEditorLifecycleStateCodec.Playmode,
+                IpcEditorBlockingReasonCodec.PlayMode,
+                canAcceptExecutionRequests: false,
+                new IpcPlayModeSnapshot(
+                    State: IpcPlayModeStateNames.Exiting,
+                    Transition: IpcPlayModeTransitionNames.Exiting,
+                    IsPlaying: true,
+                    IsPlayingOrWillChangePlaymode: true,
+                    Generation: generation));
         }
 
         private static UnityEditorLifecycleSnapshot CreateLifecycleSnapshot (
@@ -438,6 +579,41 @@ namespace MackySoft.Ucli.Unity.Tests
             public string GetVersion ()
             {
                 return version;
+            }
+        }
+
+        private sealed class StubUnityEditorUpdateAwaiter : IUnityEditorUpdateAwaiter
+        {
+            private readonly Func<CancellationToken, Task> awaiter;
+
+            public StubUnityEditorUpdateAwaiter (Func<CancellationToken, Task> awaiter)
+            {
+                this.awaiter = awaiter ?? throw new ArgumentNullException(nameof(awaiter));
+            }
+
+            public Task WaitForNextUpdateAsync (CancellationToken cancellationToken)
+            {
+                return awaiter(cancellationToken);
+            }
+        }
+
+        private sealed class StubUnityPlayModeController : IUnityPlayModeController
+        {
+            private readonly Action exitPlayModeRequester;
+
+            public StubUnityPlayModeController (Action exitPlayModeRequester)
+            {
+                this.exitPlayModeRequester = exitPlayModeRequester ?? throw new ArgumentNullException(nameof(exitPlayModeRequester));
+            }
+
+            public void EnterPlayMode ()
+            {
+                throw new NotSupportedException();
+            }
+
+            public void ExitPlayMode ()
+            {
+                exitPlayModeRequester();
             }
         }
 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs
@@ -13,7 +13,7 @@ using UnityEngine.TestTools;
 
 namespace MackySoft.Ucli.Unity.Tests
 {
-    public sealed class PlayEnterUnityIpcMethodHandlerTests
+    public sealed class PlayExitUnityIpcMethodHandlerTests
     {
         private const string RequestPayloadHash = "request-payload-hash";
 
@@ -21,13 +21,13 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public void TryCreateRecoverableRequestPayloadHash_WhenTimeoutDiffers_ReturnsDifferentHash ()
         {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot());
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot());
             var handler = CreateHandler(readinessGate);
-            var firstRequest = CreatePlayEnterRequest("req-play-enter-hash-1", new IpcPlayEnterRequest
+            var firstRequest = CreatePlayExitRequest("req-play-exit-hash-1", new IpcPlayExitRequest
             {
                 TimeoutMilliseconds = 1000,
             });
-            var secondRequest = CreatePlayEnterRequest("req-play-enter-hash-2", new IpcPlayEnterRequest
+            var secondRequest = CreatePlayExitRequest("req-play-exit-hash-2", new IpcPlayExitRequest
             {
                 TimeoutMilliseconds = 2000,
             });
@@ -51,9 +51,9 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public void TryCreateRecoverableRequestPayloadHash_WhenTimeoutIsInvalid_ReturnsInvalidArgument ()
         {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot());
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot());
             var handler = CreateHandler(readinessGate);
-            var request = CreatePlayEnterRequest("req-play-enter-invalid-timeout", new IpcPlayEnterRequest
+            var request = CreatePlayExitRequest("req-play-exit-invalid-timeout", new IpcPlayExitRequest
             {
                 TimeoutMilliseconds = 0,
             });
@@ -71,46 +71,14 @@ namespace MackySoft.Ucli.Unity.Tests
 
         [UnityTest]
         [Category("Size.Small")]
-        public IEnumerator Handler_WhenPayloadIsInvalid_ReturnsInvalidArgumentWithoutCapturingSnapshot () => UniTask.ToCoroutine(async () =>
+        public IEnumerator Handler_WhenExitSucceeds_ReturnsExitedTransitionPayload () => UniTask.ToCoroutine(async () =>
         {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot());
-            var handler = CreateHandler(readinessGate);
-            var request = CreatePlayEnterRequest("req-play-enter-invalid", 123);
-
-            var response = await handler.HandleAsync(request, CancellationToken.None);
-
-            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
-            Assert.That(response.Errors.Count, Is.EqualTo(1));
-            Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
-            Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Handler_WhenTimeoutIsMissing_ReturnsInvalidArgumentWithoutCapturingSnapshot () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot());
-            var handler = CreateHandler(readinessGate);
-            var request = CreatePlayEnterRequest("req-play-enter-missing-timeout", new IpcPlayEnterRequest());
-
-            var response = await handler.HandleAsync(request, CancellationToken.None);
-
-            Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
-            Assert.That(response.Errors.Count, Is.EqualTo(1));
-            Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
-            Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Handler_WhenEnterSucceeds_ReturnsEnteredTransitionPayload () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "10"));
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "10"));
             var runner = CreateRunner(
                 readinessGate,
-                enterPlayModeRequester: () => readinessGate.Snapshot = CreatePlayingSnapshot(generation: "11"));
-            var handler = new PlayEnterUnityIpcMethodHandler(runner);
-            var request = CreatePlayEnterRequest("req-play-enter-success", new IpcPlayEnterRequest
+                exitPlayModeRequester: () => readinessGate.Snapshot = CreateReadyStoppedSnapshot(generation: "11"));
+            var handler = new PlayExitUnityIpcMethodHandler(runner);
+            var request = CreatePlayExitRequest("req-play-exit-success", new IpcPlayExitRequest
             {
                 TimeoutMilliseconds = 1000,
             });
@@ -120,282 +88,207 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusOk));
             Assert.That(response.Errors, Is.Empty);
             Assert.That(IpcPayloadCodec.TryDeserialize(response.Payload, out IpcPlayTransitionResponse payload, out _), Is.True);
-            Assert.That(payload.Transition.Transition, Is.EqualTo(IpcPlayTransitionCommandNames.Enter));
-            Assert.That(payload.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Entered));
+            Assert.That(payload.Transition.Transition, Is.EqualTo(IpcPlayTransitionCommandNames.Exit));
+            Assert.That(payload.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Exited));
             Assert.That(payload.Transition.After, Is.Not.Null);
-            Assert.That(payload.Transition.After!.PlayMode!.State, Is.EqualTo(IpcPlayModeStateNames.Playing));
+            Assert.That(payload.Transition.After!.LifecycleState, Is.EqualTo(IpcEditorLifecycleStateCodec.Ready));
+            Assert.That(payload.Transition.After.PlayMode!.State, Is.EqualTo(IpcPlayModeStateNames.Stopped));
             Assert.That(payload.Transition.After.PlayMode.Generation, Is.EqualTo("11"));
         });
 
         [UnityTest]
         [Category("Size.Small")]
-        public IEnumerator Runner_WhenAlreadyPlaying_ReturnsAlreadyEnteredWithoutRequestingEnter () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "21"));
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, null, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.True);
-            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.AlreadyEntered));
-            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("21"));
-            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("21"));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenAlreadyPlayingWithPendingEnter_ReturnsRecoveredEntered () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "22"));
-            var recoverableStore = new StubRecoverableIpcOperationStore();
-            var recoverableContext = CreateRecoverableContext(
-                recoverableStore,
-                new PlayEnterRecoveryPayload(CreatePlayLifecycleSnapshot(CreateReadyStoppedSnapshot(generation: "21"))));
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, recoverableContext, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.True);
-            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Entered));
-            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("21"));
-            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("22"));
-            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenNewRecoverableEnterStarts_PersistsBeforeSnapshotBeforeRequestingEnter () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "21"));
-            var recoverableStore = new StubRecoverableIpcOperationStore();
-            var recoverableContext = CreateEmptyRecoverableContext(recoverableStore);
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () =>
-                {
-                    Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
-                    enterRequestCount++;
-                    readinessGate.Snapshot = CreatePlayingSnapshot(generation: "22");
-                });
-
-            var result = await runner.EnterAsync(1000, recoverableContext, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.True);
-            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Entered));
-            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
-            Assert.That(recoverableStore.PendingPayload, Is.Not.Null);
-            Assert.That(recoverableStore.PendingPayload.Before.PlayMode!.Generation, Is.EqualTo("21"));
-            Assert.That(enterRequestCount, Is.EqualTo(1));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenPendingRecordWriteFails_DoesNotRequestEnter () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "21"));
-            var recoverableStore = new StubRecoverableIpcOperationStore
-            {
-                PendingWriteResult = false,
-                PendingWriteErrorMessage = "write failed",
-            };
-            var recoverableContext = CreateEmptyRecoverableContext(recoverableStore);
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, recoverableContext, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeEnterRejected));
-            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
-            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenPendingRecordPayloadIsInvalid_DoesNotRequestEnterAgain () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "21"));
-            var recoverableStore = new StubRecoverableIpcOperationStore();
-            var recoverableContext = CreateRecoverableContext(recoverableStore, new PlayEnterRecoveryPayload());
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, recoverableContext, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeStateUnknown));
-            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.Unknown));
-            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenPendingEnterIsStillChanging_ResumesObservationWithoutRequestingEnterAgain () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateEnteringSnapshot(generation: "21"));
-            var recoverableStore = new StubRecoverableIpcOperationStore();
-            var recoverableContext = CreateRecoverableContext(
-                recoverableStore,
-                new PlayEnterRecoveryPayload(CreatePlayLifecycleSnapshot(CreateReadyStoppedSnapshot(generation: "21"))));
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                editorUpdateAwaiter: cancellationToken =>
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    readinessGate.Snapshot = CreatePlayingSnapshot(generation: "22");
-                    return Task.CompletedTask;
-                },
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, recoverableContext, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.True);
-            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Entered));
-            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("21"));
-            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("22"));
-            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenPreconditionIsBlocked_ReturnsBlockedWithoutRequestingEnter () => UniTask.ToCoroutine(async () =>
+        public IEnumerator Runner_WhenAlreadyStopped_ReturnsAlreadyExitedWithoutRequestingExit () => UniTask.ToCoroutine(async () =>
         {
             var readinessGate = new MutableUnityEditorReadinessGate(CreateLifecycleSnapshot(
                 DaemonEditorMode.Gui,
                 IpcEditorLifecycleStateCodec.Compiling,
                 IpcEditorBlockingReasonCodec.Compile,
                 canAcceptExecutionRequests: false,
-                CreateStoppedPlayMode(generation: "31")));
-            var enterRequestCount = 0;
+                CreateStoppedPlayMode(generation: "21")));
+            var exitRequestCount = 0;
             var runner = CreateRunner(
                 readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
+                exitPlayModeRequester: () => exitRequestCount++);
 
-            var result = await runner.EnterAsync(1000, null, CancellationToken.None);
+            var result = await runner.ExitAsync(1000, null, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.AlreadyExited));
+            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("21"));
+            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("21"));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenAlreadyStoppedWithPendingExit_ReturnsRecoveredExited () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "22"));
+            var recoverableStore = new StubRecoverableIpcOperationStore();
+            var recoverableContext = CreateRecoverableContext(
+                recoverableStore,
+                new PlayExitRecoveryPayload(CreatePlayLifecycleSnapshot(CreatePlayingSnapshot(generation: "21"))));
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, recoverableContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Exited));
+            Assert.That(result.Response.Transition.Before.PlayMode!.Generation, Is.EqualTo("21"));
+            Assert.That(result.Response.Transition.After!.PlayMode!.Generation, Is.EqualTo("22"));
+            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(0));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenNewRecoverableExitStarts_PersistsBeforeSnapshotBeforeRequestingExit () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "31"));
+            var recoverableStore = new StubRecoverableIpcOperationStore();
+            var recoverableContext = CreateEmptyRecoverableContext(recoverableStore);
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () =>
+                {
+                    Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
+                    exitRequestCount++;
+                    readinessGate.Snapshot = CreateReadyStoppedSnapshot(generation: "32");
+                });
+
+            var result = await runner.ExitAsync(1000, recoverableContext, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.True);
+            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Exited));
+            Assert.That(recoverableStore.PendingWriteCallCount, Is.EqualTo(1));
+            Assert.That(recoverableStore.PendingPayload, Is.Not.Null);
+            Assert.That(recoverableStore.PendingPayload.Before.PlayMode!.Generation, Is.EqualTo("31"));
+            Assert.That(exitRequestCount, Is.EqualTo(1));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenPreconditionIsBlocked_ReturnsBlockedWithoutRequestingExit () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreateLifecycleSnapshot(
+                DaemonEditorMode.Gui,
+                IpcEditorLifecycleStateCodec.ModalBlocked,
+                IpcEditorBlockingReasonCodec.ModalDialog,
+                canAcceptExecutionRequests: false,
+                CreatePlayingPlayMode(generation: "41")));
+            var exitRequestCount = 0;
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => exitRequestCount++);
+
+            var result = await runner.ExitAsync(1000, null, CancellationToken.None);
 
             Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeTransitionBlocked));
             Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Blocked));
             Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
+            Assert.That(exitRequestCount, Is.EqualTo(0));
         });
 
         [UnityTest]
         [Category("Size.Small")]
-        public IEnumerator Runner_WhenPlayModeIsAlreadyChanging_ReturnsAlreadyChangingWithoutRequestingEnter () => UniTask.ToCoroutine(async () =>
+        public IEnumerator Runner_WhenExitRequestIsRejected_ReturnsExitRejected () => UniTask.ToCoroutine(async () =>
         {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateLifecycleSnapshot(
-                DaemonEditorMode.Gui,
-                IpcEditorLifecycleStateCodec.Playmode,
-                IpcEditorBlockingReasonCodec.PlayMode,
-                canAcceptExecutionRequests: false,
-                new IpcPlayModeSnapshot(
-                    State: IpcPlayModeStateNames.Entering,
-                    Transition: IpcPlayModeTransitionNames.Entering,
-                    IsPlaying: false,
-                    IsPlayingOrWillChangePlaymode: true,
-                    Generation: "41")));
-            var enterRequestCount = 0;
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "51"));
+            var exitRequestCount = 0;
             var runner = CreateRunner(
                 readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
+                exitPlayModeRequester: () => exitRequestCount++);
 
-            var result = await runner.EnterAsync(1000, null, CancellationToken.None);
-
-            Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeAlreadyChanging));
-            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
-            Assert.That(enterRequestCount, Is.EqualTo(0));
-        });
-
-        [UnityTest]
-        [Category("Size.Small")]
-        public IEnumerator Runner_WhenEnterRequestIsRejected_ReturnsEnterRejected () => UniTask.ToCoroutine(async () =>
-        {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "51"));
-            var enterRequestCount = 0;
-            var runner = CreateRunner(
-                readinessGate,
-                enterPlayModeRequester: () => enterRequestCount++);
-
-            var result = await runner.EnterAsync(1000, null, CancellationToken.None);
+            var result = await runner.ExitAsync(1000, null, CancellationToken.None);
 
             Assert.That(result.IsSuccess, Is.False);
-            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeEnterRejected));
+            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeExitRejected));
             Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Blocked));
             Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.NotApplied));
-            Assert.That(enterRequestCount, Is.EqualTo(1));
+            Assert.That(exitRequestCount, Is.EqualTo(1));
+        });
+
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator Runner_WhenExitCompletesButReadinessIsBlocked_ReturnsAppliedBlocked () => UniTask.ToCoroutine(async () =>
+        {
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "61"));
+            var runner = CreateRunner(
+                readinessGate,
+                exitPlayModeRequester: () => readinessGate.Snapshot = CreateLifecycleSnapshot(
+                    DaemonEditorMode.Gui,
+                    IpcEditorLifecycleStateCodec.SafeMode,
+                    IpcEditorBlockingReasonCodec.SafeMode,
+                    canAcceptExecutionRequests: false,
+                    CreateStoppedPlayMode(generation: "62")));
+
+            var result = await runner.ExitAsync(1000, null, CancellationToken.None);
+
+            Assert.That(result.IsSuccess, Is.False);
+            Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeTransitionBlocked));
+            Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Blocked));
+            Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.Applied));
+            Assert.That(result.Response.Transition.Observed.PlayMode!.State, Is.EqualTo(IpcPlayModeStateNames.Stopped));
         });
 
         [UnityTest]
         [Category("Size.Small")]
         public IEnumerator Runner_WhenTransitionTimesOut_ReturnsTimeoutWithObservedSnapshot () => UniTask.ToCoroutine(async () =>
         {
-            var readinessGate = new MutableUnityEditorReadinessGate(CreateReadyStoppedSnapshot(generation: "61"));
+            var readinessGate = new MutableUnityEditorReadinessGate(CreatePlayingSnapshot(generation: "71"));
             var runner = CreateRunner(
                 readinessGate,
                 editorUpdateAwaiter: DelayUntilCanceledAsync);
 
-            var result = await runner.EnterAsync(1, null, CancellationToken.None);
+            var result = await runner.ExitAsync(1, null, CancellationToken.None);
 
             Assert.That(result.IsSuccess, Is.False);
             Assert.That(result.Error.Code, Is.EqualTo(PlayModeErrorCodes.PlayModeTransitionTimeout));
             Assert.That(result.Response.Transition.Result, Is.EqualTo(IpcPlayTransitionResultNames.Timeout));
             Assert.That(result.Response.Transition.ApplicationState, Is.EqualTo(IpcPlayApplicationStateNames.Indeterminate));
             Assert.That(result.Response.Transition.Observed, Is.Not.Null);
-            Assert.That(result.Response.Transition.Observed!.PlayMode!.Generation, Is.EqualTo("61"));
+            Assert.That(result.Response.Transition.Observed!.PlayMode!.Generation, Is.EqualTo("71"));
         });
 
-        private static PlayEnterUnityIpcMethodHandler CreateHandler (MutableUnityEditorReadinessGate readinessGate)
+        private static PlayExitUnityIpcMethodHandler CreateHandler (MutableUnityEditorReadinessGate readinessGate)
         {
-            return new PlayEnterUnityIpcMethodHandler(CreateRunner(readinessGate));
+            return new PlayExitUnityIpcMethodHandler(CreateRunner(readinessGate));
         }
 
-        private static PlayEnterTransitionRunner CreateRunner (
+        private static PlayExitTransitionRunner CreateRunner (
             MutableUnityEditorReadinessGate readinessGate,
             Func<CancellationToken, Task> editorUpdateAwaiter = null,
-            Action enterPlayModeRequester = null)
+            Action exitPlayModeRequester = null)
         {
-            return new PlayEnterTransitionRunner(
+            return new PlayExitTransitionRunner(
                 new StubServerVersionProvider("1.2.3"),
                 readinessGate,
                 new IpcProjectIdentity("/repo/UnityProject", "project-fingerprint", "6000.1.4f1"),
                 editorUpdateAwaiter ?? CompleteEditorUpdateAsync,
-                enterPlayModeRequester ?? RequestNoop);
+                exitPlayModeRequester ?? RequestNoop);
         }
 
         private static RecoverableIpcOperationContext CreateRecoverableContext (
             IRecoverableIpcOperationStore store,
-            PlayEnterRecoveryPayload payload)
+            PlayExitRecoveryPayload payload)
         {
             return new RecoverableIpcOperationContext(
                 store,
-                IpcMethodNames.PlayEnter,
-                "req-play-enter-recoverable",
+                IpcMethodNames.PlayExit,
+                "req-play-exit-recoverable",
                 RequestPayloadHash,
                 new RecoverableIpcOperationRecord
                 {
                     SchemaVersion = 1,
                     ProjectFingerprint = "project-fingerprint",
-                    Method = IpcMethodNames.PlayEnter,
-                    RequestId = "req-play-enter-recoverable",
+                    Method = IpcMethodNames.PlayExit,
+                    RequestId = "req-play-exit-recoverable",
                     State = RecoverableIpcOperationState.Pending,
                     StartedAtUtc = DateTimeOffset.UtcNow,
                     RecoveryPayload = IpcPayloadCodec.SerializeToElement(payload),
@@ -406,8 +299,8 @@ namespace MackySoft.Ucli.Unity.Tests
         {
             return new RecoverableIpcOperationContext(
                 store,
-                IpcMethodNames.PlayEnter,
-                "req-play-enter-recoverable",
+                IpcMethodNames.PlayExit,
+                "req-play-exit-recoverable",
                 RequestPayloadHash,
                 null);
         }
@@ -427,7 +320,7 @@ namespace MackySoft.Ucli.Unity.Tests
         {
         }
 
-        private static IpcRequest CreatePlayEnterRequest (
+        private static IpcRequest CreatePlayExitRequest (
             string requestId,
             object payload)
         {
@@ -435,7 +328,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 ProtocolVersion: IpcProtocol.CurrentVersion,
                 RequestId: requestId,
                 SessionToken: "session-token",
-                Method: IpcMethodNames.PlayEnter,
+                Method: IpcMethodNames.PlayExit,
                 Payload: IpcPayloadCodec.SerializeToElement(payload));
         }
 
@@ -456,27 +349,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 IpcEditorLifecycleStateCodec.Playmode,
                 IpcEditorBlockingReasonCodec.PlayMode,
                 canAcceptExecutionRequests: false,
-                new IpcPlayModeSnapshot(
-                    State: IpcPlayModeStateNames.Playing,
-                    Transition: IpcPlayModeTransitionNames.None,
-                    IsPlaying: true,
-                    IsPlayingOrWillChangePlaymode: true,
-                    Generation: generation));
-        }
-
-        private static UnityEditorLifecycleSnapshot CreateEnteringSnapshot (string generation = "2")
-        {
-            return CreateLifecycleSnapshot(
-                DaemonEditorMode.Gui,
-                IpcEditorLifecycleStateCodec.Playmode,
-                IpcEditorBlockingReasonCodec.PlayMode,
-                canAcceptExecutionRequests: false,
-                new IpcPlayModeSnapshot(
-                    State: IpcPlayModeStateNames.Entering,
-                    Transition: IpcPlayModeTransitionNames.Entering,
-                    IsPlaying: false,
-                    IsPlayingOrWillChangePlaymode: true,
-                    Generation: generation));
+                CreatePlayingPlayMode(generation));
         }
 
         private static UnityEditorLifecycleSnapshot CreateLifecycleSnapshot (
@@ -504,6 +377,16 @@ namespace MackySoft.Ucli.Unity.Tests
                 "1.2.3",
                 "project-fingerprint",
                 snapshot);
+        }
+
+        private static IpcPlayModeSnapshot CreatePlayingPlayMode (string generation)
+        {
+            return new IpcPlayModeSnapshot(
+                State: IpcPlayModeStateNames.Playing,
+                Transition: IpcPlayModeTransitionNames.None,
+                IsPlaying: true,
+                IsPlayingOrWillChangePlaymode: true,
+                Generation: generation);
         }
 
         private static IpcPlayModeSnapshot CreateStoppedPlayMode (string generation)
@@ -566,7 +449,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             public string PendingWriteErrorMessage { get; set; }
 
-            public PlayEnterRecoveryPayload PendingPayload { get; private set; }
+            public PlayExitRecoveryPayload PendingPayload { get; private set; }
 
             public bool TryRead (
                 string method,
@@ -589,7 +472,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 out string errorMessage)
             {
                 PendingWriteCallCount++;
-                IpcPayloadCodec.TryDeserialize(recoveryPayload, out PlayEnterRecoveryPayload pendingPayload, out _);
+                IpcPayloadCodec.TryDeserialize(recoveryPayload, out PlayExitRecoveryPayload pendingPayload, out _);
                 PendingPayload = pendingPayload;
                 errorMessage = PendingWriteErrorMessage;
                 return PendingWriteResult;

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/PlayExitUnityIpcMethodHandlerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a41e0a58bd61d487da6dc923aa975afd

--- a/src/Ucli/Hosting/Cli/Play/PlayExitCommand.cs
+++ b/src/Ucli/Hosting/Cli/Play/PlayExitCommand.cs
@@ -1,18 +1,26 @@
 using ConsoleAppFramework;
+using MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Hosting.Cli.Options;
 
 namespace MackySoft.Ucli.Hosting.Cli.Play;
 
 /// <summary> Provides the <c>play exit</c> CLI command entry point. </summary>
 internal sealed class PlayExitCommand
 {
+    private readonly IPlayExitService playExitService;
+
     private readonly ICommandResultWriter commandResultWriter;
 
     /// <summary> Initializes a new instance of the <see cref="PlayExitCommand" /> class. </summary>
+    /// <param name="playExitService"> The Play Mode exit service dependency. </param>
     /// <param name="commandResultWriter"> The command-result writer dependency. </param>
-    public PlayExitCommand (ICommandResultWriter commandResultWriter)
+    public PlayExitCommand (
+        IPlayExitService playExitService,
+        ICommandResultWriter commandResultWriter)
     {
+        this.playExitService = playExitService ?? throw new ArgumentNullException(nameof(playExitService));
         this.commandResultWriter = commandResultWriter ?? throw new ArgumentNullException(nameof(commandResultWriter));
     }
 
@@ -22,7 +30,7 @@ internal sealed class PlayExitCommand
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ExitSubcommand)]
-    public int Exit (
+    public async Task<int> ExitAsync (
         string? projectPath = null,
         string? timeout = null,
         CancellationToken cancellationToken = default)
@@ -30,7 +38,21 @@ internal sealed class PlayExitCommand
         cancellationToken.ThrowIfCancellationRequested();
         CommandExecutionState.MarkStarted();
 
-        var commandResult = CommandResult.NotImplemented(UcliCommandNames.PlayExit);
+        var timeoutNormalizationResult = TimeoutOptionNormalizer.Normalize(timeout);
+        if (!timeoutNormalizationResult.IsSuccess)
+        {
+            var invalidTimeoutResult = CommandResultFactory.FromExecutionError(
+                UcliCommandNames.PlayExit,
+                timeoutNormalizationResult.Error!);
+            commandResultWriter.WriteToStandardOutput(invalidTimeoutResult);
+            return invalidTimeoutResult.ExitCode;
+        }
+
+        var input = new PlayExitCommandInput(
+            ProjectPath: projectPath,
+            TimeoutMilliseconds: timeoutNormalizationResult.TimeoutMilliseconds);
+        var executionResult = await playExitService.ExecuteAsync(input, cancellationToken).ConfigureAwait(false);
+        var commandResult = PlayExitCommandResultFactory.Create(executionResult);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Play/PlayExitCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Play/PlayExitCommandResultFactory.cs
@@ -1,37 +1,37 @@
-using MackySoft.Ucli.Application.Features.Play.UseCases.Enter;
+using MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Common.Projection;
 
 namespace MackySoft.Ucli.Hosting.Cli.Play;
 
-/// <summary> Creates command-level JSON results from Play Mode enter execution results. </summary>
-internal static class PlayEnterCommandResultFactory
+/// <summary> Creates command-level JSON results from Play Mode exit execution results. </summary>
+internal static class PlayExitCommandResultFactory
 {
-    /// <summary> Creates one command result for <c>play enter</c>. </summary>
-    /// <param name="executionResult"> The Play Mode enter execution result. </param>
+    /// <summary> Creates one command result for <c>play exit</c>. </summary>
+    /// <param name="executionResult"> The Play Mode exit execution result. </param>
     /// <returns> The command result serialized to stdout. </returns>
-    public static CommandResult Create (PlayEnterExecutionResult executionResult)
+    public static CommandResult Create (PlayExitExecutionResult executionResult)
     {
         ArgumentNullException.ThrowIfNull(executionResult);
 
         if (executionResult.IsSuccess)
         {
             return CommandResult.Success(
-                command: UcliCommandNames.PlayEnter,
+                command: UcliCommandNames.PlayExit,
                 message: executionResult.Message,
                 payload: CreatePayload(executionResult.Output!));
         }
 
         var payload = executionResult.Output is null ? null : CreatePayload(executionResult.Output);
         return CommandFailureProjector.Create(
-            UcliCommandNames.PlayEnter,
+            UcliCommandNames.PlayExit,
             executionResult.Message,
             payload,
             [executionResult.Error!]);
     }
 
-    private static object CreatePayload (PlayEnterExecutionOutput output)
+    private static object CreatePayload (PlayExitExecutionOutput output)
     {
         return new
         {
@@ -54,7 +54,7 @@ internal static class PlayEnterCommandResultFactory
         };
     }
 
-    private static object CreateTransitionPayload (PlayEnterTransitionOutput transition)
+    private static object CreateTransitionPayload (PlayExitTransitionOutput transition)
     {
         return PlayTransitionPayloadProjector.Create(
             transition.Transition,

--- a/src/Ucli/Hosting/Cli/Play/PlayTransitionPayloadProjector.cs
+++ b/src/Ucli/Hosting/Cli/Play/PlayTransitionPayloadProjector.cs
@@ -1,0 +1,52 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Hosting.Cli.Play;
+
+/// <summary> Creates public transition payload fragments for Play Mode commands. </summary>
+internal static class PlayTransitionPayloadProjector
+{
+    /// <summary> Creates the JSON-serializable transition payload. </summary>
+    /// <param name="transition"> The transition command literal. </param>
+    /// <param name="result"> The transition result literal. </param>
+    /// <param name="before"> The before snapshot payload. </param>
+    /// <param name="after"> The after snapshot payload for successful transitions. </param>
+    /// <param name="observed"> The observed snapshot payload for transition errors. </param>
+    /// <param name="applicationState"> The application-state literal for transition errors. </param>
+    /// <returns> The anonymous payload object serialized by the command-result writer. </returns>
+    public static object Create (
+        string transition,
+        string result,
+        object before,
+        object? after,
+        object? observed,
+        string? applicationState)
+    {
+        return result switch
+        {
+            IpcPlayTransitionResultNames.Entered
+                or IpcPlayTransitionResultNames.AlreadyEntered
+                or IpcPlayTransitionResultNames.Exited
+                or IpcPlayTransitionResultNames.AlreadyExited => new
+                {
+                    transition,
+                    result,
+                    before,
+                    after,
+                },
+            IpcPlayTransitionResultNames.Timeout or IpcPlayTransitionResultNames.Blocked => new
+            {
+                transition,
+                result,
+                before,
+                observed,
+                applicationState,
+            },
+            _ => new
+            {
+                transition,
+                result,
+                before,
+            },
+        };
+    }
+}

--- a/src/Ucli/UnityIntegration/Ipc/Clients/UnityDaemonIpcClient.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Clients/UnityDaemonIpcClient.cs
@@ -91,6 +91,7 @@ internal sealed class UnityDaemonIpcClient : IUnityIpcClient
 
             try
             {
+                var attemptTimeout = ResolveAttemptTimeout(dispatchRequest, remainingTimeout);
                 var response = await transportClient.SendAsync(
                         unityProject.RepositoryRoot,
                         unityProject.ProjectFingerprint,
@@ -100,7 +101,7 @@ internal sealed class UnityDaemonIpcClient : IUnityIpcClient
                             dispatchRequest.Payload,
                             requestId,
                             remainingTimeout),
-                        remainingTimeout,
+                        attemptTimeout,
                         cancellationToken)
                     .ConfigureAwait(false);
                 return UnityRequestExecutionResult.Success(UnityRequestResponseFactory.Create(response));
@@ -156,6 +157,20 @@ internal sealed class UnityDaemonIpcClient : IUnityIpcClient
     private static bool IsResponseLossOrTimeout (Exception exception)
     {
         return exception is TimeoutException or EndOfStreamException or IOException or ObjectDisposedException or InvalidOperationException;
+    }
+
+    private static TimeSpan ResolveAttemptTimeout (
+        UnityIpcDispatchRequest dispatchRequest,
+        TimeSpan remainingTimeout)
+    {
+        if (!dispatchRequest.IsRecoverable
+            || !dispatchRequest.RecoverableResponseAttemptTimeout.HasValue
+            || dispatchRequest.RecoverableResponseAttemptTimeout.Value >= remainingTimeout)
+        {
+            return remainingTimeout;
+        }
+
+        return dispatchRequest.RecoverableResponseAttemptTimeout.Value;
     }
 
     private static TimeSpan GetRetryDelay (TimeSpan remainingTimeout)

--- a/src/Ucli/UnityIntegration/Ipc/Dispatch/UnityIpcDispatchRequest.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Dispatch/UnityIpcDispatchRequest.cs
@@ -10,17 +10,25 @@ internal sealed record UnityIpcDispatchRequest
     /// <param name="payload"> The IPC payload element. </param>
     /// <param name="allowedStartupLifecycleStates"> Lifecycle states where the request may be dispatched before normal readiness. </param>
     /// <param name="isRecoverable"> Whether daemon dispatch may replay this request with the same request id after endpoint recovery. </param>
+    /// <param name="recoverableResponseAttemptTimeout"> The bounded response wait for one recoverable dispatch attempt, or <see langword="null" /> to use the full remaining timeout. </param>
     public UnityIpcDispatchRequest (
         string method,
         JsonElement payload,
         IReadOnlyList<string>? allowedStartupLifecycleStates = null,
-        bool isRecoverable = false)
+        bool isRecoverable = false,
+        TimeSpan? recoverableResponseAttemptTimeout = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(method);
+        if (recoverableResponseAttemptTimeout.HasValue)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(recoverableResponseAttemptTimeout.Value, TimeSpan.Zero);
+        }
+
         Method = method;
         Payload = payload;
         AllowedStartupLifecycleStates = allowedStartupLifecycleStates ?? Array.Empty<string>();
         IsRecoverable = isRecoverable;
+        RecoverableResponseAttemptTimeout = recoverableResponseAttemptTimeout;
     }
 
     /// <summary> Gets the IPC method name. </summary>
@@ -34,4 +42,7 @@ internal sealed record UnityIpcDispatchRequest
 
     /// <summary> Gets whether daemon dispatch may replay this request with the same request id after endpoint recovery. </summary>
     public bool IsRecoverable { get; }
+
+    /// <summary> Gets the response wait timeout for one recoverable dispatch attempt before retrying with the same request id. </summary>
+    public TimeSpan? RecoverableResponseAttemptTimeout { get; }
 }

--- a/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
@@ -43,6 +43,13 @@ internal sealed class UnityIpcRequestBuilder
                     TimeoutMilliseconds = playEnter.TimeoutMilliseconds,
                 }),
                 isRecoverable: true),
+            UnityRequestPayload.PlayExit playExit => new UnityIpcDispatchRequest(
+                IpcMethodNames.PlayExit,
+                IpcPayloadCodec.SerializeToElement(new IpcPlayExitRequest
+                {
+                    TimeoutMilliseconds = playExit.TimeoutMilliseconds,
+                }),
+                isRecoverable: true),
             UnityRequestPayload.ExecuteJson executeJson => new UnityIpcDispatchRequest(
                 IpcMethodNames.Execute,
                 CreateExecutePayload(

--- a/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
@@ -8,6 +8,8 @@ namespace MackySoft.Ucli.UnityIntegration.Ipc.Execution;
 /// <summary> Converts application Unity request payloads into IPC method dispatch requests. </summary>
 internal sealed class UnityIpcRequestBuilder
 {
+    private static readonly TimeSpan PlayExitRecoverableResponseAttemptTimeout = TimeSpan.FromMilliseconds(1000);
+
     private static readonly IReadOnlyList<string> CompileAllowedStartupLifecycleStates =
     [
         IpcEditorLifecycleStateCodec.CompileFailed,
@@ -49,7 +51,8 @@ internal sealed class UnityIpcRequestBuilder
                 {
                     TimeoutMilliseconds = playExit.TimeoutMilliseconds,
                 }),
-                isRecoverable: true),
+                isRecoverable: true,
+                recoverableResponseAttemptTimeout: PlayExitRecoverableResponseAttemptTimeout),
             UnityRequestPayload.ExecuteJson executeJson => new UnityIpcDispatchRequest(
                 IpcMethodNames.Execute,
                 CreateExecutePayload(

--- a/tests/Ucli.Application.Tests/Features/Play/UseCases/Exit/PlayExitServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Play/UseCases/Exit/PlayExitServiceTests.cs
@@ -1,0 +1,537 @@
+using System.Globalization;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
+using MackySoft.Ucli.Application.Features.Play.Common;
+using MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+using MackySoft.Ucli.Application.Shared.Configuration;
+using MackySoft.Ucli.Application.Shared.Context;
+using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Application.Tests.Play;
+
+public sealed class PlayExitServiceTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenSessionIsMissing_ReturnsSessionNotAvailableWithoutIpcCall ()
+    {
+        var context = CreateContext();
+        var sessionStore = new StubDaemonSessionStore(DaemonSessionReadResult.Success(null));
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(CreateExitedResponse())));
+        var service = CreateService(context, sessionStore, requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        Assert.Equal(PlayModeErrorCodes.PlayModeSessionNotAvailable, result.Error!.Code);
+        Assert.Equal(0, requestExecutor.CallCount);
+        Assert.Equal(context.UnityProject.RepositoryRoot, sessionStore.CapturedStorageRoot);
+        Assert.Equal(context.UnityProject.ProjectFingerprint, sessionStore.CapturedProjectFingerprint);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenRegisteredSessionIsBatchmode_ReturnsRequiresGuiEditorWithoutIpcCall ()
+    {
+        var sessionStore = new StubDaemonSessionStore(DaemonSessionReadResult.Success(CreateSession(DaemonEditorModeValues.Batchmode)));
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(CreateExitedResponse())));
+        var service = CreateService(CreateContext(), sessionStore, requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        Assert.Equal(PlayModeErrorCodes.PlayModeRequiresGuiEditor, result.Error!.Code);
+        Assert.Equal(0, requestExecutor.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenExitSucceeds_ReturnsReadyStoppedPayloadAndTransition ()
+    {
+        var context = CreateContext();
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(CreateExitedResponse())));
+        var service = CreateService(context, CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput("/repo/UnityProject", 1500), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var output = Assert.IsType<PlayExitExecutionOutput>(result.Output);
+        Assert.Equal(DaemonStatusKind.Running, output.DaemonStatus);
+        Assert.Equal(context.UnityProject.UnityProjectRoot, output.Project.ProjectPath);
+        Assert.Equal("0.5.0", output.ServerVersion);
+        Assert.Equal(DaemonEditorModeValues.Gui, output.EditorMode);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Ready, output.LifecycleState);
+        Assert.Null(output.BlockingReason);
+        Assert.True(output.CanAcceptExecutionRequests);
+        Assert.Equal(IpcPlayModeStateNames.Stopped, output.PlayMode.State);
+        Assert.Equal("3", output.PlayMode.Generation);
+        Assert.Equal(1500, output.TimeoutMilliseconds);
+        Assert.Equal(IpcPlayTransitionCommandNames.Exit, output.Transition.Transition);
+        Assert.Equal(IpcPlayTransitionResultNames.Exited, output.Transition.Result);
+        Assert.NotNull(output.Transition.Before);
+        Assert.NotNull(output.Transition.After);
+        Assert.Null(output.Transition.Observed);
+        Assert.Null(output.Transition.ApplicationState);
+
+        Assert.Equal(1, requestExecutor.CallCount);
+        Assert.Equal(UcliCommandIds.PlayExit, requestExecutor.CapturedCommand);
+        Assert.Equal(UnityExecutionMode.Daemon, requestExecutor.CapturedMode);
+        Assert.Equal(TimeSpan.FromMilliseconds(2500), requestExecutor.CapturedTimeout);
+        var payload = Assert.IsType<UnityRequestPayload.PlayExit>(requestExecutor.CapturedPayload);
+        Assert.Equal(1500, payload.TimeoutMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenAlreadyStopped_ReturnsAlreadyExitedWithoutGenerationChange ()
+    {
+        var before = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Compiling,
+            IpcEditorBlockingReasonCodec.Compile,
+            false,
+            CreateStoppedPlayMode("9"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.AlreadyExited,
+            before)
+        {
+            After = before,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var output = Assert.IsType<PlayExitExecutionOutput>(result.Output);
+        Assert.Equal(IpcPlayTransitionResultNames.AlreadyExited, output.Transition.Result);
+        Assert.Equal(IpcEditorLifecycleStateCodec.Compiling, output.LifecycleState);
+        Assert.Equal("9", output.Transition.Before.PlayMode!.Generation);
+        Assert.Equal("9", output.Transition.After!.PlayMode!.Generation);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenUnityReturnsTransitionTimeout_ReturnsFailureWithObservedPayload ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var observed = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, new IpcPlayModeSnapshot(
+            State: IpcPlayModeStateNames.Exiting,
+            Transition: IpcPlayModeTransitionNames.Exiting,
+            IsPlaying: true,
+            IsPlayingOrWillChangePlaymode: true,
+            Generation: "2"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Timeout,
+            before)
+        {
+            Observed = observed,
+            ApplicationState = IpcPlayApplicationStateNames.Indeterminate,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateErrorResponse(
+            response,
+            PlayModeErrorCodes.PlayModeTransitionTimeout,
+            "Unity Play Mode exit timed out after 1500 milliseconds.")));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, 1500), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeTransitionTimeout, result.Error!.Code);
+        Assert.NotNull(result.Output);
+        Assert.Equal(IpcPlayTransitionResultNames.Timeout, result.Output!.Transition.Result);
+        Assert.Equal(IpcPlayApplicationStateNames.Indeterminate, result.Output.Transition.ApplicationState);
+        Assert.Equal(observed.PlayMode!.State, result.Output.Transition.Observed!.PlayMode!.State);
+        Assert.Null(result.Output.Transition.After);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenUnityReturnsAppliedBlockedTransition_ReturnsFailureWithoutAfter ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var observed = CreateSnapshot(IpcEditorLifecycleStateCodec.SafeMode, IpcEditorBlockingReasonCodec.SafeMode, false, CreateStoppedPlayMode("3"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Blocked,
+            before)
+        {
+            Observed = observed,
+            ApplicationState = IpcPlayApplicationStateNames.Applied,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateErrorResponse(
+            response,
+            PlayModeErrorCodes.PlayModeTransitionBlocked,
+            "Unity Play Mode exit completed but readiness was blocked.")));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeTransitionBlocked, result.Error!.Code);
+        Assert.NotNull(result.Output);
+        Assert.Equal(IpcPlayApplicationStateNames.Applied, result.Output!.Transition.ApplicationState);
+        Assert.Null(result.Output.Transition.After);
+        Assert.Equal(IpcEditorLifecycleStateCodec.SafeMode, result.Output.LifecycleState);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenResponseProjectFingerprintDiffers_ReturnsMismatchFailure ()
+    {
+        var before = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Playmode,
+            IpcEditorBlockingReasonCodec.PlayMode,
+            false,
+            CreatePlayingPlayMode("2"),
+            projectFingerprint: "other-project-fingerprint");
+        var after = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Ready,
+            null,
+            true,
+            CreateStoppedPlayMode("3"),
+            projectFingerprint: "other-project-fingerprint");
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Exited,
+            before)
+        {
+            After = after,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("projectFingerprint mismatch", result.Error!.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenExitedDoesNotChangeGeneration_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var after = CreateSnapshot(IpcEditorLifecycleStateCodec.Ready, null, true, CreateStoppedPlayMode("2"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Exited,
+            before)
+        {
+            After = after,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenExitedAfterSnapshotIsStillPlaymode_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var after = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Playmode,
+            IpcEditorBlockingReasonCodec.PlayMode,
+            false,
+            CreateStoppedPlayMode("3"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Exited,
+            before)
+        {
+            After = after,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenUnityErrorOmitsTransitionPayload_ReturnsOriginalError ()
+    {
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateErrorResponseWithoutTransitionPayload(
+            UcliCoreErrorCodes.InvalidArgument,
+            "Unity play exit payload is invalid.")));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        Assert.Equal(UcliCoreErrorCodes.InvalidArgument, result.Error!.Code);
+        Assert.Equal("Unity play exit payload is invalid.", result.Error.Message);
+    }
+
+    private static PlayExitService CreateService (
+        ProjectContext context,
+        IDaemonSessionStore sessionStore,
+        IUnityRequestExecutor requestExecutor)
+    {
+        return CreateService(ProjectContextResolutionResult.Success(context), sessionStore, requestExecutor);
+    }
+
+    private static PlayExitService CreateService (
+        ProjectContextResolutionResult contextResult,
+        IDaemonSessionStore sessionStore,
+        IUnityRequestExecutor requestExecutor)
+    {
+        var contextResolver = new PlayCommandExecutionContextResolver(
+            new StubProjectContextResolver(contextResult),
+            sessionStore);
+        return new PlayExitService(contextResolver, requestExecutor);
+    }
+
+    private static ProjectContext CreateContext ()
+    {
+        var unityProjectRoot = Path.GetFullPath(Path.Combine(".", "sandbox", "Unity"));
+        return new ProjectContext(
+            UnityProject: new ResolvedUnityProjectContext(
+                UnityProjectRoot: unityProjectRoot,
+                RepositoryRoot: unityProjectRoot,
+                ProjectFingerprint: "project-fingerprint",
+                PathSource: UnityProjectPathSource.CommandOption,
+                UnityVersion: "6000.1.4f1"),
+            Config: UcliConfig.CreateDefault(),
+            ConfigSource: ConfigSource.Default);
+    }
+
+    private static StubDaemonSessionStore CreateGuiSessionStore ()
+    {
+        return new StubDaemonSessionStore(DaemonSessionReadResult.Success(CreateSession(DaemonEditorModeValues.Gui)));
+    }
+
+    private static DaemonSession CreateSession (string editorMode)
+    {
+        return new DaemonSession(
+            SchemaVersion: DaemonSession.CurrentSchemaVersion,
+            SessionToken: "session-token",
+            ProjectFingerprint: "project-fingerprint",
+            IssuedAtUtc: DateTimeOffset.UtcNow,
+            EditorMode: editorMode,
+            OwnerKind: DaemonSessionOwnerKindValues.User,
+            CanShutdownProcess: false,
+            EndpointTransportKind: "namedPipe",
+            EndpointAddress: "ucli-play-exit",
+            ProcessId: 1234,
+            ProcessStartedAtUtc: DateTimeOffset.UtcNow,
+            OwnerProcessId: 9876);
+    }
+
+    private static IpcPlayTransitionResponse CreateExitedResponse ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var after = CreateSnapshot(IpcEditorLifecycleStateCodec.Ready, null, true, CreateStoppedPlayMode("3"));
+        return new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Exited,
+            before)
+        {
+            After = after,
+        });
+    }
+
+    private static IpcPlayLifecycleSnapshot CreateSnapshot (
+        string lifecycleState,
+        string? blockingReason,
+        bool canAcceptExecutionRequests,
+        IpcPlayModeSnapshot playMode,
+        string projectFingerprint = "project-fingerprint")
+    {
+        return new IpcPlayLifecycleSnapshot(
+            ServerVersion: "0.5.0",
+            EditorMode: DaemonEditorModeValues.Gui,
+            UnityVersion: "6000.1.4f1",
+            ProjectFingerprint: projectFingerprint,
+            LifecycleState: lifecycleState,
+            BlockingReason: blockingReason,
+            CompileState: IpcCompileStateCodec.Ready,
+            CompileGeneration: "12",
+            DomainReloadGeneration: "7",
+            CanAcceptExecutionRequests: canAcceptExecutionRequests,
+            ObservedAtUtc: DateTimeOffset.Parse("2026-05-21T00:00:00+00:00", CultureInfo.InvariantCulture),
+            ActionRequired: null,
+            PrimaryDiagnostic: null,
+            PlayMode: playMode);
+    }
+
+    private static IpcPlayModeSnapshot CreatePlayingPlayMode (string generation)
+    {
+        return new IpcPlayModeSnapshot(
+            State: IpcPlayModeStateNames.Playing,
+            Transition: IpcPlayModeTransitionNames.None,
+            IsPlaying: true,
+            IsPlayingOrWillChangePlaymode: true,
+            Generation: generation);
+    }
+
+    private static IpcPlayModeSnapshot CreateStoppedPlayMode (string generation)
+    {
+        return new IpcPlayModeSnapshot(
+            State: IpcPlayModeStateNames.Stopped,
+            Transition: IpcPlayModeTransitionNames.None,
+            IsPlaying: false,
+            IsPlayingOrWillChangePlaymode: false,
+            Generation: generation);
+    }
+
+    private static UnityRequestResponse CreateResponse (IpcPlayTransitionResponse payload)
+    {
+        return UnityRequestResponseTestFactory.Create(new IpcResponse(
+            ProtocolVersion: IpcProtocol.CurrentVersion,
+            RequestId: "request-1",
+            Status: IpcProtocol.StatusOk,
+            Payload: IpcPayloadCodec.SerializeToElement(payload),
+            Errors: []));
+    }
+
+    private static UnityRequestResponse CreateErrorResponse (
+        IpcPlayTransitionResponse payload,
+        UcliCode code,
+        string message)
+    {
+        return UnityRequestResponseTestFactory.Create(new IpcResponse(
+            ProtocolVersion: IpcProtocol.CurrentVersion,
+            RequestId: "request-1",
+            Status: IpcProtocol.StatusError,
+            Payload: IpcPayloadCodec.SerializeToElement(payload),
+            Errors:
+            [
+                new IpcError(code, message, null),
+            ]));
+    }
+
+    private static UnityRequestResponse CreateErrorResponseWithoutTransitionPayload (
+        UcliCode code,
+        string message)
+    {
+        return UnityRequestResponseTestFactory.Create(new IpcResponse(
+            ProtocolVersion: IpcProtocol.CurrentVersion,
+            RequestId: "request-1",
+            Status: IpcProtocol.StatusError,
+            Payload: IpcPayloadCodec.SerializeToElement(new
+            {
+                ignored = true,
+            }),
+            Errors:
+            [
+                new IpcError(code, message, null),
+            ]));
+    }
+
+    private sealed class StubProjectContextResolver : IProjectContextResolver
+    {
+        private readonly ProjectContextResolutionResult result;
+
+        public StubProjectContextResolver (ProjectContextResolutionResult result)
+        {
+            this.result = result;
+        }
+
+        public ValueTask<ProjectContextResolutionResult> ResolveAsync (
+            string? projectPath,
+            CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(result);
+        }
+    }
+
+    private sealed class StubDaemonSessionStore : IDaemonSessionStore
+    {
+        private readonly DaemonSessionReadResult readResult;
+
+        public StubDaemonSessionStore (DaemonSessionReadResult readResult)
+        {
+            this.readResult = readResult;
+        }
+
+        public string? CapturedStorageRoot { get; private set; }
+
+        public string? CapturedProjectFingerprint { get; private set; }
+
+        public int ReadCallCount { get; private set; }
+
+        public ValueTask<DaemonSessionReadResult> ReadAsync (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            ReadCallCount++;
+            CapturedStorageRoot = storageRoot;
+            CapturedProjectFingerprint = projectFingerprint;
+            return ValueTask.FromResult(readResult);
+        }
+
+        public ValueTask<DaemonSessionStoreOperationResult> WriteAsync (
+            string storageRoot,
+            DaemonSession session,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ValueTask<DaemonSessionStoreOperationResult> DeleteAsync (
+            string storageRoot,
+            string projectFingerprint,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class StubUnityRequestExecutor : IUnityRequestExecutor
+    {
+        private readonly Queue<UnityRequestExecutionResult> results;
+
+        public StubUnityRequestExecutor (params UnityRequestExecutionResult[] results)
+        {
+            if (results.Length == 0)
+            {
+                throw new ArgumentException("At least one result is required.", nameof(results));
+            }
+
+            this.results = new Queue<UnityRequestExecutionResult>(results);
+        }
+
+        public int CallCount { get; private set; }
+
+        public UcliCommand CapturedCommand { get; private set; }
+
+        public UnityExecutionMode CapturedMode { get; private set; }
+
+        public TimeSpan CapturedTimeout { get; private set; }
+
+        public UnityRequestPayload? CapturedPayload { get; private set; }
+
+        public ValueTask<UnityRequestExecutionResult> ExecuteAsync (
+            UcliCommand command,
+            UnityExecutionMode mode,
+            TimeSpan timeout,
+            UcliConfig config,
+            ResolvedUnityProjectContext unityProject,
+            UnityRequestPayload payload,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            CapturedCommand = command;
+            CapturedMode = mode;
+            CapturedTimeout = timeout;
+            CapturedPayload = payload;
+            var result = results.Count == 1 ? results.Peek() : results.Dequeue();
+            return ValueTask.FromResult(result);
+        }
+    }
+}

--- a/tests/Ucli.Application.Tests/Features/Play/UseCases/Exit/PlayExitServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Play/UseCases/Exit/PlayExitServiceTests.cs
@@ -115,6 +115,36 @@ public sealed class PlayExitServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Execute_WhenAlreadyExitedChangesGeneration_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Compiling,
+            IpcEditorBlockingReasonCodec.Compile,
+            false,
+            CreateStoppedPlayMode("9"));
+        var after = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Compiling,
+            IpcEditorBlockingReasonCodec.Compile,
+            false,
+            CreateStoppedPlayMode("10"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.AlreadyExited,
+            before)
+        {
+            After = after,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Execute_WhenUnityReturnsTransitionTimeout_ReturnsFailureWithObservedPayload ()
     {
         var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
@@ -251,6 +281,94 @@ public sealed class PlayExitServiceTests
             After = after,
         });
         var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenSuccessTransitionContainsErrorFields_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var after = CreateSnapshot(IpcEditorLifecycleStateCodec.Ready, null, true, CreateStoppedPlayMode("3"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Exited,
+            before)
+        {
+            After = after,
+            Observed = before,
+            ApplicationState = IpcPlayApplicationStateNames.NotApplied,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateResponse(response)));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenTimeoutTransitionContainsAfter_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var observed = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, new IpcPlayModeSnapshot(
+            State: IpcPlayModeStateNames.Exiting,
+            Transition: IpcPlayModeTransitionNames.Exiting,
+            IsPlaying: true,
+            IsPlayingOrWillChangePlaymode: true,
+            Generation: "2"));
+        var after = CreateSnapshot(IpcEditorLifecycleStateCodec.Ready, null, true, CreateStoppedPlayMode("3"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Timeout,
+            before)
+        {
+            After = after,
+            Observed = observed,
+            ApplicationState = IpcPlayApplicationStateNames.Indeterminate,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateErrorResponse(
+            response,
+            PlayModeErrorCodes.PlayModeTransitionTimeout,
+            "Unity Play Mode exit timed out.")));
+        var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
+
+        var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(PlayModeErrorCodes.PlayModeStateUnknown, result.Error!.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenTimeoutApplicationStateIsNotIndeterminate_ReturnsStateUnknown ()
+    {
+        var before = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, CreatePlayingPlayMode("2"));
+        var observed = CreateSnapshot(IpcEditorLifecycleStateCodec.Playmode, IpcEditorBlockingReasonCodec.PlayMode, false, new IpcPlayModeSnapshot(
+            State: IpcPlayModeStateNames.Exiting,
+            Transition: IpcPlayModeTransitionNames.Exiting,
+            IsPlaying: true,
+            IsPlayingOrWillChangePlaymode: true,
+            Generation: "2"));
+        var response = new IpcPlayTransitionResponse(new IpcPlayTransitionResult(
+            IpcPlayTransitionCommandNames.Exit,
+            IpcPlayTransitionResultNames.Timeout,
+            before)
+        {
+            Observed = observed,
+            ApplicationState = IpcPlayApplicationStateNames.NotApplied,
+        });
+        var requestExecutor = new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(CreateErrorResponse(
+            response,
+            PlayModeErrorCodes.PlayModeTransitionTimeout,
+            "Unity Play Mode exit timed out.")));
         var service = CreateService(CreateContext(), CreateGuiSessionStore(), requestExecutor);
 
         var result = await service.ExecuteAsync(new PlayExitCommandInput(null, null), CancellationToken.None);

--- a/tests/Ucli.Application.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
@@ -55,6 +55,19 @@ public sealed class IpcCommandTimeoutResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Resolve_WithoutOption_UsesDefaultPlayExitOverride ()
+    {
+        var config = UcliConfig.CreateDefault();
+
+        var result = IpcCommandTimeoutResolver.ResolveNormalized(null, UcliCommandIds.PlayExit, config);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TimeSpan.FromMilliseconds(30000), result.Timeout);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Resolve_WithoutOption_UsesConfigDefaultWhenCommandOverrideIsNull ()
     {
         var config = CreateConfig(

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -363,6 +363,7 @@ public sealed class CliOutputContractTests
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultLogsUnityClearMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandLogsUnityClear).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayStatusMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandPlayStatus).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayEnterMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandPlayEnter).GetInt32());
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayExitMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandPlayExit).GetInt32());
     }
 
     private static void PrepareLegacyTemplateFiles (

--- a/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
+++ b/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
@@ -107,6 +107,8 @@ internal static class UcliContractConstants
 
         public const int IpcTimeoutDefaultPlayEnterMilliseconds = 30000;
 
+        public const int IpcTimeoutDefaultPlayExitMilliseconds = 30000;
+
         public const string IpcTimeoutCommandTest = "test";
 
         public const string IpcTimeoutCommandReady = "ready";
@@ -148,6 +150,8 @@ internal static class UcliContractConstants
         public const string IpcTimeoutCommandPlayStatus = "play.status";
 
         public const string IpcTimeoutCommandPlayEnter = "play.enter";
+
+        public const string IpcTimeoutCommandPlayExit = "play.exit";
     }
 
     internal static class TestProfile

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/play/exit-session-not-available.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/play/exit-session-not-available.json
@@ -1,0 +1,15 @@
+{
+  "protocolVersion": 1,
+  "command": "play.exit",
+  "status": "error",
+  "exitCode": 4,
+  "message": "Registered GUI daemon session is not available for Play Mode exit.",
+  "payload": {},
+  "errors": [
+    {
+      "code": "PLAYMODE_SESSION_NOT_AVAILABLE",
+      "message": "Registered GUI daemon session is not available for Play Mode exit.",
+      "opId": null
+    }
+  ]
+}

--- a/tests/Ucli.Tests/Hosting/Cli/PlayExitCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/PlayExitCommandTests.cs
@@ -1,0 +1,288 @@
+using System.Globalization;
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Status;
+using MackySoft.Ucli.Application.Features.Play.Common.Contracts;
+using MackySoft.Ucli.Application.Features.Play.UseCases.Exit;
+using MackySoft.Ucli.Application.Shared.CommandContracts;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Hosting.Cli.Play;
+using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class PlayExitCommandTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Exit_MapsOptionsToServiceInputAndCancellationToken ()
+    {
+        var service = new StubPlayExitService((_, _) => ValueTask.FromResult(PlayExitExecutionResult.Success(CreateOutput())));
+        var command = new PlayExitCommand(service, CommandResultTestWriter.Create());
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await StandardOutputCapture.ExecuteAsync(() => command.ExitAsync(
+            projectPath: "/repo/UnityProject",
+            timeout: "1234",
+            cancellationToken: cancellationTokenSource.Token));
+
+        Assert.Equal(cancellationTokenSource.Token, service.CapturedCancellationToken);
+        var input = Assert.IsType<PlayExitCommandInput>(service.CapturedInput);
+        Assert.Equal("/repo/UnityProject", input.ProjectPath);
+        Assert.Equal(1234, input.TimeoutMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Exit_WhenTimeoutIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
+    {
+        var service = new StubPlayExitService((_, _) => throw new InvalidOperationException("Service should not be called."));
+        var command = new PlayExitCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ExitAsync(
+            timeout: "abc",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, exitCode);
+        Assert.Null(service.CapturedInput);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.PlayExit,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Exit_WhenServiceSucceeds_EmitsPlayExitEnvelopeAndPayloadWithoutOpResults ()
+    {
+        var service = new StubPlayExitService((_, _) => ValueTask.FromResult(PlayExitExecutionResult.Success(CreateOutput())));
+        var command = new PlayExitCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ExitAsync(
+            timeout: "1000",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.PlayExit,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        JsonAssert.For(outputJson.RootElement.GetProperty("payload"))
+            .HasProperty("project", project => project
+                .HasString("projectPath", "/repo/UnityProject")
+                .HasString("projectFingerprint", "project-fingerprint")
+                .HasString("unityVersion", "6000.1.4f1"))
+            .HasString("daemonStatus", "running")
+            .HasString("editorMode", "gui")
+            .HasString("lifecycleState", IpcEditorLifecycleStateCodec.Ready)
+            .HasValueKind("blockingReason", JsonValueKind.Null)
+            .HasBoolean("canAcceptExecutionRequests", true)
+            .HasProperty("playMode", playMode => playMode
+                .HasString("state", IpcPlayModeStateNames.Stopped)
+                .HasString("transition", IpcPlayModeTransitionNames.None)
+                .HasBoolean("isPlaying", false)
+                .HasBoolean("isPlayingOrWillChangePlaymode", false)
+                .HasString("generation", "3"))
+            .HasProperty("transition", transition => transition
+                .HasString("transition", IpcPlayTransitionCommandNames.Exit)
+                .HasString("result", IpcPlayTransitionResultNames.Exited)
+                .HasProperty("before", _ => { })
+                .HasProperty("after", _ => { }))
+            .HasInt32("timeoutMilliseconds", 1000);
+        var transitionPayload = outputJson.RootElement.GetProperty("payload").GetProperty("transition");
+        Assert.False(transitionPayload.TryGetProperty("observed", out _));
+        Assert.False(transitionPayload.TryGetProperty("applicationState", out _));
+        Assert.False(transitionPayload.TryGetProperty("until", out _));
+        Assert.False(outputJson.RootElement.GetProperty("payload").TryGetProperty("opResults", out _));
+        Assert.DoesNotContain("\"touched\"", standardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Exit_WhenServiceReturnsTransitionFailure_EmitsErrorEnvelopeWithObservedTransitionPayload ()
+    {
+        var output = CreateOutput(IpcPlayTransitionResultNames.Timeout, includeAfter: false);
+        var failure = ApplicationFailure.Timeout(
+            "Unity Play Mode exit timed out after 1000 milliseconds.",
+            PlayModeErrorCodes.PlayModeTransitionTimeout);
+        var service = new StubPlayExitService((_, _) => ValueTask.FromResult(PlayExitExecutionResult.Failure(failure, output)));
+        var command = new PlayExitCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ExitAsync(
+            timeout: "1000",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.ToolError, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.PlayExit,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, PlayModeErrorCodes.PlayModeTransitionTimeout);
+        JsonAssert.For(outputJson.RootElement.GetProperty("payload").GetProperty("transition"))
+            .HasString("result", IpcPlayTransitionResultNames.Timeout)
+            .HasString("applicationState", IpcPlayApplicationStateNames.Indeterminate)
+            .HasProperty("observed", _ => { });
+        Assert.False(outputJson.RootElement.GetProperty("payload").GetProperty("transition").TryGetProperty("after", out _));
+        Assert.False(outputJson.RootElement.GetProperty("payload").TryGetProperty("opResults", out _));
+        Assert.DoesNotContain("\"touched\"", standardOutput, StringComparison.Ordinal);
+    }
+
+    private static PlayExitExecutionOutput CreateOutput (
+        string result = IpcPlayTransitionResultNames.Exited,
+        bool includeAfter = true,
+        string applicationState = IpcPlayApplicationStateNames.Indeterminate)
+    {
+        var before = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Playmode,
+            IpcEditorBlockingReasonCodec.PlayMode,
+            false,
+            CreatePlayMode(IpcPlayModeStateNames.Playing, IpcPlayModeTransitionNames.None, true, true, "2"));
+        var current = CreateSnapshot(
+            IpcEditorLifecycleStateCodec.Ready,
+            null,
+            true,
+            CreatePlayMode(IpcPlayModeStateNames.Stopped, IpcPlayModeTransitionNames.None, false, false, "3"));
+        var transition = new PlayExitTransitionOutput(
+            Transition: IpcPlayTransitionCommandNames.Exit,
+            Result: result,
+            Before: CreateSnapshotOutput(before),
+            After: null,
+            Observed: null,
+            ApplicationState: null);
+        if (includeAfter)
+        {
+            transition = transition with
+            {
+                After = CreateSnapshotOutput(current),
+            };
+        }
+        else
+        {
+            transition = transition with
+            {
+                Observed = CreateSnapshotOutput(current),
+                ApplicationState = applicationState,
+            };
+        }
+
+        return new PlayExitExecutionOutput(
+            Project: new ProjectIdentityInfo(
+                ProjectPath: "/repo/UnityProject",
+                ProjectFingerprint: "project-fingerprint",
+                UnityVersion: "6000.1.4f1"),
+            DaemonStatus: DaemonStatusKind.Running,
+            ServerVersion: "0.5.0",
+            EditorMode: "gui",
+            LifecycleState: IpcEditorLifecycleStateCodec.Ready,
+            BlockingReason: null,
+            CompileState: "ready",
+            CompileGeneration: "12",
+            DomainReloadGeneration: "7",
+            CanAcceptExecutionRequests: true,
+            ObservedAtUtc: DateTimeOffset.Parse("2026-05-21T00:00:00+00:00", CultureInfo.InvariantCulture),
+            ActionRequired: null,
+            PrimaryDiagnostic: null,
+            PlayMode: new PlayModeSnapshotOutput(
+                State: IpcPlayModeStateNames.Stopped,
+                Transition: IpcPlayModeTransitionNames.None,
+                IsPlaying: false,
+                IsPlayingOrWillChangePlaymode: false,
+                Generation: "3"),
+            Transition: transition,
+            TimeoutMilliseconds: 1000);
+    }
+
+    private static PlayLifecycleSnapshotOutput CreateSnapshotOutput (IpcPlayLifecycleSnapshot snapshot)
+    {
+        return new PlayLifecycleSnapshotOutput(
+            ServerVersion: snapshot.ServerVersion,
+            EditorMode: snapshot.EditorMode,
+            UnityVersion: snapshot.UnityVersion,
+            ProjectFingerprint: snapshot.ProjectFingerprint,
+            LifecycleState: snapshot.LifecycleState,
+            BlockingReason: snapshot.BlockingReason,
+            CompileState: snapshot.CompileState,
+            CompileGeneration: snapshot.CompileGeneration,
+            DomainReloadGeneration: snapshot.DomainReloadGeneration,
+            CanAcceptExecutionRequests: snapshot.CanAcceptExecutionRequests,
+            ObservedAtUtc: snapshot.ObservedAtUtc,
+            ActionRequired: snapshot.ActionRequired,
+            PrimaryDiagnostic: null,
+            PlayMode: new PlayModeSnapshotOutput(
+                State: snapshot.PlayMode!.State,
+                Transition: snapshot.PlayMode.Transition,
+                IsPlaying: snapshot.PlayMode.IsPlaying,
+                IsPlayingOrWillChangePlaymode: snapshot.PlayMode.IsPlayingOrWillChangePlaymode,
+                Generation: snapshot.PlayMode.Generation));
+    }
+
+    private static IpcPlayLifecycleSnapshot CreateSnapshot (
+        string lifecycleState,
+        string? blockingReason,
+        bool canAcceptExecutionRequests,
+        IpcPlayModeSnapshot playMode)
+    {
+        return new IpcPlayLifecycleSnapshot(
+            ServerVersion: "0.5.0",
+            EditorMode: DaemonEditorModeValues.Gui,
+            UnityVersion: "6000.1.4f1",
+            ProjectFingerprint: "project-fingerprint",
+            LifecycleState: lifecycleState,
+            BlockingReason: blockingReason,
+            CompileState: "ready",
+            CompileGeneration: "12",
+            DomainReloadGeneration: "7",
+            CanAcceptExecutionRequests: canAcceptExecutionRequests,
+            ObservedAtUtc: DateTimeOffset.Parse("2026-05-21T00:00:00+00:00", CultureInfo.InvariantCulture),
+            ActionRequired: null,
+            PrimaryDiagnostic: null,
+            PlayMode: playMode);
+    }
+
+    private static IpcPlayModeSnapshot CreatePlayMode (
+        string state,
+        string transition,
+        bool isPlaying,
+        bool isPlayingOrWillChangePlaymode,
+        string generation)
+    {
+        return new IpcPlayModeSnapshot(
+            State: state,
+            Transition: transition,
+            IsPlaying: isPlaying,
+            IsPlayingOrWillChangePlaymode: isPlayingOrWillChangePlaymode,
+            Generation: generation);
+    }
+
+    private sealed class StubPlayExitService : IPlayExitService
+    {
+        private readonly Func<PlayExitCommandInput, CancellationToken, ValueTask<PlayExitExecutionResult>> handler;
+
+        public StubPlayExitService (Func<PlayExitCommandInput, CancellationToken, ValueTask<PlayExitExecutionResult>> handler)
+        {
+            this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
+        }
+
+        public PlayExitCommandInput? CapturedInput { get; private set; }
+
+        public CancellationToken CapturedCancellationToken { get; private set; }
+
+        public ValueTask<PlayExitExecutionResult> ExecuteAsync (
+            PlayExitCommandInput input,
+            CancellationToken cancellationToken = default)
+        {
+            CapturedInput = input;
+            CapturedCancellationToken = cancellationToken;
+            return handler(input, cancellationToken);
+        }
+    }
+}

--- a/tests/Ucli.Tests/PlayCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/PlayCliOutputContractTests.cs
@@ -94,22 +94,23 @@ public sealed class PlayCliOutputContractTests
         Assert.DoesNotContain("Argument '--timeout' is not recognized.", result.StdErr, StringComparison.Ordinal);
     }
 
-    [Theory]
-    [InlineData(UcliCommandNames.ExitSubcommand, UcliCommandNames.PlayExit)]
+    [Fact]
     [Trait("Size", "Medium")]
-    public async Task PlayCommand_WithProjectPathAndTimeoutOptions_ReturnsRegisteredStubResult (
-        string subcommand,
-        string expectedCommand)
+    public async Task PlayExit_WithProjectPathAndTimeoutOptions_WhenGuiSessionIsMissing_ReturnsSessionNotAvailable ()
     {
+        using var scope = TestDirectories.CreateTempScope("play-cli-output-contract", "exit-session-not-available");
+        var unityProjectPath = UnityProjectTestFactory.CreateMinimalUnityProject(scope, "UnityProject");
+
         var result = await CliProcessRunner.RunCommandAsync(
             UcliCommandNames.Play,
-            subcommand,
+            UcliCommandNames.ExitSubcommand,
             "--projectPath",
-            "/tmp/ucli-play-contract",
+            unityProjectPath,
             "--timeout",
             "1000");
 
-        AssertPlayStubResult(result, expectedCommand);
+        JsonGoldenFileAssert.Matches(CliOutputGoldenFiles.GetPath("play", "exit-session-not-available.json"), result.StdOut);
+        Assert.Equal((int)CliExitCode.ToolError, result.ExitCode);
         Assert.DoesNotContain("Argument '--projectPath' is not recognized.", result.StdErr, StringComparison.Ordinal);
         Assert.DoesNotContain("Argument '--timeout' is not recognized.", result.StdErr, StringComparison.Ordinal);
     }

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -265,18 +265,27 @@ public sealed class CliOutputSchemaArtifactTests
               "after": {{CreatePlayingPlayLifecycleSnapshotJson()}}
             }
             """));
-        using var exitDocument = JsonDocument.Parse(
+        using var exitDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
             $$"""
             {
-              "transition": {
-                "transition": "exit",
-                "result": "exited",
-                "before": {{CreatePlayLifecycleSnapshotJson()}},
-                "applicationState": "applied"
-              },
-              "timeoutMilliseconds": 1000
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}}
             }
-            """);
+            """));
+        using var alreadyExitedDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "alreadyExited",
+              "before": {{CreateCompilingStoppedPlayLifecycleSnapshotJson()}},
+              "after": {{CreateCompilingStoppedPlayLifecycleSnapshotJson()}}
+            }
+            """,
+            lifecycleState: "compiling",
+            blockingReasonJson: "\"compile\"",
+            canAcceptExecutionRequests: false));
         using var waitDocument = JsonDocument.Parse(
             $$"""
             {
@@ -294,6 +303,7 @@ public sealed class CliOutputSchemaArtifactTests
         Assert.Empty(schemaSet.Validate("cli-output/payload/play.status.schema.json", statusDocument.RootElement));
         Assert.Empty(schemaSet.Validate("cli-output/payload/play.enter.schema.json", enterDocument.RootElement));
         Assert.Empty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", exitDocument.RootElement));
+        Assert.Empty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", alreadyExitedDocument.RootElement));
         Assert.Empty(schemaSet.Validate("cli-output/payload/play.wait.schema.json", waitDocument.RootElement));
     }
 
@@ -1096,6 +1106,20 @@ public sealed class CliOutputSchemaArtifactTests
             generation: "43");
     }
 
+    private static string CreateReadyStoppedPlayLifecycleSnapshotJson ()
+    {
+        return CreatePlayLifecycleSnapshotJson(generation: "44");
+    }
+
+    private static string CreateCompilingStoppedPlayLifecycleSnapshotJson ()
+    {
+        return CreatePlayLifecycleSnapshotJson(
+            lifecycleState: "compiling",
+            blockingReasonJson: "\"compile\"",
+            canAcceptExecutionRequests: false,
+            generation: "44");
+    }
+
     private static string CreatePlayEnterPayloadJson (
         string transitionJson,
         string lifecycleState = "playmode",
@@ -1131,6 +1155,44 @@ public sealed class CliOutputSchemaArtifactTests
                 "isPlaying": {{JsonSerializer.Serialize(isPlaying)}},
                 "isPlayingOrWillChangePlaymode": {{JsonSerializer.Serialize(isPlayingOrWillChangePlaymode)}},
                 "generation": "43"
+              },
+              "transition": {{transitionJson}},
+              "timeoutMilliseconds": 1000
+            }
+            """;
+    }
+
+    private static string CreatePlayExitPayloadJson (
+        string transitionJson,
+        string lifecycleState = "ready",
+        string blockingReasonJson = "null",
+        bool canAcceptExecutionRequests = true)
+    {
+        return $$"""
+            {
+              "project": {
+                "projectPath": "/repo/UnityProject",
+                "projectFingerprint": "project-fingerprint",
+                "unityVersion": "6000.1.4f1"
+              },
+              "daemonStatus": "running",
+              "serverVersion": "0.5.0",
+              "editorMode": "gui",
+              "lifecycleState": "{{lifecycleState}}",
+              "blockingReason": {{blockingReasonJson}},
+              "compileState": "idle",
+              "compileGeneration": "12",
+              "domainReloadGeneration": "7",
+              "canAcceptExecutionRequests": {{JsonSerializer.Serialize(canAcceptExecutionRequests)}},
+              "observedAtUtc": "2026-05-21T00:00:00+00:00",
+              "actionRequired": null,
+              "primaryDiagnostic": null,
+              "playMode": {
+                "state": "stopped",
+                "transition": "none",
+                "isPlaying": false,
+                "isPlayingOrWillChangePlaymode": false,
+                "generation": "44"
               },
               "transition": {{transitionJson}},
               "timeoutMilliseconds": 1000

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -524,6 +524,210 @@ public sealed class CliOutputSchemaArtifactTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void PlayExitPayloadSchema_ValidatesSuccessAndFailureTransitionShapes ()
+    {
+        using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
+        using var successDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}}
+            }
+            """));
+        using var timeoutDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "timeout",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "observed": {{CreatePlayLifecycleSnapshotJson(playModeState: "exiting", playModeTransition: "exiting", lifecycleState: "playmode", blockingReasonJson: "\"playMode\"", canAcceptExecutionRequests: false, isPlaying: true, isPlayingOrWillChangePlaymode: true)}},
+              "applicationState": "indeterminate"
+            }
+            """,
+            lifecycleState: "playmode",
+            blockingReasonJson: "\"playMode\"",
+            canAcceptExecutionRequests: false,
+            playModeState: "exiting",
+            playModeTransition: "exiting",
+            isPlaying: true,
+            isPlayingOrWillChangePlaymode: true,
+            generation: "42"));
+        using var blockedDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "blocked",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "observed": {{CreatePlayLifecycleSnapshotJson(lifecycleState: "safeMode", blockingReasonJson: "\"safeMode\"", canAcceptExecutionRequests: false, generation: "44")}},
+              "applicationState": "applied"
+            }
+            """,
+            lifecycleState: "safeMode",
+            blockingReasonJson: "\"safeMode\"",
+            canAcceptExecutionRequests: false));
+        using var successWithoutAfterDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}}
+            }
+            """));
+        using var timeoutWithoutObservedDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "timeout",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "applicationState": "indeterminate"
+            }
+            """,
+            lifecycleState: "playmode",
+            blockingReasonJson: "\"playMode\"",
+            canAcceptExecutionRequests: false,
+            playModeState: "exiting",
+            playModeTransition: "exiting",
+            isPlaying: true,
+            isPlayingOrWillChangePlaymode: true,
+            generation: "42"));
+        using var successWithErrorFieldsDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}},
+              "observed": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "applicationState": "notApplied"
+            }
+            """));
+        using var timeoutWithAfterDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "timeout",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}},
+              "observed": {{CreatePlayLifecycleSnapshotJson(playModeState: "exiting", playModeTransition: "exiting", lifecycleState: "playmode", blockingReasonJson: "\"playMode\"", canAcceptExecutionRequests: false, isPlaying: true, isPlayingOrWillChangePlaymode: true)}},
+              "applicationState": "indeterminate"
+            }
+            """,
+            lifecycleState: "playmode",
+            blockingReasonJson: "\"playMode\"",
+            canAcceptExecutionRequests: false,
+            playModeState: "exiting",
+            playModeTransition: "exiting",
+            isPlaying: true,
+            isPlayingOrWillChangePlaymode: true,
+            generation: "42"));
+        using var timeoutWithNotAppliedApplicationStateDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "timeout",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "observed": {{CreatePlayLifecycleSnapshotJson(playModeState: "exiting", playModeTransition: "exiting", lifecycleState: "playmode", blockingReasonJson: "\"playMode\"", canAcceptExecutionRequests: false, isPlaying: true, isPlayingOrWillChangePlaymode: true)}},
+              "applicationState": "notApplied"
+            }
+            """,
+            lifecycleState: "playmode",
+            blockingReasonJson: "\"playMode\"",
+            canAcceptExecutionRequests: false,
+            playModeState: "exiting",
+            playModeTransition: "exiting",
+            isPlaying: true,
+            isPlayingOrWillChangePlaymode: true,
+            generation: "42"));
+        using var successWithPlayingAfterDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreatePlayingPlayLifecycleSnapshotJson()}}
+            }
+            """));
+        using var alreadyExitedWithPlayingBeforeDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "alreadyExited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}}
+            }
+            """));
+        using var successWithPlayingTopLevelDocument = JsonDocument.Parse(CreatePlayExitPayloadJson(
+            $$"""
+            {
+              "transition": "exit",
+              "result": "exited",
+              "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+              "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}}
+            }
+            """,
+            lifecycleState: "playmode",
+            blockingReasonJson: "\"playMode\"",
+            canAcceptExecutionRequests: false,
+            playModeState: "playing",
+            isPlaying: true,
+            isPlayingOrWillChangePlaymode: true,
+            generation: "43"));
+        using var exitWithOpResultsDocument = JsonDocument.Parse(
+            $$"""
+            {
+              "project": {
+                "projectPath": "/repo/UnityProject",
+                "projectFingerprint": "project-fingerprint",
+                "unityVersion": "6000.1.4f1"
+              },
+              "daemonStatus": "running",
+              "serverVersion": "0.5.0",
+              "editorMode": "gui",
+              "lifecycleState": "ready",
+              "blockingReason": null,
+              "compileState": "idle",
+              "compileGeneration": "12",
+              "domainReloadGeneration": "7",
+              "canAcceptExecutionRequests": true,
+              "observedAtUtc": "2026-05-21T00:00:00+00:00",
+              "actionRequired": null,
+              "primaryDiagnostic": null,
+              "playMode": {
+                "state": "stopped",
+                "transition": "none",
+                "isPlaying": false,
+                "isPlayingOrWillChangePlaymode": false,
+                "generation": "44"
+              },
+              "transition": {
+                "transition": "exit",
+                "result": "exited",
+                "before": {{CreatePlayingPlayLifecycleSnapshotJson()}},
+                "after": {{CreateReadyStoppedPlayLifecycleSnapshotJson()}}
+              },
+              "timeoutMilliseconds": 1000,
+              "opResults": []
+            }
+            """);
+
+        Assert.Empty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", successDocument.RootElement));
+        Assert.Empty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", timeoutDocument.RootElement));
+        Assert.Empty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", blockedDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", successWithoutAfterDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", timeoutWithoutObservedDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", successWithErrorFieldsDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", timeoutWithAfterDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", timeoutWithNotAppliedApplicationStateDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", successWithPlayingAfterDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", alreadyExitedWithPlayingBeforeDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", successWithPlayingTopLevelDocument.RootElement));
+        Assert.NotEmpty(schemaSet.Validate("cli-output/payload/play.exit.schema.json", exitWithOpResultsDocument.RootElement));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void PlayLifecycleSnapshotSchemas_ValidatePrimaryDiagnosticContract ()
     {
         using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
@@ -1166,7 +1370,12 @@ public sealed class CliOutputSchemaArtifactTests
         string transitionJson,
         string lifecycleState = "ready",
         string blockingReasonJson = "null",
-        bool canAcceptExecutionRequests = true)
+        bool canAcceptExecutionRequests = true,
+        string playModeState = "stopped",
+        string playModeTransition = "none",
+        bool isPlaying = false,
+        bool isPlayingOrWillChangePlaymode = false,
+        string generation = "44")
     {
         return $$"""
             {
@@ -1188,11 +1397,11 @@ public sealed class CliOutputSchemaArtifactTests
               "actionRequired": null,
               "primaryDiagnostic": null,
               "playMode": {
-                "state": "stopped",
-                "transition": "none",
-                "isPlaying": false,
-                "isPlayingOrWillChangePlaymode": false,
-                "generation": "44"
+                "state": "{{playModeState}}",
+                "transition": "{{playModeTransition}}",
+                "isPlaying": {{JsonSerializer.Serialize(isPlaying)}},
+                "isPlayingOrWillChangePlaymode": {{JsonSerializer.Serialize(isPlayingOrWillChangePlaymode)}},
+                "generation": "{{generation}}"
               },
               "transition": {{transitionJson}},
               "timeoutMilliseconds": 1000

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -574,7 +574,7 @@ public sealed class UcliConfigStoreTests
 
     private static void AssertDefaultIpcTimeouts (IReadOnlyDictionary<string, int?> actual)
     {
-        Assert.Equal(21, actual.Count);
+        Assert.Equal(22, actual.Count);
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandTest));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandReady));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandVerify));
@@ -596,6 +596,7 @@ public sealed class UcliConfigStoreTests
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandLogsUnityClear));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandPlayStatus));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandPlayEnter));
+        Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandPlayExit));
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultTestMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandTest]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultReadyMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandReady]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultVerifyMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandVerify]);
@@ -617,5 +618,6 @@ public sealed class UcliConfigStoreTests
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultLogsUnityClearMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandLogsUnityClear]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayStatusMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandPlayStatus]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayEnterMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandPlayEnter]);
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlayExitMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandPlayExit]);
     }
 }

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityDaemonIpcClientTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Clients/UnityDaemonIpcClientTests.cs
@@ -127,6 +127,49 @@ public sealed class UnityDaemonIpcClientTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task SendAsync_WhenRecoverableResponseAttemptTimesOutBeforeDeadline_RetriesWithSameRequestId ()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var transportClient = new StubUnityIpcTransportClient();
+        transportClient.EnqueueException(new TimeoutException("response wait timed out"));
+        transportClient.EnqueueResponse(CreateResponse("req-recovered"));
+        var sessionTokenProvider = new StubDaemonSessionTokenProvider(
+            DaemonSessionTokenResolutionResult.Success("daemon-token-1"),
+            DaemonSessionTokenResolutionResult.Success("daemon-token-2"));
+        var client = new UnityDaemonIpcClient(
+            transportClient,
+            sessionTokenProvider,
+            timeProvider: timeProvider);
+        var attemptTimeout = TimeSpan.FromMilliseconds(250);
+
+        var sendTask = client.SendAsync(
+                CreateContext(),
+                new UnityIpcDispatchRequest(
+                    IpcMethodNames.PlayExit,
+                    CreateDispatchPayload(),
+                    isRecoverable: true,
+                    recoverableResponseAttemptTimeout: attemptTimeout),
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None)
+            .AsTask();
+        Assert.False(sendTask.IsCompleted);
+        Assert.Equal(attemptTimeout, transportClient.Timeouts[0]);
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(100));
+        var result = await sendTask;
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, sessionTokenProvider.CallCount);
+        Assert.Equal(2, transportClient.CallCount);
+        Assert.Equal("daemon-token-1", transportClient.Requests[0].SessionToken);
+        Assert.Equal("daemon-token-2", transportClient.Requests[1].SessionToken);
+        Assert.Equal(transportClient.Requests[0].RequestId, transportClient.Requests[1].RequestId);
+        Assert.Equal(attemptTimeout, transportClient.Timeouts[1]);
+        Assert.StartsWith($"{IpcMethodNames.PlayExit}-", transportClient.Requests[0].RequestId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task SendAsync_WhenRecoverableSessionTokenIsTemporarilyUnavailableDuringRecovery_WaitsAndSendsRecoveredSessionToken ()
     {
         var timeProvider = new ManualTimeProvider();
@@ -244,6 +287,8 @@ public sealed class UnityDaemonIpcClientTests
 
         public List<IpcRequest> Requests { get; } = new();
 
+        public List<TimeSpan> Timeouts { get; } = new();
+
         public Exception? Exception { get; set; }
 
         public IpcRequest? LastRequest { get; private set; }
@@ -275,6 +320,7 @@ public sealed class UnityDaemonIpcClientTests
             CallCount++;
             LastRequest = request;
             Requests.Add(request);
+            Timeouts.Add(timeout);
 
             if (QueuedExceptions.Count != 0)
             {

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
@@ -87,6 +87,21 @@ public sealed class UnityIpcRequestBuilderTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Build_WithPlayExit_CreatesPlayExitPayload ()
+    {
+        var builder = new UnityIpcRequestBuilder();
+
+        var request = builder.Build(new UnityRequestPayload.PlayExit(2500));
+
+        Assert.Equal(IpcMethodNames.PlayExit, request.Method);
+        Assert.True(request.IsRecoverable);
+        Assert.True(IpcPayloadCodec.TryDeserialize(request.Payload, out IpcPlayExitRequest payload, out _));
+        Assert.Equal(2500, payload.TimeoutMilliseconds);
+        Assert.Empty(request.AllowedStartupLifecycleStates);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void UnityIpcRequestFactory_WithCompileDispatchTimeout_InjectsTimeoutPayload ()
     {
         var payload = IpcPayloadCodec.SerializeToElement(new IpcCompileRequest("run-1"));

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
@@ -95,6 +95,7 @@ public sealed class UnityIpcRequestBuilderTests
 
         Assert.Equal(IpcMethodNames.PlayExit, request.Method);
         Assert.True(request.IsRecoverable);
+        Assert.Equal(TimeSpan.FromMilliseconds(1000), request.RecoverableResponseAttemptTimeout);
         Assert.True(IpcPayloadCodec.TryDeserialize(request.Payload, out IpcPlayExitRequest payload, out _));
         Assert.Equal(2500, payload.TimeoutMilliseconds);
         Assert.Empty(request.AllowedStartupLifecycleStates);

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -1073,20 +1073,31 @@ internal static class Program
 
     private static Dictionary<string, object?> CreatePlayExitPayloadSchema ()
     {
+        return OneOfSchema(
+            CreatePlayExitPayloadVariantSchema(
+                PlayLifecyclePayloadState.ReadyStopped,
+                CreatePlayExitExitedTransitionResultSchema()),
+            CreatePlayExitPayloadVariantSchema(
+                PlayLifecyclePayloadState.Stopped,
+                CreatePlayExitAlreadyExitedTransitionResultSchema()),
+            CreatePlayExitPayloadVariantSchema(
+                PlayLifecyclePayloadState.Any,
+                CreatePlayExitTimeoutTransitionResultSchema()),
+            CreatePlayExitPayloadVariantSchema(
+                PlayLifecyclePayloadState.Any,
+                CreatePlayExitBlockedTransitionResultSchema()));
+    }
+
+    private static Dictionary<string, object?> CreatePlayExitPayloadVariantSchema (
+        PlayLifecyclePayloadState payloadState,
+        Dictionary<string, object?> transitionSchema)
+    {
         return ObjectSchema(
             additionalProperties: false,
-            Optional(
-                "transition",
-                CreatePlayTransitionResultSchema(
-                    IpcPlayTransitionCommandNames.Exit,
-                    [
-                        IpcPlayTransitionResultNames.Exited,
-                        IpcPlayTransitionResultNames.AlreadyExited,
-                        IpcPlayTransitionResultNames.Timeout,
-                        IpcPlayTransitionResultNames.Blocked,
-                    ],
-                    includeUntil: false)),
-            Optional("timeoutMilliseconds", IntegerSchema()));
+            CreatePlayLifecyclePayloadProperties(
+                payloadState,
+                Required("transition", transitionSchema),
+                Required("timeoutMilliseconds", IntegerSchema())));
     }
 
     private static Dictionary<string, object?> CreatePlayWaitPayloadSchema ()
@@ -1108,11 +1119,20 @@ internal static class Program
 
     private static SchemaProperty[] CreatePlayLifecyclePayloadProperties (params SchemaProperty[] extraProperties)
     {
-        return CreatePlayLifecyclePayloadProperties(constrainEnteredState: false, extraProperties);
+        return CreatePlayLifecyclePayloadProperties(PlayLifecyclePayloadState.Any, extraProperties);
     }
 
     private static SchemaProperty[] CreatePlayLifecyclePayloadProperties (
         bool constrainEnteredState,
+        params SchemaProperty[] extraProperties)
+    {
+        return CreatePlayLifecyclePayloadProperties(
+            constrainEnteredState ? PlayLifecyclePayloadState.Entered : PlayLifecyclePayloadState.Any,
+            extraProperties);
+    }
+
+    private static SchemaProperty[] CreatePlayLifecyclePayloadProperties (
+        PlayLifecyclePayloadState payloadState,
         params SchemaProperty[] extraProperties)
     {
         var properties = new List<SchemaProperty>
@@ -1121,16 +1141,16 @@ internal static class Program
             Required("daemonStatus", ConstString("running")),
             Required("serverVersion", NullableStringSchema()),
             Required("editorMode", ConstString(DaemonEditorModeValues.Gui)),
-            Required("lifecycleState", constrainEnteredState ? ConstString(IpcEditorLifecycleStateCodec.Playmode) : NullableStringSchema()),
-            Required("blockingReason", constrainEnteredState ? ConstString(IpcEditorBlockingReasonCodec.PlayMode) : NullableStringSchema()),
+            Required("lifecycleState", CreateLifecycleStateSchema(payloadState)),
+            Required("blockingReason", CreateBlockingReasonSchema(payloadState)),
             Required("compileState", NullableStringSchema()),
             Required("compileGeneration", NullableStringSchema()),
             Required("domainReloadGeneration", NullableStringSchema()),
-            Required("canAcceptExecutionRequests", constrainEnteredState ? ConstBoolean(false) : BooleanSchema()),
+            Required("canAcceptExecutionRequests", CreateCanAcceptExecutionRequestsSchema(payloadState)),
             Required("observedAtUtc", NullableStringSchema()),
             Required("actionRequired", NullableStringSchema()),
             Required("primaryDiagnostic", CreatePrimaryDiagnosticSchema()),
-            Required("playMode", constrainEnteredState ? CreateEnteredPlayModeSnapshotSchema() : CreatePlayModeSnapshotSchema()),
+            Required("playMode", CreatePlayModeSnapshotSchema(payloadState)),
         };
 
         properties.AddRange(extraProperties);
@@ -1194,6 +1214,54 @@ internal static class Program
                     IpcPlayApplicationStateNames.Unknown)));
     }
 
+    private static Dictionary<string, object?> CreatePlayExitExitedTransitionResultSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("transition", ConstString(IpcPlayTransitionCommandNames.Exit)),
+            Required("result", ConstString(IpcPlayTransitionResultNames.Exited)),
+            Required("before", CreateEnteredPlayLifecycleSnapshotSchema()),
+            Required("after", CreateReadyStoppedPlayLifecycleSnapshotSchema()));
+    }
+
+    private static Dictionary<string, object?> CreatePlayExitAlreadyExitedTransitionResultSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("transition", ConstString(IpcPlayTransitionCommandNames.Exit)),
+            Required("result", ConstString(IpcPlayTransitionResultNames.AlreadyExited)),
+            Required("before", CreateStoppedPlayLifecycleSnapshotSchema()),
+            Required("after", CreateStoppedPlayLifecycleSnapshotSchema()));
+    }
+
+    private static Dictionary<string, object?> CreatePlayExitTimeoutTransitionResultSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("transition", ConstString(IpcPlayTransitionCommandNames.Exit)),
+            Required("result", ConstString(IpcPlayTransitionResultNames.Timeout)),
+            Required("before", CreatePlayLifecycleSnapshotSchema()),
+            Required("observed", CreatePlayLifecycleSnapshotSchema()),
+            Required("applicationState", ConstString(IpcPlayApplicationStateNames.Indeterminate)));
+    }
+
+    private static Dictionary<string, object?> CreatePlayExitBlockedTransitionResultSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("transition", ConstString(IpcPlayTransitionCommandNames.Exit)),
+            Required("result", ConstString(IpcPlayTransitionResultNames.Blocked)),
+            Required("before", CreatePlayLifecycleSnapshotSchema()),
+            Required("observed", CreatePlayLifecycleSnapshotSchema()),
+            Required(
+                "applicationState",
+                EnumSchema(
+                    IpcPlayApplicationStateNames.NotApplied,
+                    IpcPlayApplicationStateNames.Applied,
+                    IpcPlayApplicationStateNames.Indeterminate,
+                    IpcPlayApplicationStateNames.Unknown)));
+    }
+
     private static Dictionary<string, object?> CreatePlayTransitionResultSchema (
         string transitionCommand,
         string[] results,
@@ -1236,15 +1304,25 @@ internal static class Program
 
     private static Dictionary<string, object?> CreatePlayLifecycleSnapshotSchema ()
     {
-        return CreatePlayLifecycleSnapshotSchema(constrainEnteredState: false);
+        return CreatePlayLifecycleSnapshotSchema(PlayLifecyclePayloadState.Any);
     }
 
     private static Dictionary<string, object?> CreateEnteredPlayLifecycleSnapshotSchema ()
     {
-        return CreatePlayLifecycleSnapshotSchema(constrainEnteredState: true);
+        return CreatePlayLifecycleSnapshotSchema(PlayLifecyclePayloadState.Entered);
     }
 
-    private static Dictionary<string, object?> CreatePlayLifecycleSnapshotSchema (bool constrainEnteredState)
+    private static Dictionary<string, object?> CreateReadyStoppedPlayLifecycleSnapshotSchema ()
+    {
+        return CreatePlayLifecycleSnapshotSchema(PlayLifecyclePayloadState.ReadyStopped);
+    }
+
+    private static Dictionary<string, object?> CreateStoppedPlayLifecycleSnapshotSchema ()
+    {
+        return CreatePlayLifecycleSnapshotSchema(PlayLifecyclePayloadState.Stopped);
+    }
+
+    private static Dictionary<string, object?> CreatePlayLifecycleSnapshotSchema (PlayLifecyclePayloadState payloadState)
     {
         return ObjectSchema(
             additionalProperties: false,
@@ -1252,16 +1330,16 @@ internal static class Program
             Required("editorMode", NullableStringSchema()),
             Required("unityVersion", NullableStringSchema()),
             Required("projectFingerprint", NullableStringSchema()),
-            Required("lifecycleState", constrainEnteredState ? ConstString(IpcEditorLifecycleStateCodec.Playmode) : NullableStringSchema()),
-            Required("blockingReason", constrainEnteredState ? ConstString(IpcEditorBlockingReasonCodec.PlayMode) : NullableStringSchema()),
+            Required("lifecycleState", CreateLifecycleStateSchema(payloadState)),
+            Required("blockingReason", CreateBlockingReasonSchema(payloadState)),
             Required("compileState", NullableStringSchema()),
             Required("compileGeneration", NullableStringSchema()),
             Required("domainReloadGeneration", NullableStringSchema()),
-            Required("canAcceptExecutionRequests", constrainEnteredState ? ConstBoolean(false) : BooleanSchema()),
+            Required("canAcceptExecutionRequests", CreateCanAcceptExecutionRequestsSchema(payloadState)),
             Required("observedAtUtc", NullableStringSchema()),
             Required("actionRequired", NullableStringSchema()),
             Required("primaryDiagnostic", CreatePrimaryDiagnosticSchema()),
-            Required("playMode", constrainEnteredState ? CreateEnteredPlayModeSnapshotSchema() : NullablePlayModeSnapshotSchema()));
+            Required("playMode", payloadState == PlayLifecyclePayloadState.Any ? NullablePlayModeSnapshotSchema() : CreatePlayModeSnapshotSchema(payloadState)));
     }
 
     private static Dictionary<string, object?> NullablePlayModeSnapshotSchema ()
@@ -1278,39 +1356,96 @@ internal static class Program
 
     private static Dictionary<string, object?> CreatePlayModeSnapshotSchema ()
     {
-        return CreatePlayModeSnapshotSchema(constrainEnteredState: false);
+        return CreatePlayModeSnapshotSchema(PlayLifecyclePayloadState.Any);
     }
 
     private static Dictionary<string, object?> CreateEnteredPlayModeSnapshotSchema ()
     {
-        return CreatePlayModeSnapshotSchema(constrainEnteredState: true);
+        return CreatePlayModeSnapshotSchema(PlayLifecyclePayloadState.Entered);
     }
 
-    private static Dictionary<string, object?> CreatePlayModeSnapshotSchema (bool constrainEnteredState)
+    private static Dictionary<string, object?> CreatePlayModeSnapshotSchema (PlayLifecyclePayloadState payloadState)
     {
         return ObjectSchema(
             additionalProperties: false,
             Required(
                 "state",
-                constrainEnteredState
-                    ? ConstString(IpcPlayModeStateNames.Playing)
-                    : EnumSchema(
-                        IpcPlayModeStateNames.Stopped,
-                        IpcPlayModeStateNames.Entering,
-                        IpcPlayModeStateNames.Playing,
-                        IpcPlayModeStateNames.Exiting,
-                        IpcPlayModeStateNames.Unknown)),
+                CreatePlayModeStateSchema(payloadState)),
             Required(
                 "transition",
-                constrainEnteredState
-                    ? ConstString(IpcPlayModeTransitionNames.None)
-                    : EnumSchema(
+                payloadState == PlayLifecyclePayloadState.Any
+                    ? EnumSchema(
                         IpcPlayModeTransitionNames.None,
                         IpcPlayModeTransitionNames.Entering,
-                        IpcPlayModeTransitionNames.Exiting)),
-            Required("isPlaying", constrainEnteredState ? ConstBoolean(true) : BooleanSchema()),
-            Required("isPlayingOrWillChangePlaymode", BooleanSchema()),
+                        IpcPlayModeTransitionNames.Exiting)
+                    : ConstString(IpcPlayModeTransitionNames.None)),
+            Required("isPlaying", CreateIsPlayingSchema(payloadState)),
+            Required("isPlayingOrWillChangePlaymode", CreateIsPlayingOrWillChangePlaymodeSchema(payloadState)),
             Required("generation", NullableStringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateLifecycleStateSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState switch
+        {
+            PlayLifecyclePayloadState.Entered => ConstString(IpcEditorLifecycleStateCodec.Playmode),
+            PlayLifecyclePayloadState.ReadyStopped => ConstString(IpcEditorLifecycleStateCodec.Ready),
+            _ => NullableStringSchema(),
+        };
+    }
+
+    private static Dictionary<string, object?> CreateBlockingReasonSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState switch
+        {
+            PlayLifecyclePayloadState.Entered => ConstString(IpcEditorBlockingReasonCodec.PlayMode),
+            PlayLifecyclePayloadState.ReadyStopped => NullSchema(),
+            _ => NullableStringSchema(),
+        };
+    }
+
+    private static Dictionary<string, object?> CreateCanAcceptExecutionRequestsSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState switch
+        {
+            PlayLifecyclePayloadState.Entered => ConstBoolean(false),
+            PlayLifecyclePayloadState.ReadyStopped => ConstBoolean(true),
+            _ => BooleanSchema(),
+        };
+    }
+
+    private static Dictionary<string, object?> CreatePlayModeStateSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState switch
+        {
+            PlayLifecyclePayloadState.Entered => ConstString(IpcPlayModeStateNames.Playing),
+            PlayLifecyclePayloadState.Stopped => ConstString(IpcPlayModeStateNames.Stopped),
+            PlayLifecyclePayloadState.ReadyStopped => ConstString(IpcPlayModeStateNames.Stopped),
+            _ => EnumSchema(
+                IpcPlayModeStateNames.Stopped,
+                IpcPlayModeStateNames.Entering,
+                IpcPlayModeStateNames.Playing,
+                IpcPlayModeStateNames.Exiting,
+                IpcPlayModeStateNames.Unknown),
+        };
+    }
+
+    private static Dictionary<string, object?> CreateIsPlayingSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState switch
+        {
+            PlayLifecyclePayloadState.Entered => ConstBoolean(true),
+            PlayLifecyclePayloadState.Stopped => ConstBoolean(false),
+            PlayLifecyclePayloadState.ReadyStopped => ConstBoolean(false),
+            _ => BooleanSchema(),
+        };
+    }
+
+    private static Dictionary<string, object?> CreateIsPlayingOrWillChangePlaymodeSchema (PlayLifecyclePayloadState payloadState)
+    {
+        return payloadState is PlayLifecyclePayloadState.Stopped or PlayLifecyclePayloadState.ReadyStopped
+            ? ConstBoolean(false)
+            : BooleanSchema();
     }
 
     private static Dictionary<string, object?> CreateDaemonStartPayloadSchema ()
@@ -1730,4 +1865,12 @@ internal static class Program
         string Name,
         Dictionary<string, object?> Schema,
         bool Required);
+
+    private enum PlayLifecyclePayloadState
+    {
+        Any,
+        Entered,
+        Stopped,
+        ReadyStopped,
+    }
 }


### PR DESCRIPTION
## Summary
- Implement `ucli play exit` as a daemon-only Play Mode control command for existing registered GUI sessions.
- Add Unity IPC handling for `play.exit`, including recoverable pending state, response replay, timeout, blocked, and already-exited behavior.
- Update the public play.exit output schema and CLI golden coverage for the lifecycle transition payload.

## Scope
- CLI/Application: `PlayExitCommand`, `PlayExitService`, daemon request payload mapping, and shared Play transition/lifecycle payload projection.
- Unity IPC: `PlayExitUnityIpcMethodHandler`, `PlayExitTransitionRunner`, recovery payloads, request decoding, and DI registration for Play transition runners.
- Contracts/tests: generated `play.exit` schema, .NET service/CLI/schema tests, and Unity editor transition/recovery tests.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format && bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/verify.sh --include-unity --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`)
- Coverage: N/A

## Risks / Rollback
- Main risk is Play Mode lifecycle classification around Unity domain reload and blocked editor states. Rollback by reverting the three commits in this branch.
- One existing Supervisor bootstrap timing test timed out once during an intermediate verify run; the targeted retry passed, and the final full verify passed.

## Checklist
- [x] GUI session missing returns `PLAYMODE_SESSION_NOT_AVAILABLE` without launching Unity.
- [x] Batchmode sessions are rejected with `PLAYMODE_REQUIRES_GUI_EDITOR`.
- [x] `exited`, `alreadyExited`, `timeout`, and `blocked` payload shapes are covered.
- [x] `opResults` and `touched` remain absent from play exit output.

Closes #331