### PR TITLE
Reduce hot-path string allocations

### DIFF
--- a/src/Ucli.Contracts/Ipc/Logs/Shared/IpcLogCursorCodec.cs
+++ b/src/Ucli.Contracts/Ipc/Logs/Shared/IpcLogCursorCodec.cs
@@ -23,7 +23,23 @@ public static class IpcLogCursorCodec
             throw new ArgumentOutOfRangeException(nameof(sequence), sequence, "sequence must be non-negative.");
         }
 
-        return string.Concat(streamId, ":", sequence.ToString(CultureInfo.InvariantCulture));
+        var sequenceTextLength = GetNonNegativeInt64TextLength(sequence);
+        var length = checked(streamId.Length + 1 + sequenceTextLength);
+        return string.Create(
+            length,
+            (StreamId: streamId, Sequence: sequence),
+            static (destination, state) =>
+            {
+                state.StreamId.AsSpan().CopyTo(destination);
+                destination[state.StreamId.Length] = ':';
+                if (!state.Sequence.TryFormat(
+                        destination[(state.StreamId.Length + 1)..],
+                        out _,
+                        provider: CultureInfo.InvariantCulture))
+                {
+                    throw new InvalidOperationException("Cursor buffer is too small for sequence formatting.");
+                }
+            });
     }
 
     /// <summary> Tries to parse one opaque cursor value. </summary>
@@ -51,9 +67,9 @@ public static class IpcLogCursorCodec
             return false;
         }
 
-        var parsedStreamId = cursor.Substring(0, separatorIndex);
-        var sequenceText = cursor.Substring(separatorIndex + 1);
-        if (string.IsNullOrWhiteSpace(parsedStreamId)
+        var parsedStreamId = cursor.AsSpan(0, separatorIndex);
+        var sequenceText = cursor.AsSpan(separatorIndex + 1);
+        if (IsWhiteSpace(parsedStreamId)
             || !long.TryParse(sequenceText, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedSequence)
             || parsedSequence < 0)
         {
@@ -62,8 +78,34 @@ public static class IpcLogCursorCodec
             return false;
         }
 
-        streamId = parsedStreamId;
+        streamId = parsedStreamId.ToString();
         sequence = parsedSequence;
+        return true;
+    }
+
+    private static int GetNonNegativeInt64TextLength (long value)
+    {
+        var length = 1;
+        var remaining = value;
+        while (remaining >= 10)
+        {
+            length++;
+            remaining /= 10;
+        }
+
+        return length;
+    }
+
+    private static bool IsWhiteSpace (ReadOnlySpan<char> value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (!char.IsWhiteSpace(value[i]))
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 }

--- a/src/Ucli.Infrastructure/Cryptography/Sha256LowerHex.cs
+++ b/src/Ucli.Infrastructure/Cryptography/Sha256LowerHex.cs
@@ -24,9 +24,13 @@ internal static class Sha256LowerHex
     /// <returns> The lowercase hexadecimal digest string. </returns>
     public static string Compute (ReadOnlySpan<byte> bytes)
     {
-        var inputBytes = bytes.ToArray();
+        Span<byte> hashBytes = stackalloc byte[32];
         using var sha256 = SHA256.Create();
-        var hashBytes = sha256.ComputeHash(inputBytes);
+        if (!sha256.TryComputeHash(bytes, hashBytes, out var bytesWritten) || bytesWritten != hashBytes.Length)
+        {
+            throw new InvalidOperationException("SHA-256 hash computation failed.");
+        }
+
         return ToLowerHex(hashBytes);
     }
 

--- a/src/Ucli.Infrastructure/Cryptography/Utf8Sha256HashWriter.cs
+++ b/src/Ucli.Infrastructure/Cryptography/Utf8Sha256HashWriter.cs
@@ -1,0 +1,82 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MackySoft.Ucli.Infrastructure.Cryptography;
+
+/// <summary> Incrementally computes a SHA-256 digest from UTF-8 encoded text fragments. </summary>
+internal sealed class Utf8Sha256HashWriter : IDisposable
+{
+    private const int CharChunkSize = 256;
+    private const int ByteChunkSize = 1024;
+
+    private readonly IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+    private bool disposed;
+
+    /// <summary> Appends one UTF-8 text fragment to the hash input. </summary>
+    public void Append (string value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        Append(value.AsSpan());
+    }
+
+    /// <summary> Appends one UTF-8 character to the hash input. </summary>
+    public void Append (char value)
+    {
+        Span<char> chars = stackalloc char[1];
+        chars[0] = value;
+        Append(chars);
+    }
+
+    /// <summary> Completes the current digest and resets the writer for another hash. </summary>
+    public string GetHashAndReset ()
+    {
+        ThrowIfDisposed();
+        return Sha256LowerHex.ToLowerHex(hash.GetHashAndReset());
+    }
+
+    /// <inheritdoc />
+    public void Dispose ()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        hash.Dispose();
+        disposed = true;
+    }
+
+    private void Append (ReadOnlySpan<char> value)
+    {
+        ThrowIfDisposed();
+        Span<byte> bytes = stackalloc byte[ByteChunkSize];
+        while (!value.IsEmpty)
+        {
+            var charCount = Math.Min(value.Length, CharChunkSize);
+            if (charCount < value.Length
+                && char.IsHighSurrogate(value[charCount - 1])
+                && char.IsLowSurrogate(value[charCount]))
+            {
+                charCount--;
+            }
+
+            var chars = value[..charCount];
+            var byteCount = Encoding.UTF8.GetBytes(chars, bytes);
+            hash.AppendData(bytes[..byteCount]);
+            value = value[charCount..];
+        }
+    }
+
+    private void ThrowIfDisposed ()
+    {
+        if (disposed)
+        {
+            throw new ObjectDisposedException(nameof(Utf8Sha256HashWriter));
+        }
+    }
+}

--- a/src/Ucli.Infrastructure/Index/Inputs/IndexInputFileHasher.cs
+++ b/src/Ucli.Infrastructure/Index/Inputs/IndexInputFileHasher.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using MackySoft.Ucli.Infrastructure.Cryptography;
 using MackySoft.Ucli.Infrastructure.Paths;
 
@@ -79,8 +78,14 @@ internal static class IndexInputFileHasher
     /// <summary> Computes a SHA-256 lower-hex hash for one UTF-8 text value. </summary>
     public static string ComputeUtf8Hash (string text)
     {
-        var bytes = Encoding.UTF8.GetBytes(text);
-        return Sha256LowerHex.Compute(bytes);
+        if (text == null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        using var hashWriter = new Utf8Sha256HashWriter();
+        hashWriter.Append(text);
+        return hashWriter.GetHashAndReset();
     }
 
     private static async ValueTask<string?> TryHashDirectoryFilesAsync (
@@ -142,18 +147,18 @@ internal static class IndexInputFileHasher
             return ComputeUtf8Hash(string.Empty);
         }
 
-        var buffer = new StringBuilder(files.Count * 80);
+        using var hashWriter = new Utf8Sha256HashWriter();
         for (var i = 0; i < files.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!await TryAppendFileHashMetadataAsync(buffer, files[i], cancellationToken).ConfigureAwait(false))
+            if (!await TryAppendFileHashMetadataAsync(hashWriter, files[i], cancellationToken).ConfigureAwait(false))
             {
                 return null;
             }
         }
 
-        return ComputeUtf8Hash(buffer.ToString());
+        return hashWriter.GetHashAndReset();
     }
 
     private static IndexCoreInputFileHashes? TryCreateCoreInputFileHashes (
@@ -175,7 +180,7 @@ internal static class IndexInputFileHasher
     }
 
     private static async ValueTask<bool> TryAppendFileHashMetadataAsync (
-        StringBuilder buffer,
+        Utf8Sha256HashWriter hashWriter,
         string filePath,
         CancellationToken cancellationToken)
     {
@@ -186,10 +191,10 @@ internal static class IndexInputFileHasher
         }
 
         var normalizedPath = PathStringNormalizer.NormalizeAbsolutePathForHash(filePath);
-        buffer.Append(normalizedPath);
-        buffer.Append('\n');
-        buffer.Append(fileHash);
-        buffer.Append('\n');
+        hashWriter.Append(normalizedPath);
+        hashWriter.Append('\n');
+        hashWriter.Append(fileHash);
+        hashWriter.Append('\n');
         return true;
     }
 

--- a/src/Ucli.Infrastructure/Text/SpanTextWriter.cs
+++ b/src/Ucli.Infrastructure/Text/SpanTextWriter.cs
@@ -1,0 +1,49 @@
+using System.Globalization;
+
+namespace MackySoft.Ucli.Infrastructure.Text;
+
+/// <summary> Writes small fixed-size text fragments into a caller-provided character span. </summary>
+internal ref struct SpanTextWriter
+{
+    private readonly Span<char> destination;
+    private int offset;
+
+    /// <summary> Initializes a new instance of the <see cref="SpanTextWriter" /> struct. </summary>
+    public SpanTextWriter (Span<char> destination)
+    {
+        this.destination = destination;
+        offset = 0;
+    }
+
+    /// <summary> Appends one character. </summary>
+    public void Append (char value)
+    {
+        destination[offset++] = value;
+    }
+
+    /// <summary> Appends one string value. </summary>
+    public void Append (string value)
+    {
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        value.AsSpan().CopyTo(destination.Slice(offset));
+        offset += value.Length;
+    }
+
+    /// <summary> Appends one integer using invariant-culture formatting. </summary>
+    public void AppendInvariant (long value)
+    {
+        if (!value.TryFormat(
+                destination.Slice(offset),
+                out var written,
+                provider: CultureInfo.InvariantCulture))
+        {
+            throw new InvalidOperationException("Text buffer is too small for invariant integer formatting.");
+        }
+
+        offset += written;
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Diagnostics/UnityLogs/UnityLogCollector.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Diagnostics/UnityLogs/UnityLogCollector.cs
@@ -1,6 +1,7 @@
 using System;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Text;
+using MackySoft.Ucli.Infrastructure.Text;
 using UnityEditor.Compilation;
 using UnityEngine;
 
@@ -104,20 +105,122 @@ namespace MackySoft.Ucli.Unity.Ipc
             var level = NormalizeCompileLevel(message.type);
             if (!StringValueNormalizer.TryTrimToNonEmpty(message.file, out var file))
             {
-                return string.Concat(level, " ", normalizedMessage);
+                return CreateCompileMessage(level, normalizedMessage);
             }
 
             if (message.line > 0 && message.column > 0)
             {
-                return string.Concat(file, "(", message.line, ",", message.column, "): ", level, " ", normalizedMessage);
+                return CreateCompileMessage(file, message.line, message.column, level, normalizedMessage);
             }
 
             if (message.line > 0)
             {
-                return string.Concat(file, "(", message.line, "): ", level, " ", normalizedMessage);
+                return CreateCompileMessage(file, message.line, level, normalizedMessage);
             }
 
-            return string.Concat(file, ": ", level, " ", normalizedMessage);
+            return CreateCompileMessage(file, level, normalizedMessage);
+        }
+
+        private static string CreateCompileMessage (
+            string level,
+            string message)
+        {
+            var length = checked(level.Length + 1 + message.Length);
+            return string.Create(
+                length,
+                (Level: level, Message: message),
+                static (destination, state) =>
+                {
+                    var writer = new SpanTextWriter(destination);
+                    writer.Append(state.Level);
+                    writer.Append(' ');
+                    writer.Append(state.Message);
+                });
+        }
+
+        private static string CreateCompileMessage (
+            string file,
+            string level,
+            string message)
+        {
+            var length = checked(file.Length + 2 + level.Length + 1 + message.Length);
+            return string.Create(
+                length,
+                (File: file, Level: level, Message: message),
+                static (destination, state) =>
+                {
+                    var writer = new SpanTextWriter(destination);
+                    writer.Append(state.File);
+                    writer.Append(": ");
+                    writer.Append(state.Level);
+                    writer.Append(' ');
+                    writer.Append(state.Message);
+                });
+        }
+
+        private static string CreateCompileMessage (
+            string file,
+            int line,
+            string level,
+            string message)
+        {
+            var lineLength = GetPositiveInt32TextLength(line);
+            var length = checked(file.Length + 1 + lineLength + 3 + level.Length + 1 + message.Length);
+            return string.Create(
+                length,
+                (File: file, Line: line, Level: level, Message: message),
+                static (destination, state) =>
+                {
+                    var writer = new SpanTextWriter(destination);
+                    writer.Append(state.File);
+                    writer.Append('(');
+                    writer.AppendInvariant(state.Line);
+                    writer.Append("): ");
+                    writer.Append(state.Level);
+                    writer.Append(' ');
+                    writer.Append(state.Message);
+                });
+        }
+
+        private static string CreateCompileMessage (
+            string file,
+            int line,
+            int column,
+            string level,
+            string message)
+        {
+            var lineLength = GetPositiveInt32TextLength(line);
+            var columnLength = GetPositiveInt32TextLength(column);
+            var length = checked(file.Length + 1 + lineLength + 1 + columnLength + 3 + level.Length + 1 + message.Length);
+            return string.Create(
+                length,
+                (File: file, Line: line, Column: column, Level: level, Message: message),
+                static (destination, state) =>
+                {
+                    var writer = new SpanTextWriter(destination);
+                    writer.Append(state.File);
+                    writer.Append('(');
+                    writer.AppendInvariant(state.Line);
+                    writer.Append(',');
+                    writer.AppendInvariant(state.Column);
+                    writer.Append("): ");
+                    writer.Append(state.Level);
+                    writer.Append(' ');
+                    writer.Append(state.Message);
+                });
+        }
+
+        private static int GetPositiveInt32TextLength (int value)
+        {
+            var length = 1;
+            var remaining = value;
+            while (remaining >= 10)
+            {
+                length++;
+                remaining /= 10;
+            }
+
+            return length;
         }
     }
 }

--- a/src/Ucli/Hosting/Cli/Common/Streaming/CliStreamEntryWriter.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/CliStreamEntryWriter.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Text;
 using System.Text.Json;
 using MackySoft.Ucli.Contracts.Ipc;
 
@@ -15,6 +17,7 @@ internal sealed class CliStreamEntryWriter
     private readonly string streamId;
     private readonly TextWriter errorWriter;
     private readonly TimeProvider timeProvider;
+    private readonly ArrayBufferWriter<byte> jsonBuffer = new();
 
     private long sequence;
 
@@ -40,15 +43,22 @@ internal sealed class CliStreamEntryWriter
         ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
         ArgumentNullException.ThrowIfNull(payload);
 
-        var entry = new CliStreamEntryEnvelope(
-            ProtocolVersion: IpcProtocol.CurrentVersion,
-            Command: command,
-            StreamId: streamId,
-            Sequence: checked(++sequence),
-            Timestamp: timeProvider.GetUtcNow().ToString("O"),
-            Event: eventName,
-            Payload: payload);
-        errorWriter.WriteLine(JsonSerializer.Serialize(entry, SerializerOptions));
+        jsonBuffer.Clear();
+        using (var writer = new Utf8JsonWriter(jsonBuffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("protocolVersion", IpcProtocol.CurrentVersion);
+            writer.WriteString("command", command);
+            writer.WriteString("streamId", streamId);
+            writer.WriteNumber("sequence", checked(++sequence));
+            writer.WriteString("timestamp", timeProvider.GetUtcNow().ToString("O"));
+            writer.WriteString("event", eventName);
+            writer.WritePropertyName("payload");
+            JsonSerializer.Serialize(writer, payload, payload.GetType(), SerializerOptions);
+            writer.WriteEndObject();
+        }
+
+        WriteUtf8JsonLine(jsonBuffer.WrittenSpan);
     }
 
     /// <summary> Writes one human-readable text entry line. </summary>
@@ -57,12 +67,26 @@ internal sealed class CliStreamEntryWriter
         errorWriter.WriteLine(CliTextEntrySanitizer.Sanitize(text));
     }
 
-    private sealed record CliStreamEntryEnvelope (
-        int ProtocolVersion,
-        string Command,
-        string StreamId,
-        long Sequence,
-        string Timestamp,
-        string Event,
-        object Payload);
+    /// <summary> Writes one human-readable text entry line that has already been sanitized. </summary>
+    public void WritePreSanitizedTextEntry (string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        errorWriter.WriteLine(text);
+    }
+
+    private void WriteUtf8JsonLine (ReadOnlySpan<byte> utf8Json)
+    {
+        var maxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Json.Length);
+        var charBuffer = ArrayPool<char>.Shared.Rent(maxCharCount);
+        try
+        {
+            var charCount = Encoding.UTF8.GetChars(utf8Json, charBuffer);
+            errorWriter.Write(charBuffer.AsSpan(0, charCount));
+            errorWriter.WriteLine();
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(charBuffer);
+        }
+    }
 }

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+using MackySoft.Ucli.Infrastructure.Text;
 
 namespace MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 
@@ -110,16 +111,36 @@ internal sealed class LogsDaemonReadCommand
             return nextCursor;
         }
 
-        var textLine = string.Concat(
-            daemonLogEvent.Timestamp,
-            " ",
-            daemonLogEvent.Level,
-            " ",
-            daemonLogEvent.Category,
-            " ",
-            LogsTextUtilities.NormalizeSingleLine(daemonLogEvent.Message));
-        entryWriter.WriteTextEntry(textLine);
+        entryWriter.WritePreSanitizedTextEntry(CreateTextLine(daemonLogEvent));
         return nextCursor;
+    }
+
+    private static string CreateTextLine (IpcDaemonLogEvent daemonLogEvent)
+    {
+        var message = LogsTextUtilities.NormalizeSingleLine(daemonLogEvent.Message);
+        var length = checked(
+            daemonLogEvent.Timestamp.Length
+            + 1
+            + daemonLogEvent.Level.Length
+            + 1
+            + daemonLogEvent.Category.Length
+            + 1
+            + message.Length);
+
+        return string.Create(
+            length,
+            (daemonLogEvent.Timestamp, daemonLogEvent.Level, daemonLogEvent.Category, Message: message),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(state.Timestamp);
+                writer.Append(' ');
+                writer.Append(state.Level);
+                writer.Append(' ');
+                writer.Append(state.Category);
+                writer.Append(' ');
+                writer.Append(state.Message);
+            });
     }
 
     /// <summary> Represents one NDJSON output line for daemon log events. </summary>

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
 using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+using MackySoft.Ucli.Infrastructure.Text;
 
 namespace MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 
@@ -114,25 +115,46 @@ internal sealed class LogsUnityReadCommand
             return nextCursor;
         }
 
-        var line = string.Concat(
-            unityLogEvent.Timestamp,
-            " ",
-            unityLogEvent.Level,
-            " ",
-            unityLogEvent.Source,
-            " ",
-            LogsTextUtilities.NormalizeSingleLine(unityLogEvent.Message));
-        if (string.IsNullOrWhiteSpace(unityLogEvent.StackTrace))
-        {
-            entryWriter.WriteTextEntry(line);
-            return nextCursor;
-        }
-
-        entryWriter.WriteTextEntry(string.Concat(
-            line,
-            " | ",
-            LogsTextUtilities.NormalizeSingleLine(unityLogEvent.StackTrace)));
+        entryWriter.WritePreSanitizedTextEntry(CreateTextLine(unityLogEvent));
         return nextCursor;
+    }
+
+    private static string CreateTextLine (IpcUnityLogEvent unityLogEvent)
+    {
+        var message = LogsTextUtilities.NormalizeSingleLine(unityLogEvent.Message);
+        var hasStackTrace = !string.IsNullOrWhiteSpace(unityLogEvent.StackTrace);
+        var stackTrace = hasStackTrace
+            ? LogsTextUtilities.NormalizeSingleLine(unityLogEvent.StackTrace)
+            : string.Empty;
+        var length = checked(
+            unityLogEvent.Timestamp.Length
+            + 1
+            + unityLogEvent.Level.Length
+            + 1
+            + unityLogEvent.Source.Length
+            + 1
+            + message.Length
+            + (hasStackTrace ? 3 + stackTrace.Length : 0));
+
+        return string.Create(
+            length,
+            (unityLogEvent.Timestamp, unityLogEvent.Level, unityLogEvent.Source, Message: message, HasStackTrace: hasStackTrace, StackTrace: stackTrace),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(state.Timestamp);
+                writer.Append(' ');
+                writer.Append(state.Level);
+                writer.Append(' ');
+                writer.Append(state.Source);
+                writer.Append(' ');
+                writer.Append(state.Message);
+                if (state.HasStackTrace)
+                {
+                    writer.Append(" | ");
+                    writer.Append(state.StackTrace);
+                }
+            });
     }
 
     /// <summary> Represents one NDJSON output line for Unity log events. </summary>

--- a/src/Ucli/Hosting/Cli/Testing/CliTestRunProgressSink.cs
+++ b/src/Ucli/Hosting/Cli/Testing/CliTestRunProgressSink.cs
@@ -1,7 +1,7 @@
-using System.Globalization;
 using MackySoft.Ucli.Application.Features.Testing.Run.Progress;
 using MackySoft.Ucli.Contracts.Testing;
 using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+using MackySoft.Ucli.Infrastructure.Text;
 
 namespace MackySoft.Ucli.Hosting.Cli.Testing;
 
@@ -36,53 +36,102 @@ internal sealed class CliTestRunProgressSink : ITestRunProgressSink
             return ValueTask.CompletedTask;
         }
 
-        entryWriter.WriteTextEntry(CreateTextLine(eventName, payload));
+        if (TryCreateTextLine(eventName, payload, out var textLine))
+        {
+            entryWriter.WriteTextEntry(textLine);
+        }
+
         return ValueTask.CompletedTask;
     }
 
-    private static string CreateTextLine (
+    private static bool TryCreateTextLine (
         string eventName,
-        object payload)
+        object payload,
+        out string textLine)
     {
-        return (eventName, payload) switch
+        switch (eventName, payload)
         {
-            (TestRunProgressEventNames.RunStarted, TestRunStartedEntry entry) => string.Concat(
-                "test run started",
-                FormatProperty(entry.RunId, " runId="),
-                FormatProperty(entry.TestPlatform, " platform="),
-                FormatProperty(entry.TestFilter, " filter=")),
-            (TestRunProgressEventNames.CaseStarted, TestCaseStartedEntry entry) => string.Concat(
-                "test case started",
-                FormatProperty(entry.TestName, " name="),
-                FormatProperty(entry.TestId, " id="),
-                FormatProperty(entry.AssemblyName, " assembly=")),
-            (TestRunProgressEventNames.CaseFinished, TestCaseFinishedEntry entry) => string.Concat(
-                "test case finished",
-                FormatProperty(entry.TestName, " name="),
-                FormatProperty(entry.Result, " result="),
-                FormatProperty(entry.DurationMilliseconds, " durationMs=")),
-            (TestRunProgressEventNames.RunDiagnostic, TestRunDiagnosticEntry entry) => string.Concat(
-                "test run diagnostic",
-                FormatProperty(entry.Severity, " severity="),
-                FormatProperty(entry.Code, " code="),
-                FormatProperty(entry.Message, " message=")),
-            _ => string.Concat(eventName, " ", payload),
+            case (TestRunProgressEventNames.RunStarted, TestRunStartedEntry):
+            case (TestRunProgressEventNames.CaseStarted, TestCaseStartedEntry):
+                textLine = string.Empty;
+                return false;
+            case (TestRunProgressEventNames.CaseFinished, TestCaseFinishedEntry entry):
+                textLine = CreateCaseFinishedTextLine(entry);
+                return true;
+            case (TestRunProgressEventNames.RunDiagnostic, TestRunDiagnosticEntry entry):
+                textLine = CreateDiagnosticTextLine(entry);
+                return true;
+            default:
+                textLine = string.Concat(eventName, " ", payload);
+                return true;
+        }
+    }
+
+    private static string CreateCaseFinishedTextLine (TestCaseFinishedEntry entry)
+    {
+        var caseResult = FormatCaseResult(entry.Result);
+        var durationLength = GetInt64TextLength(entry.DurationMilliseconds);
+        var length = checked(caseResult.Length + 1 + entry.TestName.Length + 2 + durationLength + 4);
+
+        return string.Create(
+            length,
+            (CaseResult: caseResult, entry.TestName, entry.DurationMilliseconds),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(state.CaseResult);
+                writer.Append(' ');
+                writer.Append(state.TestName);
+                writer.Append(" [");
+                writer.AppendInvariant(state.DurationMilliseconds);
+                writer.Append(" ms]");
+            });
+    }
+
+    private static string CreateDiagnosticTextLine (TestRunDiagnosticEntry entry)
+    {
+        var length = checked(entry.Severity.Length + 1 + entry.Code.Length + 2 + entry.Message.Length);
+        return string.Create(
+            length,
+            entry,
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(state.Severity);
+                writer.Append(' ');
+                writer.Append(state.Code);
+                writer.Append(": ");
+                writer.Append(state.Message);
+            });
+    }
+
+    private static string FormatCaseResult (string result)
+    {
+        return result switch
+        {
+            "pass" => "Passed",
+            "fail" => "Failed",
+            "skipped" => "Skipped",
+            "inconclusive" => "Inconclusive",
+            _ => result,
         };
     }
 
-    private static string FormatProperty (
-        string? value,
-        string prefix)
+    private static int GetInt64TextLength (long value)
     {
-        return string.IsNullOrWhiteSpace(value)
-            ? string.Empty
-            : string.Concat(prefix, value);
-    }
+        if (value == 0)
+        {
+            return 1;
+        }
 
-    private static string FormatProperty (
-        long value,
-        string prefix)
-    {
-        return string.Concat(prefix, value.ToString(CultureInfo.InvariantCulture));
+        var length = value < 0 ? 1 : 0;
+        var remaining = value;
+        while (remaining != 0)
+        {
+            length++;
+            remaining /= 10;
+        }
+
+        return length;
     }
 }

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
@@ -319,29 +319,66 @@ public sealed class TestRunCommandTests
             IpcProtocol.StatusOk,
             (int)CliExitCode.Success);
         Assert.Equal(
-            "test run diagnostic severity=info code=TEST_PROGRESS_STUB message=line 1\\nline 2" + Environment.NewLine,
+            "info TEST_PROGRESS_STUB: line 1\\nline 2" + Environment.NewLine,
             standardError);
     }
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task Run_WithTextFormat_WritesTextProgressToStandardError ()
+    public async Task Run_WithTextFormat_WritesDotnetStyleCompletedCasesToStandardError ()
     {
         var service = new StubTestRunService(async (_, progressSink, cancellationToken) =>
         {
             Assert.NotNull(progressSink);
             await progressSink!.OnEntryAsync(
+                TestRunProgressEventNames.RunStarted,
+                new TestRunStartedEntry(
+                    "run-id",
+                    "editmode",
+                    null,
+                    ["MyGame.Tests"],
+                    []),
+                cancellationToken);
+            await progressSink.OnEntryAsync(
                 TestRunProgressEventNames.CaseStarted,
                 new TestCaseStartedEntry(
                     "run-id",
-                    "test-id",
+                    "test-id-pass",
                     "SmokeTest.Passes",
                     "MyGame.Tests",
                     "editmode",
                     ["smoke"]),
                 cancellationToken);
-            return TestRunServiceResult.Pass(
-                message: "Unity test execution completed.",
+            await progressSink.OnEntryAsync(
+                TestRunProgressEventNames.CaseFinished,
+                new TestCaseFinishedEntry(
+                    "run-id",
+                    "test-id-pass",
+                    "SmokeTest.Passes",
+                    "MyGame.Tests",
+                    "editmode",
+                    ["smoke"],
+                    "pass",
+                    42,
+                    null,
+                    null),
+                cancellationToken);
+            await progressSink.OnEntryAsync(
+                TestRunProgressEventNames.CaseFinished,
+                new TestCaseFinishedEntry(
+                    "run-id",
+                    "test-id-fail",
+                    "SmokeTest.Fails",
+                    "MyGame.Tests",
+                    "editmode",
+                    ["smoke"],
+                    "fail",
+                    13,
+                    "assertion failed",
+                    "at SmokeTest.Fails()"),
+                cancellationToken);
+            return TestRunServiceResult.Fail(
+                message: "Unity test execution completed with failures.",
                 runId: "run-id",
                 artifactsDir: "/tmp/ucli-test-run-artifacts",
                 summaryJsonPath: "/tmp/ucli-test-run-artifacts/summary.json");
@@ -352,15 +389,16 @@ public sealed class TestRunCommandTests
             format: "text",
             cancellationToken: CancellationToken.None));
 
-        Assert.Equal((int)CliExitCode.Success, exitCode);
+        Assert.Equal(1, exitCode);
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
             UcliCommandNames.TestRun,
             IpcProtocol.StatusOk,
-            (int)CliExitCode.Success);
+            1);
         Assert.Equal(
-            "test case started name=SmokeTest.Passes id=test-id assembly=MyGame.Tests" + Environment.NewLine,
+            "Passed SmokeTest.Passes [42 ms]" + Environment.NewLine
+                + "Failed SmokeTest.Fails [13 ms]" + Environment.NewLine,
             standardError);
     }
 


### PR DESCRIPTION
## Summary
- Reduces avoidable string and byte-array allocation on hot paths for CLI stream output, log rendering, log cursors, Unity compile logs, and index input hashing.
- Keeps CLI JSON field names/order, cursor format, and logs text layout stable while changing test text stream output to dotnet-style completed case lines.
- Adds internal infrastructure helpers for span-based text construction and incremental UTF-8 SHA-256 hashing.

## Scope
- CLI streaming/logs/test output: writes JSON stream entries with `Utf8JsonWriter` and reusable buffers, avoids double sanitize for logs text, and formats test progress as completed case lines.
- Shared cursor and Unity logs: formats cursors and compile messages with `string.Create`/span formatting while preserving serialized forms.
- Index hashing: streams normalized paths, delimiters, and file hashes into SHA-256 without building a whole metadata string or UTF-8 byte array first.

## Verification
- PASS: `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter "FullyQualifiedName~TestRunCommandTests|FullyQualifiedName~LogsDaemonReadCommandTests|FullyQualifiedName~LogsUnityReadCommandTests|FullyQualifiedName~CliTextEntrySanitizerTests"`
- PASS: `dotnet test tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj --filter "FullyQualifiedName~IpcCommonContractTests"`
- PASS: `dotnet test tests/Ucli.Infrastructure.Tests/Ucli.Infrastructure.Tests.csproj --filter "FullyQualifiedName~IndexInput"`
- PASS: `bash scripts/code-quality.sh format --include <changed files>`
- PASS: `bash scripts/code-quality.sh verify --include <changed files>`
- PASS: `bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor" --test-filter "MackySoft.Ucli.Unity.Tests"`
- PASS: `bash scripts/verify.sh --include-unity --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`

## Risks / Rollback
- Main risk is subtle output drift in stream/log/test text formatting; targeted and full verification covered the changed contracts.
- Rollback is the single commit `183e20b1` if allocation-focused changes need to be backed out.

## Checklist
- [x] JSON stream envelope property names and order preserved.
- [x] Cursor format preserved.
- [x] Logs text layout preserved.
- [x] Test text stream failed case output verified.

Issue: none (ad-hoc task)
