### PR TITLE
docs(build): align build run docs and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Use normal edit steps for planned, reviewable Unity changes.
 
 ## 🏗️ Building Player Artifacts
 
-Use `ucli build run` when CI or release automation needs Unity BuildPipeline results as reviewable evidence:
+Use `ucli build run` to run Unity BuildPipeline from a build profile and collect machine-readable build results:
 
 ```bash
 ucli build run --profilePath .ucli/build/player.json

--- a/README.md
+++ b/README.md
@@ -351,6 +351,26 @@ ucli eval --mode daemon --allowDangerous \
 
 Use normal edit steps for planned, reviewable Unity changes.
 
+## 🏗️ Building Player Artifacts
+
+Use `ucli build run` when CI or release automation needs Unity BuildPipeline results as reviewable evidence:
+
+```bash
+ucli build run --profilePath .ucli/build/player.json
+```
+
+The build profile defines the target, scenes, options, and output policy. `ucli build run` writes the final JSON result to standard output, and may write progress entries to standard error before that final result.
+
+Build artifacts are written under `.ucli/local/fingerprints/<projectFingerprint>/artifacts/build/<runId>/`.
+
+| Artifact | Use it for |
+| --- | --- |
+| `build.json` | uCLI build run metadata, resolved inputs, generation validity, summary, and artifact references. |
+| `build-report.json` | Normalized Unity BuildReport data. |
+| `build.log` | Unity log entries for the build execution window. |
+| `output-manifest.json` | File sizes and digests for generated player output files. |
+| `output/` | Generated player output files. |
+
 ## 🧪 Verifying Changes
 
 Run Unity tests after applying edits:
@@ -700,6 +720,7 @@ Custom operations are not hidden shortcuts. Once they are in the catalog, they f
 | `ucli plan` | Prepare a separated review gate and receive a `planToken`. |
 | `ucli validate` | Diagnose static request validation without running `plan` or `call`. |
 | `ucli verify` | Return a JSON verification result for Unity-side checks. |
+| `ucli build run` | Run Unity BuildPipeline from a build profile and return build evidence. |
 | `ucli logs` | Read Unity or daemon logs. |
 | `ucli daemon` | Manage daemon sessions. |
 | `ucli test` | Run Unity Test Framework tests. |

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
@@ -23,12 +23,12 @@ internal sealed class BuildRunCommand
         this.commandResultWriter = commandResultWriter ?? throw new ArgumentNullException(nameof(commandResultWriter));
     }
 
-    /// <summary> Executes the build run command and emits the JSON result contract. </summary>
-    /// <param name="profilePath"> --profilePath, build profile JSON path. </param>
+    /// <summary> Runs Unity BuildPipeline from a build profile and emits final JSON with build artifact references: build.json, build-report.json, build.log, output-manifest.json, output/. </summary>
+    /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines target, scenes, options, and output policy. </param>
     /// <param name="projectPath"> -p|--projectPath, optional target Unity project path. </param>
     /// <param name="mode"> Unity execution mode (auto|daemon|oneshot). </param>
     /// <param name="timeout"> Timeout in milliseconds. </param>
-    /// <param name="format"> Progress entry format (text|json). </param>
+    /// <param name="format"> Progress entry format (text|json) for entries written to standard error. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.RunSubcommand)]

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
@@ -23,7 +23,7 @@ internal sealed class BuildRunCommand
         this.commandResultWriter = commandResultWriter ?? throw new ArgumentNullException(nameof(commandResultWriter));
     }
 
-    /// <summary> Runs Unity BuildPipeline from a build profile and emits final JSON with build artifact references: build.json, build-report.json, build.log, output-manifest.json, output/. </summary>
+    /// <summary> Runs Unity BuildPipeline from a build profile and emits final JSON with build artifacts: build.json, build-report.json, build.log, output-manifest.json, output/. </summary>
     /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines target, scenes, options, and output policy. </param>
     /// <param name="projectPath"> -p|--projectPath, optional target Unity project path. </param>
     /// <param name="mode"> Unity execution mode (auto|daemon|oneshot). </param>

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+using MackySoft.Tests;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class BuildRunCommandTests
+{
+    private static readonly string[] CurrentArtifactNames =
+    [
+        "build.json",
+        "build-report.json",
+        "build.log",
+        "output-manifest.json",
+        "output/",
+    ];
+
+    private static readonly string[] RemovedArtifactNames =
+    [
+        "build-summary.json",
+        "profile-snapshot.json",
+        "lifecycle.json",
+        "manifest.json",
+    ];
+
+    private static readonly string[] UndocumentedFeatureNames =
+    [
+        "build profile init",
+        "output path override",
+        "retry reconciliation",
+        "dirty state",
+        "project mutation audit",
+    ];
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task BuildRun_WithHelpOutput_DescribesCurrentBuildArtifactsOnly ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Build,
+            UcliCommandNames.RunSubcommand,
+            "--help");
+
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        foreach (var artifactName in CurrentArtifactNames)
+        {
+            Assert.Contains(artifactName, result.StdOut, StringComparison.Ordinal);
+        }
+
+        foreach (var artifactName in RemovedArtifactNames)
+        {
+            Assert.DoesNotMatch(CreateStandaloneArtifactNamePattern(artifactName), result.StdOut);
+        }
+
+        Assert.DoesNotContain("sha256:", result.StdOut, StringComparison.Ordinal);
+        foreach (var featureName in UndocumentedFeatureNames)
+        {
+            Assert.DoesNotContain(featureName, result.StdOut, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static Regex CreateStandaloneArtifactNamePattern (string artifactName)
+    {
+        return new Regex(
+            "(?<![A-Za-z0-9-])" + Regex.Escape(artifactName) + "(?![A-Za-z0-9-])",
+            RegexOptions.CultureInvariant);
+    }
+}

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using MackySoft.Tests;
 
 namespace MackySoft.Ucli.Tests;
@@ -14,26 +13,9 @@ public sealed class BuildRunCommandTests
         "output/",
     ];
 
-    private static readonly string[] RemovedArtifactNames =
-    [
-        "build-summary.json",
-        "profile-snapshot.json",
-        "lifecycle.json",
-        "manifest.json",
-    ];
-
-    private static readonly string[] UndocumentedFeatureNames =
-    [
-        "build profile init",
-        "output path override",
-        "retry reconciliation",
-        "dirty state",
-        "project mutation audit",
-    ];
-
     [Fact]
     [Trait("Size", "Medium")]
-    public async Task BuildRun_WithHelpOutput_DescribesCurrentBuildArtifactsOnly ()
+    public async Task BuildRun_WithHelpOutput_DescribesBuildArtifacts ()
     {
         var result = await CliProcessRunner.RunCommandAsync(
             UcliCommandNames.Build,
@@ -45,23 +27,5 @@ public sealed class BuildRunCommandTests
         {
             Assert.Contains(artifactName, result.StdOut, StringComparison.Ordinal);
         }
-
-        foreach (var artifactName in RemovedArtifactNames)
-        {
-            Assert.DoesNotMatch(CreateStandaloneArtifactNamePattern(artifactName), result.StdOut);
-        }
-
-        Assert.DoesNotContain("sha256:", result.StdOut, StringComparison.Ordinal);
-        foreach (var featureName in UndocumentedFeatureNames)
-        {
-            Assert.DoesNotContain(featureName, result.StdOut, StringComparison.OrdinalIgnoreCase);
-        }
-    }
-
-    private static Regex CreateStandaloneArtifactNamePattern (string artifactName)
-    {
-        return new Regex(
-            "(?<![A-Za-z0-9-])" + Regex.Escape(artifactName) + "(?![A-Za-z0-9-])",
-            RegexOptions.CultureInvariant);
     }
 }


### PR DESCRIPTION
## Summary
- Add README guidance for running `ucli build run` from a build profile and reading the generated build artifacts.
- Update `build run --help` text to describe the emitted build artifacts.
- Add process-based help coverage for the artifact names shown to users.

## Scope
- README: add `ucli build run` usage guidance and a Command Guide entry.
- CLI help source: update `BuildRunCommand` XML comments used by `build run --help`.
- Tests: add a `build run --help` contract test for the documented artifact names.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh verify --include README.md src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs`)
- Help output: PASS (`dotnet run --project src/Ucli -- build run --help`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, 1641 tests)
- Coverage: N/A

## Risks / Rollback
- Low risk; this is limited to documentation, help text, and help-output coverage.
- Roll back this branch if wording needs to be reverted.

## Checklist
- [x] README explains the build profile flow and artifact directory.
- [x] `build run --help` lists the build artifacts.
- [x] Help output coverage verifies the artifact names shown to users.

Closes #387