### PR TITLE
fix(skills): default project repo root from cwd

### DIFF
--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -125,13 +125,9 @@ while IFS= read -r relative_path; do
 done < <(list_host_independent_skill_files)
 
 install_repo="$(mktemp -d "${temp_root%/}/ucli-skills-install.XXXXXX")"
-git init --quiet "${install_repo}"
-(
-  cd "${install_repo}"
-  "${tool_path}/ucli" skills install --host openai --scope project >/dev/null
-  "${tool_path}/ucli" skills install --host openai --scope project >/dev/null
-  "${tool_path}/ucli" skills doctor --host openai --scope project >/dev/null
-)
+"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
+"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
+"${tool_path}/ucli" skills doctor --host openai --scope project --repoRoot "${install_repo}" >/dev/null
 installed_path="${install_repo}/.agents/skills"
 if [[ ! -d "${installed_path}" ]]; then
   echo "ucli skills install did not create the project skills directory: ${installed_path}" >&2

--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -125,9 +125,13 @@ while IFS= read -r relative_path; do
 done < <(list_host_independent_skill_files)
 
 install_repo="$(mktemp -d "${temp_root%/}/ucli-skills-install.XXXXXX")"
-"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
-"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
-"${tool_path}/ucli" skills doctor --host openai --scope project --repoRoot "${install_repo}" >/dev/null
+git init --quiet "${install_repo}"
+(
+  cd "${install_repo}"
+  "${tool_path}/ucli" skills install --host openai --scope project >/dev/null
+  "${tool_path}/ucli" skills install --host openai --scope project >/dev/null
+  "${tool_path}/ucli" skills doctor --host openai --scope project >/dev/null
+)
 installed_path="${install_repo}/.agents/skills"
 if [[ ! -d "${installed_path}" ]]; then
   echo "ucli skills install did not create the project skills directory: ${installed_path}" >&2

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -1,6 +1,7 @@
 using MackySoft.AgentSkills.Distribution;
 using MackySoft.AgentSkills.Hosts.Registration;
 using MackySoft.AgentSkills.Installation.Targeting;
+using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Infrastructure.Paths;
 using MackySoft.Ucli.Infrastructure.Storage;
@@ -14,6 +15,9 @@ internal static class SkillsCommandOptionNormalizer
     private const string UserScopeLiteral = "user";
     private const string DirectoryExportFormatLiteral = "directory";
     private const string ZipExportFormatLiteral = "zip";
+    private const string UnityAssetsDirectoryName = "Assets";
+    private const string UnityPackagesDirectoryName = "Packages";
+    private const string UnityProjectSettingsDirectoryName = "ProjectSettings";
 
     /// <summary> Normalizes a required host option to its canonical host key. </summary>
     /// <param name="command"> The command name used for error results. </param>
@@ -105,12 +109,81 @@ internal static class SkillsCommandOptionNormalizer
             return null;
         }
 
-        if (!string.IsNullOrWhiteSpace(repoRoot))
+        return !string.IsNullOrWhiteSpace(repoRoot)
+            ? NormalizeExplicitRepositoryRoot(command, repoRoot, out errorResult)
+            : ResolveDefaultRepositoryRoot(command, out errorResult);
+    }
+
+    /// <summary> Validates target-directory usage for a resolved scope. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="scope"> The normalized scope. </param>
+    /// <param name="repositoryRoot"> The resolved repository root. </param>
+    /// <param name="targetDir"> The raw target directory option. </param>
+    /// <param name="errorResult"> The emitted error result when validation fails. </param>
+    /// <returns> <see langword="true" /> when the target directory can be passed to the SKILL installer; otherwise <see langword="false" />. </returns>
+    public static bool ValidateTargetDirectoryForScope (
+        string command,
+        SkillScopeKind scope,
+        string? repositoryRoot,
+        string? targetDir,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        errorResult = null;
+        if (scope != SkillScopeKind.Project || string.IsNullOrWhiteSpace(targetDir))
         {
-            return NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
+            return true;
         }
 
-        return ResolveDefaultRepositoryRoot(command, out errorResult);
+        if (string.IsNullOrWhiteSpace(repositoryRoot))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Project-scope target directory validation requires a repository root.");
+            return false;
+        }
+
+        string normalizedRepositoryRoot;
+        string normalizedTargetRoot;
+        try
+        {
+            normalizedRepositoryRoot = NormalizeComparisonPath(repositoryRoot);
+            normalizedTargetRoot = Path.IsPathFullyQualified(targetDir)
+                ? NormalizeComparisonPath(targetDir)
+                : NormalizeComparisonPath(Path.Combine(normalizedRepositoryRoot, targetDir));
+        }
+        catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"Option '--targetDir' is invalid: {ex.Message}");
+            return false;
+        }
+
+        if (IsSamePath(normalizedTargetRoot, normalizedRepositoryRoot))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must point to a SKILL target directory, not the repository root.");
+            return false;
+        }
+
+        var gitMarkerPath = Path.Combine(normalizedRepositoryRoot, UcliStoragePathNames.GitMarkerName);
+        if (IsSameOrUnderPath(normalizedTargetRoot, gitMarkerPath))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must not point inside the Git metadata directory.");
+            return false;
+        }
+
+        var ucliDirectoryPath = Path.Combine(normalizedRepositoryRoot, UcliStoragePathNames.UcliDirectoryName);
+        if (IsSameOrUnderPath(normalizedTargetRoot, ucliDirectoryPath))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must not point inside the uCLI storage directory.");
+            return false;
+        }
+
+        if (Directory.Exists(normalizedTargetRoot) && IsUnityProjectRoot(normalizedTargetRoot))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must point to a SKILL target directory, not a Unity project root.");
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary> Normalizes the optional export format. </summary>
@@ -173,6 +246,20 @@ internal static class SkillsCommandOptionNormalizer
         }
     }
 
+    private static string? NormalizeExplicitRepositoryRoot (
+        string command,
+        string repoRoot,
+        out CommandResult? errorResult)
+    {
+        var normalizedRepositoryRoot = NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
+        if (errorResult is not null)
+        {
+            return null;
+        }
+
+        return ValidateRepositoryRoot(command, normalizedRepositoryRoot!, "Option '--repoRoot'", out errorResult);
+    }
+
     private static string? ResolveDefaultRepositoryRoot (
         string command,
         out CommandResult? errorResult)
@@ -181,7 +268,16 @@ internal static class SkillsCommandOptionNormalizer
         try
         {
             var currentDirectoryPath = Path.GetFullPath(Environment.CurrentDirectory);
-            return UcliStoragePathResolver.ResolveStorageRoot(currentDirectoryPath);
+            var repositoryRoot = UcliStoragePathResolver.TryResolveRepositoryRoot(currentDirectoryPath);
+            if (repositoryRoot is not null)
+            {
+                return repositoryRoot;
+            }
+
+            errorResult = CommandResult.InvalidArgument(
+                command,
+                "Could not resolve a Git repository root from the current working directory. Run the command inside a Git repository or specify --repoRoot.");
+            return null;
         }
         catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
         {
@@ -190,5 +286,84 @@ internal static class SkillsCommandOptionNormalizer
                 $"Current working directory path is invalid: {Environment.CurrentDirectory}. {ex.Message}");
             return null;
         }
+    }
+
+    private static string? ValidateRepositoryRoot (
+        string command,
+        string repositoryRoot,
+        string sourceName,
+        out CommandResult? errorResult)
+    {
+        errorResult = null;
+        if (!Directory.Exists(repositoryRoot))
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} must point to an existing directory: {repositoryRoot}");
+            return null;
+        }
+
+        string? resolvedRepositoryRoot;
+        try
+        {
+            resolvedRepositoryRoot = UcliStoragePathResolver.TryResolveRepositoryRoot(repositoryRoot);
+        }
+        catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} is invalid: {ex.Message}");
+            return null;
+        }
+
+        if (resolvedRepositoryRoot is null)
+        {
+            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} must point to a Git repository root: {repositoryRoot}");
+            return null;
+        }
+
+        if (!IsSamePath(resolvedRepositoryRoot, repositoryRoot))
+        {
+            errorResult = CommandResult.InvalidArgument(
+                command,
+                $"{sourceName} must point to the Git repository root, not a subdirectory. Resolved repository root: {resolvedRepositoryRoot}");
+            return null;
+        }
+
+        return resolvedRepositoryRoot;
+    }
+
+    private static bool IsUnityProjectRoot (string directoryPath)
+    {
+        return Directory.Exists(Path.Combine(directoryPath, UnityAssetsDirectoryName))
+            && Directory.Exists(Path.Combine(directoryPath, UnityPackagesDirectoryName))
+            && Directory.Exists(Path.Combine(directoryPath, UnityProjectSettingsDirectoryName));
+    }
+
+    private static bool IsSameOrUnderPath (
+        string path,
+        string parentPath)
+    {
+        if (IsSamePath(path, parentPath))
+        {
+            return true;
+        }
+
+        var normalizedParent = NormalizeComparisonPath(parentPath);
+        var parentPrefix = Path.EndsInDirectorySeparator(normalizedParent)
+            ? normalizedParent
+            : normalizedParent + Path.DirectorySeparatorChar;
+        return NormalizeComparisonPath(path).StartsWith(parentPrefix, PathComparison);
+    }
+
+    private static bool IsSamePath (
+        string left,
+        string right)
+    {
+        return string.Equals(NormalizeComparisonPath(left), NormalizeComparisonPath(right), PathComparison);
+    }
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static string NormalizeComparisonPath (string path)
+    {
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
     }
 }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -2,6 +2,8 @@ using MackySoft.AgentSkills.Distribution;
 using MackySoft.AgentSkills.Hosts.Registration;
 using MackySoft.AgentSkills.Installation.Targeting;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
+using MackySoft.Ucli.Infrastructure.Paths;
+using MackySoft.Ucli.Infrastructure.Storage;
 
 namespace MackySoft.Ucli.Hosting.Cli.Skills;
 
@@ -103,7 +105,12 @@ internal static class SkillsCommandOptionNormalizer
             return null;
         }
 
-        return NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
+        if (!string.IsNullOrWhiteSpace(repoRoot))
+        {
+            return NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
+        }
+
+        return ResolveDefaultRepositoryRoot(command, out errorResult);
     }
 
     /// <summary> Normalizes the optional export format. </summary>
@@ -162,6 +169,25 @@ internal static class SkillsCommandOptionNormalizer
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
             errorResult = CommandResult.InvalidArgument(command, $"Option '--{optionName}' is invalid: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static string? ResolveDefaultRepositoryRoot (
+        string command,
+        out CommandResult? errorResult)
+    {
+        errorResult = null;
+        try
+        {
+            var currentDirectoryPath = Path.GetFullPath(Environment.CurrentDirectory);
+            return UcliStoragePathResolver.ResolveStorageRoot(currentDirectoryPath);
+        }
+        catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
+        {
+            errorResult = CommandResult.InvalidArgument(
+                command,
+                $"Current working directory path is invalid: {Environment.CurrentDirectory}. {ex.Message}");
             return null;
         }
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -1,7 +1,6 @@
 using MackySoft.AgentSkills.Distribution;
 using MackySoft.AgentSkills.Hosts.Registration;
 using MackySoft.AgentSkills.Installation.Targeting;
-using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Infrastructure.Paths;
 using MackySoft.Ucli.Infrastructure.Storage;
@@ -15,9 +14,6 @@ internal static class SkillsCommandOptionNormalizer
     private const string UserScopeLiteral = "user";
     private const string DirectoryExportFormatLiteral = "directory";
     private const string ZipExportFormatLiteral = "zip";
-    private const string UnityAssetsDirectoryName = "Assets";
-    private const string UnityPackagesDirectoryName = "Packages";
-    private const string UnityProjectSettingsDirectoryName = "ProjectSettings";
 
     /// <summary> Normalizes a required host option to its canonical host key. </summary>
     /// <param name="command"> The command name used for error results. </param>
@@ -109,81 +105,12 @@ internal static class SkillsCommandOptionNormalizer
             return null;
         }
 
-        return !string.IsNullOrWhiteSpace(repoRoot)
-            ? NormalizeExplicitRepositoryRoot(command, repoRoot, out errorResult)
-            : ResolveDefaultRepositoryRoot(command, out errorResult);
-    }
-
-    /// <summary> Validates target-directory usage for a resolved scope. </summary>
-    /// <param name="command"> The command name used for error results. </param>
-    /// <param name="scope"> The normalized scope. </param>
-    /// <param name="repositoryRoot"> The resolved repository root. </param>
-    /// <param name="targetDir"> The raw target directory option. </param>
-    /// <param name="errorResult"> The emitted error result when validation fails. </param>
-    /// <returns> <see langword="true" /> when the target directory can be passed to the SKILL installer; otherwise <see langword="false" />. </returns>
-    public static bool ValidateTargetDirectoryForScope (
-        string command,
-        SkillScopeKind scope,
-        string? repositoryRoot,
-        string? targetDir,
-        out CommandResult? errorResult)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(command);
-
-        errorResult = null;
-        if (scope != SkillScopeKind.Project || string.IsNullOrWhiteSpace(targetDir))
+        if (!string.IsNullOrWhiteSpace(repoRoot))
         {
-            return true;
+            return NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
         }
 
-        if (string.IsNullOrWhiteSpace(repositoryRoot))
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Project-scope target directory validation requires a repository root.");
-            return false;
-        }
-
-        string normalizedRepositoryRoot;
-        string normalizedTargetRoot;
-        try
-        {
-            normalizedRepositoryRoot = NormalizeComparisonPath(repositoryRoot);
-            normalizedTargetRoot = Path.IsPathFullyQualified(targetDir)
-                ? NormalizeComparisonPath(targetDir)
-                : NormalizeComparisonPath(Path.Combine(normalizedRepositoryRoot, targetDir));
-        }
-        catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
-        {
-            errorResult = CommandResult.InvalidArgument(command, $"Option '--targetDir' is invalid: {ex.Message}");
-            return false;
-        }
-
-        if (IsSamePath(normalizedTargetRoot, normalizedRepositoryRoot))
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must point to a SKILL target directory, not the repository root.");
-            return false;
-        }
-
-        var gitMarkerPath = Path.Combine(normalizedRepositoryRoot, UcliStoragePathNames.GitMarkerName);
-        if (IsSameOrUnderPath(normalizedTargetRoot, gitMarkerPath))
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must not point inside the Git metadata directory.");
-            return false;
-        }
-
-        var ucliDirectoryPath = Path.Combine(normalizedRepositoryRoot, UcliStoragePathNames.UcliDirectoryName);
-        if (IsSameOrUnderPath(normalizedTargetRoot, ucliDirectoryPath))
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must not point inside the uCLI storage directory.");
-            return false;
-        }
-
-        if (Directory.Exists(normalizedTargetRoot) && IsUnityProjectRoot(normalizedTargetRoot))
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Option '--targetDir' must point to a SKILL target directory, not a Unity project root.");
-            return false;
-        }
-
-        return true;
+        return ResolveDefaultRepositoryRoot(command, out errorResult);
     }
 
     /// <summary> Normalizes the optional export format. </summary>
@@ -246,20 +173,6 @@ internal static class SkillsCommandOptionNormalizer
         }
     }
 
-    private static string? NormalizeExplicitRepositoryRoot (
-        string command,
-        string repoRoot,
-        out CommandResult? errorResult)
-    {
-        var normalizedRepositoryRoot = NormalizeRequiredFullPath(command, "repoRoot", repoRoot, out errorResult);
-        if (errorResult is not null)
-        {
-            return null;
-        }
-
-        return ValidateRepositoryRoot(command, normalizedRepositoryRoot!, "Option '--repoRoot'", out errorResult);
-    }
-
     private static string? ResolveDefaultRepositoryRoot (
         string command,
         out CommandResult? errorResult)
@@ -268,16 +181,7 @@ internal static class SkillsCommandOptionNormalizer
         try
         {
             var currentDirectoryPath = Path.GetFullPath(Environment.CurrentDirectory);
-            var repositoryRoot = UcliStoragePathResolver.TryResolveRepositoryRoot(currentDirectoryPath);
-            if (repositoryRoot is not null)
-            {
-                return repositoryRoot;
-            }
-
-            errorResult = CommandResult.InvalidArgument(
-                command,
-                "Could not resolve a Git repository root from the current working directory. Run the command inside a Git repository or specify --repoRoot.");
-            return null;
+            return UcliStoragePathResolver.ResolveStorageRoot(currentDirectoryPath);
         }
         catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
         {
@@ -286,84 +190,5 @@ internal static class SkillsCommandOptionNormalizer
                 $"Current working directory path is invalid: {Environment.CurrentDirectory}. {ex.Message}");
             return null;
         }
-    }
-
-    private static string? ValidateRepositoryRoot (
-        string command,
-        string repositoryRoot,
-        string sourceName,
-        out CommandResult? errorResult)
-    {
-        errorResult = null;
-        if (!Directory.Exists(repositoryRoot))
-        {
-            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} must point to an existing directory: {repositoryRoot}");
-            return null;
-        }
-
-        string? resolvedRepositoryRoot;
-        try
-        {
-            resolvedRepositoryRoot = UcliStoragePathResolver.TryResolveRepositoryRoot(repositoryRoot);
-        }
-        catch (Exception ex) when (PathFormatExceptionClassifier.IsPathFormatException(ex))
-        {
-            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} is invalid: {ex.Message}");
-            return null;
-        }
-
-        if (resolvedRepositoryRoot is null)
-        {
-            errorResult = CommandResult.InvalidArgument(command, $"{sourceName} must point to a Git repository root: {repositoryRoot}");
-            return null;
-        }
-
-        if (!IsSamePath(resolvedRepositoryRoot, repositoryRoot))
-        {
-            errorResult = CommandResult.InvalidArgument(
-                command,
-                $"{sourceName} must point to the Git repository root, not a subdirectory. Resolved repository root: {resolvedRepositoryRoot}");
-            return null;
-        }
-
-        return resolvedRepositoryRoot;
-    }
-
-    private static bool IsUnityProjectRoot (string directoryPath)
-    {
-        return Directory.Exists(Path.Combine(directoryPath, UnityAssetsDirectoryName))
-            && Directory.Exists(Path.Combine(directoryPath, UnityPackagesDirectoryName))
-            && Directory.Exists(Path.Combine(directoryPath, UnityProjectSettingsDirectoryName));
-    }
-
-    private static bool IsSameOrUnderPath (
-        string path,
-        string parentPath)
-    {
-        if (IsSamePath(path, parentPath))
-        {
-            return true;
-        }
-
-        var normalizedParent = NormalizeComparisonPath(parentPath);
-        var parentPrefix = Path.EndsInDirectorySeparator(normalizedParent)
-            ? normalizedParent
-            : normalizedParent + Path.DirectorySeparatorChar;
-        return NormalizeComparisonPath(path).StartsWith(parentPrefix, PathComparison);
-    }
-
-    private static bool IsSamePath (
-        string left,
-        string right)
-    {
-        return string.Equals(NormalizeComparisonPath(left), NormalizeComparisonPath(right), PathComparison);
-    }
-
-    private static StringComparison PathComparison =>
-        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-
-    private static string NormalizeComparisonPath (string path)
-    {
-        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
     }
 }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -87,6 +87,17 @@ internal sealed class SkillsDoctorCommand
             return errorResult.ExitCode;
         }
 
+        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
+                UcliCommandNames.SkillsDoctor,
+                normalizedScope.Value,
+                repositoryRoot,
+                targetDir,
+                out errorResult))
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult!);
+            return errorResult!.ExitCode;
+        }
+
         var targetResult = targetResolver.ResolveTarget(new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot, targetDir));
         if (!targetResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -40,7 +40,7 @@ internal sealed class SkillsDoctorCommand
     /// <summary> Executes the skills doctor command and emits the JSON result contract. </summary>
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="scope"> Required install scope (project|user). </param>
-    /// <param name="repoRoot"> --repoRoot, Required repository root for project scope. </param>
+    /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -87,17 +87,6 @@ internal sealed class SkillsDoctorCommand
             return errorResult.ExitCode;
         }
 
-        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
-                UcliCommandNames.SkillsDoctor,
-                normalizedScope.Value,
-                repositoryRoot,
-                targetDir,
-                out errorResult))
-        {
-            commandResultWriter.WriteToStandardOutput(errorResult!);
-            return errorResult!.ExitCode;
-        }
-
         var targetResult = targetResolver.ResolveTarget(new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot, targetDir));
         if (!targetResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -90,17 +90,6 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
-        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
-                UcliCommandNames.SkillsInstall,
-                normalizedScope.Value,
-                repositoryRoot,
-                targetDir,
-                out errorResult))
-        {
-            commandResultWriter.WriteToStandardOutput(errorResult!);
-            return errorResult!.ExitCode;
-        }
-
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -90,6 +90,17 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
+        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
+                UcliCommandNames.SkillsInstall,
+                normalizedScope.Value,
+                repositoryRoot,
+                targetDir,
+                out errorResult))
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult!);
+            return errorResult!.ExitCode;
+        }
+
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -37,7 +37,7 @@ internal sealed class SkillsInstallCommand
     /// <summary> Executes the skills install command and emits the JSON result contract. </summary>
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="scope"> Required install scope (project|user). </param>
-    /// <param name="repoRoot"> --repoRoot, Required repository root for project scope. </param>
+    /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="dryRun"> --dryRun, Whether to return the install plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -88,6 +88,17 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
+        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
+                UcliCommandNames.SkillsUninstall,
+                normalizedScope.Value,
+                repositoryRoot,
+                targetDir,
+                out errorResult))
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult!);
+            return errorResult!.ExitCode;
+        }
+
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -37,7 +37,7 @@ internal sealed class SkillsUninstallCommand
     /// <summary> Executes the skills uninstall command and emits the JSON result contract. </summary>
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="scope"> Required install scope (project|user). </param>
-    /// <param name="repoRoot"> --repoRoot, Required repository root for project scope. </param>
+    /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="dryRun"> --dryRun, Whether to return the uninstall plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be deleted. </param>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -88,17 +88,6 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
-        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
-                UcliCommandNames.SkillsUninstall,
-                normalizedScope.Value,
-                repositoryRoot,
-                targetDir,
-                out errorResult))
-        {
-            commandResultWriter.WriteToStandardOutput(errorResult!);
-            return errorResult!.ExitCode;
-        }
-
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -90,6 +90,17 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
+        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
+                UcliCommandNames.SkillsUpdate,
+                normalizedScope.Value,
+                repositoryRoot,
+                targetDir,
+                out errorResult))
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult!);
+            return errorResult!.ExitCode;
+        }
+
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -90,17 +90,6 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
-        if (!SkillsCommandOptionNormalizer.ValidateTargetDirectoryForScope(
-                UcliCommandNames.SkillsUpdate,
-                normalizedScope.Value,
-                repositoryRoot,
-                targetDir,
-                out errorResult))
-        {
-            commandResultWriter.WriteToStandardOutput(errorResult!);
-            return errorResult!.ExitCode;
-        }
-
         var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -37,7 +37,7 @@ internal sealed class SkillsUpdateCommand
     /// <summary> Executes the skills update command and emits the JSON result contract. </summary>
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="scope"> Required install scope (project|user). </param>
-    /// <param name="repoRoot"> --repoRoot, Required repository root for project scope. </param>
+    /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="dryRun"> --dryRun, Whether to return the update plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -448,7 +448,7 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
-    public async Task SkillsProjectScope_WithoutRepoRootAndGitMarker_ReturnsInvalidArgument ()
+    public async Task SkillsProjectScope_WithoutRepoRootAndGitMarker_UsesWorkingDirectory ()
     {
         using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "project-default-repo-root-no-git");
         var workingDirectory = scope.CreateDirectory("workspace");
@@ -459,66 +459,16 @@ public sealed class SkillsCliOutputContractTests
             dryRun: true);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
             command: UcliCommandNames.SkillsInstall,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        var payload = outputJson.RootElement.GetProperty("payload");
+        FileSystemAssert.ForPath(payload.GetProperty("repositoryRoot").GetString()!).EqualsNormalized(workingDirectory);
+        FileSystemAssert.ForPath(payload.GetProperty("targetRoot").GetString()!).EqualsNormalized(Path.Combine(workingDirectory, ".agents", "skills"));
         FileSystemAssert.ForPath(Path.Combine(workingDirectory, ".agents")).DoesNotExist();
-    }
-
-    [Theory]
-    [Trait("Size", "Medium")]
-    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
-    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
-    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
-    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
-    public async Task SkillsProjectScope_WithMissingRepoRoot_ReturnsInvalidArgument (
-        string subcommand,
-        string expectedCommand)
-    {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"project-missing-repo-root-{subcommand}");
-        var repoRoot = scope.GetPath("missing-repo");
-
-        var result = await RunScopedCommandWithoutRepositoryRootSetupAsync(subcommand, repoRoot, host: "openai", scope: "project", targetDir: null);
-
-        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-        CommandResultAssert.HasStandardEnvelope(
-            outputJson.RootElement,
-            command: expectedCommand,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
-    }
-
-    [Theory]
-    [Trait("Size", "Medium")]
-    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
-    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
-    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
-    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
-    public async Task SkillsProjectScope_WithRepoRootSubdirectory_ReturnsInvalidArgument (
-        string subcommand,
-        string expectedCommand)
-    {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"project-subdirectory-repo-root-{subcommand}");
-        var repoRoot = scope.CreateDirectory("repo");
-        EnsureGitRepositoryMarker(repoRoot);
-        var subdirectory = scope.CreateDirectory(Path.Combine("repo", "src", "tool"));
-
-        var result = await RunScopedCommandWithoutRepositoryRootSetupAsync(subcommand, subdirectory, host: "openai", scope: "project", targetDir: null);
-
-        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-        CommandResultAssert.HasStandardEnvelope(
-            outputJson.RootElement,
-            command: expectedCommand,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
     }
 
     [Fact]
@@ -1071,74 +1021,6 @@ public sealed class SkillsCliOutputContractTests
         CommandResultAssert.HasSingleError(outputJson.RootElement, PathUnsafeCode);
     }
 
-    [Theory]
-    [Trait("Size", "Medium")]
-    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
-    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
-    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
-    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
-    public async Task SkillsScopedSubcommand_WithRepositoryRootTargetDir_ReturnsInvalidArgument (
-        string subcommand,
-        string expectedCommand)
-    {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"repo-root-target-{subcommand}");
-        var repoRoot = scope.CreateDirectory("repo");
-
-        var result = await RunScopedCommandAsync(subcommand, repoRoot, host: "openai", scope: "project", targetDir: ".");
-
-        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-        CommandResultAssert.HasStandardEnvelope(
-            outputJson.RootElement,
-            command: expectedCommand,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
-    }
-
-    [Theory]
-    [Trait("Size", "Medium")]
-    [InlineData(".git/skills")]
-    [InlineData(".ucli/skills")]
-    public async Task SkillsInstall_WithInternalStorageTargetDir_ReturnsInvalidArgument (string targetDir)
-    {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "internal-storage-target");
-        var repoRoot = scope.CreateDirectory("repo");
-
-        var result = await RunScopedCommandAsync(UcliCommandNames.InstallSubcommand, repoRoot, host: "openai", scope: "project", targetDir: targetDir);
-
-        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-        CommandResultAssert.HasStandardEnvelope(
-            outputJson.RootElement,
-            command: UcliCommandNames.SkillsInstall,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
-    }
-
-    [Fact]
-    [Trait("Size", "Medium")]
-    public async Task SkillsInstall_WithUnityProjectRootTargetDir_ReturnsInvalidArgument ()
-    {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "unity-project-root-target");
-        var repoRoot = scope.CreateDirectory("repo");
-        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "Assets"));
-        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "Packages"));
-        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "ProjectSettings"));
-
-        var result = await RunScopedCommandAsync(UcliCommandNames.InstallSubcommand, repoRoot, host: "openai", scope: "project", targetDir: Path.Combine("src", "Ucli.Unity"));
-
-        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
-        CommandResultAssert.HasStandardEnvelope(
-            outputJson.RootElement,
-            command: UcliCommandNames.SkillsInstall,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
-    }
-
     [Fact]
     [Trait("Size", "Medium")]
     public async Task SkillsDoctor_WithInstalledTarget_ReturnsHealthy ()
@@ -1389,33 +1271,6 @@ public sealed class SkillsCliOutputContractTests
         bool force = false,
         bool printDiff = false)
     {
-        return RunScopedCommandCoreAsync(subcommand, repoRoot, host, scope, targetDir, dryRun, force, printDiff, ensureProjectRepositoryRoot: true);
-    }
-
-    private static Task<CommandExecutionResult> RunScopedCommandWithoutRepositoryRootSetupAsync (
-        string subcommand,
-        string repoRoot,
-        string? host,
-        string? scope,
-        string? targetDir,
-        bool dryRun = false,
-        bool force = false,
-        bool printDiff = false)
-    {
-        return RunScopedCommandCoreAsync(subcommand, repoRoot, host, scope, targetDir, dryRun, force, printDiff, ensureProjectRepositoryRoot: false);
-    }
-
-    private static Task<CommandExecutionResult> RunScopedCommandCoreAsync (
-        string subcommand,
-        string repoRoot,
-        string? host,
-        string? scope,
-        string? targetDir,
-        bool dryRun,
-        bool force,
-        bool printDiff,
-        bool ensureProjectRepositoryRoot)
-    {
         var args = new List<string>
         {
             UcliCommandNames.Skills,
@@ -1431,11 +1286,6 @@ public sealed class SkillsCliOutputContractTests
         {
             args.Add("--scope");
             args.Add(scope);
-        }
-
-        if (ensureProjectRepositoryRoot && string.Equals(scope, "project", StringComparison.OrdinalIgnoreCase))
-        {
-            EnsureGitRepositoryMarker(repoRoot);
         }
 
         args.AddRange([
@@ -1465,11 +1315,6 @@ public sealed class SkillsCliOutputContractTests
         }
 
         return CliProcessRunner.RunCommandAsync(args.ToArray());
-    }
-
-    private static void EnsureGitRepositoryMarker (string repoRoot)
-    {
-        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
     }
 
     private static Task<CommandExecutionResult> RunOpenAiDoctorAsync (string repoRoot)

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -448,7 +448,7 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
-    public async Task SkillsProjectScope_WithoutRepoRootAndGitMarker_UsesWorkingDirectory ()
+    public async Task SkillsProjectScope_WithoutRepoRootAndGitMarker_ReturnsInvalidArgument ()
     {
         using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "project-default-repo-root-no-git");
         var workingDirectory = scope.CreateDirectory("workspace");
@@ -459,16 +459,66 @@ public sealed class SkillsCliOutputContractTests
             dryRun: true);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
             command: UcliCommandNames.SkillsInstall,
-            status: "ok",
-            exitCode: (int)CliExitCode.Success);
-        var payload = outputJson.RootElement.GetProperty("payload");
-        FileSystemAssert.ForPath(payload.GetProperty("repositoryRoot").GetString()!).EqualsNormalized(workingDirectory);
-        FileSystemAssert.ForPath(payload.GetProperty("targetRoot").GetString()!).EqualsNormalized(Path.Combine(workingDirectory, ".agents", "skills"));
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
         FileSystemAssert.ForPath(Path.Combine(workingDirectory, ".agents")).DoesNotExist();
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsProjectScope_WithMissingRepoRoot_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"project-missing-repo-root-{subcommand}");
+        var repoRoot = scope.GetPath("missing-repo");
+
+        var result = await RunScopedCommandWithoutRepositoryRootSetupAsync(subcommand, repoRoot, host: "openai", scope: "project", targetDir: null);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsProjectScope_WithRepoRootSubdirectory_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"project-subdirectory-repo-root-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+        EnsureGitRepositoryMarker(repoRoot);
+        var subdirectory = scope.CreateDirectory(Path.Combine("repo", "src", "tool"));
+
+        var result = await RunScopedCommandWithoutRepositoryRootSetupAsync(subcommand, subdirectory, host: "openai", scope: "project", targetDir: null);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
     }
 
     [Fact]
@@ -1021,6 +1071,74 @@ public sealed class SkillsCliOutputContractTests
         CommandResultAssert.HasSingleError(outputJson.RootElement, PathUnsafeCode);
     }
 
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsScopedSubcommand_WithRepositoryRootTargetDir_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"repo-root-target-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunScopedCommandAsync(subcommand, repoRoot, host: "openai", scope: "project", targetDir: ".");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(".git/skills")]
+    [InlineData(".ucli/skills")]
+    public async Task SkillsInstall_WithInternalStorageTargetDir_ReturnsInvalidArgument (string targetDir)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "internal-storage-target");
+        var repoRoot = scope.CreateDirectory("repo");
+
+        var result = await RunScopedCommandAsync(UcliCommandNames.InstallSubcommand, repoRoot, host: "openai", scope: "project", targetDir: targetDir);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsInstall_WithUnityProjectRootTargetDir_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "unity-project-root-target");
+        var repoRoot = scope.CreateDirectory("repo");
+        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "Assets"));
+        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "Packages"));
+        scope.CreateDirectory(Path.Combine("repo", "src", "Ucli.Unity", "ProjectSettings"));
+
+        var result = await RunScopedCommandAsync(UcliCommandNames.InstallSubcommand, repoRoot, host: "openai", scope: "project", targetDir: Path.Combine("src", "Ucli.Unity"));
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
     [Fact]
     [Trait("Size", "Medium")]
     public async Task SkillsDoctor_WithInstalledTarget_ReturnsHealthy ()
@@ -1271,6 +1389,33 @@ public sealed class SkillsCliOutputContractTests
         bool force = false,
         bool printDiff = false)
     {
+        return RunScopedCommandCoreAsync(subcommand, repoRoot, host, scope, targetDir, dryRun, force, printDiff, ensureProjectRepositoryRoot: true);
+    }
+
+    private static Task<CommandExecutionResult> RunScopedCommandWithoutRepositoryRootSetupAsync (
+        string subcommand,
+        string repoRoot,
+        string? host,
+        string? scope,
+        string? targetDir,
+        bool dryRun = false,
+        bool force = false,
+        bool printDiff = false)
+    {
+        return RunScopedCommandCoreAsync(subcommand, repoRoot, host, scope, targetDir, dryRun, force, printDiff, ensureProjectRepositoryRoot: false);
+    }
+
+    private static Task<CommandExecutionResult> RunScopedCommandCoreAsync (
+        string subcommand,
+        string repoRoot,
+        string? host,
+        string? scope,
+        string? targetDir,
+        bool dryRun,
+        bool force,
+        bool printDiff,
+        bool ensureProjectRepositoryRoot)
+    {
         var args = new List<string>
         {
             UcliCommandNames.Skills,
@@ -1286,6 +1431,11 @@ public sealed class SkillsCliOutputContractTests
         {
             args.Add("--scope");
             args.Add(scope);
+        }
+
+        if (ensureProjectRepositoryRoot && string.Equals(scope, "project", StringComparison.OrdinalIgnoreCase))
+        {
+            EnsureGitRepositoryMarker(repoRoot);
         }
 
         args.AddRange([
@@ -1315,6 +1465,11 @@ public sealed class SkillsCliOutputContractTests
         }
 
         return CliProcessRunner.RunCommandAsync(args.ToArray());
+    }
+
+    private static void EnsureGitRepositoryMarker (string repoRoot)
+    {
+        Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
     }
 
     private static Task<CommandExecutionResult> RunOpenAiDoctorAsync (string repoRoot)

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -415,6 +415,62 @@ public sealed class SkillsCliOutputContractTests
         }
     }
 
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsProjectScope_WithoutRepoRoot_UsesWorkingDirectoryGitRoot (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"project-default-repo-root-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+        scope.CreateDirectory(Path.Combine("repo", ".git"));
+        var workingDirectory = scope.CreateDirectory(Path.Combine("repo", "src", "tool"));
+        var seed = await RunOpenAiInstallAsync(repoRoot);
+        Assert.Equal((int)CliExitCode.Success, seed.ExitCode);
+
+        var result = await RunProjectCommandWithoutRepoRootAsync(subcommand, workingDirectory);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        var payload = outputJson.RootElement.GetProperty("payload");
+        FileSystemAssert.ForPath(payload.GetProperty("repositoryRoot").GetString()!).EqualsNormalized(repoRoot);
+        FileSystemAssert.ForPath(payload.GetProperty("targetRoot").GetString()!).EqualsNormalized(Path.Combine(repoRoot, ".agents", "skills"));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsProjectScope_WithoutRepoRootAndGitMarker_UsesWorkingDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "project-default-repo-root-no-git");
+        var workingDirectory = scope.CreateDirectory("workspace");
+
+        var result = await RunProjectCommandWithoutRepoRootAsync(
+            UcliCommandNames.InstallSubcommand,
+            workingDirectory,
+            dryRun: true);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsInstall,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        var payload = outputJson.RootElement.GetProperty("payload");
+        FileSystemAssert.ForPath(payload.GetProperty("repositoryRoot").GetString()!).EqualsNormalized(workingDirectory);
+        FileSystemAssert.ForPath(payload.GetProperty("targetRoot").GetString()!).EqualsNormalized(Path.Combine(workingDirectory, ".agents", "skills"));
+        FileSystemAssert.ForPath(Path.Combine(workingDirectory, ".agents")).DoesNotExist();
+    }
+
     [Fact]
     [Trait("Size", "Medium")]
     public async Task SkillsUserScope_WithoutTargetDir_UsesOpenAiCodexHomeDefault ()
@@ -1181,6 +1237,28 @@ public sealed class SkillsCliOutputContractTests
         bool printDiff = false)
     {
         return RunScopedCommandAsync(UcliCommandNames.InstallSubcommand, repoRoot, host, "project", targetDir, dryRun, force, printDiff);
+    }
+
+    private static Task<CommandExecutionResult> RunProjectCommandWithoutRepoRootAsync (
+        string subcommand,
+        string workingDirectory,
+        bool dryRun = false)
+    {
+        var args = new List<string>
+        {
+            UcliCommandNames.Skills,
+            subcommand,
+            "--host",
+            "openai",
+            "--scope",
+            "project",
+        };
+        if (dryRun)
+        {
+            args.Add("--dryRun");
+        }
+
+        return CliProcessRunner.RunCommandWithWorkingDirectoryAsync(workingDirectory, args.ToArray());
     }
 
     private static Task<CommandExecutionResult> RunScopedCommandAsync (


### PR DESCRIPTION
## Summary
- Allow project-scoped `ucli skills install/update/uninstall/doctor` commands to omit `--repoRoot`.
- Resolve the default project repository root from the current working directory using the existing storage-root resolver.
- Keep existing path validation behavior unchanged; this PR does not add extra guards for explicit `--repoRoot` or `--targetDir`.
- Add CLI contract coverage for Git-root discovery and non-Git CWD fallback.

## Verification
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter FullyQualifiedName~SkillsCliOutputContractTests`
- Previous run on this branch before reverting guards: `bash scripts/verify.sh`

Issueなし運用。
