### PR TITLE
Fix ready readIndexMode aliases and startup diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ uCLI includes a read index for read-heavy automation. It lets agents and scripts
 
 Mutations still re-resolve against live Unity state. The read index improves planning and validation, but it is never the source of truth for `call`.
 
-For read-heavy workflows, `--readIndexMode` controls whether query-like commands may use stored index data:
+For read-heavy workflows, `--readIndexMode` controls whether query-like commands may use stored index data. The `--read-index-mode` spelling is accepted as an alias.
 
 | Mode | Behavior |
 | --- | --- |
@@ -978,12 +978,14 @@ Common options:
 | `--projectPath <path>` | Unity-backed commands | Target Unity project path. Overrides `UCLI_PROJECT_PATH` and current-directory resolution. |
 | `--mode auto\|daemon\|oneshot` | Unity-backed commands | Choose daemon reuse or one-shot batchmode. |
 | `--timeout <milliseconds>` | Unity-backed commands | Override the command timeout. |
-| `--readIndexMode disabled\|allowStale\|requireFresh` | Query-like commands | Control read-index use. |
+| `--readIndexMode disabled\|allowStale\|requireFresh`, `--read-index-mode disabled\|allowStale\|requireFresh` | Query-like commands | Control read-index use. |
 | `--failFast` | Unity-backed commands | Fail when the Unity editor lifecycle is not ready instead of waiting. |
 | `--withPlan` | `ucli call` | Run a plan pass inside `call` and include it in the result. |
 | `--planToken <token>` | `ucli call` | Apply a request using a token returned by `ucli plan`. |
 | `--allowDangerous` | `ucli call`, `ucli eval` | Allow operations whose catalog policy is `dangerous`. |
 | `--allowPlayMode` | `ucli plan`, `ucli call`, `ucli eval` | Allow guarded Play Mode mutation in a GUI Editor session. |
+
+Use `--mode daemon` when CI must fail specifically because no daemon is running. With `--mode auto`, a missing daemon may resolve to a one-shot probe; if that startup does not reach an IPC endpoint, inspect `payload.startup`, `payload.diagnosis`, and `retryDisposition`.
 
 > **NOTE:** Project path resolution uses `--projectPath`, then `UCLI_PROJECT_PATH`, then the command default. The default is usually the current working directory.
 

--- a/src/Ucli/Hosting/Cli/Assurance/ReadyCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/ReadyCommandResultFactory.cs
@@ -36,12 +36,19 @@ internal static class ReadyCommandResultFactory
 
     private static object? CreateFailurePayload (ReadyExecutionResult executionResult)
     {
-        return executionResult.Project is null
-            ? null
-            : new
-            {
-                project = ProjectIdentityPayloadProjector.Create(executionResult.Project),
-            };
+        if (executionResult.Project is null && executionResult.Errors.All(static error => error.StartupFailure is null))
+        {
+            return null;
+        }
+
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (executionResult.Project is not null)
+        {
+            payload["project"] = ProjectIdentityPayloadProjector.Create(executionResult.Project);
+        }
+
+        StartupFailurePayloadProjector.AppendFromFailures(payload, executionResult.Errors);
+        return payload;
     }
 
     private static CommandResult CreateSuccess (ReadyExecutionResult executionResult)

--- a/tests/Ucli.Application.Tests/Features/Assurance/Ready/ReadyServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Ready/ReadyServiceTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance;
 using MackySoft.Ucli.Application.Features.Assurance.Ready;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
@@ -332,6 +333,37 @@ public sealed class ReadyServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Execute_WithOneshotStartupFailure_PreservesStartupFailureOnCommandFailure ()
+    {
+        var startupFailure = CreateStartupFailureDetail();
+        var service = CreateService(
+            modeDecisionService: new StubModeDecisionService(UnityExecutionModeDecisionResult.Success(new UnityExecutionModeDecision(
+                UnityExecutionMode.Auto,
+                DaemonRunning: false,
+                UnityExecutionTarget.Oneshot,
+                TimeSpan.FromSeconds(10)))),
+            unityRequestExecutor: new StubUnityRequestExecutor(UnityRequestExecutionResult.Failure(new UnityRequestFailure(
+                DaemonErrorCodes.DaemonStartupBlocked,
+                "Unity startup is blocked.",
+                startupFailure))));
+
+        var result = await service.ExecuteAsync(new ReadyCommandInput(
+            ProjectPath: null,
+            Target: ReadyTarget.Execution,
+            Mode: UnityExecutionMode.Auto,
+            TimeoutMilliseconds: 10000,
+            ReadIndexMode: null,
+            IsReadIndexModeSpecified: false,
+            FailFast: true));
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(DaemonErrorCodes.DaemonStartupBlocked, error.Code);
+        Assert.Same(startupFailure, error.StartupFailure);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Execute_WithOneshotPingProjectFingerprintMismatch_ReturnsCommandFailure ()
     {
         var service = CreateService(
@@ -488,6 +520,46 @@ public sealed class ReadyServiceTests
                 IsPlaying: false,
                 IsPlayingOrWillChangePlaymode: false,
                 Generation: "2"));
+    }
+
+    private static StartupFailureDetail CreateStartupFailureDetail ()
+    {
+        return new StartupFailureDetail(
+            Startup: new DaemonStartupObservationOutput(
+                StartupStatus: "blocked",
+                StartupBlockingReason: "compile",
+                LaunchAttemptId: null,
+                EditorMode: "batchmode",
+                OwnerKind: "cli",
+                CanShutdownProcess: true,
+                ProcessId: 1234,
+                StartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                ElapsedMilliseconds: null,
+                ProcessAction: "terminated",
+                ProcessTermination: null,
+                ArtifactPath: null,
+                RetryDisposition: "retryAfterFix"),
+            Diagnosis: new DaemonDiagnosisOutput(
+                Reason: "unityScriptCompilationFailed",
+                Message: "Unity startup is blocked.",
+                ReportedBy: "cli",
+                IsInferred: true,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:06+00:00"),
+                ProcessId: 1234,
+                EditorInstancePath: null,
+                ProcessStartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                UnityLogPath: "/repo/.ucli/local/logs/unity.log",
+                StartupPhase: "scriptCompilation",
+                ActionRequired: "fixCompileErrors",
+                PrimaryDiagnostic: new DaemonPrimaryDiagnosticOutput(
+                    Kind: "compiler",
+                    Code: "CS0246",
+                    File: "Assets/Scripts/Broken.cs",
+                    Line: 10,
+                    Column: 5,
+                    Message: "error CS0246")),
+            RetryDisposition: "retryAfterFix",
+            SafeToRetryImmediately: false);
     }
 
     private sealed class StubProjectContextResolver : IProjectContextResolver

--- a/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/ReadyCommandTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance;
 using MackySoft.Ucli.Application.Features.Assurance.Ready;
+using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Shared.CommandContracts;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Contracts.Configuration;
@@ -191,6 +192,78 @@ public sealed class ReadyCommandTests
         Assert.Contains("--readIndexMode", result.StdOut, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("--readIndexMode")]
+    [InlineData("--read-index-mode")]
+    [Trait("Size", "Medium")]
+    public async Task Ready_WithReadIndexModeOptionAlias_IsAcceptedByParser (string readIndexModeOption)
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Ready,
+            "--for",
+            "readIndex",
+            readIndexModeOption,
+            "allowStale",
+            UcliContractConstants.CliOption.Timeout,
+            "abc");
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.DoesNotContain($"Argument '{readIndexModeOption}' is not recognized.", result.StdErr, StringComparison.Ordinal);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Ready,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
+        Assert.Contains("timeout must be a positive integer", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Ready_WithStartupFailure_EmitsProjectAndStartupDiagnosis ()
+    {
+        var startupFailure = CreateStartupFailureDetail();
+        var service = new StubReadyService((_, _) => ValueTask.FromResult(ReadyExecutionResult.Failure(
+            ApplicationFailure.UnityIpcFailure(
+                "Unity startup is blocked.",
+                DaemonErrorCodes.DaemonStartupBlocked,
+                startupFailure: startupFailure),
+            CreateProject())));
+        var command = new ReadyCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ReadyAsync(
+            @for: "execution",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.ToolError, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Ready,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.ToolError);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, DaemonErrorCodes.DaemonStartupBlocked);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        JsonAssert.For(payload)
+            .HasProperty("project", project => project
+                .HasString("projectPath", "<projectPath>")
+                .HasString("projectFingerprint", "<projectFingerprint>"))
+            .HasProperty("startup", startup => startup
+                .HasString("startupStatus", "blocked")
+                .HasString("startupBlockingReason", "compile"))
+            .HasProperty("diagnosis", diagnosis => diagnosis
+                .HasString("reason", "unityScriptCompilationFailed")
+                .HasProperty("primaryDiagnostic", primaryDiagnostic => primaryDiagnostic
+                    .HasString("code", "CS0246")))
+            .HasString("retryDisposition", "retryAfterFix")
+            .HasBoolean("safeToRetryImmediately", false);
+        Assert.False(payload.TryGetProperty("lifecycleState", out _));
+        Assert.False(payload.TryGetProperty("blockingReason", out _));
+        Assert.False(payload.TryGetProperty("canAcceptExecutionRequests", out _));
+    }
+
     private static ReadyExecutionOutput CreateOutput (
         string verdict = ReadyVerdictValues.Pass)
     {
@@ -343,6 +416,46 @@ public sealed class ReadyCommandTests
             ["resolvedMode"] = resolvedMode,
             ["sessionKind"] = sessionKind,
         };
+    }
+
+    private static StartupFailureDetail CreateStartupFailureDetail ()
+    {
+        return new StartupFailureDetail(
+            Startup: new DaemonStartupObservationOutput(
+                StartupStatus: "blocked",
+                StartupBlockingReason: "compile",
+                LaunchAttemptId: null,
+                EditorMode: "batchmode",
+                OwnerKind: "cli",
+                CanShutdownProcess: true,
+                ProcessId: 1234,
+                StartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                ElapsedMilliseconds: null,
+                ProcessAction: "terminated",
+                ProcessTermination: null,
+                ArtifactPath: null,
+                RetryDisposition: "retryAfterFix"),
+            Diagnosis: new DaemonDiagnosisOutput(
+                Reason: "unityScriptCompilationFailed",
+                Message: "Unity startup is blocked.",
+                ReportedBy: "cli",
+                IsInferred: true,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:06+00:00"),
+                ProcessId: 1234,
+                EditorInstancePath: null,
+                ProcessStartedAtUtc: DateTimeOffset.Parse("2026-03-12T04:05:01+00:00"),
+                UnityLogPath: "/repo/.ucli/local/logs/unity.log",
+                StartupPhase: "scriptCompilation",
+                ActionRequired: "fixCompileErrors",
+                PrimaryDiagnostic: new DaemonPrimaryDiagnosticOutput(
+                    Kind: "compiler",
+                    Code: "CS0246",
+                    File: "Assets/Scripts/Broken.cs",
+                    Line: 10,
+                    Column: 5,
+                    Message: "error CS0246")),
+            RetryDisposition: "retryAfterFix",
+            SafeToRetryImmediately: false);
     }
 
     private static IReadOnlyList<ReadyReadIndexArtifactOutput> CreateReadIndexArtifacts ()


### PR DESCRIPTION
## Summary
- Ensures `ready` can emit project identity and existing startup diagnosis fields in the same failure payload.
- Covers both `--readIndexMode` and `--read-index-mode` parser spellings for `ready --for readIndex`.
- Updates README guidance for read-index aliases and daemon-required checks versus auto-mode startup diagnostics.

## Scope
- `ReadyCommandResultFactory` now builds a structured failure payload and appends startup failure projection fields.
- `ReadyCommandTests` covers read-index option alias parsing and startup diagnosis payload projection without lifecycle claim fields.
- `ReadyServiceTests` covers preservation of one-shot startup failure detail on command failure.
- `README.md` aligns common option documentation with the supported aliases and startup diagnosis contract.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh verify --include ...`, `git diff --check`)
- Tests: PASS (`dotnet test Ucli.slnx --no-restore --filter "FullyQualifiedName~ReadyCommandTests|FullyQualifiedName~ReadyServiceTests"`, `bash scripts/test-dotnet.sh`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to the `ready` error payload shape adding already-defined startup diagnosis fields when startup failures exist.
- Rollback is to revert the two commits on this branch; parser alias behavior remains covered by contract tests.

## Checklist
- [x] `ready` failure payload includes project identity and startup diagnosis fields together.
- [x] Startup failure payload does not expose lifecycle readiness claim fields.
- [x] `--readIndexMode` and `--read-index-mode` are both covered for `ready --for readIndex`.
- [x] README common options and mode guidance are aligned.

Closes #351