### PR TITLE
build: implement assurance payload and claims

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -10,6 +10,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Semantics;
 internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticInvariantRule
 {
     private const string UnknownGeneration = "unknown";
+    private const string UnverifiedClaimStatus = "unverified";
 
     private static readonly IReadOnlyList<string> RequiredReportKeys =
     [
@@ -18,6 +19,9 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         BuildReportRefs.BuildOutputManifest,
         BuildReportRefs.BuildLog,
     ];
+
+    private static readonly IReadOnlySet<string> AllowedBuildEffects =
+        new HashSet<string>(ContractLiteralCodec.GetLiterals<BuildEffect>(), StringComparer.Ordinal);
 
     /// <inheritdoc />
     public void ValidateClaim (
@@ -42,7 +46,12 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         ValidateBuildGenerations(buildElement, violations);
         ValidateBuildLogCompletionReason(buildElement, violations);
         ValidateVerifier(payload, violations);
-        ValidateClaimEvidence(claimElement, claimPath, claimId, violations);
+        ValidateClaimEvidence(buildElement, claimElement, claimPath, claimId, violations);
+        if (BuildClaimCodes.UnityBuildCompleted.EqualsValue(claimId))
+        {
+            ValidateCompletedClaim(buildElement, claimElement, claimPath, violations);
+        }
+
         if (BuildClaimCodes.UnityBuildSucceeded.EqualsValue(claimId))
         {
             ValidateSucceededClaim(buildElement, claimElement, claimPath, violations);
@@ -208,6 +217,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         ValidateGenerationSnapshot(generationsElement, "before", "$.build.generations.before", violations);
         ValidateGenerationSnapshot(generationsElement, "after", "$.build.generations.after", violations);
         ValidateGenerationSnapshot(generationsElement, "validFor", "$.build.generations.validFor", violations);
+        ValidateValidForGenerationSnapshot(generationsElement, violations);
     }
 
     private static void ValidateBuildLogCompletionReason (
@@ -245,15 +255,28 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        var expectedStatus = HasCompleteGenerationSnapshots(buildElement)
-            ? ContractLiteralCodec.ToValue(BuildClaimStatus.Passed)
-            : ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
-        if (!string.Equals(status, expectedStatus, StringComparison.Ordinal))
+        if (HasCompleteGenerationSnapshots(buildElement))
+        {
+            var passedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
+            if (!string.Equals(status, passedLiteral, StringComparison.Ordinal))
+            {
+                AddViolation(
+                    violations,
+                    BuildPropertyPath(claimPath, "status"),
+                    "UNITY_BUILD_VALID_FOR_GENERATION must be passed for complete generation snapshots.");
+            }
+
+            return;
+        }
+
+        var indeterminateLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
+        if (!string.Equals(status, indeterminateLiteral, StringComparison.Ordinal)
+            && !string.Equals(status, UnverifiedClaimStatus, StringComparison.Ordinal))
         {
             AddViolation(
                 violations,
                 BuildPropertyPath(claimPath, "status"),
-                $"UNITY_BUILD_VALID_FOR_GENERATION must be {expectedStatus} for the declared generation snapshots.");
+                "UNITY_BUILD_VALID_FOR_GENERATION must be indeterminate or unverified when generation snapshots are incomplete.");
         }
     }
 
@@ -266,21 +289,18 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
 
         return HasCompleteGenerationSnapshot(generationsElement, "before")
             && HasCompleteGenerationSnapshot(generationsElement, "after")
-            && HasCompleteGenerationSnapshot(generationsElement, "validFor");
+            && HasCompleteGenerationSnapshot(generationsElement, "validFor")
+            && GenerationSnapshotsMatch(generationsElement, "after", "validFor");
     }
 
     private static bool HasCompleteGenerationSnapshot (
         JsonElement generationsElement,
         string propertyName)
     {
-        if (!generationsElement.TryGetProperty(propertyName, out var snapshotElement) || snapshotElement.ValueKind != JsonValueKind.Object)
-        {
-            return false;
-        }
-
-        return TryReadKnownGeneration(snapshotElement, "compileGeneration")
-            && TryReadKnownGeneration(snapshotElement, "domainReloadGeneration")
-            && TryReadKnownGeneration(snapshotElement, "assetRefreshGeneration");
+        return TryReadGenerationSnapshot(generationsElement, propertyName, out var snapshot)
+            && IsKnownGeneration(snapshot.CompileGeneration)
+            && IsKnownGeneration(snapshot.DomainReloadGeneration)
+            && IsKnownGeneration(snapshot.AssetRefreshGeneration);
     }
 
     private static bool TryReadGenerations (
@@ -308,6 +328,25 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         ValidateGenerationValue(snapshotElement, "assetRefreshGeneration", propertyPath, violations);
     }
 
+    private static void ValidateValidForGenerationSnapshot (
+        JsonElement generationsElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!HasCompleteGenerationSnapshot(generationsElement, "after")
+            || !HasCompleteGenerationSnapshot(generationsElement, "validFor"))
+        {
+            return;
+        }
+
+        if (!GenerationSnapshotsMatch(generationsElement, "after", "validFor"))
+        {
+            AddViolation(
+                violations,
+                "$.build.generations.validFor",
+                "Build generations.validFor must match generations.after.");
+        }
+    }
+
     private static void ValidateGenerationValue (
         JsonElement snapshotElement,
         string propertyName,
@@ -320,12 +359,50 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
     }
 
-    private static bool TryReadKnownGeneration (
-        JsonElement snapshotElement,
-        string propertyName)
+    private static bool IsKnownGeneration (string generation)
     {
-        return TryReadString(snapshotElement, propertyName, out var generation)
-            && !string.Equals(generation, UnknownGeneration, StringComparison.Ordinal);
+        return !string.Equals(generation, UnknownGeneration, StringComparison.Ordinal);
+    }
+
+    private static bool GenerationSnapshotsMatch (
+        JsonElement generationsElement,
+        string leftPropertyName,
+        string rightPropertyName)
+    {
+        return TryReadGenerationSnapshot(generationsElement, leftPropertyName, out var left)
+            && TryReadGenerationSnapshot(generationsElement, rightPropertyName, out var right)
+            && GenerationSnapshotsMatch(left, right);
+    }
+
+    private static bool GenerationSnapshotsMatch (
+        (string CompileGeneration, string DomainReloadGeneration, string AssetRefreshGeneration) left,
+        (string CompileGeneration, string DomainReloadGeneration, string AssetRefreshGeneration) right)
+    {
+        return string.Equals(left.CompileGeneration, right.CompileGeneration, StringComparison.Ordinal)
+            && string.Equals(left.DomainReloadGeneration, right.DomainReloadGeneration, StringComparison.Ordinal)
+            && string.Equals(left.AssetRefreshGeneration, right.AssetRefreshGeneration, StringComparison.Ordinal);
+    }
+
+    private static bool TryReadGenerationSnapshot (
+        JsonElement generationsElement,
+        string propertyName,
+        out (string CompileGeneration, string DomainReloadGeneration, string AssetRefreshGeneration) snapshot)
+    {
+        snapshot = default;
+        if (!generationsElement.TryGetProperty(propertyName, out var snapshotElement) || snapshotElement.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!TryReadString(snapshotElement, "compileGeneration", out var compileGeneration)
+            || !TryReadString(snapshotElement, "domainReloadGeneration", out var domainReloadGeneration)
+            || !TryReadString(snapshotElement, "assetRefreshGeneration", out var assetRefreshGeneration))
+        {
+            return false;
+        }
+
+        snapshot = (compileGeneration, domainReloadGeneration, assetRefreshGeneration);
+        return true;
     }
 
     private static void ValidateVerifier (
@@ -368,14 +445,28 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        var effects = effectsElement
-            .EnumerateArray()
-            .Where(static item => item.ValueKind == JsonValueKind.String)
-            .Select(static item => item.GetString() ?? string.Empty)
-            .ToArray();
-        if (!effects.SequenceEqual(ContractLiteralCodec.GetLiterals<BuildEffect>(), StringComparer.Ordinal))
+        var seenEffects = new HashSet<string>(StringComparer.Ordinal);
+        var index = 0;
+        foreach (var effectElement in effectsElement.EnumerateArray())
         {
-            AddViolation(violations, effectsPath, "Build verifier effects must match the build effect literal set.");
+            if (effectElement.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(effectElement.GetString()))
+            {
+                AddViolation(violations, $"{effectsPath}[{index}]", "Build verifier effect must be a non-empty string.");
+                index++;
+                continue;
+            }
+
+            var effect = effectElement.GetString()!;
+            if (!AllowedBuildEffects.Contains(effect))
+            {
+                AddViolation(violations, $"{effectsPath}[{index}]", "Build verifier effect must be one of the build effect literals.");
+            }
+            else if (!seenEffects.Add(effect))
+            {
+                AddViolation(violations, $"{effectsPath}[{index}]", "Build verifier effects must not contain duplicates.");
+            }
+
+            index++;
         }
     }
 
@@ -432,12 +523,46 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
     }
 
+    private static void ValidateCompletedClaim (
+        JsonElement buildElement,
+        JsonElement claimElement,
+        string claimPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadBuildResult(buildElement, out var result)
+            || !TryReadString(claimElement, "status", out var status)
+            || !ContractLiteralCodec.TryParse<IpcBuildReportResult>(result, out var parsedResult))
+        {
+            return;
+        }
+
+        var passedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
+        var indeterminateLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
+        var expectedStatus = parsedResult is IpcBuildReportResult.Succeeded or IpcBuildReportResult.Failed or IpcBuildReportResult.Canceled
+            ? passedLiteral
+            : indeterminateLiteral;
+        if (!string.Equals(status, expectedStatus, StringComparison.Ordinal))
+        {
+            AddViolation(
+                violations,
+                BuildPropertyPath(claimPath, "status"),
+                $"UNITY_BUILD_COMPLETED must be {expectedStatus} for the BuildReport result.");
+        }
+    }
+
     private static void ValidateClaimEvidence (
+        JsonElement buildElement,
         JsonElement claimElement,
         string claimPath,
         string claimId,
         List<AssuranceSemanticInvariantViolation> violations)
     {
+        if (BuildClaimCodes.UnityBuildValidForGeneration.EqualsValue(claimId))
+        {
+            ValidateGenerationClaimEvidence(buildElement, claimElement, claimPath, violations);
+            return;
+        }
+
         var expectedEvidenceRef = ResolveExpectedEvidenceRef(claimId);
         if (expectedEvidenceRef == null)
         {
@@ -464,6 +589,70 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             violations,
             BuildPropertyPath(claimPath, "evidence"),
             $"Build claim {claimId} evidence must reference reports.{expectedEvidenceRef}.");
+    }
+
+    private static void ValidateGenerationClaimEvidence (
+        JsonElement buildElement,
+        JsonElement claimElement,
+        string claimPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!claimElement.TryGetProperty("evidence", out var evidenceElement) || evidenceElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, BuildPropertyPath(claimPath, "evidence"), "Build claim UNITY_BUILD_VALID_FOR_GENERATION must include evidence.");
+            return;
+        }
+
+        foreach (var evidence in evidenceElement.EnumerateArray())
+        {
+            if (evidence.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            if (TryReadString(evidence, "evidenceRef", out var evidenceRef)
+                && string.Equals(evidenceRef, BuildReportRefs.Build, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (EvidenceDataMatchesBuildGenerations(buildElement, evidence))
+            {
+                return;
+            }
+        }
+
+        AddViolation(
+            violations,
+            BuildPropertyPath(claimPath, "evidence"),
+            "UNITY_BUILD_VALID_FOR_GENERATION evidence must reference reports.build or include payload.build.generations data.");
+    }
+
+    private static bool EvidenceDataMatchesBuildGenerations (
+        JsonElement buildElement,
+        JsonElement evidenceElement)
+    {
+        if (!TryReadGenerations(buildElement, out var generationsElement)
+            || !evidenceElement.TryGetProperty("data", out var dataElement)
+            || dataElement.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return GenerationSnapshotsMatch(generationsElement, "before", dataElement, "before")
+            && GenerationSnapshotsMatch(generationsElement, "after", dataElement, "after")
+            && GenerationSnapshotsMatch(generationsElement, "validFor", dataElement, "validFor");
+    }
+
+    private static bool GenerationSnapshotsMatch (
+        JsonElement leftGenerationsElement,
+        string leftPropertyName,
+        JsonElement rightGenerationsElement,
+        string rightPropertyName)
+    {
+        return TryReadGenerationSnapshot(leftGenerationsElement, leftPropertyName, out var left)
+            && TryReadGenerationSnapshot(rightGenerationsElement, rightPropertyName, out var right)
+            && GenerationSnapshotsMatch(left, right);
     }
 
     private static string? ResolveExpectedEvidenceRef (string claimId)
@@ -541,6 +730,16 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         string path,
         string message)
     {
+        for (var i = 0; i < violations.Count; i++)
+        {
+            var violation = violations[i];
+            if (string.Equals(violation.Path, path, StringComparison.Ordinal)
+                && string.Equals(violation.Message, message, StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
         violations.Add(new AssuranceSemanticInvariantViolation(path, message));
     }
 }

--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -9,6 +9,8 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Semantics;
 /// <summary> Validates build-specific semantic invariants inside the common assurance payload shape. </summary>
 internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticInvariantRule
 {
+    private const string UnknownGeneration = "unknown";
+
     private static readonly IReadOnlyList<string> RequiredReportKeys =
     [
         BuildReportRefs.Build,
@@ -33,13 +35,22 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
 
         ValidateReports(payload, violations);
+        ValidateBuildProfile(buildElement, violations);
         ValidateBuildOutput(payload, violations);
+        ValidateBuildSummary(buildElement, violations);
+        ValidateBuildLogs(buildElement, violations);
+        ValidateBuildGenerations(buildElement, violations);
         ValidateBuildLogCompletionReason(buildElement, violations);
         ValidateVerifier(payload, violations);
         ValidateClaimEvidence(claimElement, claimPath, claimId, violations);
         if (BuildClaimCodes.UnityBuildSucceeded.EqualsValue(claimId))
         {
             ValidateSucceededClaim(buildElement, claimElement, claimPath, violations);
+        }
+
+        if (BuildClaimCodes.UnityBuildValidForGeneration.EqualsValue(claimId))
+        {
+            ValidateGenerationClaim(buildElement, claimElement, claimPath, violations);
         }
     }
 
@@ -123,6 +134,82 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
     }
 
+    private static void ValidateBuildProfile (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!buildElement.TryGetProperty("profile", out var profileElement) || profileElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.profile", "Build payload must declare profile.");
+            return;
+        }
+
+        if (!TryReadString(profileElement, "path", out _))
+        {
+            AddViolation(violations, "$.build.profile.path", "Build profile must declare path.");
+        }
+
+        if (!TryReadString(profileElement, "digest", out _))
+        {
+            AddViolation(violations, "$.build.profile.digest", "Build profile must declare digest.");
+        }
+    }
+
+    private static void ValidateBuildSummary (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!buildElement.TryGetProperty("summary", out var summaryElement) || summaryElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.summary", "Build payload must declare summary.");
+            return;
+        }
+
+        if (!TryReadString(summaryElement, "reportRef", out var reportRef))
+        {
+            AddViolation(violations, "$.build.summary.reportRef", "Build summary must declare reportRef.");
+        }
+        else if (!string.Equals(reportRef, BuildReportRefs.BuildReport, StringComparison.Ordinal))
+        {
+            AddViolation(violations, "$.build.summary.reportRef", "Build summary reportRef must resolve to reports.buildReport.");
+        }
+    }
+
+    private static void ValidateBuildLogs (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!buildElement.TryGetProperty("logs", out var logsElement) || logsElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.logs", "Build payload must declare logs.");
+            return;
+        }
+
+        if (!TryReadString(logsElement, "reportRef", out var reportRef))
+        {
+            AddViolation(violations, "$.build.logs.reportRef", "Build logs must declare reportRef.");
+        }
+        else if (!string.Equals(reportRef, BuildReportRefs.BuildLog, StringComparison.Ordinal))
+        {
+            AddViolation(violations, "$.build.logs.reportRef", "Build logs reportRef must resolve to reports.buildLog.");
+        }
+    }
+
+    private static void ValidateBuildGenerations (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadGenerations(buildElement, out var generationsElement))
+        {
+            AddViolation(violations, "$.build.generations", "Build payload must declare generations.");
+            return;
+        }
+
+        ValidateGenerationSnapshot(generationsElement, "before", "$.build.generations.before", violations);
+        ValidateGenerationSnapshot(generationsElement, "after", "$.build.generations.after", violations);
+        ValidateGenerationSnapshot(generationsElement, "validFor", "$.build.generations.validFor", violations);
+    }
+
     private static void ValidateBuildLogCompletionReason (
         JsonElement buildElement,
         List<AssuranceSemanticInvariantViolation> violations)
@@ -145,6 +232,100 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
                 "$.build.logs.completionReason",
                 "Build log completionReason must match the BuildReport result.");
         }
+    }
+
+    private static void ValidateGenerationClaim (
+        JsonElement buildElement,
+        JsonElement claimElement,
+        string claimPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadString(claimElement, "status", out var status))
+        {
+            return;
+        }
+
+        var expectedStatus = HasCompleteGenerationSnapshots(buildElement)
+            ? ContractLiteralCodec.ToValue(BuildClaimStatus.Passed)
+            : ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
+        if (!string.Equals(status, expectedStatus, StringComparison.Ordinal))
+        {
+            AddViolation(
+                violations,
+                BuildPropertyPath(claimPath, "status"),
+                $"UNITY_BUILD_VALID_FOR_GENERATION must be {expectedStatus} for the declared generation snapshots.");
+        }
+    }
+
+    private static bool HasCompleteGenerationSnapshots (JsonElement buildElement)
+    {
+        if (!TryReadGenerations(buildElement, out var generationsElement))
+        {
+            return false;
+        }
+
+        return HasCompleteGenerationSnapshot(generationsElement, "before")
+            && HasCompleteGenerationSnapshot(generationsElement, "after")
+            && HasCompleteGenerationSnapshot(generationsElement, "validFor");
+    }
+
+    private static bool HasCompleteGenerationSnapshot (
+        JsonElement generationsElement,
+        string propertyName)
+    {
+        if (!generationsElement.TryGetProperty(propertyName, out var snapshotElement) || snapshotElement.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return TryReadKnownGeneration(snapshotElement, "compileGeneration")
+            && TryReadKnownGeneration(snapshotElement, "domainReloadGeneration")
+            && TryReadKnownGeneration(snapshotElement, "assetRefreshGeneration");
+    }
+
+    private static bool TryReadGenerations (
+        JsonElement buildElement,
+        out JsonElement generationsElement)
+    {
+        return buildElement.TryGetProperty("generations", out generationsElement)
+            && generationsElement.ValueKind == JsonValueKind.Object;
+    }
+
+    private static void ValidateGenerationSnapshot (
+        JsonElement generationsElement,
+        string propertyName,
+        string propertyPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!generationsElement.TryGetProperty(propertyName, out var snapshotElement) || snapshotElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, propertyPath, $"Build generations must declare {propertyName}.");
+            return;
+        }
+
+        ValidateGenerationValue(snapshotElement, "compileGeneration", propertyPath, violations);
+        ValidateGenerationValue(snapshotElement, "domainReloadGeneration", propertyPath, violations);
+        ValidateGenerationValue(snapshotElement, "assetRefreshGeneration", propertyPath, violations);
+    }
+
+    private static void ValidateGenerationValue (
+        JsonElement snapshotElement,
+        string propertyName,
+        string ownerPath,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadString(snapshotElement, propertyName, out _))
+        {
+            AddViolation(violations, BuildPropertyPath(ownerPath, propertyName), "Build generation value must be a non-empty string.");
+        }
+    }
+
+    private static bool TryReadKnownGeneration (
+        JsonElement snapshotElement,
+        string propertyName)
+    {
+        return TryReadString(snapshotElement, propertyName, out var generation)
+            && !string.Equals(generation, UnknownGeneration, StringComparison.Ordinal);
     }
 
     private static void ValidateVerifier (

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -79,6 +79,7 @@ public sealed class BuildServiceTests
         Assert.Equal(ContractLiteralCodec.ToValue(BuildProfileOutputKind.UcliArtifact), output.Build.Output.Kind);
         Assert.Equal(artifactStore.PreparedPaths!.ArtifactsDirectory, output.Build.Output.ArtifactRoot);
         Assert.Equal(artifactStore.PreparedPaths.OutputDirectory, output.Build.Output.OutputRoot);
+        Assert.Equal(BuildReportRefs.BuildOutputManifest, output.Build.Output.ManifestRef);
         Assert.Equal("manifest-digest", output.Build.Output.ManifestDigest);
         Assert.Equal(
             [BuildReportRefs.Build, BuildReportRefs.BuildLog, BuildReportRefs.BuildOutputManifest, BuildReportRefs.BuildReport],
@@ -88,6 +89,8 @@ public sealed class BuildServiceTests
         Assert.Equal("output-manifest-artifact-digest", output.Reports[BuildReportRefs.BuildOutputManifest].Digest);
         Assert.Equal("build-log-digest", output.Reports[BuildReportRefs.BuildLog].Digest);
         Assert.All(output.Reports, report => Assert.Equal(report.Key, report.Value.Kind));
+        Assert.True(output.Reports.ContainsKey(output.Build.Output.ManifestRef));
+        AssertEvidenceRefsResolveToReports(output);
         Assert.Equal(10, output.Claims.Count);
         Assert.All(output.Claims, claim => Assert.True(claim.Required));
         var verifier = Assert.Single(output.Verifiers);
@@ -98,6 +101,14 @@ public sealed class BuildServiceTests
         Assert.Equal(
             ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
             artifactStore.WrittenMetadata!.Summary.GetProperty("result").GetString());
+        Assert.Equal(output.Build.Profile.Path, artifactStore.WrittenMetadata.Profile.GetProperty("path").GetString());
+        Assert.Equal(output.Build.Profile.Digest, artifactStore.WrittenMetadata.Profile.GetProperty("digest").GetString());
+        Assert.Equal(output.Build.Summary.ReportRef, artifactStore.WrittenMetadata.Summary.GetProperty("reportRef").GetString());
+        Assert.Equal(output.Build.Logs.ReportRef, artifactStore.WrittenMetadata.Logs.GetProperty("reportRef").GetString());
+        Assert.Equal(output.Build.Output.ManifestRef, artifactStore.WrittenMetadata.Output.GetProperty("manifestRef").GetString());
+        Assert.Equal(output.Build.Generations.Before.CompileGeneration, artifactStore.WrittenMetadata.Generations.GetProperty("before").GetProperty("compileGeneration").GetString());
+        Assert.Equal(output.Build.Generations.After.DomainReloadGeneration, artifactStore.WrittenMetadata.Generations.GetProperty("after").GetProperty("domainReloadGeneration").GetString());
+        Assert.Equal(output.Build.Generations.ValidFor.AssetRefreshGeneration, artifactStore.WrittenMetadata.Generations.GetProperty("validFor").GetProperty("assetRefreshGeneration").GetString());
         Assert.Equal("ready", artifactStore.WrittenMetadata.Lifecycle.GetProperty("before").GetProperty("lifecycleState").GetString());
         Assert.Equal("ready", artifactStore.WrittenMetadata.Lifecycle.GetProperty("after").GetProperty("lifecycleState").GetString());
         AssertProgressEvents(
@@ -692,6 +703,24 @@ public sealed class BuildServiceTests
         UcliCode code)
     {
         return output.Claims.Single(claim => string.Equals(claim.Id, code.Value, StringComparison.Ordinal));
+    }
+
+    private static void AssertEvidenceRefsResolveToReports (BuildExecutionOutput output)
+    {
+        foreach (var claim in output.Claims)
+        {
+            foreach (var evidence in claim.Evidence)
+            {
+                if (evidence.EvidenceRef == null)
+                {
+                    continue;
+                }
+
+                Assert.True(
+                    output.Reports.ContainsKey(evidence.EvidenceRef),
+                    $"Claim {claim.Id} references missing report '{evidence.EvidenceRef}'.");
+            }
+        }
     }
 
     private static AssuranceSemanticInvariantValidator CreateBuildSemanticInvariantValidator ()

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -54,6 +54,69 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Validate_WithBuildPayloadMissingProfile_ReturnsProfilePath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(includeBuildProfile: false));
+
+        AssertViolationPath(result, "$.build.profile");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildOutputManifestRefMismatch_ReturnsManifestRefPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(buildManifestRef: "build"));
+
+        AssertViolationPath(result, "$.build.output.manifestRef");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildSummaryReportRefMismatch_ReturnsSummaryReportRefPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(summaryReportRef: "build"));
+
+        AssertViolationPath(result, "$.build.summary.reportRef");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildLogsReportRefMismatch_ReturnsLogsReportRefPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(logsReportRef: "buildReport"));
+
+        AssertViolationPath(result, "$.build.logs.reportRef");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildVerifierEffectsMismatch_ReturnsEffectsPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(verifierEffects: ["unityBuildPipeline"]));
+
+        AssertViolationPath(result, "$.verifiers[0].effects");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildPayloadMissingGenerations_ReturnsGenerationsPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(includeBuildGenerations: false));
+
+        AssertViolationPath(result, "$.build.generations");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithIncompleteBuildGenerationAndPassedClaim_ReturnsGenerationClaimStatusPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(validForAssetRefreshGeneration: "unknown"));
+
+        AssertViolationPath(result, BuildGenerationClaimPath("status"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Validate_WithBuildClaimEvidenceRefMismatch_ReturnsClaimEvidencePath ()
     {
         var result = ValidateBuildPayload(CreateBuildPayload(buildSucceededEvidenceRef: "build"));
@@ -814,7 +877,14 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         string buildSucceededClaimStatus = "passed",
         bool includeBuildLogReport = true,
         bool includeBuildLogDigest = true,
-        string? buildSucceededEvidenceRef = null)
+        string? buildSucceededEvidenceRef = null,
+        bool includeBuildProfile = true,
+        string buildManifestRef = "buildOutputManifest",
+        string summaryReportRef = "buildReport",
+        string logsReportRef = "buildLog",
+        IReadOnlyList<string>? verifierEffects = null,
+        bool includeBuildGenerations = true,
+        string validForAssetRefreshGeneration = "asset-after")
     {
         var reports = new Dictionary<string, object>(StringComparer.Ordinal)
         {
@@ -865,23 +935,56 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                 residualRisks = Array.Empty<object>(),
             })
             .ToArray();
+        object? profile = includeBuildProfile
+            ? new
+            {
+                path = ".ucli/build/player.json",
+                digest = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            }
+            : null;
+        object? generations = includeBuildGenerations
+            ? new
+            {
+                before = new
+                {
+                    compileGeneration = "compile-before",
+                    domainReloadGeneration = "domain-before",
+                    assetRefreshGeneration = "asset-before",
+                },
+                after = new
+                {
+                    compileGeneration = "compile-after",
+                    domainReloadGeneration = "domain-after",
+                    assetRefreshGeneration = "asset-after",
+                },
+                validFor = new
+                {
+                    compileGeneration = "compile-after",
+                    domainReloadGeneration = "domain-after",
+                    assetRefreshGeneration = validForAssetRefreshGeneration,
+                },
+            }
+            : null;
         return JsonSerializer.Serialize(new
         {
             verdict = "pass",
             build = new
             {
+                profile,
                 output = new
                 {
-                    manifestRef = "buildOutputManifest",
+                    manifestRef = buildManifestRef,
                     manifestDigest = "manifest-digest",
                 },
+                generations,
                 summary = new
                 {
                     result = buildResult,
+                    reportRef = summaryReportRef,
                 },
                 logs = new
                 {
-                    reportRef = "buildLog",
+                    reportRef = logsReportRef,
                     entryCount = 1,
                     errorCount = 0,
                     warningCount = 0,
@@ -897,7 +1000,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                     deterministic = false,
                     required = true,
                     primaryClaims = BuildClaimCodes.All.Select(static code => code.Value).ToArray(),
-                    effects = ContractLiteralCodec.GetLiterals<BuildEffect>(),
+                    effects = verifierEffects ?? ContractLiteralCodec.GetLiterals<BuildEffect>(),
                     reportRef = "build",
                 },
             },
@@ -918,6 +1021,19 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         }
 
         throw new InvalidOperationException("Build claim catalog must contain UNITY_BUILD_SUCCEEDED.");
+    }
+
+    private static string BuildGenerationClaimPath (string propertyName)
+    {
+        for (var i = 0; i < BuildClaimCodes.All.Count; i++)
+        {
+            if (BuildClaimCodes.All[i].Equals(BuildClaimCodes.UnityBuildValidForGeneration))
+            {
+                return $"$.claims[{i}].{propertyName}";
+            }
+        }
+
+        throw new InvalidOperationException("Build claim catalog must contain UNITY_BUILD_VALID_FOR_GENERATION.");
     }
 
     private static object[] CreateBuildEvidence (

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -59,6 +59,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         var result = ValidateBuildPayload(CreateBuildPayload(includeBuildProfile: false));
 
         AssertViolationPath(result, "$.build.profile");
+        Assert.Single(result.Violations, static violation => string.Equals(violation.Path, "$.build.profile", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -90,11 +91,39 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void Validate_WithBuildVerifierEffectsMismatch_ReturnsEffectsPath ()
+    public void Validate_WithBuildVerifierEffectsSubset_ReturnsNoViolations ()
     {
         var result = ValidateBuildPayload(CreateBuildPayload(verifierEffects: ["unityBuildPipeline"]));
 
-        AssertViolationPath(result, "$.verifiers[0].effects");
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildVerifierUnknownEffect_ReturnsEffectsPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(verifierEffects: ["unknownEffect"]));
+
+        AssertViolationPath(result, "$.verifiers[0].effects[0]");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildVerifierNonStringEffect_ReturnsEffectsPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(verifierEffects: [1]));
+
+        AssertViolationPath(result, "$.verifiers[0].effects[0]");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildVerifierDuplicateEffect_ReturnsEffectsPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(verifierEffects: ["unityBuildPipeline", "unityBuildPipeline"]));
+
+        AssertViolationPath(result, "$.verifiers[0].effects[1]");
     }
 
     [Fact]
@@ -117,6 +146,60 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Validate_WithIncompleteBuildGenerationAndUnverifiedClaim_ReturnsNoViolations ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            verdict: "incomplete",
+            buildGenerationClaimStatus: "unverified",
+            validForAssetRefreshGeneration: "unknown"));
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithCompleteBuildGenerationAndUnverifiedClaim_ReturnsGenerationClaimStatusPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            verdict: "incomplete",
+            buildGenerationClaimStatus: "unverified"));
+
+        AssertViolationPath(result, BuildGenerationClaimPath("status"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildGenerationValidForMismatch_ReturnsValidForPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(validForAssetRefreshGeneration: "asset-other"));
+
+        AssertViolationPath(result, "$.build.generations.validFor");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildGenerationDataOnlyEvidence_ReturnsNoViolations ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(buildGenerationEvidenceDataOnly: true));
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildGenerationDataOnlyEvidenceMismatch_ReturnsGenerationClaimEvidencePath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            buildGenerationEvidenceDataOnly: true,
+            buildGenerationEvidenceDataValidForAssetRefreshGeneration: "asset-evidence"));
+
+        AssertViolationPath(result, BuildGenerationClaimPath("evidence"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Validate_WithBuildClaimEvidenceRefMismatch_ReturnsClaimEvidencePath ()
     {
         var result = ValidateBuildPayload(CreateBuildPayload(buildSucceededEvidenceRef: "build"));
@@ -134,6 +217,56 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             buildSucceededClaimStatus: "passed"));
 
         AssertViolationPath(result, BuildSucceededClaimPath("status"));
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("failed", "failed")]
+    [InlineData("canceled", "canceled")]
+    public void Validate_WithTerminalUnsuccessfulBuildResultAndExpectedClaims_ReturnsNoViolations (
+        string buildResult,
+        string buildCompletionReason)
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            verdict: "fail",
+            buildResult: buildResult,
+            buildCompletionReason: buildCompletionReason,
+            buildSucceededClaimStatus: "failed"));
+
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Violations);
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("failed", "failed")]
+    [InlineData("canceled", "canceled")]
+    public void Validate_WithTerminalBuildResultAndFailedCompletedClaim_ReturnsCompletedClaimStatusPath (
+        string buildResult,
+        string buildCompletionReason)
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            verdict: "fail",
+            buildResult: buildResult,
+            buildCompletionReason: buildCompletionReason,
+            buildCompletedClaimStatus: "failed",
+            buildSucceededClaimStatus: "failed"));
+
+        AssertViolationPath(result, BuildCompletedClaimPath("status"));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithUnknownBuildResultAndPassedCompletedClaim_ReturnsCompletedClaimStatusPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            verdict: "fail",
+            buildResult: "unknown",
+            buildCompletionReason: "failed",
+            buildCompletedClaimStatus: "passed",
+            buildSucceededClaimStatus: "failed"));
+
+        AssertViolationPath(result, BuildCompletedClaimPath("status"));
     }
 
     [Fact]
@@ -872,17 +1005,22 @@ public sealed class AssuranceSemanticInvariantValidatorTests
     }
 
     private static string CreateBuildPayload (
+        string verdict = "pass",
         string buildResult = "succeeded",
         string buildCompletionReason = "completed",
+        string buildCompletedClaimStatus = "passed",
         string buildSucceededClaimStatus = "passed",
+        string buildGenerationClaimStatus = "passed",
         bool includeBuildLogReport = true,
         bool includeBuildLogDigest = true,
         string? buildSucceededEvidenceRef = null,
+        bool buildGenerationEvidenceDataOnly = false,
+        string? buildGenerationEvidenceDataValidForAssetRefreshGeneration = null,
         bool includeBuildProfile = true,
         string buildManifestRef = "buildOutputManifest",
         string summaryReportRef = "buildReport",
         string logsReportRef = "buildLog",
-        IReadOnlyList<string>? verifierEffects = null,
+        IReadOnlyList<object>? verifierEffects = null,
         bool includeBuildGenerations = true,
         string validForAssetRefreshGeneration = "asset-after")
     {
@@ -923,18 +1061,6 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                 };
         }
 
-        var claims = BuildClaimCodes.All
-            .Select(code => new
-            {
-                id = code.Value,
-                status = code.Equals(BuildClaimCodes.UnityBuildSucceeded) ? buildSucceededClaimStatus : "passed",
-                coverage = "full",
-                required = true,
-                verifierRef = "build",
-                evidence = CreateBuildEvidence(code.Value, buildSucceededEvidenceRef),
-                residualRisks = Array.Empty<object>(),
-            })
-            .ToArray();
         object? profile = includeBuildProfile
             ? new
             {
@@ -943,31 +1069,38 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             }
             : null;
         object? generations = includeBuildGenerations
-            ? new
-            {
-                before = new
-                {
-                    compileGeneration = "compile-before",
-                    domainReloadGeneration = "domain-before",
-                    assetRefreshGeneration = "asset-before",
-                },
-                after = new
-                {
-                    compileGeneration = "compile-after",
-                    domainReloadGeneration = "domain-after",
-                    assetRefreshGeneration = "asset-after",
-                },
-                validFor = new
-                {
-                    compileGeneration = "compile-after",
-                    domainReloadGeneration = "domain-after",
-                    assetRefreshGeneration = validForAssetRefreshGeneration,
-                },
-            }
+            ? CreateBuildGenerations(validForAssetRefreshGeneration)
             : null;
+        var generationEvidenceData = buildGenerationEvidenceDataValidForAssetRefreshGeneration == null
+            ? generations
+            : CreateBuildGenerations(buildGenerationEvidenceDataValidForAssetRefreshGeneration);
+        var claims = BuildClaimCodes.All
+            .Select(code =>
+            {
+                var status = ResolveBuildClaimStatus(
+                    code,
+                    buildCompletedClaimStatus,
+                    buildSucceededClaimStatus,
+                    buildGenerationClaimStatus);
+                return new
+                {
+                    id = code.Value,
+                    status,
+                    coverage = ResolveBuildClaimCoverage(status),
+                    required = true,
+                    verifierRef = "build",
+                    evidence = CreateBuildEvidence(
+                        code.Value,
+                        buildSucceededEvidenceRef,
+                        buildGenerationEvidenceDataOnly,
+                        generationEvidenceData),
+                    residualRisks = Array.Empty<object>(),
+                };
+            })
+            .ToArray();
         return JsonSerializer.Serialize(new
         {
-            verdict = "pass",
+            verdict,
             build = new
             {
                 profile,
@@ -1000,7 +1133,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                     deterministic = false,
                     required = true,
                     primaryClaims = BuildClaimCodes.All.Select(static code => code.Value).ToArray(),
-                    effects = verifierEffects ?? ContractLiteralCodec.GetLiterals<BuildEffect>(),
+                    effects = verifierEffects ?? ContractLiteralCodec.GetLiterals<BuildEffect>().Cast<object>().ToArray(),
                     reportRef = "build",
                 },
             },
@@ -1008,6 +1141,63 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             reports,
             residualRisks = Array.Empty<object>(),
         });
+    }
+
+    private static object CreateBuildGenerations (string validForAssetRefreshGeneration)
+    {
+        return new
+        {
+            before = new
+            {
+                compileGeneration = "compile-before",
+                domainReloadGeneration = "domain-before",
+                assetRefreshGeneration = "asset-before",
+            },
+            after = new
+            {
+                compileGeneration = "compile-after",
+                domainReloadGeneration = "domain-after",
+                assetRefreshGeneration = "asset-after",
+            },
+            validFor = new
+            {
+                compileGeneration = "compile-after",
+                domainReloadGeneration = "domain-after",
+                assetRefreshGeneration = validForAssetRefreshGeneration,
+            },
+        };
+    }
+
+    private static string ResolveBuildClaimStatus (
+        UcliCode code,
+        string buildCompletedClaimStatus,
+        string buildSucceededClaimStatus,
+        string buildGenerationClaimStatus)
+    {
+        if (code.Equals(BuildClaimCodes.UnityBuildCompleted))
+        {
+            return buildCompletedClaimStatus;
+        }
+
+        if (code.Equals(BuildClaimCodes.UnityBuildSucceeded))
+        {
+            return buildSucceededClaimStatus;
+        }
+
+        if (code.Equals(BuildClaimCodes.UnityBuildValidForGeneration))
+        {
+            return buildGenerationClaimStatus;
+        }
+
+        return "passed";
+    }
+
+    private static string ResolveBuildClaimCoverage (string status)
+    {
+        return string.Equals(status, "indeterminate", StringComparison.Ordinal)
+            || string.Equals(status, "unverified", StringComparison.Ordinal)
+            ? "none"
+            : "full";
     }
 
     private static string BuildSucceededClaimPath (string propertyName)
@@ -1021,6 +1211,19 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         }
 
         throw new InvalidOperationException("Build claim catalog must contain UNITY_BUILD_SUCCEEDED.");
+    }
+
+    private static string BuildCompletedClaimPath (string propertyName)
+    {
+        for (var i = 0; i < BuildClaimCodes.All.Count; i++)
+        {
+            if (BuildClaimCodes.All[i].Equals(BuildClaimCodes.UnityBuildCompleted))
+            {
+                return $"$.claims[{i}].{propertyName}";
+            }
+        }
+
+        throw new InvalidOperationException("Build claim catalog must contain UNITY_BUILD_COMPLETED.");
     }
 
     private static string BuildGenerationClaimPath (string propertyName)
@@ -1038,8 +1241,22 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     private static object[] CreateBuildEvidence (
         string claimId,
-        string? buildSucceededEvidenceRef)
+        string? buildSucceededEvidenceRef,
+        bool buildGenerationEvidenceDataOnly,
+        object? buildGenerationEvidenceData)
     {
+        if (BuildClaimCodes.UnityBuildValidForGeneration.EqualsValue(claimId) && buildGenerationEvidenceDataOnly)
+        {
+            return
+            [
+                new
+                {
+                    kind = "evidence",
+                    data = buildGenerationEvidenceData,
+                },
+            ];
+        }
+
         var evidenceRef = ResolveBuildEvidenceRef(claimId);
         if (BuildClaimCodes.UnityBuildSucceeded.EqualsValue(claimId) && buildSucceededEvidenceRef != null)
         {

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandResultFactoryTests.cs
@@ -1,6 +1,7 @@
 using MackySoft.Ucli.Application.Features.Assurance.Build.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Vocabulary;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Hosting.Cli.Assurance;
 
@@ -20,6 +21,38 @@ public sealed class BuildRunCommandResultFactoryTests
         Assert.Equal(1, result.ExitCode);
         Assert.Empty(result.Errors);
         Assert.Same(output, result.Payload);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Create_WithDirtySceneCommandFailure_ReturnsErrorStatusAndDirtyStatePayload ()
+    {
+        var dirtyState = new IpcBuildDirtyState(
+            Checked: true,
+            Dirty: true,
+            Items:
+            [
+                new IpcBuildDirtyStateItem(
+                    ContractLiteralCodec.ToValue(IpcBuildDirtyStateItemKind.Scene),
+                    "Assets/Scenes/Main.unity"),
+            ]);
+        var project = new ProjectIdentityInfo(
+            ProjectPath: "/workspace/UnityProject",
+            ProjectFingerprint: "project-fingerprint",
+            UnityVersion: "6000.1.4f1");
+        var executionResult = BuildExecutionResult.Failure(
+            ExecutionError.InternalError("Dirty scene state is present.", BuildErrorCodes.BuildDirtyStatePresent),
+            project,
+            dirtyState);
+
+        var result = BuildRunCommandResultFactory.Create(executionResult);
+
+        Assert.Equal(IpcProtocol.StatusError, result.Status);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(BuildErrorCodes.BuildDirtyStatePresent, error.Code);
+        var payload = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(result.Payload);
+        Assert.True(payload.ContainsKey("project"));
+        Assert.Same(dirtyState, payload["dirtyState"]);
     }
 
     private static BuildExecutionOutput CreateOutput (string verdict)


### PR DESCRIPTION
## Summary
- Completes the build.run assurance payload contract around stable report keys, build projection, evidence references, and generation validity.
- Adds build-specific semantic invariant checks so invalid payload shapes fail validation early.
- Strengthens service and CLI result tests for BuildReport failure and dirty-scene command failure behavior.

## Scope
- Build assurance semantic validation for profile, reportRef, generations, verifier effects, and generation claim status.
- Build service tests covering metadata projection, manifest refs, report keys, and evidenceRef resolution.
- CLI result factory coverage for dirty-scene error payloads while preserving verifier failure as status=ok.

## Verification
- Gate level: Full
- Format: PASS (bash scripts/code-quality.sh format --include ...)
- Tests: PASS (bash scripts/test-dotnet.sh; bash scripts/verify.sh)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to stricter semantic validation for build assurance payloads; rollback is reverting commit 686313d14.

## Checklist
- [x] Stable build reports are fixed to build, buildReport, buildLog, and buildOutputManifest.
- [x] Build projection and metadata consistency are covered by tests.
- [x] BuildReport failure and command failure behavior are covered by tests.

Closes #384