### PR TITLE
fix(auth): clarify operation policy block guidance

### DIFF
--- a/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/OperationAuthorizationService.cs
+++ b/src/Ucli.Application/Features/Requests/Shared/OperationMetadata/OperationAuthorizationService.cs
@@ -26,7 +26,7 @@ internal sealed class OperationAuthorizationService : IOperationAuthorizationSer
         {
             return ValueTask.FromResult(OperationAuthorizationResult.Denied(
                 OperationAuthorizationErrorCodes.OperationNotAllowed,
-                $"Operation '{operation.Name}' is blocked by operationPolicy='{config.OperationPolicy}'."));
+                CreatePolicyBlockedMessage(operation, config)));
         }
 
         var allowlistResult = TryMatchAllowlist(operation.Name, config.OperationAllowlist);
@@ -56,6 +56,21 @@ internal sealed class OperationAuthorizationService : IOperationAuthorizationSer
         OperationPolicy configuredPolicy)
     {
         return requiredPolicy <= configuredPolicy;
+    }
+
+    /// <summary> Creates the denial message for one policy-level authorization failure. </summary>
+    /// <param name="operation"> The operation descriptor that was blocked. </param>
+    /// <param name="config"> The configuration that blocked execution. </param>
+    /// <returns> The user-facing policy failure message. </returns>
+    private static string CreatePolicyBlockedMessage (
+        UcliOperationDescriptor operation,
+        UcliConfig config)
+    {
+        var requiredPolicy = OperationPolicyCodec.ToValue(operation.Policy);
+        var configuredPolicy = OperationPolicyCodec.ToValue(config.OperationPolicy);
+        return
+            $"Operation '{operation.Name}' requires operationPolicy='{requiredPolicy}' but current operationPolicy='{configuredPolicy}'. " +
+            $"Set operationPolicy to at least '{requiredPolicy}' in .ucli/config.json only after accepting that policy's effects, or choose an operation allowed by the current policy.";
     }
 
     /// <summary> Attempts to match operation name against allowlist patterns. </summary>

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/OperationAuthorizationErrorCodeDescriptors.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/OperationAuthorizationErrorCodeDescriptors.cs
@@ -26,7 +26,10 @@ internal static class OperationAuthorizationErrorCodeDescriptors
             [
                 new UcliErrorNextActionDescriptor(
                     When: null,
-                    Action: "Change the request or policy intentionally before retrying."),
+                    Action: "Inspect errors[].message and errors[].opId to identify the blocked operation, required policy, and current operationPolicy; inspect operationAllowlist when allowlist denial is possible."),
+                new UcliErrorNextActionDescriptor(
+                    When: null,
+                    Action: "Change .ucli/config.json intentionally before retrying, or use a command allowed by the current policy."),
             ],
             relatedCodes:
             [

--- a/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/OperationAuthorizationServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Requests/Shared/OperationMetadata/OperationAuthorizationServiceTests.cs
@@ -73,6 +73,31 @@ public sealed class OperationAuthorizationServiceTests
         }
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Authorize_WhenPolicyBlocksOperation_ReturnsGenericPolicyGuidance ()
+    {
+        var service = new OperationAuthorizationService();
+        var operation = CreateOperation(
+            UcliPrimitiveOperationNames.SceneSave,
+            UcliOperationKind.Mutation,
+            OperationPolicy.Advanced);
+        var config = CreateConfig(OperationPolicy.Safe, "^ucli\\.");
+
+        var result = await service.AuthorizeAsync(operation, config, CancellationToken.None);
+
+        Assert.False(result.IsAllowed);
+        Assert.Equal(OperationAuthorizationErrorCodes.OperationNotAllowed, result.ErrorCode);
+        Assert.Contains(UcliPrimitiveOperationNames.SceneSave, result.Message, StringComparison.Ordinal);
+        Assert.Contains("requires operationPolicy='advanced'", result.Message, StringComparison.Ordinal);
+        Assert.Contains("current operationPolicy='safe'", result.Message, StringComparison.Ordinal);
+        Assert.Contains(".ucli/config.json", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("AssetDatabase", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli refresh", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli status", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli query", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static UcliOperationDescriptor CreateOperation (
         string name,
         UcliOperationKind kind,

--- a/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
+++ b/tests/Ucli.Contracts.Tests/Diagnostics/UcliErrorDescriptorTests.cs
@@ -85,6 +85,23 @@ public sealed class UcliErrorDescriptorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void OperationNotAllowedDescriptor_GuidesPolicyAndAllowlistInspection ()
+    {
+        var descriptor = FindDescriptor(OperationAuthorizationErrorCodes.OperationNotAllowed);
+
+        Assert.Contains(UcliCommandIds.Refresh, descriptor.AppliesTo);
+        Assert.Contains("operationPolicy", descriptor.Inspect);
+        Assert.Contains(
+            descriptor.NextActions,
+            static action => action.Action.Contains("errors[].message", StringComparison.Ordinal)
+                             && action.Action.Contains("operationAllowlist", StringComparison.Ordinal));
+        Assert.Contains(
+            descriptor.NextActions,
+            static action => action.Action.Contains(".ucli/config.json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void ProtocolVersionMismatchDescriptor_AppliesToValidate ()
     {
         var descriptor = FindDescriptor(IpcProtocolErrorCodes.ProtocolVersionMismatch);

--- a/tests/Ucli.Tests/RefreshCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/RefreshCliOutputContractTests.cs
@@ -173,6 +173,15 @@ public sealed class RefreshCliOutputContractTests
                 .HasString("code", "OPERATION_NOT_ALLOWED")
                 .HasValueKind("message", JsonValueKind.String)
                 .HasString("opId", "refresh"));
+        var message = outputJson.RootElement.GetProperty("errors")[0].GetProperty("message").GetString();
+        Assert.Contains("ucli.project.refresh", message, StringComparison.Ordinal);
+        Assert.Contains("advanced", message, StringComparison.Ordinal);
+        Assert.Contains("safe", message, StringComparison.Ordinal);
+        Assert.Contains(".ucli/config.json", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("AssetDatabase", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli status", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli ready", message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ucli query", message, StringComparison.OrdinalIgnoreCase);
     }
 
     private static void WriteRefreshAllowedConfig (


### PR DESCRIPTION
## Summary
- Clarifies `OPERATION_NOT_ALLOWED` diagnostics when an operation is blocked by the configured `operationPolicy`.
- Reports the blocked operation, required policy, current policy, and `.ucli/config.json` action in the existing error message field.
- Updates the code descriptor next actions and tests the generic diagnostic contract, including the `refresh` CLI regression case where the issue surfaced.

## Scope
- Authorization failure messaging for operation policy denial.
- Error code next-action guidance for `OPERATION_NOT_ALLOWED`.
- Contract tests for policy denial diagnostics.

## Verification
- `bash scripts/code-quality.sh format --include ...`
- `bash scripts/code-quality.sh verify --include ...`
- `bash scripts/test-dotnet.sh`
- `bash scripts/verify.sh`

## Notes
- No README changes.
- No JSON payload or schema changes.
- No policy downgrade for `ucli.project.refresh`.
- No new `--allowDangerous` behavior.

Closes #353
