### PR TITLE
fix(test-run): fail empty test runs by default

### DIFF
--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunCommandInput.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunCommandInput.cs
@@ -15,6 +15,7 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.Common.Contracts;
 /// <param name="TestSettingsPath"> Optional path to <c>TestSettings.json</c>. </param>
 /// <param name="TimeoutMilliseconds"> Optional timeout in milliseconds. </param>
 /// <param name="FailFast"> Whether readiness-gated Unity execution should fail immediately instead of waiting for lifecycle readiness. </param>
+/// <param name="AllowEmptyTestRun"> Whether a run that reports zero test cases should be accepted. </param>
 internal sealed record TestRunCommandInput (
     string? ProjectPath,
     string? ProfilePath,
@@ -27,4 +28,5 @@ internal sealed record TestRunCommandInput (
     string[]? AssemblyName,
     string? TestSettingsPath,
     int? TimeoutMilliseconds,
-    bool FailFast = false);
+    bool FailFast = false,
+    bool AllowEmptyTestRun = false);

--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunErrorCodeDescriptors.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunErrorCodeDescriptors.cs
@@ -51,6 +51,25 @@ internal static class TestRunErrorCodeDescriptors
             ]),
 
         UcliErrorDescriptorFactory.Create(
+            code: TestRunErrorCodes.TestRunNoTestsExecuted,
+            category: "testRun",
+            summary: "Unity test run reported no test cases.",
+            meaning: "The test runner completed, but the selected filter, category, assembly, or project state produced zero reported test cases.",
+            appliesTo: [UcliCommandIds.TestRun],
+            possiblePhases: ["testResultEvaluation"],
+            impliesNotApplied: true,
+            mayBeIndeterminate: false,
+            safeToRetry: UcliErrorRetryClassValues.ContextDependent,
+            inspect: ["payload.artifactsDir", "payload.summaryJsonPath", "errors[].message"],
+            nextActions:
+            [
+                new UcliErrorNextActionDescriptor(
+                    When: null,
+                    Action: "Fix the test filter, category, or assembly selection, or specify --allowEmptyTestRun when an empty run is intentional."),
+            ],
+            relatedCodes: [UcliCoreErrorCodes.InvalidArgument]),
+
+        UcliErrorDescriptorFactory.Create(
             code: TestRunErrorCodes.TestResultsXmlInvalid,
             category: "testRun",
             summary: "Unity test results XML is invalid.",

--- a/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunErrorCodes.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Common/Contracts/TestRunErrorCodes.cs
@@ -9,6 +9,9 @@ internal static class TestRunErrorCodes
     /// <summary> Gets the error code emitted when Unity test execution exceeds its runtime budget. </summary>
     public static readonly UcliCode UnityTestExecutionTimeout = new UcliCode("UNITY_TEST_EXECUTION_TIMEOUT");
 
+    /// <summary> Gets the error code emitted when a test run reports no executed test cases. </summary>
+    public static readonly UcliCode TestRunNoTestsExecuted = new UcliCode("TEST_RUN_NO_TESTS_EXECUTED");
+
     /// <summary> Gets the error code emitted when Unity test results XML is invalid. </summary>
     public static readonly UcliCode TestResultsXmlInvalid = new UcliCode("TEST_RESULTS_XML_INVALID");
 

--- a/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsConversionResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsConversionResult.cs
@@ -2,10 +2,12 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.Results;
 
 /// <summary> Represents one Unity results conversion result. </summary>
 /// <param name="HasFailedTests"> Indicates whether converted results contain failing tests when successful; otherwise <see langword="false" />. </param>
+/// <param name="ReportedTestCaseCount"> The number of test cases reported by Unity results XML when successful; otherwise <c>0</c>. </param>
 /// <param name="FailureKind"> The conversion failure kind on failure; otherwise <see langword="null" />. </param>
 /// <param name="ErrorMessage"> The user-facing conversion failure message on failure; otherwise <see langword="null" />. </param>
 internal sealed record UnityResultsConversionResult (
     bool HasFailedTests,
+    int ReportedTestCaseCount,
     UnityResultsConversionFailureKind? FailureKind,
     string? ErrorMessage)
 {
@@ -14,10 +16,18 @@ internal sealed record UnityResultsConversionResult (
 
     /// <summary> Creates a successful conversion result. </summary>
     /// <param name="hasFailedTests"> Indicates whether converted results contain failing tests. </param>
+    /// <param name="reportedTestCaseCount"> The number of reported test cases. </param>
     /// <returns> The successful conversion result. </returns>
-    public static UnityResultsConversionResult Success (bool hasFailedTests)
+    public static UnityResultsConversionResult Success (
+        bool hasFailedTests,
+        int reportedTestCaseCount = 1)
     {
-        return new UnityResultsConversionResult(hasFailedTests, null, null);
+        if (reportedTestCaseCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reportedTestCaseCount), reportedTestCaseCount, "Reported test case count must not be negative.");
+        }
+
+        return new UnityResultsConversionResult(hasFailedTests, reportedTestCaseCount, null, null);
     }
 
     /// <summary> Creates a failed conversion result. </summary>
@@ -28,6 +38,6 @@ internal sealed record UnityResultsConversionResult (
         UnityResultsConversionFailureKind failureKind,
         string errorMessage)
     {
-        return new UnityResultsConversionResult(false, failureKind, errorMessage);
+        return new UnityResultsConversionResult(false, 0, failureKind, errorMessage);
     }
 }

--- a/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsConverter.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsConverter.cs
@@ -74,7 +74,7 @@ internal sealed class UnityResultsConverter : IUnityResultsConverter
                 $"Failed to write results artifacts: {exception.Message}");
         }
 
-        return UnityResultsConversionResult.Success(parseResult.HasFailedTests);
+        return UnityResultsConversionResult.Success(parseResult.HasFailedTests, parseResult.ReportedTestCaseCount);
     }
 
     /// <summary> Determines whether one exception represents results XML read failure. </summary>

--- a/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsXmlParseResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/Results/UnityResultsXmlParseResult.cs
@@ -14,6 +14,9 @@ internal sealed record UnityResultsXmlParseResult (
     /// <summary> Gets a value indicating whether parsed results contain failed tests. </summary>
     public bool HasFailedTests => Counts.Failed > 0 || HasSuiteFailure;
 
+    /// <summary> Gets the number of test cases reported by Unity results XML. </summary>
+    public int ReportedTestCaseCount => Counts.Passed + Counts.Failed + Counts.Skipped;
+
     /// <summary> Represents schema-compliant aggregated counts values. </summary>
     /// <param name="Passed"> The passed-test count. </param>
     /// <param name="Failed"> The failed-test count. </param>

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Contracts/TestRunExecutionContext.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Contracts/TestRunExecutionContext.cs
@@ -9,9 +9,11 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.UseCases.TestRun.Contr
 /// <param name="Target"> The resolved Unity execution target. </param>
 /// <param name="Timeout"> The resolved timeout used for execution and daemon probing. </param>
 /// <param name="FailFast"> Whether readiness-gated Unity execution should fail immediately instead of waiting for lifecycle readiness. </param>
+/// <param name="AllowEmptyTestRun"> Whether a run that reports zero test cases should be accepted. </param>
 internal sealed record TestRunExecutionContext (
     ResolvedTestRunConfiguration Configuration,
     UcliConfig Config,
     UnityExecutionTarget Target,
     TimeSpan Timeout,
-    bool FailFast);
+    bool FailFast,
+    bool AllowEmptyTestRun);

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Contracts/TestRunExecutionPipelineResult.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Contracts/TestRunExecutionPipelineResult.cs
@@ -10,11 +10,13 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.UseCases.TestRun.Contr
 /// <param name="UnityExecutionResult"> The Unity execution result when pipeline reached execution stage; otherwise <see langword="null" />. </param>
 /// <param name="ConversionResult"> The conversion result when pipeline reached conversion stage; otherwise <see langword="null" />. </param>
 /// <param name="Error"> The pipeline infrastructure error when pipeline failed before final mapping; otherwise <see langword="null" />. </param>
+/// <param name="AllowEmptyTestRun"> Whether a run that reports zero test cases should be accepted. </param>
 internal sealed record TestRunExecutionPipelineResult (
     ArtifactsSession? Session,
     UnityTestExecutionResult? UnityExecutionResult,
     UnityResultsConversionResult? ConversionResult,
-    ExecutionError? Error)
+    ExecutionError? Error,
+    bool AllowEmptyTestRun)
 {
     /// <summary> Gets a value indicating whether pipeline completed without infrastructure errors. </summary>
     public bool IsSuccess => Error is null
@@ -30,7 +32,8 @@ internal sealed record TestRunExecutionPipelineResult (
     public static TestRunExecutionPipelineResult Success (
         ArtifactsSession session,
         UnityTestExecutionResult unityExecutionResult,
-        UnityResultsConversionResult conversionResult)
+        UnityResultsConversionResult conversionResult,
+        bool allowEmptyTestRun = false)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(unityExecutionResult);
@@ -40,7 +43,8 @@ internal sealed record TestRunExecutionPipelineResult (
             Session: session,
             UnityExecutionResult: unityExecutionResult,
             ConversionResult: conversionResult,
-            Error: null);
+            Error: null,
+            AllowEmptyTestRun: allowEmptyTestRun);
     }
 
     /// <summary> Creates one failed pipeline result with infrastructure error. </summary>
@@ -48,12 +52,14 @@ internal sealed record TestRunExecutionPipelineResult (
     /// <param name="session"> The optional prepared artifacts session. </param>
     /// <param name="unityExecutionResult"> The optional Unity execution result. </param>
     /// <param name="conversionResult"> The optional conversion result. </param>
+    /// <param name="allowEmptyTestRun"> Whether a run that reports zero test cases should be accepted. </param>
     /// <returns> The failed pipeline result. </returns>
     public static TestRunExecutionPipelineResult Failure (
         ExecutionError error,
         ArtifactsSession? session = null,
         UnityTestExecutionResult? unityExecutionResult = null,
-        UnityResultsConversionResult? conversionResult = null)
+        UnityResultsConversionResult? conversionResult = null,
+        bool allowEmptyTestRun = false)
     {
         ArgumentNullException.ThrowIfNull(error);
 
@@ -61,6 +67,7 @@ internal sealed record TestRunExecutionPipelineResult (
             Session: session,
             UnityExecutionResult: unityExecutionResult,
             ConversionResult: conversionResult,
-            Error: error);
+            Error: error,
+            AllowEmptyTestRun: allowEmptyTestRun);
     }
 }

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
@@ -61,7 +61,9 @@ internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline
         var artifactsPreparationResult = await PrepareArtifactsSafelyAsync(configuration, cancellationToken).ConfigureAwait(false);
         if (!artifactsPreparationResult.IsSuccess)
         {
-            return TestRunExecutionPipelineResult.Failure(artifactsPreparationResult.Error!);
+            return TestRunExecutionPipelineResult.Failure(
+                artifactsPreparationResult.Error!,
+                allowEmptyTestRun: context.AllowEmptyTestRun);
         }
 
         var artifactsSession = artifactsPreparationResult.Session!;
@@ -75,7 +77,10 @@ internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline
                 .ConfigureAwait(false);
             if (!progressStartResult.IsSuccess)
             {
-                return TestRunExecutionPipelineResult.Failure(progressStartResult.Error!, artifactsSession);
+                return TestRunExecutionPipelineResult.Failure(
+                    progressStartResult.Error!,
+                    artifactsSession,
+                    allowEmptyTestRun: context.AllowEmptyTestRun);
             }
         }
 
@@ -113,7 +118,8 @@ internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline
                 conversionUnexpectedError,
                 artifactsSession,
                 unityExecutionResult,
-                conversionResult);
+                conversionResult,
+                allowEmptyTestRun: context.AllowEmptyTestRun);
         }
 
         if (!completionResult.IsSuccess)
@@ -122,13 +128,15 @@ internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline
                 completionResult.Error!,
                 artifactsSession,
                 unityExecutionResult,
-                conversionResult);
+                conversionResult,
+                allowEmptyTestRun: context.AllowEmptyTestRun);
         }
 
         return TestRunExecutionPipelineResult.Success(
             artifactsSession,
             unityExecutionResult,
-            conversionResult);
+            conversionResult,
+            allowEmptyTestRun: context.AllowEmptyTestRun);
     }
 
     /// <summary> Prepares artifacts session and maps unexpected exceptions into internal errors. </summary>

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightService.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Preflight/TestRunPreflightService.cs
@@ -93,7 +93,8 @@ internal sealed class TestRunPreflightService : ITestRunPreflightService
             Config: configLoadResult.Config!,
             Target: modeDecisionResult.Decision!.Target,
             Timeout: timeoutResolutionResult.Timeout!.Value,
-            FailFast: input.FailFast);
+            FailFast: input.FailFast,
+            AllowEmptyTestRun: input.AllowEmptyTestRun);
         return TestRunPreflightResult.Success(context);
     }
 

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapper.cs
@@ -7,6 +7,9 @@ namespace MackySoft.Ucli.Application.Features.Testing.Run.UseCases.TestRun.Proje
 /// <summary> Implements mapping from pipeline outcomes to command-facing test-run results. </summary>
 internal sealed class TestRunResultMapper : ITestRunResultMapper
 {
+    private const string NoTestsExecutedMessage =
+        "Unity test execution completed without reporting any test cases. Check --testFilter, --testCategory, or --assemblyName, or specify --allowEmptyTestRun to accept an empty run.";
+
     /// <summary> Maps one execution pipeline result into service output. </summary>
     /// <param name="pipelineResult"> The execution pipeline result. </param>
     /// <returns> The mapped service output. </returns>
@@ -19,7 +22,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
             return CreateExecutionResult(
                 pipelineResult.UnityExecutionResult!,
                 pipelineResult.ConversionResult!,
-                pipelineResult.Session!);
+                pipelineResult.Session!,
+                pipelineResult.AllowEmptyTestRun);
         }
 
         if (pipelineResult.Error is not null)
@@ -40,7 +44,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
         return CreateExecutionResult(
             pipelineResult.UnityExecutionResult!,
             pipelineResult.ConversionResult!,
-            pipelineResult.Session!);
+            pipelineResult.Session!,
+            pipelineResult.AllowEmptyTestRun);
     }
 
     private static bool ShouldPreferPrimaryRunOutcome (TestRunExecutionPipelineResult pipelineResult)
@@ -55,7 +60,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
             && pipelineResult.ConversionResult is not null
             && (!pipelineResult.UnityExecutionResult.IsSuccess
                 || !pipelineResult.ConversionResult.IsSuccess
-                || pipelineResult.ConversionResult.HasFailedTests);
+                || pipelineResult.ConversionResult.HasFailedTests
+                || IsNoTestsExecutedOutcome(pipelineResult.ConversionResult, pipelineResult.AllowEmptyTestRun));
     }
 
     /// <summary> Creates final output from execution and conversion outcomes. </summary>
@@ -66,7 +72,8 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
     private static TestRunServiceResult CreateExecutionResult (
         UnityTestExecutionResult unityExecutionResult,
         UnityResultsConversionResult conversionResult,
-        ArtifactsSession session)
+        ArtifactsSession session,
+        bool allowEmptyTestRun)
     {
         if (!unityExecutionResult.IsSuccess)
         {
@@ -146,11 +153,31 @@ internal sealed class TestRunResultMapper : ITestRunResultMapper
                 summaryJsonPath: session.Paths.SummaryJsonPath);
         }
 
+        if (IsNoTestsExecutedOutcome(conversionResult, allowEmptyTestRun))
+        {
+            return TestRunServiceResult.InvalidInput(
+                message: NoTestsExecutedMessage,
+                errorCode: TestRunErrorCodes.TestRunNoTestsExecuted,
+                runId: session.RunId,
+                artifactsDir: session.Paths.ArtifactsDir,
+                summaryJsonPath: session.Paths.SummaryJsonPath);
+        }
+
         return TestRunServiceResult.Pass(
             message: "Unity test execution completed.",
             runId: session.RunId,
             artifactsDir: session.Paths.ArtifactsDir,
             summaryJsonPath: session.Paths.SummaryJsonPath);
+    }
+
+    private static bool IsNoTestsExecutedOutcome (
+        UnityResultsConversionResult conversionResult,
+        bool allowEmptyTestRun)
+    {
+        return !allowEmptyTestRun
+            && conversionResult.IsSuccess
+            && !conversionResult.HasFailedTests
+            && conversionResult.ReportedTestCaseCount == 0;
     }
 
     private static bool IsUnityExecutionInfrastructureFailure (UnityTestExecutionFailureKind failureKind)

--- a/src/Ucli.Application/Shared/Execution/InvalidArgumentErrorCodeSet.cs
+++ b/src/Ucli.Application/Shared/Execution/InvalidArgumentErrorCodeSet.cs
@@ -25,6 +25,7 @@ internal static class InvalidArgumentErrorCodeSet
             PlanTokenErrorCodes.StateChangedSincePlan,
             IpcProtocolErrorCodes.ProtocolVersionMismatch,
             OperationAuthorizationErrorCodes.OperationNotAllowed,
+            TestRunErrorCodes.TestRunNoTestsExecuted,
         };
 
         foreach (var code in ProjectContextErrorCodes.All)

--- a/src/Ucli/Hosting/Cli/Testing/TestRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/Testing/TestRunCommand.cs
@@ -41,6 +41,7 @@ internal sealed class TestRunCommand
     /// <param name="testSettingsPath"> -s|--testSettingsPath, path to TestSettings.json. </param>
     /// <param name="timeout"> Timeout in milliseconds. </param>
     /// <param name="failFast"> --failFast, Fails immediately when readiness-gated Unity execution is not yet ready. </param>
+    /// <param name="allowEmptyTestRun"> --allowEmptyTestRun, Accepts a run that reports zero test cases. </param>
     /// <param name="format"> Progress entry format (text|json). </param>
     /// <param name="cancellationToken"> The cancellation token propagated by the command pipeline. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
@@ -58,6 +59,7 @@ internal sealed class TestRunCommand
         string? testSettingsPath = null,
         int? timeout = null,
         bool failFast = false,
+        bool allowEmptyTestRun = false,
         string? format = null,
         CancellationToken cancellationToken = default)
     {
@@ -112,7 +114,8 @@ internal sealed class TestRunCommand
                     AssemblyName: SplitCommaSeparatedValues(assemblyName),
                     TestSettingsPath: testSettingsPath,
                     TimeoutMilliseconds: timeout,
-                    FailFast: failFast),
+                    FailFast: failFast,
+                    AllowEmptyTestRun: allowEmptyTestRun),
                 progressSink,
                 cancellationToken).ConfigureAwait(false);
             var commandResult = TestRunCommandResultFactory.Create(serviceResult);

--- a/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/Projection/TestRunResultMapperTests.cs
@@ -81,6 +81,48 @@ public sealed class TestRunResultMapperTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Map_WithNoReportedTestCasesAndEmptyRunNotAllowed_ReturnsInvalidInputWithArtifactsContext ()
+    {
+        var session = CreateSession();
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Success(
+            session,
+            UnityTestExecutionResult.Success(0),
+            UnityResultsConversionResult.Success(hasFailedTests: false, reportedTestCaseCount: 0)));
+
+        Assert.Null(result.Result);
+        Assert.Equal(TestRunErrorKind.InvalidInput, result.ErrorKind);
+        Assert.Equal(ApplicationOutcome.InvalidArgument, result.Outcome);
+        Assert.Equal(TestRunErrorCodes.TestRunNoTestsExecuted, result.ErrorCode);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Map_WithNoReportedTestCasesAndEmptyRunAllowed_ReturnsPass ()
+    {
+        var session = CreateSession();
+        var mapper = new TestRunResultMapper();
+
+        var result = mapper.Map(TestRunExecutionPipelineResult.Success(
+            session,
+            UnityTestExecutionResult.Success(0),
+            UnityResultsConversionResult.Success(hasFailedTests: false, reportedTestCaseCount: 0),
+            allowEmptyTestRun: true));
+
+        Assert.Equal(TestRunResultKind.Pass, result.Result);
+        Assert.Null(result.ErrorKind);
+        Assert.Equal(ApplicationOutcome.Success, result.Outcome);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Map_WithPipelineErrorAndSession_PreservesArtifactsContext ()
     {
         var session = CreateSession();

--- a/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
@@ -51,6 +51,45 @@ public sealed class TestRunServiceTests
         Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
     }
 
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("NoSuchTestName", null)]
+    [InlineData(null, "NoSuchCategory")]
+    public async Task Execute_WithFilteredEmptyRun_ReturnsNoTestsExecutedInvalidInput (
+        string? testFilter,
+        string? testCategory)
+    {
+        var configuration = CreateResolvedConfiguration();
+        var session = CreateArtifactsSession(configuration);
+        var input = CreateInput() with
+        {
+            TestFilter = testFilter,
+            TestCategory = testCategory is null ? null : [testCategory],
+        };
+
+        var service = CreateService(
+            configurationResolver: new StubConfigurationResolver(TestRunConfigurationResolutionResult.Success(configuration)),
+            modeDecisionService: new StubModeDecisionService(UnityExecutionModeDecisionResult.Success(
+                new UnityExecutionModeDecision(UnityExecutionMode.Oneshot, false, UnityExecutionTarget.Oneshot, TimeSpan.FromSeconds(30)))),
+            artifactsService: new StubArtifactsService(
+                prepare: _ => ArtifactsPreparationResult.Success(session),
+                complete: (_, _) => ArtifactsCompletionResult.Success()),
+            unityTestExecutor: new StubUnityTestExecutor((_, _, _, _) => ValueTask.FromResult(UnityTestExecutionResult.Success(0))),
+            resultsConverter: new StubResultsConverter(_ => ValueTask.FromResult(UnityResultsConversionResult.Success(
+                hasFailedTests: false,
+                reportedTestCaseCount: 0))));
+
+        var result = await service.ExecuteAsync(input, cancellationToken: CancellationToken.None);
+
+        Assert.Null(result.Result);
+        Assert.Equal(TestRunErrorKind.InvalidInput, result.ErrorKind);
+        Assert.Equal(ApplicationOutcome.InvalidArgument, result.Outcome);
+        Assert.Equal(TestRunErrorCodes.TestRunNoTestsExecuted, result.ErrorCode);
+        Assert.Equal(session.RunId, result.RunId);
+        Assert.Equal(session.Paths.ArtifactsDir, result.ArtifactsDir);
+        Assert.Equal(session.Paths.SummaryJsonPath, result.SummaryJsonPath);
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task Execute_WithProgressSink_EmitsRunStartedAndForwardsUnityProgress ()

--- a/tests/Ucli.Tests/Features/Testing/Run/Results/UnityResultsConverterTests.cs
+++ b/tests/Ucli.Tests/Features/Testing/Run/Results/UnityResultsConverterTests.cs
@@ -47,6 +47,28 @@ public sealed class UnityResultsConverterTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Convert_WithEmptyTestRun_ReportsZeroTestCases ()
+    {
+        using var scope = CreateSessionScope("empty-test-run", out var session);
+        scope.WriteFile("results.xml", "<test-run />");
+
+        var converter = CreateConverter();
+
+        var result = await converter.ConvertAsync(session, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(result.HasFailedTests);
+        Assert.Equal(0, result.ReportedTestCaseCount);
+
+        using var summaryDocument = JsonDocument.Parse(File.ReadAllText(session.Paths.SummaryJsonPath));
+        Assert.Equal("pass", summaryDocument.RootElement.GetProperty("status").GetString());
+        Assert.Equal(0, summaryDocument.RootElement.GetProperty("counts").GetProperty("passed").GetInt32());
+        Assert.Equal(0, summaryDocument.RootElement.GetProperty("counts").GetProperty("failed").GetInt32());
+        Assert.Equal(0, summaryDocument.RootElement.GetProperty("counts").GetProperty("skipped").GetInt32());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Convert_WithInvalidXml_ReturnsInvalidResultsXmlFailure ()
     {
         using var scope = CreateSessionScope("invalid-xml", out var session);

--- a/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs
@@ -40,6 +40,7 @@ public sealed class TestRunCommandTests
             testSettingsPath: "/repo/UnityProject/ProjectSettings/TestSettings.json",
             timeout: 120,
             failFast: true,
+            allowEmptyTestRun: true,
             cancellationToken: cancellationTokenSource.Token));
 
         Assert.Equal((int)CliExitCode.Success, exitCode);
@@ -60,6 +61,7 @@ public sealed class TestRunCommandTests
         Assert.Equal("/repo/UnityProject/ProjectSettings/TestSettings.json", input.TestSettingsPath);
         Assert.Equal(120, input.TimeoutMilliseconds);
         Assert.True(input.FailFast);
+        Assert.True(input.AllowEmptyTestRun);
         JsonGoldenFileAssert.Matches(
             CliOutputGoldenFiles.GetPath("test-run", "success.json"),
             standardOutput,


### PR DESCRIPTION
## Summary
- `test run` の結果XMLが test case を1件も報告しなかった場合、既定で `TEST_RUN_NO_TESTS_EXECUTED` の `invalidInput` として失敗させます。
- 明示オプション `--allowEmptyTestRun` を追加し、0件実行を許可する用途だけ opt-in できるようにしました。
- 報告 test case 数を Unity 結果変換から result mapper まで伝搬し、suite-level failure は従来どおり fail として扱います。

## Verification
- `bash scripts/code-quality.sh verify --include src/Ucli.Application/Features/Testing/Run src/Ucli.Application/Shared/Execution/InvalidArgumentErrorCodeSet.cs src/Ucli/Hosting/Cli/Testing/TestRunCommand.cs tests/Ucli.Application.Tests/Features/Testing/Run tests/Ucli.Tests/Features/Testing/Run tests/Ucli.Tests/Hosting/Cli/TestRunCommandTests.cs`
- `bash scripts/test-dotnet.sh`
- `bash scripts/verify.sh`

Closes #354