### PR TITLE
feat(compile): stream host-side progress entries

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Compile/Contracts/ICompileService.cs
+++ b/src/Ucli.Application/Features/Assurance/Compile/Contracts/ICompileService.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
+
 namespace MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 
 /// <summary> Executes compile assurance probes and produces compile claim packets. </summary>
@@ -5,9 +7,11 @@ internal interface ICompileService
 {
     /// <summary> Executes one compile assurance command. </summary>
     /// <param name="input"> The compile command input. </param>
+    /// <param name="progressSink"> The optional progress sink that receives public compile stream entries. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The compile execution result. </returns>
     ValueTask<CompileExecutionResult> ExecuteAsync (
         CompileCommandInput input,
+        ICommandProgressSink? progressSink = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Ucli.Application/Features/Assurance/Compile/Execution/CompileService.cs
+++ b/src/Ucli.Application/Features/Assurance/Compile/Execution/CompileService.cs
@@ -3,6 +3,8 @@ using MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Vocabulary;
 using MackySoft.Ucli.Application.Shared.Context;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Contracts.Text;
@@ -16,6 +18,7 @@ internal sealed class CompileService : ICompileService
     private const string SummaryReportRef = "compile.summary";
     private const string DiagnosticsReportRef = "compile.diagnostics";
     private const string RefreshOriginDiagnosticsRead = "diagnosticsRead";
+    private const string ProgressObservationSourceHostDispatch = "hostDispatch";
     private const string UnknownGeneration = "unknown";
 
     private static readonly IReadOnlyList<CompileResidualRiskOutput> EmptyResidualRisks =
@@ -53,11 +56,13 @@ internal sealed class CompileService : ICompileService
     /// <inheritdoc />
     public async ValueTask<CompileExecutionResult> ExecuteAsync (
         CompileCommandInput input,
+        ICommandProgressSink? progressSink = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(input);
         cancellationToken.ThrowIfCancellationRequested();
 
+        var resolvedProgressSink = progressSink ?? NullCommandProgressSink.Instance;
         var contextResult = await projectContextResolver.ResolveAsync(input.ProjectPath, cancellationToken).ConfigureAwait(false);
         if (!contextResult.IsSuccess)
         {
@@ -109,12 +114,23 @@ internal sealed class CompileService : ICompileService
         }
 
         var runId = runIdFactory.Create();
+        await EmitStartedAsync(
+                resolvedProgressSink,
+                runId,
+                project,
+                requestedMode,
+                executionTarget,
+                timeout,
+                cancellationToken)
+            .ConfigureAwait(false);
+        await EmitRefreshStartedAsync(resolvedProgressSink, runId, cancellationToken).ConfigureAwait(false);
         var responseSummary = await DispatchCompileAsync(
                 context,
                 project,
                 ResolveExecutionMode(executionTarget),
                 requestTimeout,
                 runId,
+                resolvedProgressSink,
                 cancellationToken)
             .ConfigureAwait(false);
         if (!responseSummary.IsSuccess && !responseSummary.ShouldReadArtifact)
@@ -139,6 +155,14 @@ internal sealed class CompileService : ICompileService
             }
 
             summary = artifactResult.Summary!;
+            await EmitRecoveredAsync(
+                    resolvedProgressSink,
+                    summary,
+                    artifactStore.ResolveSummaryPath(context.UnityProject, runId),
+                    responseSummary.FailureInfo,
+                    artifactResult.PollAttempts,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         var completedSummary = summary ?? throw new InvalidOperationException("Compile summary was not resolved.");
@@ -152,14 +176,23 @@ internal sealed class CompileService : ICompileService
             return CompileExecutionResult.Failure(summaryValidationFailure, project);
         }
 
+        var summaryJsonPath = artifactStore.ResolveSummaryPath(context.UnityProject, runId);
+        var diagnosticsJsonPath = artifactStore.ResolveDiagnosticsPath(context.UnityProject, runId);
         var output = CreateOutput(
             project,
             requestedMode,
             executionTarget,
             timeout,
             completedSummary,
-            artifactStore.ResolveSummaryPath(context.UnityProject, runId),
-            artifactStore.ResolveDiagnosticsPath(context.UnityProject, runId));
+            summaryJsonPath,
+            diagnosticsJsonPath);
+        await EmitCompletedAsync(
+                resolvedProgressSink,
+                output,
+                summaryJsonPath,
+                diagnosticsJsonPath,
+                cancellationToken)
+            .ConfigureAwait(false);
         return CompileExecutionResult.Success(output);
     }
 
@@ -169,6 +202,7 @@ internal sealed class CompileService : ICompileService
         UnityExecutionMode mode,
         TimeSpan requestTimeout,
         string runId,
+        ICommandProgressSink progressSink,
         CancellationToken cancellationToken)
     {
         var executionResult = await unityRequestExecutor.ExecuteAsync(
@@ -200,6 +234,7 @@ internal sealed class CompileService : ICompileService
                     return CompileDispatchResult.Failure(ApplicationFailure.FromExecutionError(writeError));
                 }
 
+                await EmitDiagnosticAsync(progressSink, diagnosticsReadSummary!, cancellationToken).ConfigureAwait(false);
                 return CompileDispatchResult.Success(diagnosticsReadSummary!);
             }
 
@@ -271,10 +306,12 @@ internal sealed class CompileService : ICompileService
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
+        var pollAttempts = 0;
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            pollAttempts++;
             var readResult = await artifactStore.ReadSummaryAsync(unityProject, runId, cancellationToken).ConfigureAwait(false);
             if (readResult.IsSuccess)
             {
@@ -286,28 +323,114 @@ internal sealed class CompileService : ICompileService
                     requireCompleted: false);
                 if (summaryValidationFailure != null)
                 {
-                    return CompileSummaryPollResult.Failure(summaryValidationFailure);
+                    return CompileSummaryPollResult.Failure(summaryValidationFailure, pollAttempts);
                 }
 
                 if (summary.Completed)
                 {
-                    return CompileSummaryPollResult.Success(summary);
+                    return CompileSummaryPollResult.Success(summary, pollAttempts);
                 }
             }
             else if (!readResult.IsMissing)
             {
-                return CompileSummaryPollResult.Failure(ApplicationFailure.FromExecutionError(readResult.Error!));
+                return CompileSummaryPollResult.Failure(ApplicationFailure.FromExecutionError(readResult.Error!), pollAttempts);
             }
 
             if (!deadline.TryGetRemainingTimeout(out var remainingTimeout))
             {
                 return CompileSummaryPollResult.Failure(dispatchFailure ?? ApplicationFailure.Timeout(
                     $"Unity compile assurance timed out after {timeout.TotalMilliseconds:0} milliseconds.",
-                    ExecutionErrorCodes.IpcTimeout));
+                    ExecutionErrorCodes.IpcTimeout), pollAttempts);
             }
 
             await TimeProviderDelay.DelayAsync(GetRetryDelay(remainingTimeout), timeProvider, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static ValueTask EmitStartedAsync (
+        ICommandProgressSink progressSink,
+        string runId,
+        ProjectIdentityInfo project,
+        UnityExecutionMode requestedMode,
+        UnityExecutionTarget executionTarget,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        return progressSink.OnEntryAsync(
+            CompileProgressEventNames.Started,
+            new CompileStartedEntry(
+                RunId: runId,
+                ProjectFingerprint: project.ProjectFingerprint,
+                RequestedMode: AssuranceExecutionModeCodec.ToRequestedModeValue(requestedMode),
+                ResolvedMode: AssuranceExecutionModeCodec.ToResolvedModeValue(executionTarget),
+                SessionKind: AssuranceExecutionModeCodec.ToSessionKindValue(executionTarget),
+                TimeoutMilliseconds: checked((int)timeout.TotalMilliseconds)),
+            cancellationToken);
+    }
+
+    private static ValueTask EmitRefreshStartedAsync (
+        ICommandProgressSink progressSink,
+        string runId,
+        CancellationToken cancellationToken)
+    {
+        return progressSink.OnEntryAsync(
+            CompileProgressEventNames.RefreshStarted,
+            new CompileRefreshStartedEntry(
+                RunId: runId,
+                RefreshOrigin: CompileEffectValues.AssetDatabaseRefresh,
+                ObservationSource: ProgressObservationSourceHostDispatch),
+            cancellationToken);
+    }
+
+    private static ValueTask EmitDiagnosticAsync (
+        ICommandProgressSink progressSink,
+        IpcCompileSummary summary,
+        CancellationToken cancellationToken)
+    {
+        return progressSink.OnEntryAsync(
+            CompileProgressEventNames.Diagnostic,
+            new CompileDiagnosticEntry(
+                RunId: summary.RunId,
+                RefreshOrigin: RefreshOriginDiagnosticsRead,
+                PrimaryDiagnostic: summary.ScriptCompilation.Diagnostics.PrimaryDiagnostic),
+            cancellationToken);
+    }
+
+    private static ValueTask EmitRecoveredAsync (
+        ICommandProgressSink progressSink,
+        IpcCompileSummary summary,
+        string summaryJsonPath,
+        ApplicationFailure? dispatchFailure,
+        int pollAttempts,
+        CancellationToken cancellationToken)
+    {
+        return progressSink.OnEntryAsync(
+            CompileProgressEventNames.Recovered,
+            new CompileRecoveredEntry(
+                RunId: summary.RunId,
+                SummaryJsonPath: summaryJsonPath,
+                DispatchFailureCode: dispatchFailure?.Code.Value,
+                PollAttempts: pollAttempts),
+            cancellationToken);
+    }
+
+    private static ValueTask EmitCompletedAsync (
+        ICommandProgressSink progressSink,
+        CompileExecutionOutput output,
+        string summaryJsonPath,
+        string diagnosticsJsonPath,
+        CancellationToken cancellationToken)
+    {
+        return progressSink.OnEntryAsync(
+            CompileProgressEventNames.Completed,
+            new CompileCompletedEntry(
+                RunId: output.Compile.RunId,
+                Verdict: output.Verdict,
+                ErrorCount: output.Compile.ScriptCompilation.Diagnostics.ErrorCount,
+                WarningCount: output.Compile.ScriptCompilation.Diagnostics.WarningCount,
+                SummaryJsonPath: summaryJsonPath,
+                DiagnosticsJsonPath: diagnosticsJsonPath),
+            cancellationToken);
     }
 
     private static CompileExecutionOutput CreateOutput (
@@ -710,20 +833,25 @@ internal sealed class CompileService : ICompileService
 
     private sealed record CompileSummaryPollResult (
         IpcCompileSummary? Summary,
-        ApplicationFailure? FailureInfo)
+        ApplicationFailure? FailureInfo,
+        int PollAttempts)
     {
         public bool IsSuccess => Summary != null && FailureInfo == null;
 
-        public static CompileSummaryPollResult Success (IpcCompileSummary summary)
+        public static CompileSummaryPollResult Success (
+            IpcCompileSummary summary,
+            int pollAttempts)
         {
             ArgumentNullException.ThrowIfNull(summary);
-            return new CompileSummaryPollResult(summary, null);
+            return new CompileSummaryPollResult(summary, null, pollAttempts);
         }
 
-        public static CompileSummaryPollResult Failure (ApplicationFailure failure)
+        public static CompileSummaryPollResult Failure (
+            ApplicationFailure failure,
+            int pollAttempts)
         {
             ArgumentNullException.ThrowIfNull(failure);
-            return new CompileSummaryPollResult(null, failure);
+            return new CompileSummaryPollResult(null, failure, pollAttempts);
         }
     }
 }

--- a/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
+++ b/src/Ucli.Application/Features/Assurance/Verify/Execution/VerifyService.cs
@@ -378,6 +378,7 @@ internal sealed class VerifyService : IVerifyService
                     ProjectPath: input.ProjectPath,
                     Mode: input.Mode,
                     TimeoutMilliseconds: ToTimeoutMilliseconds(timeout)),
+                progressSink: null,
                 cancellationToken)
             .ConfigureAwait(false);
         if (!result.IsSuccess)

--- a/src/Ucli.Contracts/Assurance/Compile/CompileCompletedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileCompletedEntry.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>compile.completed</c> stream payload. </summary>
+public sealed record CompileCompletedEntry (
+    string RunId,
+    string Verdict,
+    int ErrorCount,
+    int WarningCount,
+    string SummaryJsonPath,
+    string DiagnosticsJsonPath);

--- a/src/Ucli.Contracts/Assurance/Compile/CompileDiagnosticEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileDiagnosticEntry.cs
@@ -1,0 +1,9 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>compile.diagnostic</c> stream payload. </summary>
+public sealed record CompileDiagnosticEntry (
+    string RunId,
+    string RefreshOrigin,
+    IpcPrimaryDiagnostic? PrimaryDiagnostic);

--- a/src/Ucli.Contracts/Assurance/Compile/CompileProgressEventNames.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileProgressEventNames.cs
@@ -1,0 +1,20 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Defines the closed <c>compile</c> stream event set. </summary>
+public static class CompileProgressEventNames
+{
+    /// <summary> Gets the event emitted after compile run identity and execution target are established. </summary>
+    public const string Started = "compile.started";
+
+    /// <summary> Gets the event emitted when the host starts dispatching the compile refresh request. </summary>
+    public const string RefreshStarted = "compile.refresh.started";
+
+    /// <summary> Gets the event emitted when a completed summary is recovered from artifacts. </summary>
+    public const string Recovered = "compile.recovered";
+
+    /// <summary> Gets the event emitted when startup diagnosis is projected into a diagnostics-read summary. </summary>
+    public const string Diagnostic = "compile.diagnostic";
+
+    /// <summary> Gets the event emitted after the final compile payload has been built. </summary>
+    public const string Completed = "compile.completed";
+}

--- a/src/Ucli.Contracts/Assurance/Compile/CompileRecoveredEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileRecoveredEntry.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>compile.recovered</c> stream payload. </summary>
+public sealed record CompileRecoveredEntry (
+    string RunId,
+    string SummaryJsonPath,
+    string? DispatchFailureCode,
+    int PollAttempts);

--- a/src/Ucli.Contracts/Assurance/Compile/CompileRefreshStartedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileRefreshStartedEntry.cs
@@ -1,0 +1,7 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>compile.refresh.started</c> stream payload. </summary>
+public sealed record CompileRefreshStartedEntry (
+    string RunId,
+    string RefreshOrigin,
+    string ObservationSource);

--- a/src/Ucli.Contracts/Assurance/Compile/CompileStartedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Compile/CompileStartedEntry.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Contracts.Assurance;
+
+/// <summary> Represents the <c>compile.started</c> stream payload. </summary>
+public sealed record CompileStartedEntry (
+    string RunId,
+    string ProjectFingerprint,
+    string RequestedMode,
+    string ResolvedMode,
+    string SessionKind,
+    int TimeoutMilliseconds);

--- a/src/Ucli/Hosting/Cli/Assurance/CompileCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/CompileCommand.cs
@@ -2,6 +2,7 @@ using ConsoleAppFramework;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Hosting.Cli.Common.Execution;
+using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
 using MackySoft.Ucli.Hosting.Cli.Options;
 
 namespace MackySoft.Ucli.Hosting.Cli.Assurance;
@@ -65,11 +66,16 @@ internal sealed class CompileCommand
             return errorResult.ExitCode;
         }
 
+        var progressSink = new CliCommandProgressSink(
+            formatResult.Format,
+            new CliStreamEntryWriter(UcliCommandNames.Compile),
+            new CompileProgressTextProjector());
         var executionResult = await compileService.ExecuteAsync(
                 new CompileCommandInput(
                     ProjectPath: projectPath,
                     Mode: modeResult.Mode,
                     TimeoutMilliseconds: timeoutResult.TimeoutMilliseconds),
+                progressSink,
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = CompileCommandResultFactory.Create(executionResult);

--- a/src/Ucli/Hosting/Cli/Assurance/CompileProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/CompileProgressTextProjector.cs
@@ -1,0 +1,252 @@
+using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Hosting.Cli.Common.Streaming;
+using MackySoft.Ucli.Infrastructure.Text;
+
+namespace MackySoft.Ucli.Hosting.Cli.Assurance;
+
+/// <summary> Projects compile progress payloads into human-readable text entries. </summary>
+internal sealed class CompileProgressTextProjector : ICliCommandProgressTextProjector
+{
+    /// <inheritdoc />
+    public bool TryCreateTextEntry<TPayload> (
+        string eventName,
+        TPayload payload,
+        out string text)
+        where TPayload : notnull
+    {
+        switch (eventName, payload)
+        {
+            case (CompileProgressEventNames.Started, CompileStartedEntry entry):
+                text = CreateStartedText(entry);
+                return true;
+            case (CompileProgressEventNames.RefreshStarted, CompileRefreshStartedEntry entry):
+                text = CreateRefreshStartedText(entry);
+                return true;
+            case (CompileProgressEventNames.Recovered, CompileRecoveredEntry entry):
+                text = CreateRecoveredText(entry);
+                return true;
+            case (CompileProgressEventNames.Diagnostic, CompileDiagnosticEntry entry):
+                text = CreateDiagnosticText(entry);
+                return true;
+            case (CompileProgressEventNames.Completed, CompileCompletedEntry entry):
+                text = CreateCompletedText(entry);
+                return true;
+            default:
+                text = CliProgressTextFormatter.CreateDelimitedEntry(eventName, " ", payload);
+                return true;
+        }
+    }
+
+    private static string CreateStartedText (CompileStartedEntry entry)
+    {
+        const string Prefix = "compile runId=";
+        const string RequestedModeLabel = " requestedMode=";
+        const string ResolvedModeLabel = " resolvedMode=";
+        const string SessionKindLabel = " sessionKind=";
+        const string TimeoutLabel = " timeoutMs=";
+        const string Status = " started";
+
+        var timeoutLength = GetInt64TextLength(entry.TimeoutMilliseconds);
+        var length = checked(Prefix.Length
+            + entry.RunId.Length
+            + RequestedModeLabel.Length
+            + entry.RequestedMode.Length
+            + ResolvedModeLabel.Length
+            + entry.ResolvedMode.Length
+            + SessionKindLabel.Length
+            + entry.SessionKind.Length
+            + TimeoutLabel.Length
+            + timeoutLength
+            + Status.Length);
+        return string.Create(
+            length,
+            entry,
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(Prefix);
+                writer.Append(state.RunId);
+                writer.Append(RequestedModeLabel);
+                writer.Append(state.RequestedMode);
+                writer.Append(ResolvedModeLabel);
+                writer.Append(state.ResolvedMode);
+                writer.Append(SessionKindLabel);
+                writer.Append(state.SessionKind);
+                writer.Append(TimeoutLabel);
+                writer.AppendInvariant(state.TimeoutMilliseconds);
+                writer.Append(Status);
+            });
+    }
+
+    private static string CreateRefreshStartedText (CompileRefreshStartedEntry entry)
+    {
+        const string Prefix = "compile refresh runId=";
+        const string OriginLabel = " refreshOrigin=";
+        const string SourceLabel = " observationSource=";
+        const string Status = " started";
+
+        var length = checked(Prefix.Length
+            + entry.RunId.Length
+            + OriginLabel.Length
+            + entry.RefreshOrigin.Length
+            + SourceLabel.Length
+            + entry.ObservationSource.Length
+            + Status.Length);
+        return string.Create(
+            length,
+            entry,
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(Prefix);
+                writer.Append(state.RunId);
+                writer.Append(OriginLabel);
+                writer.Append(state.RefreshOrigin);
+                writer.Append(SourceLabel);
+                writer.Append(state.ObservationSource);
+                writer.Append(Status);
+            });
+    }
+
+    private static string CreateRecoveredText (CompileRecoveredEntry entry)
+    {
+        const string Prefix = "compile recovery runId=";
+        const string PollsLabel = " pollAttempts=";
+        const string SummaryLabel = " summaryJsonPath=";
+        const string Status = " recovered";
+
+        var pollAttemptsLength = GetInt64TextLength(entry.PollAttempts);
+        var length = checked(Prefix.Length
+            + entry.RunId.Length
+            + PollsLabel.Length
+            + pollAttemptsLength
+            + SummaryLabel.Length
+            + entry.SummaryJsonPath.Length
+            + Status.Length);
+        return string.Create(
+            length,
+            entry,
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(Prefix);
+                writer.Append(state.RunId);
+                writer.Append(PollsLabel);
+                writer.AppendInvariant(state.PollAttempts);
+                writer.Append(SummaryLabel);
+                writer.Append(state.SummaryJsonPath);
+                writer.Append(Status);
+            });
+    }
+
+    private static string CreateDiagnosticText (CompileDiagnosticEntry entry)
+    {
+        const string Prefix = "compile diagnostic runId=";
+        const string OriginLabel = " refreshOrigin=";
+        const string Separator = ": ";
+
+        var diagnostic = entry.PrimaryDiagnostic;
+        if (diagnostic is null)
+        {
+            var length = checked(Prefix.Length + entry.RunId.Length + OriginLabel.Length + entry.RefreshOrigin.Length);
+            return string.Create(
+                length,
+                entry,
+                static (destination, state) =>
+                {
+                    var writer = new SpanTextWriter(destination);
+                    writer.Append(Prefix);
+                    writer.Append(state.RunId);
+                    writer.Append(OriginLabel);
+                    writer.Append(state.RefreshOrigin);
+                });
+        }
+
+        var code = string.IsNullOrWhiteSpace(diagnostic.Code) ? "compiler" : diagnostic.Code;
+        var kind = string.IsNullOrWhiteSpace(diagnostic.Kind) ? "compiler" : diagnostic.Kind;
+        var message = string.IsNullOrWhiteSpace(diagnostic.Message) ? "diagnostics-read summary created" : diagnostic.Message;
+        var diagnosticLength = checked(
+            Prefix.Length
+            + entry.RunId.Length
+            + OriginLabel.Length
+            + entry.RefreshOrigin.Length
+            + 1
+            + kind.Length
+            + 1
+            + code.Length
+            + Separator.Length
+            + message.Length);
+        return string.Create(
+            diagnosticLength,
+            (entry.RunId, entry.RefreshOrigin, Kind: kind, Code: code, Message: message),
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(Prefix);
+                writer.Append(state.RunId);
+                writer.Append(OriginLabel);
+                writer.Append(state.RefreshOrigin);
+                writer.Append(' ');
+                writer.Append(state.Kind);
+                writer.Append(' ');
+                writer.Append(state.Code);
+                writer.Append(Separator);
+                writer.Append(state.Message);
+            });
+    }
+
+    private static string CreateCompletedText (CompileCompletedEntry entry)
+    {
+        const string Prefix = "compile runId=";
+        const string VerdictLabel = " verdict=";
+        const string ErrorsLabel = " errorCount=";
+        const string WarningsLabel = " warningCount=";
+        const string Status = " completed";
+
+        var errorCountLength = GetInt64TextLength(entry.ErrorCount);
+        var warningCountLength = GetInt64TextLength(entry.WarningCount);
+        var length = checked(Prefix.Length
+            + entry.RunId.Length
+            + VerdictLabel.Length
+            + entry.Verdict.Length
+            + ErrorsLabel.Length
+            + errorCountLength
+            + WarningsLabel.Length
+            + warningCountLength
+            + Status.Length);
+        return string.Create(
+            length,
+            entry,
+            static (destination, state) =>
+            {
+                var writer = new SpanTextWriter(destination);
+                writer.Append(Prefix);
+                writer.Append(state.RunId);
+                writer.Append(VerdictLabel);
+                writer.Append(state.Verdict);
+                writer.Append(ErrorsLabel);
+                writer.AppendInvariant(state.ErrorCount);
+                writer.Append(WarningsLabel);
+                writer.AppendInvariant(state.WarningCount);
+                writer.Append(Status);
+            });
+    }
+
+    private static int GetInt64TextLength (long value)
+    {
+        if (value == 0)
+        {
+            return 1;
+        }
+
+        var length = value < 0 ? 1 : 0;
+        var remaining = value;
+        while (remaining != 0)
+        {
+            length++;
+            remaining /= 10;
+        }
+
+        return length;
+    }
+}

--- a/tests/Ucli.Application.Tests/Features/Assurance/Compile/CompileServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Compile/CompileServiceTests.cs
@@ -2,12 +2,15 @@ using System.Text.Json;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Artifacts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Execution;
+using MackySoft.Ucli.Application.Features.Assurance.Compile.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Vocabulary;
 using MackySoft.Ucli.Application.Features.Daemon.Common.CommandContracts;
 using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
 using MackySoft.Ucli.Application.Shared.Foundation;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 
@@ -20,12 +23,13 @@ public sealed class CompileServiceTests
     public async Task Execute_WithSuccessfulCompileResponse_ReturnsPassOutput ()
     {
         var unityRequestExecutor = new StubUnityRequestExecutor(CreateCompileResponseResult(CreateSummary()));
+        var progressSink = new CollectingProgressSink();
         var service = CreateService(unityRequestExecutor: unityRequestExecutor);
 
         var result = await service.ExecuteAsync(new CompileCommandInput(
             ProjectPath: null,
             Mode: UnityExecutionMode.Auto,
-            TimeoutMilliseconds: 10000));
+            TimeoutMilliseconds: 10000), progressSink);
 
         Assert.True(result.IsSuccess);
         var output = result.Output!;
@@ -36,6 +40,24 @@ public sealed class CompileServiceTests
         Assert.Equal(3, output.Claims.Count);
         var payload = Assert.IsType<UnityRequestPayload.Compile>(unityRequestExecutor.CapturedPayload);
         Assert.Equal("run-1", payload.RunId);
+        AssertProgressEvents(
+            progressSink,
+            CompileProgressEventNames.Started,
+            CompileProgressEventNames.RefreshStarted,
+            CompileProgressEventNames.Completed);
+        var startedEntry = Assert.IsType<CompileStartedEntry>(progressSink.Entries[0].Payload);
+        Assert.Equal("run-1", startedEntry.RunId);
+        Assert.Equal("project-fingerprint", startedEntry.ProjectFingerprint);
+        Assert.Equal("auto", startedEntry.RequestedMode);
+        Assert.Equal("oneshot", startedEntry.ResolvedMode);
+        Assert.Equal("transientProbe", startedEntry.SessionKind);
+        Assert.Equal(10000, startedEntry.TimeoutMilliseconds);
+        var refreshEntry = Assert.IsType<CompileRefreshStartedEntry>(progressSink.Entries[1].Payload);
+        Assert.Equal("assetDatabaseRefresh", refreshEntry.RefreshOrigin);
+        Assert.Equal("hostDispatch", refreshEntry.ObservationSource);
+        var completedEntry = Assert.IsType<CompileCompletedEntry>(progressSink.Entries[2].Payload);
+        Assert.Equal(CompileVerdictValues.Pass, completedEntry.Verdict);
+        Assert.Equal(0, completedEntry.ErrorCount);
     }
 
     [Fact]
@@ -87,6 +109,7 @@ public sealed class CompileServiceTests
     public async Task Execute_WithCompileTimeoutResponse_ReadsRecoveredArtifact ()
     {
         var artifactStore = new StubCompileRunArtifactReader(CompileRunArtifactReadResult.Success(CreateSummary(errorCount: 1)));
+        var progressSink = new CollectingProgressSink();
         var service = CreateService(
             unityRequestExecutor: new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(new UnityRequestResponse(
                 default,
@@ -97,11 +120,34 @@ public sealed class CompileServiceTests
         var result = await service.ExecuteAsync(new CompileCommandInput(
             ProjectPath: null,
             Mode: UnityExecutionMode.Oneshot,
-            TimeoutMilliseconds: 10000));
+            TimeoutMilliseconds: 10000), progressSink);
 
         Assert.True(result.IsSuccess);
         Assert.Equal(1, artifactStore.ReadCount);
         Assert.Equal(CompileVerdictValues.Fail, result.Output!.Verdict);
+        AssertProgressEvents(
+            progressSink,
+            CompileProgressEventNames.Started,
+            CompileProgressEventNames.RefreshStarted,
+            CompileProgressEventNames.Recovered,
+            CompileProgressEventNames.Completed);
+        var recoveredEntry = Assert.IsType<CompileRecoveredEntry>(progressSink.Entries[2].Payload);
+        Assert.Equal("run-1", recoveredEntry.RunId);
+        Assert.Equal("/workspace/.ucli/local/compile/run-1/summary.json", recoveredEntry.SummaryJsonPath);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout.Value, recoveredEntry.DispatchFailureCode);
+        Assert.Equal(1, recoveredEntry.PollAttempts);
+
+        var resultWithoutProgress = await CreateService(
+                unityRequestExecutor: new StubUnityRequestExecutor(UnityRequestExecutionResult.Success(new UnityRequestResponse(
+                    default,
+                    [new OperationExecutionError(ExecutionErrorCodes.IpcTimeout, "Unity compile assurance timed out.", null)],
+                    HasFailureStatus: true))),
+                artifactStore: new StubCompileRunArtifactReader(CompileRunArtifactReadResult.Success(CreateSummary(errorCount: 1))))
+            .ExecuteAsync(new CompileCommandInput(
+                ProjectPath: null,
+                Mode: UnityExecutionMode.Oneshot,
+                TimeoutMilliseconds: 10000));
+        AssertCompileOutputsMatch(result.Output!, resultWithoutProgress.Output!);
     }
 
     [Fact]
@@ -109,6 +155,7 @@ public sealed class CompileServiceTests
     public async Task Execute_WithStartupCompilerDiagnostic_ReturnsDiagnosticsReadFailurePacket ()
     {
         var artifactStore = new StubCompileRunArtifactReader();
+        var progressSink = new CollectingProgressSink();
         var service = CreateService(
             unityRequestExecutor: new StubUnityRequestExecutor(UnityRequestExecutionResult.Failure(new UnityRequestFailure(
                 DaemonErrorCodes.DaemonStartupBlocked,
@@ -119,7 +166,7 @@ public sealed class CompileServiceTests
         var result = await service.ExecuteAsync(new CompileCommandInput(
             ProjectPath: null,
             Mode: UnityExecutionMode.Oneshot,
-            TimeoutMilliseconds: 10000));
+            TimeoutMilliseconds: 10000), progressSink);
 
         Assert.True(result.IsSuccess);
         var output = result.Output!;
@@ -132,6 +179,16 @@ public sealed class CompileServiceTests
         Assert.Equal(0, artifactStore.ReadCount);
         Assert.Equal(1, artifactStore.WriteCount);
         Assert.Equal("diagnosticsRead", artifactStore.WrittenSummary!.Refresh.Origin);
+        AssertProgressEvents(
+            progressSink,
+            CompileProgressEventNames.Started,
+            CompileProgressEventNames.RefreshStarted,
+            CompileProgressEventNames.Diagnostic,
+            CompileProgressEventNames.Completed);
+        var diagnosticEntry = Assert.IsType<CompileDiagnosticEntry>(progressSink.Entries[2].Payload);
+        Assert.Equal("run-1", diagnosticEntry.RunId);
+        Assert.Equal("diagnosticsRead", diagnosticEntry.RefreshOrigin);
+        Assert.Equal("CS0246", diagnosticEntry.PrimaryDiagnostic!.Code);
     }
 
     [Fact]
@@ -344,6 +401,52 @@ public sealed class CompileServiceTests
             RetryDisposition: "manualActionRequired",
             SafeToRetryImmediately: false);
     }
+
+    private static void AssertProgressEvents (
+        CollectingProgressSink progressSink,
+        params string[] eventNames)
+    {
+        Assert.Equal(eventNames.Length, progressSink.Entries.Count);
+        for (var i = 0; i < eventNames.Length; i++)
+        {
+            Assert.Equal(eventNames[i], progressSink.Entries[i].EventName);
+        }
+    }
+
+    private static void AssertCompileOutputsMatch (
+        CompileExecutionOutput expected,
+        CompileExecutionOutput actual)
+    {
+        Assert.Equal(expected.Verdict, actual.Verdict);
+        Assert.Equal(expected.Claims.Select(static claim => claim.Id), actual.Claims.Select(static claim => claim.Id));
+        Assert.Equal(expected.Claims.Select(static claim => claim.Status), actual.Claims.Select(static claim => claim.Status));
+        Assert.Equal(
+            expected.Reports.OrderBy(static entry => entry.Key, StringComparer.Ordinal),
+            actual.Reports.OrderBy(static entry => entry.Key, StringComparer.Ordinal));
+        Assert.Equal(expected.ResidualRisks, actual.ResidualRisks);
+    }
+
+    private sealed class CollectingProgressSink : ICommandProgressSink
+    {
+        private readonly List<ProgressEntry> entries = [];
+
+        public IReadOnlyList<ProgressEntry> Entries => entries;
+
+        public ValueTask OnEntryAsync<TPayload> (
+            string eventName,
+            TPayload payload,
+            CancellationToken cancellationToken = default)
+            where TPayload : notnull
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            entries.Add(new ProgressEntry(eventName, payload));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed record ProgressEntry (
+        string EventName,
+        object Payload);
 
     private sealed class StubProjectContextResolver : IProjectContextResolver
     {

--- a/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Verify/VerifyServiceTests.cs
@@ -283,6 +283,7 @@ public sealed class VerifyServiceTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(800, compileService.CapturedInput!.TimeoutMilliseconds);
+        Assert.Null(compileService.CapturedProgressSink);
     }
 
     [Fact]
@@ -1209,13 +1210,17 @@ public sealed class VerifyServiceTests
 
         public CompileCommandInput? CapturedInput { get; private set; }
 
+        public ICommandProgressSink? CapturedProgressSink { get; private set; }
+
         public ValueTask<CompileExecutionResult> ExecuteAsync (
             CompileCommandInput input,
+            ICommandProgressSink? progressSink = null,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ExecuteCount++;
             CapturedInput = input;
+            CapturedProgressSink = progressSink;
             return ValueTask.FromResult(resultFactory(input));
         }
     }

--- a/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using MackySoft.Tests;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Index;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Testing;
@@ -921,6 +922,86 @@ public sealed class IpcContractSerializationTests
                             .HasString("code", "CS1002")))));
         Assert.False(responseDocument.RootElement.TryGetProperty("summaryJsonPath", out _));
         Assert.False(responseDocument.RootElement.TryGetProperty("diagnosticsJsonPath", out _));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void CompileProgressContracts_SerializeWithCamelCaseFields ()
+    {
+        var startedPayload = new CompileStartedEntry(
+            RunId: "run-1",
+            ProjectFingerprint: "project-fingerprint",
+            RequestedMode: "auto",
+            ResolvedMode: "oneshot",
+            SessionKind: "transientProbe",
+            TimeoutMilliseconds: 10000);
+        var refreshPayload = new CompileRefreshStartedEntry(
+            RunId: "run-1",
+            RefreshOrigin: "assetDatabaseRefresh",
+            ObservationSource: "hostDispatch");
+        var recoveredPayload = new CompileRecoveredEntry(
+            RunId: "run-1",
+            SummaryJsonPath: "/tmp/ucli/compile/run-1/summary.json",
+            DispatchFailureCode: IpcTransportErrorCodes.IpcTimeout.Value,
+            PollAttempts: 2);
+        var diagnosticPayload = new CompileDiagnosticEntry(
+            RunId: "run-1",
+            RefreshOrigin: "diagnosticsRead",
+            PrimaryDiagnostic: new IpcPrimaryDiagnostic(
+                Kind: "compiler",
+                Code: "CS1002",
+                File: "Assets/Broken.cs",
+                Line: 4,
+                Column: 16,
+                Message: "; expected"));
+        var completedPayload = new CompileCompletedEntry(
+            RunId: "run-1",
+            Verdict: "fail",
+            ErrorCount: 1,
+            WarningCount: 0,
+            SummaryJsonPath: "/tmp/ucli/compile/run-1/summary.json",
+            DiagnosticsJsonPath: "/tmp/ucli/compile/run-1/diagnostics.json");
+
+        using var startedDocument = JsonDocument.Parse(JsonSerializer.Serialize(startedPayload, SerializerOptions));
+        using var refreshDocument = JsonDocument.Parse(JsonSerializer.Serialize(refreshPayload, SerializerOptions));
+        using var recoveredDocument = JsonDocument.Parse(JsonSerializer.Serialize(recoveredPayload, SerializerOptions));
+        using var diagnosticDocument = JsonDocument.Parse(JsonSerializer.Serialize(diagnosticPayload, SerializerOptions));
+        using var completedDocument = JsonDocument.Parse(JsonSerializer.Serialize(completedPayload, SerializerOptions));
+
+        Assert.Equal("compile.started", CompileProgressEventNames.Started);
+        Assert.Equal("compile.refresh.started", CompileProgressEventNames.RefreshStarted);
+        Assert.Equal("compile.recovered", CompileProgressEventNames.Recovered);
+        Assert.Equal("compile.diagnostic", CompileProgressEventNames.Diagnostic);
+        Assert.Equal("compile.completed", CompileProgressEventNames.Completed);
+        JsonAssert.For(startedDocument.RootElement)
+            .HasString("runId", "run-1")
+            .HasString("projectFingerprint", "project-fingerprint")
+            .HasString("requestedMode", "auto")
+            .HasString("resolvedMode", "oneshot")
+            .HasString("sessionKind", "transientProbe")
+            .HasInt32("timeoutMilliseconds", 10000);
+        JsonAssert.For(refreshDocument.RootElement)
+            .HasString("runId", "run-1")
+            .HasString("refreshOrigin", "assetDatabaseRefresh")
+            .HasString("observationSource", "hostDispatch");
+        JsonAssert.For(recoveredDocument.RootElement)
+            .HasString("runId", "run-1")
+            .HasString("summaryJsonPath", "/tmp/ucli/compile/run-1/summary.json")
+            .HasString("dispatchFailureCode", IpcTransportErrorCodes.IpcTimeout.Value)
+            .HasInt32("pollAttempts", 2);
+        JsonAssert.For(diagnosticDocument.RootElement)
+            .HasString("runId", "run-1")
+            .HasString("refreshOrigin", "diagnosticsRead")
+            .HasProperty("primaryDiagnostic", primaryDiagnostic => primaryDiagnostic
+                .HasString("kind", "compiler")
+                .HasString("code", "CS1002"));
+        JsonAssert.For(completedDocument.RootElement)
+            .HasString("runId", "run-1")
+            .HasString("verdict", "fail")
+            .HasInt32("errorCount", 1)
+            .HasInt32("warningCount", 0)
+            .HasString("summaryJsonPath", "/tmp/ucli/compile/run-1/summary.json")
+            .HasString("diagnosticsJsonPath", "/tmp/ucli/compile/run-1/diagnostics.json");
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Hosting/Cli/CompileCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/CompileCommandTests.cs
@@ -1,9 +1,12 @@
+using System.Text.Json;
 using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Vocabulary;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Assurance;
 using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
@@ -16,7 +19,7 @@ public sealed class CompileCommandTests
     [Trait("Size", "Small")]
     public async Task Compile_MapsOptionsToServiceInputAndCancellationToken ()
     {
-        var service = new StubCompileService((_, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
+        var service = new StubCompileService((_, _, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
         using var cancellationTokenSource = new CancellationTokenSource();
 
@@ -31,13 +34,14 @@ public sealed class CompileCommandTests
         Assert.Equal("/repo/UnityProject", input.ProjectPath);
         Assert.Equal(UnityExecutionMode.Daemon, input.Mode);
         Assert.Equal(1234, input.TimeoutMilliseconds);
+        Assert.NotNull(service.CapturedProgressSink);
     }
 
     [Fact]
     [Trait("Size", "Small")]
     public async Task Compile_WhenModeIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
     {
-        var service = new StubCompileService((_, _) => throw new InvalidOperationException("Service should not be called."));
+        var service = new StubCompileService((_, _, _) => throw new InvalidOperationException("Service should not be called."));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
 
         var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.CompileAsync(
@@ -60,7 +64,7 @@ public sealed class CompileCommandTests
     [Trait("Size", "Small")]
     public async Task Compile_WithPassOutput_MatchesGolden ()
     {
-        var service = new StubCompileService((_, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
+        var service = new StubCompileService((_, _, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
 
         var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.CompileAsync(
@@ -81,7 +85,7 @@ public sealed class CompileCommandTests
     public async Task Compile_WithSupportedFormat_WritesOnlyFinalCommandResult (
         string format)
     {
-        var service = new StubCompileService((_, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
+        var service = new StubCompileService((_, _, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput())));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
 
         var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.CompileAsync(
@@ -99,9 +103,71 @@ public sealed class CompileCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Compile_WithJsonFormat_WritesProgressEntryToStandardError ()
+    {
+        var service = new StubCompileService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                CompileProgressEventNames.Completed,
+                CreateCompletedEntry(),
+                cancellationToken);
+            return CompileExecutionResult.Success(CreateOutput());
+        });
+        var command = new CompileCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.CompileAsync(
+            format: "json",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Compile,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        var line = Assert.Single(standardError.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+        using var entryJson = JsonDocument.Parse(line);
+        AssertCompileStreamEnvelope(entryJson.RootElement, sequence: 1, CompileProgressEventNames.Completed);
+        Assert.Equal("pass", entryJson.RootElement.GetProperty("payload").GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Compile_WithDefaultFormat_WritesTextProgressToStandardError ()
+    {
+        var service = new StubCompileService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                CompileProgressEventNames.Completed,
+                CreateCompletedEntry(),
+                cancellationToken);
+            return CompileExecutionResult.Success(CreateOutput());
+        });
+        var command = new CompileCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.CompileAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Compile,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        Assert.Equal(
+            "compile runId=run-1 verdict=pass errorCount=0 warningCount=0 completed" + Environment.NewLine,
+            standardError);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Compile_WhenFormatIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
     {
-        var service = new StubCompileService((_, _) => throw new InvalidOperationException("Service should not be called."));
+        var service = new StubCompileService((_, _, _) => throw new InvalidOperationException("Service should not be called."));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
 
         var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.CompileAsync(
@@ -145,7 +211,7 @@ public sealed class CompileCommandTests
     [Trait("Size", "Small")]
     public async Task Compile_WithCompileErrorOutput_ReturnsOkEnvelopeWithFailureExitCodeAndMatchesGolden ()
     {
-        var service = new StubCompileService((_, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput(errorCount: 1))));
+        var service = new StubCompileService((_, _, _) => ValueTask.FromResult(CompileExecutionResult.Success(CreateOutput(errorCount: 1))));
         var command = new CompileCommand(service, CommandResultTestWriter.Create());
 
         var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.CompileAsync(
@@ -171,6 +237,31 @@ public sealed class CompileCommandTests
         return new JsonGoldenFileNormalization()
             .NormalizeStringPropertyValue("projectPath", "<projectPath>")
             .NormalizeStringPropertyValue("projectFingerprint", "<projectFingerprint>");
+    }
+
+    private static void AssertCompileStreamEnvelope (
+        JsonElement root,
+        int sequence,
+        string eventName)
+    {
+        Assert.Equal(1, root.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(UcliCommandNames.Compile, root.GetProperty("command").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("streamId").GetString()));
+        Assert.Equal(sequence, root.GetProperty("sequence").GetInt32());
+        Assert.True(DateTimeOffset.TryParse(root.GetProperty("timestamp").GetString(), out _));
+        Assert.Equal(eventName, root.GetProperty("event").GetString());
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("payload").ValueKind);
+    }
+
+    private static CompileCompletedEntry CreateCompletedEntry ()
+    {
+        return new CompileCompletedEntry(
+            RunId: "run-1",
+            Verdict: "pass",
+            ErrorCount: 0,
+            WarningCount: 0,
+            SummaryJsonPath: "/tmp/ucli/compile/run-1/summary.json",
+            DiagnosticsJsonPath: "/tmp/ucli/compile/run-1/diagnostics.json");
     }
 
     private static CompileExecutionOutput CreateOutput (int errorCount = 0)
@@ -304,24 +395,28 @@ public sealed class CompileCommandTests
 
     private sealed class StubCompileService : ICompileService
     {
-        private readonly Func<CompileCommandInput, CancellationToken, ValueTask<CompileExecutionResult>> handler;
+        private readonly Func<CompileCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<CompileExecutionResult>> handler;
 
-        public StubCompileService (Func<CompileCommandInput, CancellationToken, ValueTask<CompileExecutionResult>> handler)
+        public StubCompileService (Func<CompileCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<CompileExecutionResult>> handler)
         {
             this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
         public CompileCommandInput? CapturedInput { get; private set; }
 
+        public ICommandProgressSink? CapturedProgressSink { get; private set; }
+
         public CancellationToken CapturedCancellationToken { get; private set; }
 
         public ValueTask<CompileExecutionResult> ExecuteAsync (
             CompileCommandInput input,
+            ICommandProgressSink? progressSink = null,
             CancellationToken cancellationToken = default)
         {
             CapturedInput = input;
+            CapturedProgressSink = progressSink;
             CapturedCancellationToken = cancellationToken;
-            return handler(input, cancellationToken);
+            return handler(input, progressSink, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds public compile progress payload contracts for host-observed compile stream entries.
- Wires `ucli compile --format text|json` to the shared progress sink while keeping stdout reserved for the final `CommandResult` JSON.
- Preserves recoverable compile IPC, artifact polling, summary and diagnostics artifacts as the authoritative compile result path.

## Scope
- `src/Ucli.Contracts/Assurance/Compile`: compile stream event names and payload contracts.
- `CompileService`: emits started, refresh dispatch, diagnostic, recovered, and completed entries without changing final compile output.
- `CompileCommand`: connects `CliCommandProgressSink` and text projection for compile.
- Tests: contract serialization, CLI stdout/stderr separation, service event ordering, recovery, diagnostics-read, and verify compile-step silence.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`, `bash scripts/code-quality.sh verify --include ...`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, `bash scripts/verify.sh`)
- Practical: PASS (`bash scripts/update-local-shared-packages.sh --repo-root ... --prune`, Unity batchmode package resolve/import, then `ucli compile -p src/Ucli.Unity --mode oneshot --timeout 120000 --format json` and default text format both returned verdict `pass`)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to compile progress stream projection and optional sink emission; final compile payload and artifact contracts remain authoritative.
- Rollback by reverting this commit restores compile to final-result-only CLI output.

## Checklist
- [x] stdout remains final `CommandResult` JSON only
- [x] stderr emits NDJSON for `--format json`
- [x] default text entry wording follows existing progress entry style
- [x] verify compile step does not inherit compile progress output
- [x] package-resolved Unity compile path validated

Closes #363