### PR TITLE
fix(ready): align readIndex readiness artifact scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ For read-heavy workflows, `--readIndexMode` controls whether query-like commands
 | `allowStale` | Use stored index data even when it is stale, and fall back when it is unavailable. |
 | `requireFresh` | Use stored index data only when it is fresh; otherwise refresh from Unity when the command supports it. |
 
+`ucli ready --for readIndex --readIndexMode requireFresh` checks the global read-index surfaces used by public read commands: `ops.catalog`, `asset-search.lookup`, and `guid-path.lookup`. It does not require unconnected schema catalogs or path-specific `scene-tree-lite` snapshots; validate a scene snapshot with `ucli query scene tree --path <scene> --readIndexMode requireFresh`.
+
 The operation catalog is also available from the CLI:
 
 ```bash

--- a/schemas/v1/cli-output/payload/ready.schema.json
+++ b/schemas/v1/cli-output/payload/ready.schema.json
@@ -336,6 +336,9 @@
                   "failed"
                 ]
               },
+              "required": {
+                "type": "boolean"
+              },
               "freshness": {
                 "type": [
                   "string",
@@ -365,11 +368,18 @@
                   "string",
                   "null"
                 ]
+              },
+              "actionRequired": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "required": [
               "name",
-              "status"
+              "status",
+              "required"
             ]
           }
         }

--- a/src/Ucli.Application/Features/Assurance/Ready/ReadyReadIndexArtifactOutput.cs
+++ b/src/Ucli.Application/Features/Assurance/Ready/ReadyReadIndexArtifactOutput.cs
@@ -6,6 +6,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Ready;
 internal sealed record ReadyReadIndexArtifactOutput (
     string Name,
     string Status,
+    bool Required = true,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? Freshness = null,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -15,4 +16,6 @@ internal sealed record ReadyReadIndexArtifactOutput (
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     string? Code = null,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    string? Message = null);
+    string? Message = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    string? ActionRequired = null);

--- a/src/Ucli.Application/Features/Assurance/Ready/ReadyReadIndexObservation.cs
+++ b/src/Ucli.Application/Features/Assurance/Ready/ReadyReadIndexObservation.cs
@@ -48,10 +48,11 @@ internal readonly record struct ReadyReadIndexObservation (
 
         return new ReadyReadIndexObservation(
             new ReadyReadIndexOutput(ReadIndexModeCodec.ToValue(mode), artifacts),
-            artifacts.Any(static artifact => string.Equals(
-                artifact.Status,
-                ReadyReadIndexArtifactStatusValues.Failed,
-                StringComparison.Ordinal)),
+            artifacts.Any(static artifact => artifact.Required
+                && string.Equals(
+                    artifact.Status,
+                    ReadyReadIndexArtifactStatusValues.Failed,
+                    StringComparison.Ordinal)),
             IsDisabled: false);
     }
 }

--- a/src/Ucli.Application/Features/Assurance/Ready/ReadyService.cs
+++ b/src/Ucli.Application/Features/Assurance/Ready/ReadyService.cs
@@ -10,6 +10,12 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Ready;
 /// <summary> Executes readiness probes and compiles the result into an assurance packet. </summary>
 internal sealed class ReadyService : IReadyService
 {
+    private const string OpsCatalogReadinessActionRequired =
+        "Run `ucli ops list --readIndexMode requireFresh` to refresh ops catalog readIndex artifacts.";
+
+    private const string AssetLookupReadinessActionRequired =
+        "Run `ucli query assets find --pathPrefix Assets --limit 1 --readIndexMode disabled` to refresh asset lookup readIndex artifacts.";
+
     private static readonly IReadOnlyDictionary<string, ReadyReportOutput> EmptyReports =
         new Dictionary<string, ReadyReportOutput>(StringComparer.Ordinal);
 
@@ -371,7 +377,6 @@ internal sealed class ReadyService : IReadyService
     {
         var artifacts = new List<ReadyReadIndexArtifactOutput>
         {
-            await ReadInputsManifestAsync(unityProject, cancellationToken).ConfigureAwait(false),
             await ReadArtifactAsync(
                     "ops.catalog",
                     IndexFreshnessTarget.OpsCatalog,
@@ -380,27 +385,9 @@ internal sealed class ReadyService : IReadyService
                     static value => value.GeneratedAtUtc,
                     unityProject,
                     mode,
-                    cancellationToken)
-                .ConfigureAwait(false),
-            await ReadArtifactAsync(
-                    "types.catalog",
-                    IndexFreshnessTarget.TypesCatalog,
-                    cancellationToken => readIndexArtifactReader.ReadTypesCatalogAsync(unityProject, cancellationToken),
-                    static value => value.SourceInputsHash,
-                    static value => value.GeneratedAtUtc,
-                    unityProject,
-                    mode,
-                    cancellationToken)
-                .ConfigureAwait(false),
-            await ReadArtifactAsync(
-                    "schemas.catalog",
-                    IndexFreshnessTarget.SchemasCatalog,
-                    cancellationToken => readIndexArtifactReader.ReadSchemasCatalogAsync(unityProject, cancellationToken),
-                    static value => value.SourceInputsHash,
-                    static value => value.GeneratedAtUtc,
-                    unityProject,
-                    mode,
-                    cancellationToken)
+                    required: true,
+                    actionRequired: OpsCatalogReadinessActionRequired,
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false),
             await ReadArtifactAsync(
                     "asset-search.lookup",
@@ -410,7 +397,9 @@ internal sealed class ReadyService : IReadyService
                     static value => value.GeneratedAtUtc,
                     unityProject,
                     mode,
-                    cancellationToken)
+                    required: true,
+                    actionRequired: AssetLookupReadinessActionRequired,
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false),
             await ReadArtifactAsync(
                     "guid-path.lookup",
@@ -420,28 +409,13 @@ internal sealed class ReadyService : IReadyService
                     static value => value.GeneratedAtUtc,
                     unityProject,
                     mode,
-                    cancellationToken)
+                    required: true,
+                    actionRequired: AssetLookupReadinessActionRequired,
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false),
         };
 
         return ReadyReadIndexObservation.FromArtifacts(mode, artifacts);
-    }
-
-    private async ValueTask<ReadyReadIndexArtifactOutput> ReadInputsManifestAsync (
-        ResolvedUnityProjectContext unityProject,
-        CancellationToken cancellationToken)
-    {
-        var result = await readIndexArtifactReader.ReadInputsManifestAsync(unityProject, cancellationToken).ConfigureAwait(false);
-        if (!result.IsSuccess)
-        {
-            return CreateFailedReadIndexArtifact("inputs.manifest", result.Error!);
-        }
-
-        return new ReadyReadIndexArtifactOutput(
-            Name: "inputs.manifest",
-            Status: ReadyReadIndexArtifactStatusValues.Available,
-            SourceInputsHash: result.Value!.CombinedHash,
-            GeneratedAtUtc: result.Value.GeneratedAtUtc);
     }
 
     private async ValueTask<ReadyReadIndexArtifactOutput> ReadArtifactAsync<T> (
@@ -452,13 +426,15 @@ internal sealed class ReadyService : IReadyService
         Func<T, DateTimeOffset> getGeneratedAtUtc,
         ResolvedUnityProjectContext unityProject,
         ReadIndexMode mode,
+        bool required,
+        string actionRequired,
         CancellationToken cancellationToken)
         where T : class
     {
         var result = await readAsync(cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccess)
         {
-            return CreateFailedReadIndexArtifact(name, result.Error!);
+            return CreateFailedReadIndexArtifact(name, result.Error!, required: required, actionRequired: actionRequired);
         }
 
         var value = result.Value!;
@@ -471,18 +447,33 @@ internal sealed class ReadyService : IReadyService
             .ConfigureAwait(false);
         if (!freshnessResult.IsSuccess)
         {
-            return CreateFailedReadIndexArtifact(name, freshnessResult.Error!, freshnessResult.Freshness, sourceInputsHash, getGeneratedAtUtc(value));
+            return CreateFailedReadIndexArtifact(
+                name,
+                freshnessResult.Error!,
+                freshnessResult.Freshness,
+                sourceInputsHash,
+                getGeneratedAtUtc(value),
+                required,
+                actionRequired);
         }
 
         var constrainedFreshnessResult = IndexFreshnessPolicy.ApplyModeConstraint(mode, freshnessResult.Freshness);
         if (!constrainedFreshnessResult.IsSuccess)
         {
-            return CreateFailedReadIndexArtifact(name, constrainedFreshnessResult.Error!, constrainedFreshnessResult.Freshness, sourceInputsHash, getGeneratedAtUtc(value));
+            return CreateFailedReadIndexArtifact(
+                name,
+                constrainedFreshnessResult.Error!,
+                constrainedFreshnessResult.Freshness,
+                sourceInputsHash,
+                getGeneratedAtUtc(value),
+                required,
+                actionRequired);
         }
 
         return new ReadyReadIndexArtifactOutput(
             Name: name,
             Status: ReadyReadIndexArtifactStatusValues.Available,
+            Required: required,
             Freshness: ReadIndexAccessUtilities.DescribeFreshness(constrainedFreshnessResult.Freshness),
             SourceInputsHash: sourceInputsHash,
             GeneratedAtUtc: getGeneratedAtUtc(value));
@@ -493,18 +484,22 @@ internal sealed class ReadyService : IReadyService
         IndexServiceError error,
         IndexFreshness? freshness = null,
         string? sourceInputsHash = null,
-        DateTimeOffset? generatedAtUtc = null)
+        DateTimeOffset? generatedAtUtc = null,
+        bool required = true,
+        string? actionRequired = null)
     {
         ArgumentNullException.ThrowIfNull(error);
 
         return new ReadyReadIndexArtifactOutput(
             Name: name,
             Status: ReadyReadIndexArtifactStatusValues.Failed,
+            Required: required,
             Freshness: freshness.HasValue ? ReadIndexAccessUtilities.DescribeFreshness(freshness.Value) : null,
             SourceInputsHash: sourceInputsHash,
             GeneratedAtUtc: generatedAtUtc,
             Code: error.Code.Value,
-            Message: error.Message);
+            Message: error.Message,
+            ActionRequired: actionRequired);
     }
 
     private static ReadyExecutionOutput CreateOutput (

--- a/src/Ucli/Hosting/Cli/Assurance/ReadyCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/ReadyCommand.cs
@@ -26,7 +26,7 @@ internal sealed class ReadyCommand
     /// <param name="for">Readiness target (execution|mutation|test|readIndex).</param>
     /// <param name="projectPath">-p|--projectPath, Optional target Unity project path.</param>
     /// <param name="mode">Unity execution mode (auto|daemon|oneshot).</param>
-    /// <param name="readIndexMode">Read-index mode. Supported only with --for readIndex.</param>
+    /// <param name="readIndexMode">--readIndexMode, Read-index mode. Supported only with --for readIndex.</param>
     /// <param name="timeout">Timeout in milliseconds.</param>
     /// <param name="failFast">--failFast, Fails immediately when Unity editor lifecycle is not yet ready.</param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>

--- a/tests/Ucli.Application.Tests/Features/Assurance/Ready/ReadyServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Ready/ReadyServiceTests.cs
@@ -165,10 +165,44 @@ public sealed class ReadyServiceTests
         Assert.Null(output.Lifecycle);
         Assert.NotNull(output.ReadIndex);
         Assert.Equal(ReadIndexModeValues.AllowStale, output.ReadIndex.Mode);
-        Assert.Equal(6, output.ReadIndex.Artifacts.Count);
+        Assert.Equal(
+            ["ops.catalog", "asset-search.lookup", "guid-path.lookup"],
+            output.ReadIndex.Artifacts.Select(static artifact => artifact.Name));
+        Assert.All(output.ReadIndex.Artifacts, static artifact => Assert.True(artifact.Required));
         var claim = Assert.Single(output.Claims);
         Assert.Equal(ReadyValidityKindValues.ProbeOnly, claim.Validity.Kind);
         Assert.False(claim.Validity.GuaranteesReusableSession);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithReadIndexTarget_WhenRequiredArtifactIsMissing_ReturnsFailedClaimWithActionRequired ()
+    {
+        var service = CreateService(
+            readIndexArtifactReader: new SuccessfulReadIndexArtifactReader(missingArtifactName: "asset-search.lookup"));
+
+        var result = await service.ExecuteAsync(new ReadyCommandInput(
+            ProjectPath: null,
+            Target: ReadyTarget.ReadIndex,
+            Mode: null,
+            TimeoutMilliseconds: 10000,
+            ReadIndexMode: ReadIndexMode.RequireFresh,
+            IsReadIndexModeSpecified: true,
+            FailFast: false));
+
+        Assert.True(result.IsSuccess);
+        var output = Assert.IsType<ReadyExecutionOutput>(result.Output);
+        Assert.Equal(ReadyVerdictValues.Fail, output.Verdict);
+        var claim = Assert.Single(output.Claims);
+        Assert.Equal(ReadyClaimStatusValues.Failed, claim.Status);
+
+        var artifact = Assert.Single(
+            output.ReadIndex!.Artifacts,
+            static artifact => string.Equals(artifact.Name, "asset-search.lookup", StringComparison.Ordinal));
+        Assert.True(artifact.Required);
+        Assert.Equal(ReadyReadIndexArtifactStatusValues.Failed, artifact.Status);
+        Assert.Equal(ReadIndexErrorCodes.ReadIndexBootstrapFailed.Value, artifact.Code);
+        Assert.Contains("query assets find", artifact.ActionRequired, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -692,10 +726,22 @@ public sealed class ReadyServiceTests
     {
         private static readonly DateTimeOffset GeneratedAtUtc = DateTimeOffset.Parse("2026-05-17T00:00:00Z");
 
+        private readonly string? missingArtifactName;
+
+        public SuccessfulReadIndexArtifactReader (string? missingArtifactName = null)
+        {
+            this.missingArtifactName = missingArtifactName;
+        }
+
         public ValueTask<ReadIndexArtifactReadResult<IndexOpsCatalogJsonContract>> ReadOpsCatalogAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
+            if (IsMissing("ops.catalog"))
+            {
+                return Missing<IndexOpsCatalogJsonContract>("ops.catalog.json");
+            }
+
             return Success(new IndexOpsCatalogJsonContract(1, GeneratedAtUtc, "source-hash", []));
         }
 
@@ -712,20 +758,25 @@ public sealed class ReadyServiceTests
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
-            return Success(new IndexTypesCatalogJsonContract(1, GeneratedAtUtc, "source-hash", []));
+            throw new NotSupportedException("types.catalog is not part of readIndex readiness.");
         }
 
         public ValueTask<ReadIndexArtifactReadResult<IndexSchemasCatalogJsonContract>> ReadSchemasCatalogAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
-            return Success(new IndexSchemasCatalogJsonContract(1, GeneratedAtUtc, "source-hash", []));
+            throw new NotSupportedException("schemas.catalog is not part of readIndex readiness.");
         }
 
         public ValueTask<ReadIndexArtifactReadResult<IndexAssetSearchLookupJsonContract>> ReadAssetSearchLookupAsync (
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
+            if (IsMissing("asset-search.lookup"))
+            {
+                return Missing<IndexAssetSearchLookupJsonContract>("lookups/asset-search.lookup.json");
+            }
+
             return Success(new IndexAssetSearchLookupJsonContract(1, GeneratedAtUtc, "source-hash", []));
         }
 
@@ -733,6 +784,11 @@ public sealed class ReadyServiceTests
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
+            if (IsMissing("guid-path.lookup"))
+            {
+                return Missing<IndexGuidPathLookupJsonContract>("lookups/guid-path.lookup.json");
+            }
+
             return Success(new IndexGuidPathLookupJsonContract(1, GeneratedAtUtc, "source-hash", []));
         }
 
@@ -748,17 +804,20 @@ public sealed class ReadyServiceTests
             ResolvedUnityProjectContext unityProject,
             CancellationToken cancellationToken = default)
         {
-            return Success(new IndexInputsManifestJsonContract(
-                SchemaVersion: 1,
-                GeneratedAtUtc: GeneratedAtUtc,
-                ScriptAssembliesHash: "assemblies-hash",
-                PackagesManifestHash: "manifest-hash",
-                PackagesLockHash: "lock-hash",
-                AssemblyDefinitionHash: "asmdef-hash",
-                AssetsContentHash: "assets-hash",
-                AssetSearchHash: "asset-search-hash",
-                GuidPathHash: "guid-path-hash",
-                CombinedHash: "source-hash"));
+            throw new NotSupportedException("inputs.manifest is not part of readIndex readiness.");
+        }
+
+        private bool IsMissing (string artifactName)
+        {
+            return string.Equals(missingArtifactName, artifactName, StringComparison.Ordinal);
+        }
+
+        private static ValueTask<ReadIndexArtifactReadResult<T>> Missing<T> (string artifactPath)
+            where T : class
+        {
+            return ValueTask.FromResult(ReadIndexArtifactReadResult<T>.Failure(
+                ReadIndexErrorCodes.ReadIndexBootstrapFailed,
+                $"Index contract file '{artifactPath}' does not exist."));
         }
 
         private static ValueTask<ReadIndexArtifactReadResult<T>> Success<T> (T value)

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/ready/read-index-success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/ready/read-index-success.json
@@ -49,28 +49,9 @@
               "mode": "allowStale",
               "artifacts": [
                 {
-                  "name": "inputs.manifest",
-                  "status": "available",
-                  "sourceInputsHash": "source-hash",
-                  "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-                },
-                {
                   "name": "ops.catalog",
                   "status": "available",
-                  "freshness": "fresh",
-                  "sourceInputsHash": "source-hash",
-                  "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-                },
-                {
-                  "name": "types.catalog",
-                  "status": "available",
-                  "freshness": "fresh",
-                  "sourceInputsHash": "source-hash",
-                  "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-                },
-                {
-                  "name": "schemas.catalog",
-                  "status": "available",
+                  "required": true,
                   "freshness": "fresh",
                   "sourceInputsHash": "source-hash",
                   "generatedAtUtc": "2026-05-17T00:00:00+00:00"
@@ -78,6 +59,7 @@
                 {
                   "name": "asset-search.lookup",
                   "status": "available",
+                  "required": true,
                   "freshness": "fresh",
                   "sourceInputsHash": "source-hash",
                   "generatedAtUtc": "2026-05-17T00:00:00+00:00"
@@ -85,6 +67,7 @@
                 {
                   "name": "guid-path.lookup",
                   "status": "available",
+                  "required": true,
                   "freshness": "fresh",
                   "sourceInputsHash": "source-hash",
                   "generatedAtUtc": "2026-05-17T00:00:00+00:00"
@@ -108,28 +91,9 @@
       "mode": "allowStale",
       "artifacts": [
         {
-          "name": "inputs.manifest",
-          "status": "available",
-          "sourceInputsHash": "source-hash",
-          "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-        },
-        {
           "name": "ops.catalog",
           "status": "available",
-          "freshness": "fresh",
-          "sourceInputsHash": "source-hash",
-          "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-        },
-        {
-          "name": "types.catalog",
-          "status": "available",
-          "freshness": "fresh",
-          "sourceInputsHash": "source-hash",
-          "generatedAtUtc": "2026-05-17T00:00:00+00:00"
-        },
-        {
-          "name": "schemas.catalog",
-          "status": "available",
+          "required": true,
           "freshness": "fresh",
           "sourceInputsHash": "source-hash",
           "generatedAtUtc": "2026-05-17T00:00:00+00:00"
@@ -137,6 +101,7 @@
         {
           "name": "asset-search.lookup",
           "status": "available",
+          "required": true,
           "freshness": "fresh",
           "sourceInputsHash": "source-hash",
           "generatedAtUtc": "2026-05-17T00:00:00+00:00"
@@ -144,6 +109,7 @@
         {
           "name": "guid-path.lookup",
           "status": "available",
+          "required": true,
           "freshness": "fresh",
           "sourceInputsHash": "source-hash",
           "generatedAtUtc": "2026-05-17T00:00:00+00:00"

--- a/tests/Ucli.Tests/Hosting/Cli/CliCommandRegistrationContractTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/CliCommandRegistrationContractTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.RegularExpressions;
 using MackySoft.Tests;
 using MackySoft.Ucli.Hosting.Cli.Common.Startup;
 
@@ -5,6 +7,10 @@ namespace MackySoft.Ucli.Tests.Cli;
 
 public sealed class CliCommandRegistrationContractTests
 {
+    private static readonly Regex KebabCaseLongOptionPattern = new(
+        "--[a-z][A-Za-z0-9]*-[A-Za-z0-9-]*",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     [Fact]
     [Trait("Size", "Medium")]
     public async Task HelpOutput_CommandPathsMatchCommandCatalog ()
@@ -30,6 +36,46 @@ public sealed class CliCommandRegistrationContractTests
             .ToArray();
 
         Assert.Equal(publicLeafCommandNames, registeredPublicCommandNames);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task HelpOutput_MultiWordLongOptionsExposeCamelCaseAlias ()
+    {
+        var failures = new List<string>();
+
+        foreach (var commandPath in UcliCommandCatalog.CommandPaths.Order(StringComparer.Ordinal))
+        {
+            var result = await CliProcessRunner.RunCommandAsync(
+                [.. commandPath.Split(' ', StringSplitOptions.RemoveEmptyEntries), "--help"]);
+
+            Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+
+            foreach (var optionHelpLine in ExtractOptionHelpLines(result.StdOut))
+            {
+                foreach (Match match in KebabCaseLongOptionPattern.Matches(optionHelpLine))
+                {
+                    var kebabCaseOption = match.Value;
+                    if (HasKnownAlternativePublicOption(commandPath, kebabCaseOption, optionHelpLine))
+                    {
+                        continue;
+                    }
+
+                    var camelCaseOption = ToCamelCaseLongOption(kebabCaseOption);
+                    if (!optionHelpLine.Contains(camelCaseOption, StringComparison.Ordinal))
+                    {
+                        failures.Add(
+                            $"{commandPath}: expected {camelCaseOption} next to {kebabCaseOption} in `{optionHelpLine.Trim()}`.");
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            "Every multi-word long option must expose its camelCase public spelling."
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, failures));
     }
 
     private static string[] ExtractHelpCommandPaths (string helpOutput)
@@ -63,6 +109,19 @@ public sealed class CliCommandRegistrationContractTests
         return commandPaths.ToArray();
     }
 
+    private static IEnumerable<string> ExtractOptionHelpLines (string helpOutput)
+    {
+        var lines = helpOutput.Split('\n');
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("-", StringComparison.Ordinal) && trimmed.Contains("--", StringComparison.Ordinal))
+            {
+                yield return line.TrimEnd('\r');
+            }
+        }
+    }
+
     private static string[] ExtractPublicLeafCommandNames ()
     {
         var knownCommandNames = UcliPublicCommandCatalog.KnownCommands
@@ -73,6 +132,36 @@ public sealed class CliCommandRegistrationContractTests
                 otherCommandName.Length > commandName.Length
                 && otherCommandName.StartsWith(commandName + ".", StringComparison.Ordinal)))
             .ToArray();
+    }
+
+    private static bool HasKnownAlternativePublicOption (
+        string commandPath,
+        string kebabCaseOption,
+        string optionHelpLine)
+    {
+        return (string.Equals(commandPath, $"{UcliCommandNames.Ops} {UcliCommandNames.ListSubcommand}", StringComparison.Ordinal)
+            && string.Equals(kebabCaseOption, "--operation-kind", StringComparison.Ordinal)
+            && optionHelpLine.Contains("--kind", StringComparison.Ordinal))
+            || (string.Equals(commandPath, $"{UcliCommandNames.Test} {UcliCommandNames.RunSubcommand}", StringComparison.Ordinal)
+            && string.Equals(kebabCaseOption, "--execution-mode", StringComparison.Ordinal)
+            && optionHelpLine.Contains("--mode", StringComparison.Ordinal));
+    }
+
+    private static string ToCamelCaseLongOption (string kebabCaseOption)
+    {
+        var value = kebabCaseOption[2..];
+        var segments = value.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        var builder = new StringBuilder(kebabCaseOption.Length);
+        builder.Append("--");
+        builder.Append(segments[0]);
+
+        for (var i = 1; i < segments.Length; i++)
+        {
+            builder.Append(char.ToUpperInvariant(segments[i][0]));
+            builder.Append(segments[i][1..]);
+        }
+
+        return builder.ToString();
     }
 
     private static string ExtractCommandPath (string helpLine)

--- a/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
@@ -179,6 +179,18 @@ public sealed class ReadyCommandTests
             CreateReadyGoldenNormalization());
     }
 
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Ready_WithHelpOutput_IncludesReadIndexModeCamelCaseOption ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Ready,
+            "--help");
+
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        Assert.Contains("--readIndexMode", result.StdOut, StringComparison.Ordinal);
+    }
+
     private static ReadyExecutionOutput CreateOutput (
         string verdict = ReadyVerdictValues.Pass)
     {

--- a/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
@@ -338,14 +338,7 @@ public sealed class ReadyCommandTests
         var generatedAtUtc = DateTimeOffset.Parse("2026-05-17T00:00:00Z");
         return
         [
-            new ReadyReadIndexArtifactOutput(
-                Name: "inputs.manifest",
-                Status: ReadyReadIndexArtifactStatusValues.Available,
-                SourceInputsHash: "source-hash",
-                GeneratedAtUtc: generatedAtUtc),
             CreateCatalogArtifact("ops.catalog", generatedAtUtc),
-            CreateCatalogArtifact("types.catalog", generatedAtUtc),
-            CreateCatalogArtifact("schemas.catalog", generatedAtUtc),
             CreateCatalogArtifact("asset-search.lookup", generatedAtUtc),
             CreateCatalogArtifact("guid-path.lookup", generatedAtUtc),
         ];

--- a/tests/Ucli.Tests/ReadyCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/ReadyCliOutputContractTests.cs
@@ -43,7 +43,7 @@ public sealed class ReadyCliOutputContractTests
         Assert.Equal(AssuranceSessionKindValues.ArtifactOnly, payload.GetProperty("sessionKind").GetString());
         Assert.Equal(JsonValueKind.Null, payload.GetProperty("lifecycle").ValueKind);
         Assert.Equal(JsonValueKind.Object, payload.GetProperty("readIndex").ValueKind);
-        Assert.Equal(6, payload.GetProperty("readIndex").GetProperty("artifacts").GetArrayLength());
+        Assert.Equal(3, payload.GetProperty("readIndex").GetProperty("artifacts").GetArrayLength());
     }
 
     private static AssuranceSemanticInvariantValidator CreateValidator ()

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -528,11 +528,13 @@ internal static class Program
             additionalProperties: false,
             Required("name", StringSchema()),
             Required("status", EnumSchema("available", "failed")),
+            Required("required", BooleanSchema()),
             Optional("freshness", NullableStringSchema()),
             Optional("sourceInputsHash", NullableStringSchema()),
             Optional("generatedAtUtc", NullableStringSchema()),
             Optional("code", NullableStringSchema()),
-            Optional("message", NullableStringSchema()));
+            Optional("message", NullableStringSchema()),
+            Optional("actionRequired", NullableStringSchema()));
     }
 
     private static Dictionary<string, object?> CreateCompilePayloadSchema ()


### PR DESCRIPTION
## Summary
- Align `ready --for readIndex --readIndexMode requireFresh` with the global readIndex artifacts used by public read commands.
- Treat `ops.catalog`, `asset-search.lookup`, and `guid-path.lookup` as the required readiness surface.
- Add `required` and `actionRequired` to readIndex artifact output so missing required artifacts include a public recovery command.

## Scope
- Ready service: narrows artifact observation and failure semantics to required artifacts.
- CLI output schema: updates generated ready payload schema for `required` and `actionRequired`.
- Tests and golden files: cover readiness pass surface and missing artifact diagnostics.
- Documentation: updates README readIndex readiness guidance.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format`)
- Tests: PASS (`bash scripts/code-quality.sh verify`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk: consumers that assumed readiness listed unconnected catalog artifacts will see a smaller artifact list. The schema and golden output were updated to make the contract explicit.
- Rollback: revert the three commits on this branch to restore the previous readiness artifact set and output shape.

## Checklist
- [x] Acceptance Criteria を満たす回帰テストを追加
- [x] 生成 schema の drift がないことを確認
- [x] README の readIndex readiness 説明を更新

Closes #350