### PR TITLE
test(assurance): lock issue 289 contract surfaces

### DIFF
--- a/docs/uCLI-command-reference.md
+++ b/docs/uCLI-command-reference.md
@@ -12,7 +12,7 @@
 | `ucli ready` | 次の操作へ進める readiness claim を返す | 状態観測と bounded wait だけを行い、暗黙修復は行わない |
 | `ucli refresh` | プロジェクト更新を独立コマンドとして実行する | 固定の `ucli.project.refresh` を実行する |
 | `ucli compile` | script compilation と domain reload の保証 claim を返す | 専用 top-level command とし、`refresh` の拡張や primitive operation wrapper にはしない |
-| `ucli play` | Unity Editor Play Mode を明示制御する | `status` / `enter` / `exit` / `wait` を持つ lifecycle command |
+| `ucli play` | Unity Editor Play Mode を明示制御する | `status` / `enter` / `exit` を持つ lifecycle command |
 | `ucli resolve` | selector 1 件を GlobalObjectId へ解決する | scene-tree-lite index を優先し、必要時だけ Unity IPC へ fallback する |
 | `ucli query` | 型付きサブコマンドで検索・構造取得・スキーマ取得を行う | `assets find` / `scene tree` / `go describe` / `comp schema` / `asset schema` を持つ |
 | `ucli validate` | JSON リクエストを静的に lint する | Unity へ接続せず readIndex snapshot を参照する |
@@ -27,6 +27,50 @@
 | `ucli test` | Unity Test Framework 実行と結果正規化を扱う | `run` / `profile init` |
 
 ## 公開コマンド
+
+### 実行可能 command paths
+
+| Command |
+| --- |
+| `ucli init` |
+| `ucli status` |
+| `ucli ready` |
+| `ucli compile` |
+| `ucli verify` |
+| `ucli refresh` |
+| `ucli resolve` |
+| `ucli validate` |
+| `ucli plan` |
+| `ucli call` |
+| `ucli daemon start` |
+| `ucli daemon stop` |
+| `ucli daemon cleanup` |
+| `ucli daemon status` |
+| `ucli daemon list` |
+| `ucli logs daemon read` |
+| `ucli logs unity read` |
+| `ucli logs unity clear` |
+| `ucli ops list` |
+| `ucli ops describe` |
+| `ucli codes list` |
+| `ucli codes describe` |
+| `ucli play status` |
+| `ucli play enter` |
+| `ucli play exit` |
+| `ucli skills list` |
+| `ucli skills export` |
+| `ucli skills install` |
+| `ucli skills update` |
+| `ucli skills uninstall` |
+| `ucli skills doctor` |
+| `ucli query assets find` |
+| `ucli query scene tree` |
+| `ucli query go describe` |
+| `ucli query comp schema` |
+| `ucli query asset schema` |
+| `ucli test run` |
+| `ucli test profile init` |
+
 - `ucli ops`
   - `list` は利用可能なオペレーション一覧を返す。
   - `list` は `--nameRegex <regex>`、`--kind <query|mutation|command>`、`--maxPolicy <safe|advanced|dangerous>` による絞り込みを受け付ける。
@@ -71,7 +115,7 @@
   - 専用 top-level command とし、`refresh` の拡張や primitive operation wrapper にはしない。
 - `ucli play`
   - Unity Editor Play Mode の状態観測と明示遷移を行う。
-  - `status` / `enter` / `exit` / `wait` を持つ。
+  - `status` / `enter` / `exit` を持つ。
   - `--projectPath <string?>`、`--timeout <int>` を受け付ける。
   - Play Mode enter / exit は primitive operation や JSON request step として扱わない。
 - `ucli verify`

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -112,6 +112,54 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Validate_WithRequiredVerifierWithoutPrimaryClaims_ReturnsPrimaryClaimsPath ()
+    {
+        var payload = """
+            {
+              "verdict": "pass",
+              "verifiers": [
+                {
+                  "id": "ready",
+                  "kind": "ready",
+                  "deterministic": true,
+                  "required": true,
+                  "primaryClaims": [],
+                  "reportRef": "ready-log"
+                }
+              ],
+              "claims": [
+                {
+                  "id": "UNITY_READY_EXECUTION",
+                  "status": "passed",
+                  "coverage": "full",
+                  "required": true,
+                  "verifierRef": "ready",
+                  "evidence": [
+                    {
+                      "kind": "log",
+                      "evidenceRef": "ready-log"
+                    }
+                  ],
+                  "residualRisks": []
+                }
+              ],
+              "reports": {
+                "ready-log": {
+                  "kind": "log",
+                  "path": "artifacts/ready.log"
+                }
+              },
+              "residualRisks": []
+            }
+            """;
+
+        var result = Validate(payload);
+
+        AssertViolationPath(result, "$.verifiers[0].primaryClaims");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Validate_WithRequiredClaimOwnedByOptionalVerifier_ReturnsClaimRequiredPath ()
     {
         var payload = """

--- a/tests/Ucli.Application.Tests/Features/Assurance/Verify/Execution/PostRead/PostReadClaimBuilderTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Verify/Execution/PostRead/PostReadClaimBuilderTests.cs
@@ -221,6 +221,30 @@ public sealed class PostReadClaimBuilderTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Build_WithHierarchyPathUnrepresentableDiagnostic_ReturnsPartialReadSurfaceClaim ()
+    {
+        var input = CreateInput(
+            CreateOperationResult(diagnostics:
+            [
+                new VerifyFromDiagnostic(
+                    Code: ExecuteRequestErrorCodes.HierarchyPathUnrepresentableObjects.Value,
+                    Severity: IpcExecuteDiagnosticSeverityNames.Warning,
+                    CoverageImpact: IpcExecuteDiagnosticCoverageImpactNames.Partial,
+                    Message: "Hierarchy paths cannot represent every object.")
+            ]),
+            readPostconditionRequirementCount: 1);
+
+        var claimSet = PostReadClaimBuilder.Build(input, profileRequired: true);
+
+        var claim = Assert.Single(claimSet.Claims, static claim => string.Equals(claim.Id, VerifyClaimCodes.ReadSurfaceSafe.Value, StringComparison.Ordinal));
+        Assert.Equal(VerifyClaimStatusValues.Passed, claim.Status);
+        Assert.Equal(VerifyCoverageValues.Partial, claim.Coverage);
+        Assert.Empty(claim.ResidualRisks);
+        Assert.Empty(claimSet.ResidualRisks);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Build_WithUnboundCoverageDiagnostic_ReturnsBlockingResidualRisk ()
     {
         var input = CreateInput(CreateOperationResult(

--- a/tests/Ucli.Tests/CliOutputGoldenContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputGoldenContractTests.cs
@@ -1,0 +1,448 @@
+using System.Text.Json;
+using MackySoft.Ucli.Application.Features.Assurance.Compile.Catalog;
+using MackySoft.Ucli.Application.Features.Assurance.Compile.Semantics;
+using MackySoft.Ucli.Application.Features.Assurance.Ready;
+using MackySoft.Ucli.Application.Features.Assurance.Semantics;
+using MackySoft.Ucli.Application.Features.Assurance.Verify.Catalog;
+using MackySoft.Ucli.Application.Features.Assurance.Verify.Semantics;
+using MackySoft.Ucli.Application.Features.CodeCatalog.Catalog;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class CliOutputGoldenContractTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    private static readonly string CliOutputGoldenRoot = Path.Combine(
+        RepositoryRoot,
+        "tests",
+        "Ucli.Tests",
+        "GoldenFiles",
+        "Json",
+        "CliOutput");
+
+    [Theory]
+    [MemberData(nameof(GetCliOutputGoldenFiles))]
+    [Trait("Size", "Small")]
+    public void AssuranceCommandGoldens_WithOkStatus_SatisfyCommonShapeAndSemanticInvariants (string relativePath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepositoryRoot, relativePath)));
+        var root = document.RootElement;
+        var command = ReadRequiredString(root, "command", "$.command");
+        if (!IsAssuranceCommand(command)
+            || !string.Equals(ReadRequiredString(root, "status", "$.status"), IpcProtocol.StatusOk, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var payload = ReadRequiredObject(root, "payload", "$.payload");
+        AssertPropertyKind(payload, "verdict", JsonValueKind.String, "$.payload.verdict");
+        AssertPropertyKind(payload, "project", JsonValueKind.Object, "$.payload.project");
+        AssertPropertyKind(payload, "verifiers", JsonValueKind.Array, "$.payload.verifiers");
+        AssertPropertyKind(payload, "claims", JsonValueKind.Array, "$.payload.claims");
+        AssertPropertyKind(payload, "reports", JsonValueKind.Object, "$.payload.reports");
+        AssertPropertyKind(payload, "residualRisks", JsonValueKind.Array, "$.payload.residualRisks");
+
+        var result = CreateAssuranceValidator().Validate(payload);
+
+        Assert.True(
+            result.IsValid,
+            string.Join(Environment.NewLine, result.Violations.Select(static violation => $"{violation.Path}: {violation.Message}")));
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCliOutputGoldenFiles))]
+    [Trait("Size", "Small")]
+    public void CliOutputGoldens_UcliOwnedCodesResolveToCodeCatalog (string relativePath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepositoryRoot, relativePath)));
+        var root = document.RootElement;
+        var catalog = CreateCodeCatalog();
+        var command = ReadRequiredString(root, "command", "$.command");
+
+        ValidateEnvelopeErrorCodes(catalog, root);
+        if (!TryGetProperty(root, "payload", JsonValueKind.Object, out var payload))
+        {
+            return;
+        }
+
+        ValidateOperationDiagnosticCodes(catalog, payload);
+        ValidateAssuranceCodeFields(catalog, payload);
+        ValidateCodesPayloadCodes(catalog, command, payload);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCliOutputGoldenFiles))]
+    [Trait("Size", "Small")]
+    public void OpsDescribeGoldens_AssuranceContractsExposeLatestShape (string relativePath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(RepositoryRoot, relativePath)));
+        var root = document.RootElement;
+        if (!string.Equals(ReadRequiredString(root, "command", "$.command"), "ops.describe", StringComparison.Ordinal)
+            || !TryGetProperty(root, "payload", JsonValueKind.Object, out var payload)
+            || !TryGetProperty(payload, "operation", JsonValueKind.Object, out var operation))
+        {
+            return;
+        }
+
+        var assurance = ReadRequiredObject(operation, "assurance", "$.payload.operation.assurance");
+        AssertPropertyKind(assurance, "sideEffects", JsonValueKind.Array, "$.payload.operation.assurance.sideEffects");
+        AssertBooleanProperty(assurance, "mayDirty", "$.payload.operation.assurance.mayDirty");
+        AssertBooleanProperty(assurance, "mayPersist", "$.payload.operation.assurance.mayPersist");
+        AssertPropertyKind(assurance, "touchedKinds", JsonValueKind.Array, "$.payload.operation.assurance.touchedKinds");
+        AssertPropertyKind(assurance, "planMode", JsonValueKind.String, "$.payload.operation.assurance.planMode");
+        AssertPropertyKind(assurance, "planSemantics", JsonValueKind.String, "$.payload.operation.assurance.planSemantics");
+        AssertPropertyKind(assurance, "callSemantics", JsonValueKind.String, "$.payload.operation.assurance.callSemantics");
+        AssertPropertyKind(assurance, "touchedContract", JsonValueKind.String, "$.payload.operation.assurance.touchedContract");
+        AssertPropertyKind(assurance, "readPostconditionContract", JsonValueKind.String, "$.payload.operation.assurance.readPostconditionContract");
+        AssertPropertyKind(assurance, "failureSemantics", JsonValueKind.String, "$.payload.operation.assurance.failureSemantics");
+        AssertPropertyKind(assurance, "dangerousNotes", JsonValueKind.Array, "$.payload.operation.assurance.dangerousNotes");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void RepositoryArtifacts_DoNotReferenceErrorsCommand ()
+    {
+        string[] prohibitedCommandFragments =
+        [
+            "ucli errors",
+            "errors describe",
+            "errors list",
+            "errors explain",
+        ];
+        var violations = EnumerateDocumentedArtifactPaths()
+            .SelectMany(path => FindProhibitedCommandFragments(path, prohibitedCommandFragments))
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    public static IEnumerable<object[]> GetCliOutputGoldenFiles ()
+    {
+        return Directory
+            .EnumerateFiles(CliOutputGoldenRoot, "*.json", SearchOption.AllDirectories)
+            .Order(StringComparer.Ordinal)
+            .Select(path => new object[]
+            {
+                Path.GetRelativePath(RepositoryRoot, path),
+            });
+    }
+
+    private static bool IsAssuranceCommand (string command)
+    {
+        return string.Equals(command, "ready", StringComparison.Ordinal)
+            || string.Equals(command, "compile", StringComparison.Ordinal)
+            || string.Equals(command, "verify", StringComparison.Ordinal);
+    }
+
+    private static AssuranceSemanticInvariantValidator CreateAssuranceValidator ()
+    {
+        return new AssuranceSemanticInvariantValidator(
+            CreateCodeCatalog(),
+            [
+                new ReadyAssuranceSemanticInvariantRule(),
+                new CompileAssuranceSemanticInvariantRule(),
+                new VerifyAssuranceSemanticInvariantRule(),
+            ]);
+    }
+
+    private static CodeCatalog CreateCodeCatalog ()
+    {
+        return new CodeCatalog(
+        [
+            new ContractsCodeCatalogContributor(),
+            new ApplicationCodeCatalogContributor(),
+            new ReadyCodeCatalogContributor(),
+            new CompileCodeCatalogContributor(),
+            new VerifyCodeCatalogContributor(),
+        ]);
+    }
+
+    private static void ValidateEnvelopeErrorCodes (
+        ICodeCatalog catalog,
+        JsonElement root)
+    {
+        if (!TryGetProperty(root, "errors", JsonValueKind.Array, out var errors))
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var error in errors.EnumerateArray())
+        {
+            if (error.ValueKind == JsonValueKind.Object && TryGetString(error, "code", out var code))
+            {
+                AssertCatalogCode(catalog, code, CodeCatalogKindValues.Error, $"$.errors[{index}].code");
+            }
+
+            index++;
+        }
+    }
+
+    private static void ValidateOperationDiagnosticCodes (
+        ICodeCatalog catalog,
+        JsonElement payload)
+    {
+        if (!TryGetProperty(payload, "opResults", JsonValueKind.Array, out var opResults))
+        {
+            return;
+        }
+
+        var opResultIndex = 0;
+        foreach (var opResult in opResults.EnumerateArray())
+        {
+            if (opResult.ValueKind != JsonValueKind.Object
+                || !TryGetProperty(opResult, "diagnostics", JsonValueKind.Array, out var diagnostics))
+            {
+                opResultIndex++;
+                continue;
+            }
+
+            var diagnosticIndex = 0;
+            foreach (var diagnostic in diagnostics.EnumerateArray())
+            {
+                if (diagnostic.ValueKind == JsonValueKind.Object && TryGetString(diagnostic, "code", out var code))
+                {
+                    AssertCatalogCode(catalog, code, expectedKind: null, $"$.payload.opResults[{opResultIndex}].diagnostics[{diagnosticIndex}].code");
+                }
+
+                diagnosticIndex++;
+            }
+
+            opResultIndex++;
+        }
+    }
+
+    private static void ValidateAssuranceCodeFields (
+        ICodeCatalog catalog,
+        JsonElement payload)
+    {
+        if (TryGetProperty(payload, "claims", JsonValueKind.Array, out var claims))
+        {
+            var claimIndex = 0;
+            foreach (var claim in claims.EnumerateArray())
+            {
+                if (claim.ValueKind != JsonValueKind.Object)
+                {
+                    claimIndex++;
+                    continue;
+                }
+
+                if (TryGetString(claim, "id", out var claimId))
+                {
+                    AssertCatalogCode(catalog, claimId, CodeCatalogKindValues.Claim, $"$.payload.claims[{claimIndex}].id");
+                }
+
+                ValidateResidualRiskCodes(
+                    catalog,
+                    claim,
+                    $"$.payload.claims[{claimIndex}].residualRisks");
+                claimIndex++;
+            }
+        }
+
+        ValidateResidualRiskCodes(catalog, payload, "$.payload.residualRisks");
+    }
+
+    private static void ValidateResidualRiskCodes (
+        ICodeCatalog catalog,
+        JsonElement owner,
+        string path)
+    {
+        if (!TryGetProperty(owner, "residualRisks", JsonValueKind.Array, out var residualRisks))
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var residualRisk in residualRisks.EnumerateArray())
+        {
+            if (residualRisk.ValueKind == JsonValueKind.Object && TryGetString(residualRisk, "code", out var code))
+            {
+                AssertCatalogCode(catalog, code, CodeCatalogKindValues.Risk, $"{path}[{index}].code");
+            }
+
+            index++;
+        }
+    }
+
+    private static void ValidateCodesPayloadCodes (
+        ICodeCatalog catalog,
+        string command,
+        JsonElement payload)
+    {
+        if (!string.Equals(command, "codes.describe", StringComparison.Ordinal)
+            && !string.Equals(command, "codes.list", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (TryGetString(payload, "code", out var code))
+        {
+            AssertCatalogCode(catalog, code, expectedKind: null, "$.payload.code");
+        }
+
+        if (!TryGetProperty(payload, "codes", JsonValueKind.Array, out var codes))
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var codeEntry in codes.EnumerateArray())
+        {
+            if (codeEntry.ValueKind == JsonValueKind.Object && TryGetString(codeEntry, "code", out var codeValue))
+            {
+                AssertCatalogCode(catalog, codeValue, expectedKind: null, $"$.payload.codes[{index}].code");
+            }
+
+            index++;
+        }
+    }
+
+    private static void AssertCatalogCode (
+        ICodeCatalog catalog,
+        string code,
+        string? expectedKind,
+        string path)
+    {
+        Assert.True(UcliCode.TryCreate(code, out var codeValue), $"{path} contains an invalid uCLI code value '{code}'.");
+        Assert.True(catalog.TryFind(codeValue, out var descriptor), $"{path} code '{code}' is not registered in the production code catalog.");
+        if (expectedKind != null)
+        {
+            Assert.Equal(expectedKind, descriptor.Kind);
+        }
+    }
+
+    private static JsonElement ReadRequiredObject (
+        JsonElement owner,
+        string propertyName,
+        string path)
+    {
+        Assert.True(owner.TryGetProperty(propertyName, out var property), $"{path} is missing.");
+        Assert.Equal(JsonValueKind.Object, property.ValueKind);
+        return property;
+    }
+
+    private static string ReadRequiredString (
+        JsonElement owner,
+        string propertyName,
+        string path)
+    {
+        Assert.True(owner.TryGetProperty(propertyName, out var property), $"{path} is missing.");
+        Assert.Equal(JsonValueKind.String, property.ValueKind);
+        return property.GetString() ?? string.Empty;
+    }
+
+    private static void AssertPropertyKind (
+        JsonElement owner,
+        string propertyName,
+        JsonValueKind expectedKind,
+        string path)
+    {
+        Assert.True(owner.TryGetProperty(propertyName, out var property), $"{path} is missing.");
+        Assert.Equal(expectedKind, property.ValueKind);
+    }
+
+    private static void AssertBooleanProperty (
+        JsonElement owner,
+        string propertyName,
+        string path)
+    {
+        Assert.True(owner.TryGetProperty(propertyName, out var property), $"{path} is missing.");
+        Assert.True(property.ValueKind is JsonValueKind.True or JsonValueKind.False, $"{path} must be boolean.");
+    }
+
+    private static bool TryGetProperty (
+        JsonElement owner,
+        string propertyName,
+        JsonValueKind expectedKind,
+        out JsonElement property)
+    {
+        if (owner.ValueKind == JsonValueKind.Object
+            && owner.TryGetProperty(propertyName, out property)
+            && property.ValueKind == expectedKind)
+        {
+            return true;
+        }
+
+        property = default;
+        return false;
+    }
+
+    private static bool TryGetString (
+        JsonElement owner,
+        string propertyName,
+        out string value)
+    {
+        if (owner.ValueKind == JsonValueKind.Object
+            && owner.TryGetProperty(propertyName, out var property)
+            && property.ValueKind == JsonValueKind.String)
+        {
+            value = property.GetString() ?? string.Empty;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateDocumentedArtifactPaths ()
+    {
+        var readmePath = Path.Combine(RepositoryRoot, "README.md");
+        if (File.Exists(readmePath))
+        {
+            yield return readmePath;
+        }
+
+        string[] roots =
+        [
+            Path.Combine(RepositoryRoot, "docs"),
+            Path.Combine(RepositoryRoot, "skills", "definitions"),
+            Path.Combine(RepositoryRoot, "skills", "generated"),
+            CliOutputGoldenRoot,
+        ];
+        foreach (var root in roots)
+        {
+            if (!Directory.Exists(root))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories).Order(StringComparer.Ordinal))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private static IEnumerable<string> FindProhibitedCommandFragments (
+        string path,
+        IReadOnlyList<string> prohibitedCommandFragments)
+    {
+        var text = File.ReadAllText(path);
+        for (var i = 0; i < prohibitedCommandFragments.Count; i++)
+        {
+            if (text.Contains(prohibitedCommandFragments[i], StringComparison.OrdinalIgnoreCase))
+            {
+                yield return $"{Path.GetRelativePath(RepositoryRoot, path)} contains '{prohibitedCommandFragments[i]}'.";
+            }
+        }
+    }
+
+    private static string FindRepositoryRoot ()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Ucli.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved from test base directory.");
+    }
+}

--- a/tests/Ucli.Tests/Hosting/Cli/CliCommandRegistrationContractTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/CliCommandRegistrationContractTests.cs
@@ -18,6 +18,33 @@ public sealed class CliCommandRegistrationContractTests
             ExtractHelpCommandPaths(result.StdOut).Order(StringComparer.Ordinal).ToArray());
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public void CommandReference_CommandPathsMatchCommandCatalog ()
+    {
+        var referencePath = Path.Combine(FindRepositoryRoot(), "docs", "uCLI-command-reference.md");
+        var referenceText = File.ReadAllText(referencePath);
+
+        Assert.Equal(
+            UcliCommandCatalog.CommandPaths.Order(StringComparer.Ordinal).ToArray(),
+            ExtractCommandReferenceCommandPaths(referenceText).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void CommandCatalog_CommandPathsMatchPublicLeafCommands ()
+    {
+        var registeredPublicCommandNames = UcliCommandCatalog.CommandPaths
+            .Select(static commandPath => commandPath.Replace(' ', '.'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var publicLeafCommandNames = ExtractPublicLeafCommandNames()
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(publicLeafCommandNames, registeredPublicCommandNames);
+    }
+
     private static string[] ExtractHelpCommandPaths (string helpOutput)
     {
         var commandPaths = new List<string>();
@@ -49,6 +76,68 @@ public sealed class CliCommandRegistrationContractTests
         return commandPaths.ToArray();
     }
 
+    private static string[] ExtractCommandReferenceCommandPaths (string referenceText)
+    {
+        var commandPaths = new List<string>();
+        var lines = referenceText.Split('\n');
+        var isCommandPathSection = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd('\r');
+            var trimmedLine = line.Trim();
+            if (!isCommandPathSection)
+            {
+                isCommandPathSection = string.Equals(trimmedLine, "### 実行可能 command paths", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (trimmedLine.StartsWith("### ", StringComparison.Ordinal)
+                || trimmedLine.StartsWith("## ", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            const string commandPrefix = "| `ucli ";
+            if (!trimmedLine.StartsWith(commandPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var commandEnd = trimmedLine.IndexOf('`', commandPrefix.Length);
+            if (commandEnd < 0)
+            {
+                throw new InvalidOperationException($"Command reference row does not close the command literal: {line}");
+            }
+
+            commandPaths.Add(trimmedLine[commandPrefix.Length..commandEnd]);
+        }
+
+        if (!isCommandPathSection)
+        {
+            throw new InvalidOperationException("Command reference does not contain '### 実行可能 command paths'.");
+        }
+
+        if (commandPaths.Count == 0)
+        {
+            throw new InvalidOperationException("Command reference command path section is empty.");
+        }
+
+        return commandPaths.ToArray();
+    }
+
+    private static string[] ExtractPublicLeafCommandNames ()
+    {
+        var knownCommandNames = UcliPublicCommandCatalog.KnownCommands
+            .Select(static command => command.Name)
+            .ToArray();
+        return knownCommandNames
+            .Where(commandName => !knownCommandNames.Any(otherCommandName =>
+                otherCommandName.Length > commandName.Length
+                && otherCommandName.StartsWith(commandName + ".", StringComparison.Ordinal)))
+            .ToArray();
+    }
+
     private static string ExtractCommandPath (string helpLine)
     {
         var trimmed = helpLine.TrimStart();
@@ -61,5 +150,21 @@ public sealed class CliCommandRegistrationContractTests
         }
 
         throw new InvalidOperationException($"Command help line does not contain a description separator: {helpLine}");
+    }
+
+    private static string FindRepositoryRoot ()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Ucli.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved from test base directory.");
     }
 }


### PR DESCRIPTION
## Summary
- Fix #289 as a contract-test hardening task, without changing CLI surface, JSON schema shape, Unity implementation, or `scripts/verify.sh` ordering.
- Synchronize the public command reference with the implemented command catalog and remove the stale `play wait` documentation surface.
- Add Golden-wide assurance/code-catalog/ops-assurance regression tests that run under the .NET test suite.

## Scope
- `docs/uCLI-command-reference.md`: add executable command-path table and align `ucli play` with `status / enter / exit`.
- `tests/Ucli.Tests`: compare help output, command reference, host command paths, public command ids, assurance Goldens, code-bearing fields, `ops describe` assurance shape, and old `errors` command references.
- `tests/Ucli.Application.Tests`: add deterministic semantic invariant and post-read diagnostic coverage fixtures.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format ...`, `bash scripts/code-quality.sh verify ...`)
- Tests: PASS (`bash scripts/test-dotnet.sh ...`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to contract-test strictness and command reference wording. If a check is too strict, revert the relevant test assertion or documentation table row without touching runtime behavior.

## Checklist
- [x] Public command reference matches implemented command paths.
- [x] Assurance Goldens validate common shape and semantic invariants.
- [x] uCLI-owned code-bearing Golden fields resolve to the production code catalog.
- [x] `ops describe` assurance shape and old `errors` command references are fixed by tests.

Closes #289
