### PR TITLE
Add verify profile step progress stream

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Verify/Contracts/IVerifyService.cs
+++ b/src/Ucli.Application/Features/Assurance/Verify/Contracts/IVerifyService.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
+
 namespace MackySoft.Ucli.Application.Features.Assurance.Verify.Contracts;
 
 /// <summary> Executes verify assurance profiles and returns claim packets. </summary>
@@ -5,9 +7,11 @@ internal interface IVerifyService
 {
     /// <summary> Executes one verify profile. </summary>
     /// <param name="input"> The normalized verify command input. </param>
+    /// <param name="progressSink"> The optional command-neutral sink that receives live progress entries. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The verify execution result. </returns>
     ValueTask<VerifyExecutionResult> ExecuteAsync (
         VerifyCommandInput input,
+        ICommandProgressSink? progressSink = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
+++ b/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
@@ -11,7 +11,9 @@ using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Common;
 using MackySoft.Ucli.Application.Features.Daemon.Observability.Logs.Unity;
 using MackySoft.Ucli.Application.Features.Testing.Run.UseCases.TestRun;
 using MackySoft.Ucli.Application.Shared.Context;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Assurance;
 
 namespace MackySoft.Ucli.Application.Features.Assurance.Verify.Execution;
 
@@ -66,6 +68,7 @@ internal sealed class VerifyService : IVerifyService
     /// <inheritdoc />
     public async ValueTask<VerifyExecutionResult> ExecuteAsync (
         VerifyCommandInput input,
+        ICommandProgressSink? progressSink = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
@@ -124,23 +127,53 @@ internal sealed class VerifyService : IVerifyService
         }
 
         var profile = profileResult.Profile!;
+        var profileDigest = VerifyProfileDigestCalculator.Calculate(profile);
+        await EmitProgressEntryAsync(
+                progressSink,
+                VerifyProgressEventNames.Started,
+                CreateProgressEntry(profile, profileDigest, verdict: null),
+                cancellationToken)
+            .ConfigureAwait(false);
+
         var deadline = ExecutionDeadline.Start(timeout, timeProvider);
         var builder = new VerifyPacketBuilder();
         foreach (var step in profile.Steps)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (ShouldSkipConditionalStep(step, fromInput, builder))
+            if (!VerifyStepKindValues.IsSupported(step.Kind))
             {
+                var failure = ApplicationFailure.InvalidInput(
+                    $"Unsupported verify step kind '{step.Kind}'.",
+                    UcliCoreErrorCodes.InvalidArgument);
+                await EmitDiagnosticAsync(progressSink, failure, stepKind: null, cancellationToken).ConfigureAwait(false);
+                return VerifyExecutionResult.Failure(failure, project);
+            }
+
+            if (TryGetConditionalSkipReason(step, fromInput, builder, out var skipReason))
+            {
+                await EmitProgressEntryAsync(
+                        progressSink,
+                        VerifyProgressEventNames.StepSkipped,
+                        CreateStepProgressEntry(step, skipReason),
+                        cancellationToken)
+                    .ConfigureAwait(false);
                 continue;
             }
 
             if (!deadline.TryGetRemainingTimeout(out var stepTimeout))
             {
-                return VerifyExecutionResult.Failure(
-                    ApplicationFailure.Timeout("Timed out before verify profile step execution could begin."),
-                    project);
+                var failure = ApplicationFailure.Timeout("Timed out before verify profile step execution could begin.");
+                await EmitDiagnosticAsync(progressSink, failure, step.Kind, cancellationToken).ConfigureAwait(false);
+                return VerifyExecutionResult.Failure(failure, project);
             }
+
+            await EmitProgressEntryAsync(
+                    progressSink,
+                    VerifyProgressEventNames.StepStarted,
+                    CreateStepProgressEntry(step, skipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
 
             VerifyStepExecutionResult stepResult;
             using (var stepCancellationScope = TimeProviderCancellationScope.CreateLinked(cancellationToken, stepTimeout, timeProvider))
@@ -158,26 +191,33 @@ internal sealed class VerifyService : IVerifyService
                 }
                 catch (OperationCanceledException) when (stepCancellationScope.HasTimedOut)
                 {
-                    return VerifyExecutionResult.Failure(
-                        ApplicationFailure.Timeout("Timed out during verify profile step execution."),
-                        project);
+                    var failure = ApplicationFailure.Timeout("Timed out during verify profile step execution.");
+                    await EmitDiagnosticAsync(progressSink, failure, step.Kind, cancellationToken).ConfigureAwait(false);
+                    return VerifyExecutionResult.Failure(failure, project);
                 }
             }
 
             if (!stepResult.IsSuccess)
             {
+                await EmitDiagnosticAsync(progressSink, stepResult.Error!, step.Kind, cancellationToken).ConfigureAwait(false);
                 return VerifyExecutionResult.Failure(stepResult.Error!, project);
             }
 
+            await EmitProgressEntryAsync(
+                    progressSink,
+                    VerifyProgressEventNames.StepCompleted,
+                    CreateStepProgressEntry(step, skipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
             if (deadline.IsExpired)
             {
-                return VerifyExecutionResult.Failure(
-                    ApplicationFailure.Timeout("Timed out during verify profile step execution."),
-                    project);
+                var failure = ApplicationFailure.Timeout("Timed out during verify profile step execution.");
+                await EmitDiagnosticAsync(progressSink, failure, step.Kind, cancellationToken).ConfigureAwait(false);
+                return VerifyExecutionResult.Failure(failure, project);
             }
         }
 
-        var profileDigest = VerifyProfileDigestCalculator.Calculate(profile);
         var output = new VerifyExecutionOutput(
             Verdict: VerifyVerdictCalculator.Calculate(builder.Claims, builder.ResidualRisks),
             Project: project,
@@ -192,6 +232,12 @@ internal sealed class VerifyService : IVerifyService
                 profileDigest),
             ProfileDigest: profileDigest,
             TimeoutMilliseconds: checked((int)timeout.TotalMilliseconds));
+        await EmitProgressEntryAsync(
+                progressSink,
+                VerifyProgressEventNames.Completed,
+                CreateProgressEntry(profile, profileDigest, output.Verdict),
+                cancellationToken)
+            .ConfigureAwait(false);
         return VerifyExecutionResult.Success(output);
     }
 
@@ -555,20 +601,87 @@ internal sealed class VerifyService : IVerifyService
         return VerifyStepExecutionResult.Success();
     }
 
-    private static bool ShouldSkipConditionalStep (
+    private static bool TryGetConditionalSkipReason (
         VerifyProfileStep step,
         VerifyFromInput? fromInput,
-        VerifyPacketBuilder builder)
+        VerifyPacketBuilder builder,
+        out string skipReason)
     {
         if (string.Equals(step.Kind, VerifyStepKindValues.PostRead, StringComparison.Ordinal)
             && !step.Required
             && (fromInput is null || !fromInput.NeedsPostRead))
         {
+            skipReason = VerifyStepSkipReasons.PostReadNotNeeded;
             return true;
         }
 
-        return string.Equals(step.Kind, VerifyStepKindValues.Logs, StringComparison.Ordinal)
-            && !builder.HasNonPassingClaim;
+        if (string.Equals(step.Kind, VerifyStepKindValues.Logs, StringComparison.Ordinal)
+            && !builder.HasNonPassingClaim)
+        {
+            skipReason = VerifyStepSkipReasons.LogsNotNeeded;
+            return true;
+        }
+
+        skipReason = string.Empty;
+        return false;
+    }
+
+    private static VerifyProgressEntry CreateProgressEntry (
+        VerifyProfileDefinition profile,
+        string profileDigest,
+        string? verdict)
+    {
+        return new VerifyProgressEntry(
+            profile.Source,
+            profile.Name,
+            profile.RepositoryRelativePath,
+            profileDigest,
+            profile.Steps.Count,
+            verdict);
+    }
+
+    private static VerifyStepProgressEntry CreateStepProgressEntry (
+        VerifyProfileStep step,
+        string? skipReason)
+    {
+        return new VerifyStepProgressEntry(
+            step.Kind,
+            step.Required,
+            step.Effects.ToArray(),
+            skipReason);
+    }
+
+    private static ValueTask EmitDiagnosticAsync (
+        ICommandProgressSink? progressSink,
+        ApplicationFailure failure,
+        string? stepKind,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return EmitProgressEntryAsync(
+            progressSink,
+            VerifyProgressEventNames.Diagnostic,
+            new VerifyDiagnosticEntry(
+                failure.Code.Value,
+                failure.Message,
+                "error",
+                VerifyStepKindValues.IsSupported(stepKind ?? string.Empty) ? stepKind : null),
+            cancellationToken);
+    }
+
+    private static ValueTask EmitProgressEntryAsync (
+        ICommandProgressSink? progressSink,
+        string eventName,
+        object payload,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (progressSink is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return progressSink.OnEntryAsync(eventName, payload, cancellationToken);
     }
 
     private static VerifyClaimOutput ProjectCompileClaim (

--- a/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
+++ b/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
@@ -669,11 +669,12 @@ internal sealed class VerifyService : IVerifyService
             cancellationToken);
     }
 
-    private static ValueTask EmitProgressEntryAsync (
+    private static ValueTask EmitProgressEntryAsync<TPayload> (
         ICommandProgressSink? progressSink,
         string eventName,
-        object payload,
+        TPayload payload,
         CancellationToken cancellationToken)
+        where TPayload : notnull
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (progressSink is null)

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunExecutionPipeline.cs
@@ -328,18 +328,18 @@ internal sealed class TestRunExecutionPipeline : ITestRunExecutionPipeline
         string expectedRunId,
         ICommandProgressSink progressSink,
         CancellationToken cancellationToken)
-        where TPayload : class
+        where TPayload : notnull
     {
-        if (!IpcPayloadCodec.TryDeserialize(frame.Payload, out TPayload? payload, out var error))
+        if (!IpcPayloadCodec.TryDeserialize<TPayload>(frame.Payload, out var payload, out var error))
         {
             throw new TestRunProgressProtocolException(
                 $"Unity test-run progress payload is invalid for event '{frame.Event}'. {error}");
         }
 
-        TestRunProgressPayloadValidator.Validate(frame.Event, payload!, expectedRunId);
+        TestRunProgressPayloadValidator.Validate(frame.Event, payload, expectedRunId);
         await progressSink.OnEntryAsync(
                 frame.Event,
-                payload!,
+                payload,
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunProgressPayloadValidator.cs
+++ b/src/Ucli.Application/Features/Testing/Run/UseCases/TestRun/Pipeline/TestRunProgressPayloadValidator.cs
@@ -21,13 +21,13 @@ internal static class TestRunProgressPayloadValidator
     };
 
     /// <summary> Validates one decoded progress payload against the closed public stream-entry contract. </summary>
-    public static void Validate (
+    public static void Validate<TPayload> (
         string eventName,
-        object payload,
+        TPayload payload,
         string expectedRunId)
+        where TPayload : notnull
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
-        ArgumentNullException.ThrowIfNull(payload);
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedRunId);
 
         switch (eventName)
@@ -78,10 +78,11 @@ internal static class TestRunProgressPayloadValidator
         }
     }
 
-    private static void FailPayloadTypeMismatch (
+    private static void FailPayloadTypeMismatch<TPayload> (
         string eventName,
         string expectedTypeName,
-        object payload)
+        TPayload payload)
+        where TPayload : notnull
     {
         throw new TestRunProgressProtocolException(
             $"Unity test-run progress payload type violates contract for event '{eventName}'. Expected={expectedTypeName}, Actual={payload.GetType().Name}.");

--- a/src/Ucli.Application/Shared/Execution/Progress/ICommandProgressSink.cs
+++ b/src/Ucli.Application/Shared/Execution/Progress/ICommandProgressSink.cs
@@ -4,12 +4,14 @@ namespace MackySoft.Ucli.Application.Shared.Execution.Progress;
 internal interface ICommandProgressSink
 {
     /// <summary> Emits one progress entry. </summary>
+    /// <typeparam name="TPayload"> The concrete event payload type. </typeparam>
     /// <param name="eventName"> The command-specific event name. </param>
     /// <param name="payload"> The event payload. </param>
     /// <param name="cancellationToken"> A cancellation token propagated by caller. </param>
     /// <returns> A task that completes after the entry is accepted. </returns>
-    ValueTask OnEntryAsync (
+    ValueTask OnEntryAsync<TPayload> (
         string eventName,
-        object payload,
-        CancellationToken cancellationToken = default);
+        TPayload payload,
+        CancellationToken cancellationToken = default)
+        where TPayload : notnull;
 }

--- a/src/Ucli.Application/Shared/Execution/Progress/NullCommandProgressSink.cs
+++ b/src/Ucli.Application/Shared/Execution/Progress/NullCommandProgressSink.cs
@@ -11,10 +11,11 @@ internal sealed class NullCommandProgressSink : ICommandProgressSink
     }
 
     /// <inheritdoc />
-    public ValueTask OnEntryAsync (
+    public ValueTask OnEntryAsync<TPayload> (
         string eventName,
-        object payload,
+        TPayload payload,
         CancellationToken cancellationToken = default)
+        where TPayload : notnull
     {
         cancellationToken.ThrowIfCancellationRequested();
         return ValueTask.CompletedTask;

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyDiagnosticEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyDiagnosticEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Assurance;
 
 /// <summary> Represents the <c>verify.diagnostic</c> stream payload. </summary>
-public sealed record VerifyDiagnosticEntry (
+public readonly record struct VerifyDiagnosticEntry (
     string Code,
     string Message,
     string Severity,

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyDiagnosticEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyDiagnosticEntry.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>verify.diagnostic</c> stream payload. </summary>
+public sealed record VerifyDiagnosticEntry (
+    string Code,
+    string Message,
+    string Severity,
+    string? StepKind);

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEntry.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>verify.started</c> and <c>verify.completed</c> stream payload. </summary>
+public sealed record VerifyProgressEntry (
+    string ProfileSource,
+    string ProfileName,
+    string? ProfilePath,
+    string ProfileDigest,
+    int StepCount,
+    string? Verdict);

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Assurance;
 
 /// <summary> Represents the <c>verify.started</c> and <c>verify.completed</c> stream payload. </summary>
-public sealed record VerifyProgressEntry (
+public readonly record struct VerifyProgressEntry (
     string ProfileSource,
     string ProfileName,
     string? ProfilePath,

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEventNames.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyProgressEventNames.cs
@@ -1,0 +1,23 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Defines the closed <c>verify</c> stream event set. </summary>
+public static class VerifyProgressEventNames
+{
+    /// <summary> Gets the event emitted when verify profile execution starts. </summary>
+    public const string Started = "verify.started";
+
+    /// <summary> Gets the event emitted when one verify profile step starts. </summary>
+    public const string StepStarted = "verify.step.started";
+
+    /// <summary> Gets the event emitted when one verify profile step completes. </summary>
+    public const string StepCompleted = "verify.step.completed";
+
+    /// <summary> Gets the event emitted when one conditional verify profile step is skipped. </summary>
+    public const string StepSkipped = "verify.step.skipped";
+
+    /// <summary> Gets the event emitted for structured non-terminal verify diagnostics. </summary>
+    public const string Diagnostic = "verify.diagnostic";
+
+    /// <summary> Gets the event emitted when verify profile execution completes with a final verdict. </summary>
+    public const string Completed = "verify.completed";
+}

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyStepProgressEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyStepProgressEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Assurance;
 
 /// <summary> Represents a verify profile step progress stream payload. </summary>
-public sealed record VerifyStepProgressEntry (
+public readonly record struct VerifyStepProgressEntry (
     string Kind,
     bool Required,
     string[] Effects,

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyStepProgressEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyStepProgressEntry.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents a verify profile step progress stream payload. </summary>
+public sealed record VerifyStepProgressEntry (
+    string Kind,
+    bool Required,
+    string[] Effects,
+    string? SkipReason);

--- a/src/Ucli.Contracts/Assurance/Verify/VerifyStepSkipReasons.cs
+++ b/src/Ucli.Contracts/Assurance/Verify/VerifyStepSkipReasons.cs
@@ -1,0 +1,11 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Defines the closed verify step skip reason values. </summary>
+public static class VerifyStepSkipReasons
+{
+    /// <summary> Gets the skip reason used when no post-read verification is needed. </summary>
+    public const string PostReadNotNeeded = "postReadNotNeeded";
+
+    /// <summary> Gets the skip reason used when no failing or indeterminate claim requires log evidence. </summary>
+    public const string LogsNotNeeded = "logsNotNeeded";
+}

--- a/src/Ucli.Contracts/Ipc/Protocol/IpcPayloadCodec.cs
+++ b/src/Ucli.Contracts/Ipc/Protocol/IpcPayloadCodec.cs
@@ -56,6 +56,13 @@ public static class IpcPayloadCodec
         out T value,
         out IpcPayloadReadError error)
     {
+        if (element.ValueKind == JsonValueKind.Null)
+        {
+            value = default!;
+            error = new IpcPayloadReadError(IpcPayloadReadErrorKind.NullPayload, "IPC payload is null.");
+            return false;
+        }
+
         if (!TryValidateUniqueObjectProperties(element, "$", out var duplicatePropertyPath))
         {
             value = default!;

--- a/src/Ucli.Contracts/Testing/TestRun/TestCaseFinishedEntry.cs
+++ b/src/Ucli.Contracts/Testing/TestRun/TestCaseFinishedEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Testing;
 
 /// <summary> Represents the <c>test.case.finished</c> stream payload. </summary>
-public sealed record TestCaseFinishedEntry (
+public readonly record struct TestCaseFinishedEntry (
     string RunId,
     string TestId,
     string TestName,

--- a/src/Ucli.Contracts/Testing/TestRun/TestCaseStartedEntry.cs
+++ b/src/Ucli.Contracts/Testing/TestRun/TestCaseStartedEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Testing;
 
 /// <summary> Represents the <c>test.case.started</c> stream payload. </summary>
-public sealed record TestCaseStartedEntry (
+public readonly record struct TestCaseStartedEntry (
     string RunId,
     string TestId,
     string TestName,

--- a/src/Ucli.Contracts/Testing/TestRun/TestRunDiagnosticEntry.cs
+++ b/src/Ucli.Contracts/Testing/TestRun/TestRunDiagnosticEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Testing;
 
 /// <summary> Represents the <c>test.run.diagnostic</c> stream payload. </summary>
-public sealed record TestRunDiagnosticEntry (
+public readonly record struct TestRunDiagnosticEntry (
     string RunId,
     string Code,
     string Message,

--- a/src/Ucli.Contracts/Testing/TestRun/TestRunStartedEntry.cs
+++ b/src/Ucli.Contracts/Testing/TestRun/TestRunStartedEntry.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Contracts.Testing;
 
 /// <summary> Represents the <c>test.run.started</c> stream payload. </summary>
-public sealed record TestRunStartedEntry (
+public readonly record struct TestRunStartedEntry (
     string RunId,
     string TestPlatform,
     string? TestFilter,

--- a/src/Ucli/Hosting/Cli/Assurance/VerifyCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/VerifyCommand.cs
@@ -2,6 +2,7 @@ using ConsoleAppFramework;
 using MackySoft.Ucli.Application.Features.Assurance.Verify.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
 using MackySoft.Ucli.Hosting.Cli.Options;
 
 namespace MackySoft.Ucli.Hosting.Cli.Assurance;
@@ -71,6 +72,10 @@ internal sealed class VerifyCommand
             return errorResult.ExitCode;
         }
 
+        var progressSink = new CliCommandProgressSink(
+            formatResult.Format,
+            new CliStreamEntryWriter(UcliCommandNames.Verify),
+            new VerifyProgressTextProjector());
         var executionResult = await verifyService.ExecuteAsync(
                 new VerifyCommandInput(
                     ProjectPath: projectPath,
@@ -79,6 +84,7 @@ internal sealed class VerifyCommand
                     FromPath: from,
                     Mode: modeResult.Mode,
                     TimeoutMilliseconds: timeoutResult.TimeoutMilliseconds),
+                progressSink,
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = VerifyCommandResultFactory.Create(executionResult);

--- a/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
@@ -1,0 +1,63 @@
+using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+
+namespace MackySoft.Ucli.Hosting.Cli.Assurance;
+
+/// <summary> Projects verify progress payloads into human-readable text entries. </summary>
+internal sealed class VerifyProgressTextProjector : ICliCommandProgressTextProjector
+{
+    /// <inheritdoc />
+    public bool TryCreateTextEntry (
+        string eventName,
+        object payload,
+        out string text)
+    {
+        switch (eventName, payload)
+        {
+            case (VerifyProgressEventNames.StepStarted, VerifyStepProgressEntry entry):
+                text = CreateStepTextLine(entry, "started");
+                return true;
+            case (VerifyProgressEventNames.StepCompleted, VerifyStepProgressEntry entry):
+                text = CreateStepTextLine(entry, "completed");
+                return true;
+            case (VerifyProgressEventNames.StepSkipped, VerifyStepProgressEntry entry):
+                text = CreateStepTextLine(entry, "skipped");
+                return true;
+            case (VerifyProgressEventNames.Diagnostic, VerifyDiagnosticEntry entry):
+                text = CreateDiagnosticTextLine(entry);
+                return true;
+            default:
+                text = string.Empty;
+                return false;
+        }
+    }
+
+    private static string CreateStepTextLine (
+        VerifyStepProgressEntry entry,
+        string status)
+    {
+        return string.Concat(
+            "verify ",
+            entry.Kind,
+            " required=",
+            entry.Required ? "true" : "false",
+            " ",
+            status);
+    }
+
+    private static string CreateDiagnosticTextLine (VerifyDiagnosticEntry entry)
+    {
+        var step = string.IsNullOrWhiteSpace(entry.StepKind)
+            ? string.Empty
+            : string.Concat(" step=", entry.StepKind);
+        return string.Concat(
+            "verify diagnostic",
+            step,
+            " ",
+            entry.Severity,
+            " ",
+            entry.Code,
+            ": ",
+            entry.Message);
+    }
+}

--- a/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
@@ -8,10 +8,11 @@ namespace MackySoft.Ucli.Hosting.Cli.Assurance;
 internal sealed class VerifyProgressTextProjector : ICliCommandProgressTextProjector
 {
     /// <inheritdoc />
-    public bool TryCreateTextEntry (
+    public bool TryCreateTextEntry<TPayload> (
         string eventName,
-        object payload,
+        TPayload payload,
         out string text)
+        where TPayload : notnull
     {
         switch (eventName, payload)
         {

--- a/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/VerifyProgressTextProjector.cs
@@ -1,5 +1,6 @@
 using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+using MackySoft.Ucli.Infrastructure.Text;
 
 namespace MackySoft.Ucli.Hosting.Cli.Assurance;
 
@@ -36,28 +37,55 @@ internal sealed class VerifyProgressTextProjector : ICliCommandProgressTextProje
         VerifyStepProgressEntry entry,
         string status)
     {
-        return string.Concat(
-            "verify ",
-            entry.Kind,
-            " required=",
-            entry.Required ? "true" : "false",
-            " ",
-            status);
+        var required = entry.Required ? "true" : "false";
+        var length = checked(7 + entry.Kind.Length + 10 + required.Length + 1 + status.Length);
+        return string.Create(
+            length,
+            (entry.Kind, Required: required, Status: status),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append("verify ");
+                writer.Append(state.Kind);
+                writer.Append(" required=");
+                writer.Append(state.Required);
+                writer.Append(' ');
+                writer.Append(state.Status);
+            });
     }
 
     private static string CreateDiagnosticTextLine (VerifyDiagnosticEntry entry)
     {
-        var step = string.IsNullOrWhiteSpace(entry.StepKind)
-            ? string.Empty
-            : string.Concat(" step=", entry.StepKind);
-        return string.Concat(
-            "verify diagnostic",
-            step,
-            " ",
-            entry.Severity,
-            " ",
-            entry.Code,
-            ": ",
-            entry.Message);
+        var stepKind = entry.StepKind ?? string.Empty;
+        var hasStep = !string.IsNullOrWhiteSpace(stepKind);
+        var length = checked(
+            17
+            + (hasStep ? 6 + stepKind.Length : 0)
+            + 1
+            + entry.Severity.Length
+            + 1
+            + entry.Code.Length
+            + 2
+            + entry.Message.Length);
+
+        return string.Create(
+            length,
+            (HasStep: hasStep, StepKind: stepKind, entry.Severity, entry.Code, entry.Message),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append("verify diagnostic");
+                if (state.HasStep)
+                {
+                    writer.Append(" step=");
+                    writer.Append(state.StepKind);
+                }
+                writer.Append(' ');
+                writer.Append(state.Severity);
+                writer.Append(' ');
+                writer.Append(state.Code);
+                writer.Append(": ");
+                writer.Append(state.Message);
+            });
     }
 }

--- a/src/Ucli/Hosting/Cli/Common/Streaming/CliCommandProgressEntry.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/CliCommandProgressEntry.cs
@@ -2,7 +2,9 @@ namespace MackySoft.Ucli.Hosting.Cli.Common.Streaming;
 
 /// <summary> Represents one command progress entry before CLI stream formatting is applied. </summary>
 /// <param name="EventName"> The command-specific progress event name. </param>
+/// <typeparam name="TPayload"> The command-specific progress payload type. </typeparam>
 /// <param name="Payload"> The command-specific progress payload. </param>
-internal readonly record struct CliCommandProgressEntry (
+internal readonly record struct CliCommandProgressEntry<TPayload> (
     string EventName,
-    object Payload);
+    TPayload Payload)
+    where TPayload : notnull;

--- a/src/Ucli/Hosting/Cli/Common/Streaming/CliCommandProgressSink.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/CliCommandProgressSink.cs
@@ -21,14 +21,14 @@ internal sealed class CliCommandProgressSink : ICommandProgressSink
     }
 
     /// <inheritdoc />
-    public ValueTask OnEntryAsync (
+    public ValueTask OnEntryAsync<TPayload> (
         string eventName,
-        object payload,
+        TPayload payload,
         CancellationToken cancellationToken = default)
+        where TPayload : notnull
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
-        ArgumentNullException.ThrowIfNull(payload);
 
         if (format == CliStreamEntryFormat.Json)
         {

--- a/src/Ucli/Hosting/Cli/Common/Streaming/CliProgressTextFormatter.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/CliProgressTextFormatter.cs
@@ -1,0 +1,35 @@
+using MackySoft.Ucli.Infrastructure.Text;
+
+namespace MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+
+/// <summary> Formats small progress text entries with caller-specified delimiters. </summary>
+internal static class CliProgressTextFormatter
+{
+    /// <summary> Creates one text entry by joining an event name and payload text with a delimiter. </summary>
+    /// <typeparam name="TPayload"> The concrete event payload type. </typeparam>
+    public static string CreateDelimitedEntry<TPayload> (
+        string eventName,
+        string delimiter,
+        TPayload payload)
+        where TPayload : notnull
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
+        if (delimiter == null)
+        {
+            throw new ArgumentNullException(nameof(delimiter));
+        }
+
+        var payloadText = payload.ToString() ?? string.Empty;
+        var length = checked(eventName.Length + delimiter.Length + payloadText.Length);
+        return string.Create(
+            length,
+            (eventName, delimiter, payloadText),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(state.eventName);
+                writer.Append(state.delimiter);
+                writer.Append(state.payloadText);
+            });
+    }
+}

--- a/src/Ucli/Hosting/Cli/Common/Streaming/CliStreamEntryWriter.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/CliStreamEntryWriter.cs
@@ -36,12 +36,13 @@ internal sealed class CliStreamEntryWriter
     }
 
     /// <summary> Writes one JSON entry envelope as one NDJSON line. </summary>
-    public void WriteJsonEntry (
+    /// <typeparam name="TPayload"> The concrete event payload type. </typeparam>
+    public void WriteJsonEntry<TPayload> (
         string eventName,
-        object payload)
+        TPayload payload)
+        where TPayload : notnull
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(eventName);
-        ArgumentNullException.ThrowIfNull(payload);
 
         jsonBuffer.Clear();
         using (var writer = new Utf8JsonWriter(jsonBuffer))
@@ -54,7 +55,7 @@ internal sealed class CliStreamEntryWriter
             writer.WriteString("timestamp", timeProvider.GetUtcNow().ToString("O"));
             writer.WriteString("event", eventName);
             writer.WritePropertyName("payload");
-            JsonSerializer.Serialize(writer, payload, payload.GetType(), SerializerOptions);
+            JsonSerializer.Serialize(writer, payload, SerializerOptions);
             writer.WriteEndObject();
         }
 

--- a/src/Ucli/Hosting/Cli/Common/Streaming/ICliCommandProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Common/Streaming/ICliCommandProgressTextProjector.cs
@@ -4,12 +4,14 @@ namespace MackySoft.Ucli.Hosting.Cli.Common.Streaming;
 internal interface ICliCommandProgressTextProjector
 {
     /// <summary> Tries to create one text entry for the specified progress event. </summary>
+    /// <typeparam name="TPayload"> The concrete event payload type. </typeparam>
     /// <param name="eventName"> The command-specific event name. </param>
     /// <param name="payload"> The event payload. </param>
     /// <param name="text"> The unsanitized text entry when one should be emitted. </param>
     /// <returns> <see langword="true" /> when a text entry should be emitted; otherwise <see langword="false" />. </returns>
-    bool TryCreateTextEntry (
+    bool TryCreateTextEntry<TPayload> (
         string eventName,
-        object payload,
-        out string text);
+        TPayload payload,
+        out string text)
+        where TPayload : notnull;
 }

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
@@ -60,7 +60,7 @@ internal sealed class LogsDaemonReadCommand
         string? format = null,
         CancellationToken cancellationToken = default)
     {
-        return await LogsReadCommandExecutor.ExecuteAsync<IpcDaemonLogEvent>(
+        return await LogsReadCommandExecutor.ExecuteAsync<IpcDaemonLogEvent, JsonLinePayload>(
                 UcliCommandNames.LogsDaemonRead,
                 format,
                 commandResultWriter,
@@ -89,11 +89,11 @@ internal sealed class LogsDaemonReadCommand
     /// <summary> Creates one daemon-log progress entry. </summary>
     /// <param name="daemonLogEvent"> The daemon log event payload. </param>
     /// <param name="nextCursor"> The next cursor value returned by daemon. </param>
-    private static CliCommandProgressEntry CreateProgressEntry (
+    private static CliCommandProgressEntry<JsonLinePayload> CreateProgressEntry (
         IpcDaemonLogEvent daemonLogEvent,
         string nextCursor)
     {
-        return new CliCommandProgressEntry(
+        return new CliCommandProgressEntry<JsonLinePayload>(
             "logs.daemon.entry",
             new JsonLinePayload(
                 Timestamp: daemonLogEvent.Timestamp,
@@ -134,10 +134,11 @@ internal sealed class LogsDaemonReadCommand
 
     private sealed class TextProjector : ICliCommandProgressTextProjector
     {
-        public bool TryCreateTextEntry (
+        public bool TryCreateTextEntry<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             out string text)
+            where TPayload : notnull
         {
             if (payload is JsonLinePayload daemonLogEvent)
             {
@@ -145,7 +146,7 @@ internal sealed class LogsDaemonReadCommand
                 return true;
             }
 
-            text = string.Concat(eventName, " ", payload);
+            text = CliProgressTextFormatter.CreateDelimitedEntry(eventName, " ", payload);
             return true;
         }
     }
@@ -158,7 +159,7 @@ internal sealed class LogsDaemonReadCommand
     /// <param name="Raw"> The optional raw event payload. </param>
     /// <param name="Cursor"> The event cursor. </param>
     /// <param name="NextCursor"> The next incremental cursor. </param>
-    private sealed record JsonLinePayload (
+    private readonly record struct JsonLinePayload (
         string Timestamp,
         string Level,
         string Category,

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandExecutor.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandExecutor.cs
@@ -12,6 +12,7 @@ internal static class LogsReadCommandExecutor
 {
     /// <summary> Executes one logs read command and writes error envelopes when validation or service execution fails. </summary>
     /// <typeparam name="TLogEvent"> The streamed log event type. </typeparam>
+    /// <typeparam name="TPayload"> The emitted CLI progress payload type. </typeparam>
     /// <param name="commandName"> The command name used in emitted error envelopes. </param>
     /// <param name="format"> The requested output format. </param>
     /// <param name="commandResultWriter"> The command-result writer dependency. </param>
@@ -20,14 +21,15 @@ internal static class LogsReadCommandExecutor
     /// <param name="textProjector"> The text projection used when <paramref name="format" /> resolves to text. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The command exit code. </returns>
-    public static async Task<int> ExecuteAsync<TLogEvent> (
+    public static async Task<int> ExecuteAsync<TLogEvent, TPayload> (
         string commandName,
         string? format,
         ICommandResultWriter commandResultWriter,
         Func<Func<TLogEvent, string, CancellationToken, ValueTask>, CancellationToken, ValueTask<LogsReadServiceResult>> executeAsync,
-        Func<TLogEvent, string, CliCommandProgressEntry> createProgressEntry,
+        Func<TLogEvent, string, CliCommandProgressEntry<TPayload>> createProgressEntry,
         ICliCommandProgressTextProjector textProjector,
         CancellationToken cancellationToken)
+        where TPayload : notnull
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(commandName);
         ArgumentNullException.ThrowIfNull(commandResultWriter);

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
@@ -66,7 +66,7 @@ internal sealed class LogsUnityReadCommand
         string? format = null,
         CancellationToken cancellationToken = default)
     {
-        return await LogsReadCommandExecutor.ExecuteAsync<IpcUnityLogEvent>(
+        return await LogsReadCommandExecutor.ExecuteAsync<IpcUnityLogEvent, JsonLinePayload>(
                 UcliCommandNames.LogsUnityRead,
                 format,
                 commandResultWriter,
@@ -95,11 +95,11 @@ internal sealed class LogsUnityReadCommand
             .ConfigureAwait(false);
     }
 
-    private static CliCommandProgressEntry CreateProgressEntry (
+    private static CliCommandProgressEntry<JsonLinePayload> CreateProgressEntry (
         IpcUnityLogEvent unityLogEvent,
         string nextCursor)
     {
-        return new CliCommandProgressEntry(
+        return new CliCommandProgressEntry<JsonLinePayload>(
             "logs.unity.entry",
             new JsonLinePayload(
                 Timestamp: unityLogEvent.Timestamp,
@@ -147,10 +147,11 @@ internal sealed class LogsUnityReadCommand
 
     private sealed class TextProjector : ICliCommandProgressTextProjector
     {
-        public bool TryCreateTextEntry (
+        public bool TryCreateTextEntry<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             out string text)
+            where TPayload : notnull
         {
             if (payload is JsonLinePayload unityLogEvent)
             {
@@ -158,13 +159,13 @@ internal sealed class LogsUnityReadCommand
                 return true;
             }
 
-            text = string.Concat(eventName, " ", payload);
+            text = CliProgressTextFormatter.CreateDelimitedEntry(eventName, " ", payload);
             return true;
         }
     }
 
     /// <summary> Represents one NDJSON output line for Unity log events. </summary>
-    private sealed record JsonLinePayload (
+    private readonly record struct JsonLinePayload (
         string Timestamp,
         string Level,
         string Source,

--- a/src/Ucli/Hosting/Cli/Testing/TestRunProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Testing/TestRunProgressTextProjector.cs
@@ -8,10 +8,11 @@ namespace MackySoft.Ucli.Hosting.Cli.Testing;
 internal sealed class TestRunProgressTextProjector : ICliCommandProgressTextProjector
 {
     /// <inheritdoc />
-    public bool TryCreateTextEntry (
+    public bool TryCreateTextEntry<TPayload> (
         string eventName,
-        object payload,
+        TPayload payload,
         out string text)
+        where TPayload : notnull
     {
         switch (eventName, payload)
         {
@@ -26,7 +27,7 @@ internal sealed class TestRunProgressTextProjector : ICliCommandProgressTextProj
                 text = CreateDiagnosticTextLine(entry);
                 return true;
             default:
-                text = string.Concat(eventName, " ", payload);
+                text = CliProgressTextFormatter.CreateDelimitedEntry(eventName, " ", payload);
                 return true;
         }
     }

--- a/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
@@ -17,6 +17,8 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
+using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Testing;
 
@@ -46,6 +48,130 @@ public sealed class VerifyServiceTests
         Assert.DoesNotContain(
             result.Output.Verifiers.SelectMany(static verifier => verifier.Effects),
             static effect => VerifyEffectValues.Compile.Contains(effect, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithProgressSink_DoesNotChangeFinalOutput ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-verify", nameof(Execute_WithProgressSink_DoesNotChangeFinalOutput));
+        var input = new VerifyCommandInput(
+            ProjectPath: null,
+            Profile: "built-in:default",
+            ProfilePath: null,
+            FromPath: null,
+            Mode: UnityExecutionMode.Auto,
+            TimeoutMilliseconds: 10000);
+        var serviceWithoutProgress = CreateService(scope.FullPath);
+        var withoutProgress = await serviceWithoutProgress.ExecuteAsync(input);
+        var progressSink = new CollectingProgressSink();
+        var serviceWithProgress = CreateService(scope.FullPath);
+
+        var withProgress = await serviceWithProgress.ExecuteAsync(input, progressSink);
+
+        Assert.True(withoutProgress.IsSuccess);
+        Assert.True(withProgress.IsSuccess);
+        Assert.Equal(
+            JsonSerializer.Serialize(withoutProgress.Output),
+            JsonSerializer.Serialize(withProgress.Output));
+        Assert.NotEmpty(progressSink.Entries);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithConditionalStepsSkipped_EmitsSkipEntriesWithoutFinalVerifiers ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-verify", nameof(Execute_WithConditionalStepsSkipped_EmitsSkipEntriesWithoutFinalVerifiers));
+        var progressSink = new CollectingProgressSink();
+        var service = CreateService(scope.FullPath);
+
+        var result = await service.ExecuteAsync(
+            new VerifyCommandInput(
+                ProjectPath: null,
+                Profile: "built-in:default",
+                ProfilePath: null,
+                FromPath: null,
+                Mode: UnityExecutionMode.Auto,
+                TimeoutMilliseconds: 10000),
+            progressSink);
+
+        Assert.True(result.IsSuccess);
+        Assert.DoesNotContain(result.Output!.Verifiers, static verifier => string.Equals(verifier.Kind, VerifyStepKindValues.PostRead, StringComparison.Ordinal));
+        Assert.DoesNotContain(result.Output.Verifiers, static verifier => string.Equals(verifier.Kind, VerifyStepKindValues.Logs, StringComparison.Ordinal));
+        var skippedEntries = progressSink.Entries
+            .Where(static entry => string.Equals(entry.EventName, VerifyProgressEventNames.StepSkipped, StringComparison.Ordinal))
+            .Select(static entry => Assert.IsType<VerifyStepProgressEntry>(entry.Payload))
+            .ToArray();
+        Assert.Contains(skippedEntries, static entry =>
+            string.Equals(entry.Kind, VerifyStepKindValues.PostRead, StringComparison.Ordinal)
+            && string.Equals(entry.SkipReason, VerifyStepSkipReasons.PostReadNotNeeded, StringComparison.Ordinal));
+        Assert.Contains(skippedEntries, static entry =>
+            string.Equals(entry.Kind, VerifyStepKindValues.Logs, StringComparison.Ordinal)
+            && string.Equals(entry.SkipReason, VerifyStepSkipReasons.LogsNotNeeded, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenStepFails_EmitsDiagnosticWithoutVerifyCompleted ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-verify", nameof(Execute_WhenStepFails_EmitsDiagnosticWithoutVerifyCompleted));
+        var progressSink = new CollectingProgressSink();
+        var compileService = new StubCompileService(_ => CompileExecutionResult.Failure(
+            ExecutionError.InternalError("Compile command failed.")));
+        var service = CreateService(scope.FullPath, compileService: compileService);
+
+        var result = await service.ExecuteAsync(
+            new VerifyCommandInput(
+                ProjectPath: null,
+                Profile: "built-in:script",
+                ProfilePath: null,
+                FromPath: null,
+                Mode: UnityExecutionMode.Auto,
+                TimeoutMilliseconds: 10000),
+            progressSink);
+
+        Assert.False(result.IsSuccess);
+        Assert.DoesNotContain(progressSink.Entries, static entry => string.Equals(entry.EventName, VerifyProgressEventNames.Completed, StringComparison.Ordinal));
+        var diagnosticEntry = Assert.Single(progressSink.Entries, static entry => string.Equals(entry.EventName, VerifyProgressEventNames.Diagnostic, StringComparison.Ordinal));
+        var diagnostic = Assert.IsType<VerifyDiagnosticEntry>(diagnosticEntry.Payload);
+        Assert.Equal(VerifyStepKindValues.Compile, diagnostic.StepKind);
+        Assert.Equal("error", diagnostic.Severity);
+        Assert.Equal("Compile command failed.", diagnostic.Message);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithUnsupportedProfileStep_DoesNotEmitUnknownStepEntry ()
+    {
+        using var scope = TestDirectories.CreateTempScope("ucli-verify", nameof(Execute_WithUnsupportedProfileStep_DoesNotEmitUnknownStepEntry));
+        scope.WriteFile(
+            "verify.json",
+            """
+            {
+              "schemaVersion": 1,
+              "steps": [
+                {
+                  "kind": "external",
+                  "required": true
+                }
+              ]
+            }
+            """);
+        var progressSink = new CollectingProgressSink();
+        var service = CreateService(scope.FullPath);
+
+        var result = await service.ExecuteAsync(
+            new VerifyCommandInput(
+                ProjectPath: null,
+                Profile: null,
+                ProfilePath: "verify.json",
+                FromPath: null,
+                Mode: UnityExecutionMode.Auto,
+                TimeoutMilliseconds: 10000),
+            progressSink);
+
+        Assert.False(result.IsSuccess);
+        Assert.Empty(progressSink.Entries);
     }
 
     [Fact]
@@ -1189,4 +1315,25 @@ public sealed class VerifyServiceTests
             return ValueTask.FromResult(resultFactory(fromPath, repositoryRoot));
         }
     }
+
+    private sealed class CollectingProgressSink : ICommandProgressSink
+    {
+        private readonly List<ProgressEntry> entries = [];
+
+        public IReadOnlyList<ProgressEntry> Entries => entries;
+
+        public ValueTask OnEntryAsync (
+            string eventName,
+            object payload,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            entries.Add(new ProgressEntry(eventName, payload));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed record ProgressEntry (
+        string EventName,
+        object Payload);
 }

--- a/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
@@ -1322,10 +1322,11 @@ public sealed class VerifyServiceTests
 
         public IReadOnlyList<ProgressEntry> Entries => entries;
 
-        public ValueTask OnEntryAsync (
+        public ValueTask OnEntryAsync<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             CancellationToken cancellationToken = default)
+            where TPayload : notnull
         {
             cancellationToken.ThrowIfCancellationRequested();
             entries.Add(new ProgressEntry(eventName, payload));

--- a/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Testing/Run/UseCases/TestRun/TestRunServiceTests.cs
@@ -1382,10 +1382,11 @@ public sealed class TestRunServiceTests
 
         public IReadOnlyList<ProgressEntry> Entries => entries;
 
-        public ValueTask OnEntryAsync (
+        public ValueTask OnEntryAsync<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             CancellationToken cancellationToken = default)
+            where TPayload : notnull
         {
             cancellationToken.ThrowIfCancellationRequested();
             entries.Add(new ProgressEntry(eventName, payload));

--- a/tests/Ucli.Application.Tests/Shared/Execution/Progress/NullCommandProgressSinkTests.cs
+++ b/tests/Ucli.Application.Tests/Shared/Execution/Progress/NullCommandProgressSinkTests.cs
@@ -8,7 +8,7 @@ public sealed class NullCommandProgressSinkTests
     [Trait("Size", "Small")]
     public async Task OnEntryAsync_WithInvalidEntry_IgnoresEntry ()
     {
-        await NullCommandProgressSink.Instance.OnEntryAsync(
+        await NullCommandProgressSink.Instance.OnEntryAsync<object>(
             string.Empty,
             null!,
             CancellationToken.None);
@@ -22,7 +22,7 @@ public sealed class NullCommandProgressSinkTests
         await cancellationTokenSource.CancelAsync();
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => NullCommandProgressSink.Instance
-            .OnEntryAsync(
+            .OnEntryAsync<object>(
                 string.Empty,
                 null!,
                 cancellationTokenSource.Token)

--- a/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcPayloadCodecContractTests.cs
+++ b/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcPayloadCodecContractTests.cs
@@ -54,6 +54,22 @@ public sealed class IpcPayloadCodecContractTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void TryDeserialize_WithNullLiteralForStructPayload_ReturnsNullPayloadError ()
+    {
+        using var document = JsonDocument.Parse("null");
+
+        var result = IpcPayloadCodec.TryDeserialize(
+            document.RootElement,
+            out StructPayload payload,
+            out var error);
+
+        Assert.False(result);
+        Assert.Equal(default, payload);
+        Assert.Equal(IpcPayloadReadErrorKind.NullPayload, error.Kind);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void TryDeserialize_WithInvalidShape_ReturnsDeserializeFailed ()
     {
         using var document = JsonDocument.Parse("""{"serverVersion":123}""");
@@ -140,6 +156,8 @@ public sealed class IpcPayloadCodecContractTests
     private sealed record PayloadEnvelope (string ServerVersion);
 
     private sealed record RejectingValueEnvelope (RejectingStringValue Value);
+
+    private readonly record struct StructPayload (string ServerVersion);
 
     private sealed record RejectingStringValue : UcliStringValue
     {

--- a/tests/Ucli.Tests/Hosting/Cli/Common/Streaming/CliCommandProgressSinkTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/Common/Streaming/CliCommandProgressSinkTests.cs
@@ -79,22 +79,24 @@ public sealed class CliCommandProgressSinkTests
 
     private sealed class EchoTextProjector : ICliCommandProgressTextProjector
     {
-        public bool TryCreateTextEntry (
+        public bool TryCreateTextEntry<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             out string text)
+            where TPayload : notnull
         {
-            text = string.Concat(eventName, ": ", payload);
+            text = CliProgressTextFormatter.CreateDelimitedEntry(eventName, ": ", payload);
             return true;
         }
     }
 
     private sealed class SuppressingTextProjector : ICliCommandProgressTextProjector
     {
-        public bool TryCreateTextEntry (
+        public bool TryCreateTextEntry<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             out string text)
+            where TPayload : notnull
         {
             text = string.Empty;
             return false;
@@ -103,10 +105,11 @@ public sealed class CliCommandProgressSinkTests
 
     private sealed class ThrowingTextProjector : ICliCommandProgressTextProjector
     {
-        public bool TryCreateTextEntry (
+        public bool TryCreateTextEntry<TPayload> (
             string eventName,
-            object payload,
+            TPayload payload,
             out string text)
+            where TPayload : notnull
         {
             throw new InvalidOperationException("Text projector must not be used for JSON entries.");
         }

--- a/tests/Ucli.Tests/Hosting/Cli/VerifyCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/VerifyCommandTests.cs
@@ -1,9 +1,12 @@
+using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance.Ready;
 using MackySoft.Ucli.Application.Features.Assurance.Verify.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Verify.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Verify.Vocabulary;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Assurance;
 using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
@@ -195,6 +198,105 @@ public sealed class VerifyCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Verify_WithJsonFormat_WritesProgressEntriesToStandardErrorAndFinalResultToStandardOutput ()
+    {
+        var service = new StubVerifyService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                    VerifyProgressEventNames.StepStarted,
+                    new VerifyStepProgressEntry(
+                        VerifyStepKindValues.Ready,
+                        Required: true,
+                        Effects: [],
+                        SkipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await progressSink.OnEntryAsync(
+                    VerifyProgressEventNames.StepCompleted,
+                    new VerifyStepProgressEntry(
+                        VerifyStepKindValues.Ready,
+                        Required: true,
+                        Effects: [],
+                        SkipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return VerifyExecutionResult.Success(CreateOutput());
+        });
+        var command = new VerifyCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.VerifyAsync(
+            format: "json",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Verify,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        var lines = standardError.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        using var startedEntry = JsonDocument.Parse(lines[0]);
+        using var completedEntry = JsonDocument.Parse(lines[1]);
+        AssertVerifyStreamEnvelope(startedEntry.RootElement, sequence: 1, VerifyProgressEventNames.StepStarted);
+        AssertVerifyStreamEnvelope(completedEntry.RootElement, sequence: 2, VerifyProgressEventNames.StepCompleted);
+        Assert.Equal(VerifyStepKindValues.Ready, startedEntry.RootElement.GetProperty("payload").GetProperty("kind").GetString());
+        Assert.True(startedEntry.RootElement.GetProperty("payload").GetProperty("required").GetBoolean());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Verify_WithDefaultFormat_WritesTextProgressToStandardError ()
+    {
+        var service = new StubVerifyService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                    VerifyProgressEventNames.StepStarted,
+                    new VerifyStepProgressEntry(VerifyStepKindValues.Ready, Required: true, Effects: [], SkipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await progressSink.OnEntryAsync(
+                    VerifyProgressEventNames.StepCompleted,
+                    new VerifyStepProgressEntry(VerifyStepKindValues.Ready, Required: true, Effects: [], SkipReason: null),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await progressSink.OnEntryAsync(
+                    VerifyProgressEventNames.StepSkipped,
+                    new VerifyStepProgressEntry(VerifyStepKindValues.PostRead, Required: false, Effects: [], SkipReason: VerifyStepSkipReasons.PostReadNotNeeded),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await progressSink.OnEntryAsync(
+                    VerifyProgressEventNames.Diagnostic,
+                    new VerifyDiagnosticEntry("VERIFY_STUB", "stub diagnostic", "error", VerifyStepKindValues.Compile),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return VerifyExecutionResult.Success(CreateOutput());
+        });
+        var command = new VerifyCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.VerifyAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Verify,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        Assert.Equal(
+            "verify ready required=true started" + Environment.NewLine
+                + "verify ready required=true completed" + Environment.NewLine
+                + "verify postRead required=false skipped" + Environment.NewLine
+                + "verify diagnostic step=compile error VERIFY_STUB: stub diagnostic" + Environment.NewLine,
+            standardError);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Verify_WhenFormatIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
     {
         var service = new StubVerifyService((_, _) => throw new InvalidOperationException("Service should not be called."));
@@ -236,6 +338,20 @@ public sealed class VerifyCommandTests
             IpcProtocol.StatusOk,
             1);
         Assert.Equal(verdict, outputJson.RootElement.GetProperty("payload").GetProperty("verdict").GetString());
+    }
+
+    private static void AssertVerifyStreamEnvelope (
+        JsonElement root,
+        int sequence,
+        string eventName)
+    {
+        Assert.Equal(1, root.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(UcliCommandNames.Verify, root.GetProperty("command").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("streamId").GetString()));
+        Assert.Equal(sequence, root.GetProperty("sequence").GetInt32());
+        Assert.True(DateTimeOffset.TryParse(root.GetProperty("timestamp").GetString(), out _));
+        Assert.Equal(eventName, root.GetProperty("event").GetString());
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("payload").ValueKind);
     }
 
     private static VerifyExecutionOutput CreateOutput (
@@ -337,24 +453,33 @@ public sealed class VerifyCommandTests
 
     private sealed class StubVerifyService : IVerifyService
     {
-        private readonly Func<VerifyCommandInput, CancellationToken, ValueTask<VerifyExecutionResult>> handler;
+        private readonly Func<VerifyCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<VerifyExecutionResult>> handler;
 
         public StubVerifyService (Func<VerifyCommandInput, CancellationToken, ValueTask<VerifyExecutionResult>> handler)
+            : this((input, _, cancellationToken) => handler(input, cancellationToken))
+        {
+        }
+
+        public StubVerifyService (Func<VerifyCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<VerifyExecutionResult>> handler)
         {
             this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
         public VerifyCommandInput? CapturedInput { get; private set; }
 
+        public ICommandProgressSink? CapturedProgressSink { get; private set; }
+
         public CancellationToken CapturedCancellationToken { get; private set; }
 
         public ValueTask<VerifyExecutionResult> ExecuteAsync (
             VerifyCommandInput input,
+            ICommandProgressSink? progressSink = null,
             CancellationToken cancellationToken = default)
         {
             CapturedInput = input;
+            CapturedProgressSink = progressSink;
             CapturedCancellationToken = cancellationToken;
-            return handler(input, cancellationToken);
+            return handler(input, progressSink, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add an optional profile step progress stream for `ucli verify` using the shared command progress sink.
- Keep the final `CommandResult` on stdout while writing text or NDJSON progress entries to stderr.
- Preserve final verify payload authority for verdict, claims, reports, and residual risks.

## Scope
- Verify service now accepts an optional progress sink and emits the closed verify event set around profile step execution.
- CLI verify command wires `--format text|json` into `CliCommandProgressSink` with a verify text projector.
- Public verify progress payload contracts were added under `Ucli.Contracts`.
- Service and CLI tests cover final-output stability, skipped conditional steps, diagnostics, unknown step kind suppression, JSON stderr, and text stderr.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`, `bash scripts/code-quality.sh verify --include ...`)
- Tests: PASS (`bash scripts/verify.sh`, 1573 tests)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to verify progress streaming and CLI stderr projection; stdout final result remains the compatibility boundary.
- Rollback by reverting the two commits on this branch.
- The uCLI property reference was updated in the separate assurance workspace because that document is outside this repository.

## Checklist
- [x] Verify progress stream uses the closed event set.
- [x] JSON format writes NDJSON entries to stderr and final result to stdout.
- [x] Text format writes one-line step progress to stderr.
- [x] Invalid format remains a command failure before service execution.

Closes #362
