### PR TITLE
docs(readme): add package version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ ucli ops describe game.scene.countGameObjects --projectPath ./UnityProject
 
 ## 📦 Packages
 
-| Package | Version | Install when |
+| Package | NuGet | Install when |
 | --- | --- | --- |
 | `MackySoft.Ucli` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli?label=)](https://www.nuget.org/packages/MackySoft.Ucli) | You need the `ucli` command. |
 | `MackySoft.Ucli.Unity` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Unity?label=)](https://www.nuget.org/packages/MackySoft.Ucli.Unity) | You need Unity Editor operations in a Unity project. |

--- a/README.md
+++ b/README.md
@@ -954,12 +954,12 @@ ucli ops describe game.scene.countGameObjects --projectPath ./UnityProject
 
 ## 📦 Packages
 
-| Package | Install when |
-| --- | --- |
-| `MackySoft.Ucli` | You need the `ucli` command. |
-| `MackySoft.Ucli.Unity` | You need Unity Editor operations in a Unity project. |
-| `MackySoft.Ucli.Contracts` | You build advanced tooling that uses uCLI's shared IPC types directly. |
-| `MackySoft.Ucli.Infrastructure` | You build advanced uCLI runtime integrations that need shared infrastructure helpers. |
+| Package | Version | Install when |
+| --- | --- | --- |
+| `MackySoft.Ucli` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli?label=)](https://www.nuget.org/packages/MackySoft.Ucli) | You need the `ucli` command. |
+| `MackySoft.Ucli.Unity` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Unity?label=)](https://www.nuget.org/packages/MackySoft.Ucli.Unity) | You need Unity Editor operations in a Unity project. |
+| `MackySoft.Ucli.Contracts` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Contracts?label=)](https://www.nuget.org/packages/MackySoft.Ucli.Contracts) | You build advanced tooling that uses uCLI's shared IPC types directly. |
+| `MackySoft.Ucli.Infrastructure` | [![NuGet](https://img.shields.io/nuget/v/MackySoft.Ucli.Infrastructure?label=)](https://www.nuget.org/packages/MackySoft.Ucli.Infrastructure) | You build advanced uCLI runtime integrations that need shared infrastructure helpers. |
 
 ## 💬 Support
 


### PR DESCRIPTION
## Summary
- Add a compact NuGet column to the README package table.
- Show each published package's NuGet version directly in the package list.

## Scope
- `README.md`: update the Packages table with standard Shields NuGet version badges.

## Verification
- Gate level: Standard
- Format: PASS (`git diff --check -- README.md`)
- Tests: Skipped (docs-only change)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to README rendering. Rollback is reverting the README table change.

## Checklist
- [x] Package table remains compact.
- [x] NuGet links point to the matching package pages.

Issue: none (ad-hoc task)