### PR TITLE
logs read の daemon 未起動エラーを操作可能なコードへ変更する

### DIFF
--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
@@ -15,13 +15,6 @@ internal static class DaemonErrorCodeDescriptors
         UcliCommandIds.TestRun,
     ];
 
-    private static IReadOnlyList<UcliCommand> SessionRequiredLogCommands { get; } =
-    [
-        UcliCommandIds.LogsDaemonRead,
-        UcliCommandIds.LogsUnityRead,
-        UcliCommandIds.LogsUnityClear,
-    ];
-
     public static IReadOnlyList<UcliErrorDescriptor> All { get; } =
     [
         UcliErrorDescriptorFactory.Create(
@@ -124,12 +117,17 @@ internal static class DaemonErrorCodeDescriptors
             category: "daemon",
             summary: "No daemon session is available for the requested project.",
             meaning: "The command requires an active daemon session, but no session metadata or reachable daemon endpoint is available for the resolved Unity project.",
-            appliesTo: SessionRequiredLogCommands,
+            appliesTo:
+            [
+                UcliCommandIds.LogsDaemonRead,
+                UcliCommandIds.LogsUnityRead,
+                UcliCommandIds.LogsUnityClear,
+            ],
             possiblePhases: ["daemonSessionResolution", "ipcDispatch", "logRead"],
             impliesNotApplied: true,
             mayBeIndeterminate: false,
             safeToRetry: UcliErrorRetryClassValues.ContextDependent,
-            inspect: ["payload.actionRequired", UcliErrorInspectTargets.DaemonStatusCommand, UcliErrorInspectTargets.DaemonListCommand],
+            inspect: [UcliErrorInspectTargets.DaemonStatusCommand, UcliErrorInspectTargets.DaemonListCommand],
             nextActions:
             [
                 new UcliErrorNextActionDescriptor(

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodeDescriptors.cs
@@ -15,6 +15,13 @@ internal static class DaemonErrorCodeDescriptors
         UcliCommandIds.TestRun,
     ];
 
+    private static IReadOnlyList<UcliCommand> SessionRequiredLogCommands { get; } =
+    [
+        UcliCommandIds.LogsDaemonRead,
+        UcliCommandIds.LogsUnityRead,
+        UcliCommandIds.LogsUnityClear,
+    ];
+
     public static IReadOnlyList<UcliErrorDescriptor> All { get; } =
     [
         UcliErrorDescriptorFactory.Create(
@@ -111,6 +118,25 @@ internal static class DaemonErrorCodeDescriptors
                     Action: "Inspect daemon status and Unity logs to determine whether Unity is still starting or blocked."),
             ],
             relatedCodes: [IpcTransportErrorCodes.IpcTimeout, DaemonErrorCodes.DaemonStartupBlocked]),
+
+        UcliErrorDescriptorFactory.Create(
+            code: DaemonErrorCodes.DaemonSessionNotAvailable,
+            category: "daemon",
+            summary: "No daemon session is available for the requested project.",
+            meaning: "The command requires an active daemon session, but no session metadata or reachable daemon endpoint is available for the resolved Unity project.",
+            appliesTo: SessionRequiredLogCommands,
+            possiblePhases: ["daemonSessionResolution", "ipcDispatch", "logRead"],
+            impliesNotApplied: true,
+            mayBeIndeterminate: false,
+            safeToRetry: UcliErrorRetryClassValues.ContextDependent,
+            inspect: ["payload.actionRequired", UcliErrorInspectTargets.DaemonStatusCommand, UcliErrorInspectTargets.DaemonListCommand],
+            nextActions:
+            [
+                new UcliErrorNextActionDescriptor(
+                    When: null,
+                    Action: "Start the daemon for the project, or rerun the command with the intended projectPath."),
+            ],
+            relatedCodes: [DaemonErrorCodes.DaemonEndpointNotRegistered, IpcTransportErrorCodes.IpcTimeout]),
 
         CreateStartupProjectFixDescriptor(
             DaemonErrorCodes.EditorCompileErrors,

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodes.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/DaemonErrorCodes.cs
@@ -15,6 +15,9 @@ public static class DaemonErrorCodes
     /// <summary> Gets the error code emitted when the daemon endpoint is not registered before the startup budget expires. </summary>
     public static readonly UcliCode DaemonEndpointNotRegistered = new("DAEMON_ENDPOINT_NOT_REGISTERED");
 
+    /// <summary> Gets the error code emitted when no daemon session is available for the requested project. </summary>
+    public static readonly UcliCode DaemonSessionNotAvailable = new("DAEMON_SESSION_NOT_AVAILABLE");
+
     /// <summary> Gets the error code emitted when Unity startup is blocked by script compile errors. </summary>
     public static readonly UcliCode EditorCompileErrors = new("EDITOR_COMPILE_ERRORS");
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityIpcServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             services.AddSingleton<IUnityTestRunner, UnityTestRunner>();
             services.AddSingleton<IUnityTestResultsXmlWriter, UnityTestResultsXmlWriter>();
             services.AddSingleton<IUnityTestRunService, UnityTestRunService>();
+            services.AddSingleton<IIpcRequestTimeoutScopeFactory, IpcRequestTimeoutScopeFactory>();
             services.AddSingleton<IServerVersionProvider, AssemblyServerVersionProvider>();
             services.AddSingleton<IUnityEditorUpdateAwaiter, UnityEditorUpdateAwaiterAdapter>();
             services.AddSingleton<IUnityPlayModeController, UnityEditorPlayModeController>();

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/TestRun/TestRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/TestRun/TestRunUnityIpcMethodHandler.cs
@@ -10,12 +10,17 @@ namespace MackySoft.Ucli.Unity.Ipc
     internal sealed class TestRunUnityIpcMethodHandler : IStreamingUnityIpcMethodHandler
     {
         private readonly IUnityTestRunService testRunService;
+        private readonly IIpcRequestTimeoutScopeFactory timeoutScopeFactory;
 
         /// <summary> Initializes a new instance of the <see cref="TestRunUnityIpcMethodHandler" /> class. </summary>
         /// <param name="testRunService"> The test-run service dependency. </param>
-        public TestRunUnityIpcMethodHandler (IUnityTestRunService testRunService)
+        /// <param name="timeoutScopeFactory"> The request timeout scope factory. </param>
+        public TestRunUnityIpcMethodHandler (
+            IUnityTestRunService testRunService,
+            IIpcRequestTimeoutScopeFactory timeoutScopeFactory)
         {
             this.testRunService = testRunService ?? throw new ArgumentNullException(nameof(testRunService));
+            this.timeoutScopeFactory = timeoutScopeFactory ?? throw new ArgumentNullException(nameof(timeoutScopeFactory));
         }
 
         /// <inheritdoc />
@@ -91,7 +96,7 @@ namespace MackySoft.Ucli.Unity.Ipc
         {
             IpcResponse response;
             IUnityTestRunProgressSink progressSink = null;
-            CancellationTokenSource requestTimeoutCancellationTokenSource = null;
+            IIpcRequestTimeoutScope requestTimeoutScope = null;
             try
             {
                 if (!TryValidateTimeoutMilliseconds(testRunRequest.TimeoutMilliseconds, out var timeoutErrorMessage))
@@ -104,12 +109,10 @@ namespace MackySoft.Ucli.Unity.Ipc
                     return response;
                 }
 
-                requestTimeoutCancellationTokenSource = CreateRequestTimeoutCancellationTokenSource(
+                requestTimeoutScope = timeoutScopeFactory.CreateLinked(
                     testRunRequest.TimeoutMilliseconds,
                     cancellationToken);
-                var executionCancellationToken = requestTimeoutCancellationTokenSource != null
-                    ? requestTimeoutCancellationTokenSource.Token
-                    : cancellationToken;
+                var executionCancellationToken = requestTimeoutScope.Token;
                 progressSink = progressSinkFactory?.Invoke(executionCancellationToken);
                 var result = await testRunService.ExecuteAsync(
                     testRunRequest,
@@ -131,7 +134,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return await FlushAndReturnAsync(request, response, progressSink, cancellationToken);
             }
             catch (OperationCanceledException) when (IsRequestTimeout(
-                requestTimeoutCancellationTokenSource,
+                requestTimeoutScope,
                 cancellationToken))
             {
                 response = UnityIpcResponseFactory.CreateErrorResponse(
@@ -165,7 +168,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
             finally
             {
-                requestTimeoutCancellationTokenSource?.Dispose();
+                requestTimeoutScope?.Dispose();
             }
         }
 
@@ -212,26 +215,12 @@ namespace MackySoft.Ucli.Unity.Ipc
             return false;
         }
 
-        private static CancellationTokenSource CreateRequestTimeoutCancellationTokenSource (
-            int? timeoutMilliseconds,
-            CancellationToken cancellationToken)
-        {
-            if (!timeoutMilliseconds.HasValue)
-            {
-                return null;
-            }
-
-            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cancellationTokenSource.CancelAfter(timeoutMilliseconds.Value);
-            return cancellationTokenSource;
-        }
-
         private static bool IsRequestTimeout (
-            CancellationTokenSource requestTimeoutCancellationTokenSource,
+            IIpcRequestTimeoutScope requestTimeoutScope,
             CancellationToken callerCancellationToken)
         {
-            return requestTimeoutCancellationTokenSource != null
-                && requestTimeoutCancellationTokenSource.IsCancellationRequested
+            return requestTimeoutScope != null
+                && requestTimeoutScope.IsTimeoutCancellationRequested
                 && !callerCancellationToken.IsCancellationRequested;
         }
     }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11d773b660b774bfaa90313f6eee2d07
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScope.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScope.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Represents one request execution cancellation scope with timeout diagnostics. </summary>
+    internal interface IIpcRequestTimeoutScope : IDisposable
+    {
+        /// <summary> Gets the token observed by request execution services. </summary>
+        CancellationToken Token { get; }
+
+        /// <summary> Gets a value indicating whether this scope was cancelled by its request timeout. </summary>
+        bool IsTimeoutCancellationRequested { get; }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScope.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c2f54603825648eeb87a1152bfd3111

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScopeFactory.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScopeFactory.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Creates cancellation scopes for IPC request execution timeouts. </summary>
+    internal interface IIpcRequestTimeoutScopeFactory
+    {
+        /// <summary> Creates a cancellation scope linked to the caller token and the optional request timeout. </summary>
+        /// <param name="timeoutMilliseconds"> The timeout in milliseconds, or <c>null</c> when the request is unbounded. </param>
+        /// <param name="cancellationToken"> The caller cancellation token. </param>
+        /// <returns> The created cancellation scope. </returns>
+        IIpcRequestTimeoutScope CreateLinked (int? timeoutMilliseconds, CancellationToken cancellationToken);
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScopeFactory.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IIpcRequestTimeoutScopeFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f8b64a58c64a4a2c9617c0bc4e71929

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IpcRequestTimeoutScopeFactory.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IpcRequestTimeoutScopeFactory.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+
+namespace MackySoft.Ucli.Unity.Ipc
+{
+    /// <summary> Creates production request timeout scopes backed by <see cref="CancellationTokenSource" /> timers. </summary>
+    internal sealed class IpcRequestTimeoutScopeFactory : IIpcRequestTimeoutScopeFactory
+    {
+        /// <inheritdoc />
+        public IIpcRequestTimeoutScope CreateLinked (int? timeoutMilliseconds, CancellationToken cancellationToken)
+        {
+            if (!timeoutMilliseconds.HasValue)
+            {
+                return new PassthroughTimeoutScope(cancellationToken);
+            }
+
+            if (timeoutMilliseconds.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), "timeoutMilliseconds must be greater than zero when specified.");
+            }
+
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancellationTokenSource.CancelAfter(timeoutMilliseconds.Value);
+            return new LinkedTimeoutScope(cancellationTokenSource);
+        }
+
+        private sealed class LinkedTimeoutScope : IIpcRequestTimeoutScope
+        {
+            private readonly CancellationTokenSource cancellationTokenSource;
+
+            public LinkedTimeoutScope (CancellationTokenSource cancellationTokenSource)
+            {
+                this.cancellationTokenSource = cancellationTokenSource ?? throw new ArgumentNullException(nameof(cancellationTokenSource));
+            }
+
+            public CancellationToken Token => cancellationTokenSource.Token;
+
+            public bool IsTimeoutCancellationRequested => cancellationTokenSource.IsCancellationRequested;
+
+            public void Dispose ()
+            {
+                cancellationTokenSource.Dispose();
+            }
+        }
+
+        private sealed class PassthroughTimeoutScope : IIpcRequestTimeoutScope
+        {
+            public PassthroughTimeoutScope (CancellationToken cancellationToken)
+            {
+                Token = cancellationToken;
+            }
+
+            public CancellationToken Token { get; }
+
+            public bool IsTimeoutCancellationRequested => false;
+
+            public void Dispose ()
+            {
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IpcRequestTimeoutScopeFactory.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Timeout/IpcRequestTimeoutScopeFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 174c0205d8c9243ad9c8d0c49e29c492

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/UnityIpcMethodHandlersTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/UnityIpcMethodHandlersTests.cs
@@ -322,7 +322,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator TestRunHandler_WhenServiceSucceeds_ReturnsOkResponse () => UniTask.ToCoroutine(async () =>
         {
             var service = new StubUnityTestRunService(request => Task.FromResult(UnityTestRunServiceResult.Success(new IpcTestRunResponse(2))));
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var request = CreateTestRunRequest(
                 "req-test-run-success",
                 CreateValidTestRunPayload(failFast: true));
@@ -367,7 +367,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         null));
                 return Task.FromResult(UnityTestRunServiceResult.Success(new IpcTestRunResponse(0)));
             });
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var streamWriter = new CollectingUnityIpcStreamFrameWriter("req-test-run-stream");
             var request = CreateTestRunRequest(
                 "req-test-run-stream",
@@ -406,7 +406,7 @@ namespace MackySoft.Ucli.Unity.Tests
                         Array.Empty<string>()));
                 return Task.FromResult(UnityTestRunServiceResult.Success(new IpcTestRunResponse(0)));
             });
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var streamWriter = new CollectingUnityIpcStreamFrameWriter(
                 "req-test-run-stream-flush-error",
                 new IOException("progress write failed"));
@@ -427,39 +427,53 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator TestRunHandler_WhenRequestTimeoutElapses_ReturnsIpcTimeoutAndCancelsService () => UniTask.ToCoroutine(async () =>
         {
-            var serviceObservedCancellation = false;
+            var timeoutScopeFactory = new ManualIpcRequestTimeoutScopeFactory();
+            var serviceAwaitReadySource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var serviceCancellationObservedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var service = new StubUnityTestRunService(async (request, _, cancellationToken) =>
             {
                 try
                 {
+                    serviceAwaitReadySource.TrySetResult(true);
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    serviceObservedCancellation = true;
+                    serviceCancellationObservedSource.TrySetResult(true);
                     throw;
                 }
 
                 return UnityTestRunServiceResult.Success(new IpcTestRunResponse(0));
             });
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service, timeoutScopeFactory);
             var request = CreateTestRunRequest(
                 "req-test-run-timeout",
-                CreateValidTestRunPayload(timeoutMilliseconds: 1));
+                CreateValidTestRunPayload(timeoutMilliseconds: 1000));
 
-            var response = await handler.HandleAsync(request, CancellationToken.None);
+            var responseTask = handler.HandleAsync(request, CancellationToken.None).AsTask();
+            await TestAwaiter.WaitAsync(
+                serviceAwaitReadySource.Task,
+                "test-run service await point",
+                SignalWaitTimeout);
+
+            Assert.That(responseTask.IsCompleted, Is.False);
+
+            timeoutScopeFactory.LastScope.CancelForTimeout();
+            await TestAwaiter.WaitAsync(serviceCancellationObservedSource.Task, "test-run request timeout cancellation", SignalWaitTimeout);
+
+            var response = await TestAwaiter.WaitAsync(responseTask, "test-run timeout response", SignalWaitTimeout);
 
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcTransportErrorCodes.IpcTimeout));
-            Assert.That(serviceObservedCancellation, Is.True);
         });
 
         [UnityTest]
         [Category("Size.Small")]
         public IEnumerator TestRunHandler_WhenStreamingRequestTimeoutElapsesWithPendingProgress_WaitsForFrameAndReturnsIpcTimeout () => UniTask.ToCoroutine(async () =>
         {
-            var serviceObservedCancellation = false;
+            var timeoutScopeFactory = new ManualIpcRequestTimeoutScopeFactory();
+            var serviceAwaitReadySource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var serviceCancellationObservedSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var service = new StubUnityTestRunService(async (request, progressSink, cancellationToken) =>
             {
@@ -475,25 +489,30 @@ namespace MackySoft.Ucli.Unity.Tests
 
                 try
                 {
+                    serviceAwaitReadySource.TrySetResult(true);
                     await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    serviceObservedCancellation = true;
                     serviceCancellationObservedSource.TrySetResult(true);
                     throw;
                 }
 
                 return UnityTestRunServiceResult.Success(new IpcTestRunResponse(0));
             });
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service, timeoutScopeFactory);
             var streamWriter = new BlockingUnityIpcStreamFrameWriter("req-test-run-stream-timeout");
             var request = CreateTestRunRequest(
                 "req-test-run-stream-timeout",
-                CreateValidTestRunPayload(timeoutMilliseconds: 10));
+                CreateValidTestRunPayload(timeoutMilliseconds: 1000));
 
             var responseTask = handler.HandleStreamingAsync(request, streamWriter, CancellationToken.None).AsTask();
             await TestAwaiter.WaitAsync(streamWriter.FirstWriteObserved, "first blocked progress write", SignalWaitTimeout);
+            await TestAwaiter.WaitAsync(
+                serviceAwaitReadySource.Task,
+                "streaming test-run service await point",
+                SignalWaitTimeout);
+            timeoutScopeFactory.LastScope.CancelForTimeout();
             await TestAwaiter.WaitAsync(serviceCancellationObservedSource.Task, "streaming test-run request timeout", SignalWaitTimeout);
 
             Assert.That(responseTask.IsCompleted, Is.False);
@@ -506,7 +525,6 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
             Assert.That(response.Errors.Count, Is.EqualTo(1));
             Assert.That(response.Errors[0].Code, Is.EqualTo(IpcTransportErrorCodes.IpcTimeout));
-            Assert.That(serviceObservedCancellation, Is.True);
             Assert.That(streamWriter.ProgressFrames.Count, Is.EqualTo(1));
         });
 
@@ -556,7 +574,7 @@ namespace MackySoft.Ucli.Unity.Tests
         {
             var service = new StubUnityTestRunService(_ => Task.FromResult(UnityTestRunServiceResult.Failure(
                 new IpcError(EditorLifecycleErrorCodes.EditorBusy, "Unity editor is busy with internal work.", null))));
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var request = CreateTestRunRequest(
                 "req-test-run-lifecycle-error",
                 CreateValidTestRunPayload());
@@ -574,7 +592,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator TestRunHandler_WhenServiceThrowsArgumentException_ReturnsInvalidArgument () => UniTask.ToCoroutine(async () =>
         {
             var service = new StubUnityTestRunService(_ => throw new ArgumentException("invalid"));
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var request = CreateTestRunRequest(
                 "req-test-run-invalid-argument",
                 CreateValidTestRunPayload());
@@ -591,7 +609,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public IEnumerator TestRunHandler_WhenServiceThrowsUnexpectedException_ReturnsInternalError () => UniTask.ToCoroutine(async () =>
         {
             var service = new StubUnityTestRunService(_ => throw new InvalidOperationException("test-run-failed"));
-            var handler = new TestRunUnityIpcMethodHandler(service);
+            var handler = CreateTestRunHandler(service);
             var request = CreateTestRunRequest(
                 "req-test-run-internal-error",
                 CreateValidTestRunPayload());
@@ -608,7 +626,7 @@ namespace MackySoft.Ucli.Unity.Tests
         [Category("Size.Small")]
         public IEnumerator TestRunHandler_WhenPayloadIsInvalid_ReturnsInvalidArgument () => UniTask.ToCoroutine(async () =>
         {
-            var handler = new TestRunUnityIpcMethodHandler(
+            var handler = CreateTestRunHandler(
                 new StubUnityTestRunService(request => Task.FromResult(UnityTestRunServiceResult.Success(new IpcTestRunResponse(0)))));
             var request = CreateTestRunRequest("req-test-run-invalid-payload", 123);
 
@@ -1464,6 +1482,15 @@ namespace MackySoft.Ucli.Unity.Tests
                 readinessGate);
         }
 
+        private static TestRunUnityIpcMethodHandler CreateTestRunHandler (
+            IUnityTestRunService testRunService,
+            IIpcRequestTimeoutScopeFactory timeoutScopeFactory = null)
+        {
+            return new TestRunUnityIpcMethodHandler(
+                testRunService,
+                timeoutScopeFactory ?? new IpcRequestTimeoutScopeFactory());
+        }
+
         private static UnityLogsReadUnityIpcMethodHandler CreateUnityLogsReadHandler (IUnityLogStream stream)
         {
             return new UnityLogsReadUnityIpcMethodHandler(
@@ -1615,6 +1642,63 @@ namespace MackySoft.Ucli.Unity.Tests
                 LastRequest = request;
                 LastProgressSink = progressSink;
                 return execute(request, progressSink, cancellationToken);
+            }
+        }
+
+        private sealed class ManualIpcRequestTimeoutScopeFactory : IIpcRequestTimeoutScopeFactory
+        {
+            public ManualIpcRequestTimeoutScope LastScope { get; private set; }
+
+            public IIpcRequestTimeoutScope CreateLinked (
+                int? timeoutMilliseconds,
+                CancellationToken cancellationToken)
+            {
+                LastScope = new ManualIpcRequestTimeoutScope(cancellationToken);
+                return LastScope;
+            }
+        }
+
+        private sealed class ManualIpcRequestTimeoutScope : IIpcRequestTimeoutScope
+        {
+            private readonly CancellationTokenSource cancellationTokenSource;
+            private readonly CancellationTokenRegistration callerCancellationRegistration;
+
+            private bool disposed;
+            private bool isTimeoutCancellationRequested;
+
+            public ManualIpcRequestTimeoutScope (CancellationToken cancellationToken)
+            {
+                cancellationTokenSource = new CancellationTokenSource();
+                callerCancellationRegistration = cancellationToken.Register(
+                    static state => ((CancellationTokenSource)state).Cancel(),
+                    cancellationTokenSource);
+            }
+
+            public CancellationToken Token => cancellationTokenSource.Token;
+
+            public bool IsTimeoutCancellationRequested => isTimeoutCancellationRequested;
+
+            public void CancelForTimeout ()
+            {
+                if (disposed)
+                {
+                    throw new ObjectDisposedException(nameof(ManualIpcRequestTimeoutScope));
+                }
+
+                isTimeoutCancellationRequested = true;
+                cancellationTokenSource.Cancel();
+            }
+
+            public void Dispose ()
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                callerCancellationRegistration.Dispose();
+                cancellationTokenSource.Dispose();
+                disposed = true;
             }
         }
 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Server/UnityIpcServerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Server/UnityIpcServerTests.cs
@@ -1004,7 +1004,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 {
                     new PingUnityIpcMethodHandler(new AssemblyServerVersionProvider(), new StubUnityEditorReadinessGate(), "project-fingerprint"),
                     new ExecuteUnityIpcMethodHandler(executeRequestDispatcher),
-                    new TestRunUnityIpcMethodHandler(testRunService),
+                    new TestRunUnityIpcMethodHandler(testRunService, new IpcRequestTimeoutScopeFactory()),
                     new DaemonLogsReadUnityIpcMethodHandler(
                         daemonLogStream,
                         new DaemonLogsReadRequestValidator(),

--- a/src/Ucli/Features/Daemon/Common/Ipc/DaemonIpcRequestSender.cs
+++ b/src/Ucli/Features/Daemon/Common/Ipc/DaemonIpcRequestSender.cs
@@ -13,6 +13,8 @@ namespace MackySoft.Ucli.Features.Daemon.Common.Ipc;
 /// <summary> Implements daemon IPC sending through persisted session endpoints with domain-reload recovery retry. </summary>
 internal sealed class DaemonIpcRequestSender : IDaemonIpcRequestSender
 {
+    private const string DaemonSessionNotAvailableMessage = "No daemon session is available for the requested project. Start the daemon or check --projectPath.";
+
     private readonly IIpcTransportClient transportClient;
 
     private readonly IDaemonSessionConnectionProvider daemonSessionConnectionProvider;
@@ -72,8 +74,7 @@ internal sealed class DaemonIpcRequestSender : IDaemonIpcRequestSender
 
                 if (sessionConnectionResult.IsSessionNotAvailable)
                 {
-                    return DaemonIpcSendResult.Failure(ExecutionError.InternalError(
-                        DaemonSessionConnectionResolutionResult.SessionNotAvailableMessage));
+                    return DaemonIpcSendResult.Failure(CreateDaemonSessionNotAvailableError());
                 }
 
                 return DaemonIpcSendResult.Failure(ExecutionError.InternalError(
@@ -111,14 +112,12 @@ internal sealed class DaemonIpcRequestSender : IDaemonIpcRequestSender
                 endpointAbsenceRetryDeadline = retryDecision.EndpointAbsenceRetryDeadline;
                 if (!retryDecision.ShouldRetry)
                 {
-                    return DaemonIpcSendResult.Failure(ExecutionError.InternalError(
-                        $"Unity daemon is not running. {exception.Message}"));
+                    return DaemonIpcSendResult.Failure(CreateDaemonSessionNotAvailableError());
                 }
             }
             catch (Exception exception) when (DaemonProbeExceptionClassifier.IsNotRunning(exception))
             {
-                return DaemonIpcSendResult.Failure(ExecutionError.InternalError(
-                    $"Unity daemon is not running. {exception.Message}"));
+                return DaemonIpcSendResult.Failure(CreateDaemonSessionNotAvailableError());
             }
             catch (Exception exception)
             {
@@ -126,6 +125,13 @@ internal sealed class DaemonIpcRequestSender : IDaemonIpcRequestSender
                     $"Daemon IPC request failed. {exception.Message}"));
             }
         }
+    }
+
+    private static ExecutionError CreateDaemonSessionNotAvailableError ()
+    {
+        return ExecutionError.InternalError(
+            DaemonSessionNotAvailableMessage,
+            DaemonErrorCodes.DaemonSessionNotAvailable);
     }
 
     private async ValueTask<(bool ShouldRetry, ExecutionDeadline? EndpointAbsenceRetryDeadline)> ShouldRetryEndpointAbsenceAsync (

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandPayload.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandPayload.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization;
+
 namespace MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 
 /// <summary> Represents the final payload for <c>logs * read</c>. </summary>
 internal sealed record LogsReadCommandPayload (
     int Count,
     string? NextCursor,
-    string CompletionReason);
+    string CompletionReason,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? ActionRequired = null);

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandResultFactory.cs
@@ -9,6 +9,8 @@ namespace MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 /// <summary> Creates public command results for <c>logs * read</c>. </summary>
 internal static class LogsReadCommandResultFactory
 {
+    private const string StartDaemonOrCheckProjectPathActionRequired = "startDaemonOrCheckProjectPath";
+
     /// <summary> Creates one final command result from the logs-read service result. </summary>
     public static CommandResult Create (
         string commandName,
@@ -20,7 +22,8 @@ internal static class LogsReadCommandResultFactory
         var payload = new LogsReadCommandPayload(
             serviceResult.Count,
             serviceResult.NextCursor,
-            serviceResult.CompletionReason);
+            serviceResult.CompletionReason,
+            ResolveActionRequired(serviceResult));
         if (serviceResult.IsSuccess)
         {
             return CommandResult.Success(commandName, "Log read completed.", payload);
@@ -39,5 +42,12 @@ internal static class LogsReadCommandResultFactory
         }
 
         return ApplicationFailure.FromExecutionError(error);
+    }
+
+    private static string? ResolveActionRequired (LogsReadServiceResult serviceResult)
+    {
+        return serviceResult.Error?.Code == DaemonErrorCodes.DaemonSessionNotAvailable
+            ? StartDaemonOrCheckProjectPathActionRequired
+            : null;
     }
 }

--- a/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
+++ b/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
@@ -140,7 +140,7 @@ public sealed class UcliErrorDescriptorTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void DaemonSessionNotAvailableDescriptor_AppliesToLogCommands ()
+    public void DaemonSessionNotAvailableDescriptor_AppliesToCurrentPublicCommands ()
     {
         var descriptor = FindDescriptor(DaemonErrorCodes.DaemonSessionNotAvailable);
 
@@ -149,7 +149,9 @@ public sealed class UcliErrorDescriptorTests
         Assert.Contains(UcliCommandIds.LogsUnityRead, descriptor.AppliesTo);
         Assert.Contains(UcliCommandIds.LogsUnityClear, descriptor.AppliesTo);
         Assert.DoesNotContain(UcliCommandIds.DaemonStart, descriptor.AppliesTo);
-        Assert.Contains("payload.actionRequired", descriptor.Inspect);
+        Assert.Contains(UcliErrorInspectTargets.DaemonStatusCommand, descriptor.Inspect);
+        Assert.Contains(UcliErrorInspectTargets.DaemonListCommand, descriptor.Inspect);
+        Assert.DoesNotContain("payload.actionRequired", descriptor.Inspect);
     }
 
     [Fact]

--- a/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
+++ b/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
@@ -140,6 +140,20 @@ public sealed class UcliErrorDescriptorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void DaemonSessionNotAvailableDescriptor_AppliesToLogCommands ()
+    {
+        var descriptor = FindDescriptor(DaemonErrorCodes.DaemonSessionNotAvailable);
+
+        Assert.Equal("daemon", descriptor.Category);
+        Assert.Contains(UcliCommandIds.LogsDaemonRead, descriptor.AppliesTo);
+        Assert.Contains(UcliCommandIds.LogsUnityRead, descriptor.AppliesTo);
+        Assert.Contains(UcliCommandIds.LogsUnityClear, descriptor.AppliesTo);
+        Assert.DoesNotContain(UcliCommandIds.DaemonStart, descriptor.AppliesTo);
+        Assert.Contains("payload.actionRequired", descriptor.Inspect);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void PlayModeSessionAndStateDescriptors_ApplyToPlayCommandFamily ()
     {
         var lifecycleCodes = new[]

--- a/tests/Ucli.Tests/CodesCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CodesCliOutputContractTests.cs
@@ -170,6 +170,30 @@ public sealed class CodesCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task CodesList_WithLogsDaemonReadCommandFilter_ReturnsDaemonSessionErrors ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Codes,
+            UcliCommandNames.ListSubcommand,
+            "--kind",
+            CodeCatalogKindValues.Error,
+            "--command",
+            UcliCommandNames.LogsDaemonRead);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.CodesList,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        var codes = GetCodes(outputJson.RootElement);
+        Assert.Contains(DaemonErrorCodes.DaemonSessionNotAvailable.Value, codes);
+        Assert.Contains(IpcTransportErrorCodes.IpcTimeout.Value, codes);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task CodesList_WithPlayCommandFilter_ReturnsAllPlayModeControlErrors ()
     {
         var result = await CliProcessRunner.RunCommandAsync(

--- a/tests/Ucli.Tests/Features/Daemon/Common/Ipc/DaemonIpcRequestSenderTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Common/Ipc/DaemonIpcRequestSenderTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Observation;
 using MackySoft.Ucli.Application.Features.Daemon.Lifecycle.Session;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Features.Daemon.Common.Ipc;
 using MackySoft.Ucli.UnityIntegration.Ipc.Recovery;
@@ -12,6 +13,32 @@ namespace MackySoft.Ucli.Tests.Features.Daemon.Common.Ipc;
 
 public sealed class DaemonIpcRequestSenderTests
 {
+    private static readonly TimeSpan AsyncWaitTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenSessionIsMissing_ReturnsDaemonSessionNotAvailableWithoutTransportCall ()
+    {
+        var transportClient = new StubIpcTransportClient();
+        var sender = new DaemonIpcRequestSender(
+            transportClient,
+            new StubDaemonSessionConnectionProvider(DaemonSessionConnectionResolutionResult.SessionNotAvailable()),
+            recoveryWaiter: null);
+
+        var result = await sender.SendAsync(
+            CreateContext(),
+            sessionToken => CreateRequest("logs.unity.read", sessionToken),
+            TimeSpan.FromSeconds(5),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(0, transportClient.CallCount);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(DaemonErrorCodes.DaemonSessionNotAvailable, error.Code);
+        Assert.Contains("--projectPath", error.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task SendAsync_WhenResponseAttemptTimesOut_ReturnsTimeoutWithoutRetry ()
@@ -73,6 +100,45 @@ public sealed class DaemonIpcRequestSenderTests
         Assert.Equal(2, sessionConnectionProvider.CallCount);
         Assert.Equal("daemon-token-1", transportClient.Requests[0].SessionToken);
         Assert.Equal("daemon-token-2", transportClient.Requests[1].SessionToken);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task SendAsync_WhenEndpointRemainsAbsent_ReturnsDaemonSessionNotAvailable ()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var transportClient = new StubIpcTransportClient();
+        for (var i = 0; i < 20; i++)
+        {
+            transportClient.EnqueueException(new SocketException((int)SocketError.ConnectionRefused));
+        }
+
+        var sender = new DaemonIpcRequestSender(
+            transportClient,
+            new StubDaemonSessionConnectionProvider(CreateConnectionResult("daemon-token")),
+            recoveryWaiter: null,
+            timeProvider: timeProvider);
+
+        var sendTask = sender.SendAsync(
+                CreateContext(),
+                sessionToken => CreateRequest("logs.unity.read", sessionToken),
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None)
+            .AsTask();
+        for (var i = 0; i < 20 && !sendTask.IsCompleted; i++)
+        {
+            timeProvider.Advance(TimeSpan.FromMilliseconds(DaemonTimeouts.StartupProbeRetryDelayMilliseconds));
+            await Task.Yield();
+        }
+
+        var result = await TestAwaiter.WaitAsync(sendTask, "Endpoint absence daemon IPC send", AsyncWaitTimeout);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(transportClient.CallCount > 1);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(DaemonErrorCodes.DaemonSessionNotAvailable, error.Code);
+        Assert.Contains("--projectPath", error.Message, StringComparison.Ordinal);
     }
 
     private static ResolvedUnityProjectContext CreateContext ()

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonReadCommandTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonReadCommandTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Common;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Daemon;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
@@ -10,6 +11,8 @@ namespace MackySoft.Ucli.Tests.Logs;
 
 public sealed class LogsDaemonReadCommandTests
 {
+    private const string DaemonSessionNotAvailableMessage = "No daemon session is available for the requested project. Start the daemon or check --projectPath.";
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task Read_WhenFormatIsJson_WritesNdjsonEvents ()
@@ -104,6 +107,36 @@ public sealed class LogsDaemonReadCommandTests
         Assert.Equal(0, payload.GetProperty("count").GetInt32());
         Assert.Equal(JsonValueKind.Null, payload.GetProperty("nextCursor").ValueKind);
         Assert.Equal("error", payload.GetProperty("completionReason").GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenDaemonSessionIsNotAvailable_WritesActionRequiredResult ()
+    {
+        var command = new LogsDaemonReadCommand(new StubLogsDaemonService(static (_, _, _) =>
+        {
+            return ValueTask.FromResult(LogsReadServiceResult.Failure(ExecutionError.InternalError(
+                DaemonSessionNotAvailableMessage,
+                DaemonErrorCodes.DaemonSessionNotAvailable)));
+        }), CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.ReadAsync(format: "json"));
+
+        Assert.Equal(4, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        using var commandResult = JsonDocument.Parse(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            commandResult.RootElement,
+            UcliCommandNames.LogsDaemonRead,
+            "error",
+            4);
+        CommandResultAssert.HasSingleError(commandResult.RootElement, DaemonErrorCodes.DaemonSessionNotAvailable);
+        Assert.Equal(DaemonSessionNotAvailableMessage, commandResult.RootElement.GetProperty("message").GetString());
+        var payload = commandResult.RootElement.GetProperty("payload");
+        Assert.Equal(0, payload.GetProperty("count").GetInt32());
+        Assert.Equal(JsonValueKind.Null, payload.GetProperty("nextCursor").ValueKind);
+        Assert.Equal("error", payload.GetProperty("completionReason").GetString());
+        Assert.Equal("startDaemonOrCheckProjectPath", payload.GetProperty("actionRequired").GetString());
     }
 
     [Fact]
@@ -223,6 +256,7 @@ public sealed class LogsDaemonReadCommandTests
         Assert.Equal(count, payload.GetProperty("count").GetInt32());
         Assert.Equal(nextCursor, payload.GetProperty("nextCursor").GetString());
         Assert.Equal("completed", payload.GetProperty("completionReason").GetString());
+        Assert.False(payload.TryGetProperty("actionRequired", out _));
     }
 
     private static void AssertEntryEnvelope (

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityReadCommandTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityReadCommandTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Common;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Unity;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Daemon.Logs;
 using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
@@ -10,6 +11,8 @@ namespace MackySoft.Ucli.Tests.Logs;
 
 public sealed class LogsUnityReadCommandTests
 {
+    private const string DaemonSessionNotAvailableMessage = "No daemon session is available for the requested project. Start the daemon or check --projectPath.";
+
     [Fact]
     [Trait("Size", "Small")]
     public async Task Read_WhenFormatIsJson_WritesNdjsonEvents ()
@@ -142,6 +145,36 @@ public sealed class LogsUnityReadCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Read_WhenDaemonSessionIsNotAvailable_WritesActionRequiredResult ()
+    {
+        var command = new LogsUnityReadCommand(new StubLogsUnityService(static (_, _, _) =>
+        {
+            return ValueTask.FromResult(LogsReadServiceResult.Failure(ExecutionError.InternalError(
+                DaemonSessionNotAvailableMessage,
+                DaemonErrorCodes.DaemonSessionNotAvailable)));
+        }), CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.ReadAsync(format: "json"));
+
+        Assert.Equal(4, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        using var commandResult = JsonDocument.Parse(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            commandResult.RootElement,
+            UcliCommandNames.LogsUnityRead,
+            "error",
+            4);
+        CommandResultAssert.HasSingleError(commandResult.RootElement, DaemonErrorCodes.DaemonSessionNotAvailable);
+        Assert.Equal(DaemonSessionNotAvailableMessage, commandResult.RootElement.GetProperty("message").GetString());
+        var payload = commandResult.RootElement.GetProperty("payload");
+        Assert.Equal(0, payload.GetProperty("count").GetInt32());
+        Assert.Equal(JsonValueKind.Null, payload.GetProperty("nextCursor").ValueKind);
+        Assert.Equal("error", payload.GetProperty("completionReason").GetString());
+        Assert.Equal("startDaemonOrCheckProjectPath", payload.GetProperty("actionRequired").GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Read_WhenCancellationRequested_ReturnsSuccessExitCode ()
     {
         var command = new LogsUnityReadCommand(new ThrowingLogsUnityService(), CommandResultTestWriter.Create());
@@ -183,6 +216,7 @@ public sealed class LogsUnityReadCommandTests
         Assert.Equal(count, payload.GetProperty("count").GetInt32());
         Assert.Equal(nextCursor, payload.GetProperty("nextCursor").GetString());
         Assert.Equal("completed", payload.GetProperty("completionReason").GetString());
+        Assert.False(payload.TryGetProperty("actionRequired", out _));
     }
 
     private static void AssertEntryEnvelope (


### PR DESCRIPTION
## Summary
- `logs daemon read` / `logs unity read` の daemon セッション未利用時に `DAEMON_SESSION_NOT_AVAILABLE` を返すようにしました。
- セッション未登録、endpoint 不在、daemon not running の IPC 失敗分類を統一し、message を daemon 起動または projectPath 確認へ誘導する内容に揃えました。
- 該当失敗時だけ logs read payload に `actionRequired: "startDaemonOrCheckProjectPath"` を出し、成功時や idle timeout には混入しない契約をテストで固定しました。

## Scope
- Contracts: daemon error code と descriptor/catalog 登録
- CLI/IPC: `DaemonIpcRequestSender` の分類、logs read payload/result 生成
- Tests: IPC sender、daemon/unity logs read command、code catalog/CLI contract tests

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`, `bash scripts/code-quality.sh verify --include ...`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, `bash scripts/verify.sh`)
- Coverage: N/A

## Risks / Rollback
- Risk: セッション未利用状態の分類対象が広がるため、logs 系以外の共有 IPC 経路でも新コードが返ります。Issue の対象に含まれる `logs.unity.clear` も descriptor へ登録済みです。
- Rollback: `DaemonIpcRequestSender` の分類と `LogsReadCommandPayload` の追加フィールドを戻し、catalog から新コードを外します。

## Checklist
- [x] `DAEMON_SESSION_NOT_AVAILABLE` を catalog に登録
- [x] logs read failure payload の `actionRequired` を該当ケースだけ出力
- [x] daemon 未起動、endpoint 不在、成功/idle timeout への混入防止をテスト
- [x] PR前検証通過

Closes #352