### PR TITLE
build: expose ucli build run CLI

### DIFF
--- a/schemas/v1/cli-output/payload/build.run.schema.json
+++ b/schemas/v1/cli-output/payload/build.run.schema.json
@@ -1,0 +1,409 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/build.run.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "incomplete"
+      ]
+    },
+    "project": {
+      "$ref": "../defs/project.schema.json"
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runId": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "digest": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            }
+          },
+          "required": [
+            "path",
+            "digest"
+          ]
+        },
+        "target": {
+          "type": "string"
+        },
+        "scenes": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "source": {
+              "type": "string",
+              "enum": [
+                "editorBuildSettings",
+                "explicit"
+              ]
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "source",
+            "paths"
+          ]
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "development": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "development"
+          ]
+        },
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "ucliArtifact"
+            },
+            "artifactRoot": {
+              "type": "string"
+            },
+            "outputRoot": {
+              "type": "string"
+            },
+            "manifestRef": {
+              "type": "string",
+              "const": "buildOutputManifest"
+            },
+            "manifestDigest": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "fileCount": {
+              "type": "integer"
+            },
+            "totalBytes": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "artifactRoot",
+            "outputRoot",
+            "manifestRef",
+            "manifestDigest",
+            "fileCount",
+            "totalBytes"
+          ]
+        },
+        "generations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "before": {
+              "$ref": "#/$defs/generation"
+            },
+            "after": {
+              "$ref": "#/$defs/generation"
+            },
+            "validFor": {
+              "$ref": "#/$defs/generation"
+            }
+          },
+          "required": [
+            "before",
+            "after",
+            "validFor"
+          ]
+        },
+        "summary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "result": {
+              "type": "string",
+              "enum": [
+                "succeeded",
+                "failed",
+                "canceled",
+                "unknown"
+              ]
+            },
+            "durationMilliseconds": {
+              "type": "integer"
+            },
+            "errorCount": {
+              "type": "integer"
+            },
+            "warningCount": {
+              "type": "integer"
+            },
+            "reportRef": {
+              "type": "string",
+              "const": "buildReport"
+            }
+          },
+          "required": [
+            "result",
+            "durationMilliseconds",
+            "errorCount",
+            "warningCount",
+            "reportRef"
+          ]
+        },
+        "logs": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reportRef": {
+              "type": "string",
+              "const": "buildLog"
+            },
+            "entryCount": {
+              "type": "integer"
+            },
+            "errorCount": {
+              "type": "integer"
+            },
+            "warningCount": {
+              "type": "integer"
+            },
+            "completionReason": {
+              "type": "string",
+              "enum": [
+                "completed",
+                "failed",
+                "canceled"
+              ]
+            },
+            "window": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "startedAtUtc": {
+                  "type": "string"
+                },
+                "completedAtUtc": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "startedAtUtc",
+                "completedAtUtc"
+              ]
+            }
+          },
+          "required": [
+            "reportRef",
+            "entryCount",
+            "errorCount",
+            "warningCount",
+            "completionReason",
+            "window"
+          ]
+        }
+      },
+      "required": [
+        "runId",
+        "profile",
+        "target",
+        "scenes",
+        "options",
+        "output",
+        "generations",
+        "summary",
+        "logs"
+      ]
+    },
+    "verifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "../defs/verifier.schema.json"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "passed",
+              "failed",
+              "indeterminate"
+            ]
+          },
+          "coverage": {
+            "type": "string",
+            "enum": [
+              "full",
+              "none"
+            ]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "verifierRef": {
+            "type": "string"
+          },
+          "statement": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "object"
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "$ref": "../defs/evidence.schema.json"
+            }
+          },
+          "residualRisks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "severity": {
+                  "type": "string"
+                },
+                "blocking": {
+                  "type": "boolean"
+                },
+                "statement": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "severity",
+                "blocking",
+                "statement"
+              ]
+            }
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "coverage",
+          "required",
+          "verifierRef",
+          "statement",
+          "subject",
+          "evidence",
+          "residualRisks"
+        ]
+      }
+    },
+    "reports": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "build": {
+          "$ref": "../defs/report-ref.schema.json"
+        },
+        "buildReport": {
+          "$ref": "../defs/report-ref.schema.json"
+        },
+        "buildOutputManifest": {
+          "$ref": "../defs/report-ref.schema.json"
+        },
+        "buildLog": {
+          "$ref": "../defs/report-ref.schema.json"
+        }
+      },
+      "required": [
+        "build",
+        "buildReport",
+        "buildOutputManifest",
+        "buildLog"
+      ]
+    },
+    "residualRisks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "blocking": {
+            "type": "boolean"
+          },
+          "statement": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "severity",
+          "blocking",
+          "statement"
+        ]
+      }
+    }
+  },
+  "required": [
+    "verdict",
+    "project",
+    "build",
+    "verifiers",
+    "claims",
+    "reports",
+    "residualRisks"
+  ],
+  "$defs": {
+    "generation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "compileGeneration": {
+          "type": "string"
+        },
+        "domainReloadGeneration": {
+          "type": "string"
+        },
+        "assetRefreshGeneration": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "compileGeneration",
+        "domainReloadGeneration",
+        "assetRefreshGeneration"
+      ]
+    }
+  }
+}

--- a/schemas/v1/schema-manifest.json
+++ b/schemas/v1/schema-manifest.json
@@ -94,6 +94,12 @@
       "command": "compile"
     },
     {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/build.run.schema.json",
+      "path": "cli-output/payload/build.run.schema.json",
+      "kind": "cli-output-payload",
+      "command": "build.run"
+    },
+    {
       "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/verify.schema.json",
       "path": "cli-output/payload/verify.schema.json",
       "kind": "cli-output-payload",

--- a/src/Ucli.Contracts/Assurance/Build/BuildRunCompletedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildRunCompletedEntry.cs
@@ -1,6 +1,6 @@
 namespace MackySoft.Ucli.Contracts.Assurance;
 
-/// <summary> Represents the <c>build.completed</c> stream payload. </summary>
+/// <summary> Represents the <c>build.run.completed</c> stream payload. </summary>
 public sealed record BuildRunCompletedEntry (
     string RunId,
     string Verdict,

--- a/src/Ucli.Contracts/Assurance/Build/BuildRunProgressEventNames.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildRunProgressEventNames.cs
@@ -4,8 +4,8 @@ namespace MackySoft.Ucli.Contracts.Assurance;
 public static class BuildRunProgressEventNames
 {
     /// <summary> Gets the event emitted after build run identity, artifacts, and execution target are established. </summary>
-    public const string Started = "build.started";
+    public const string Started = "build.run.started";
 
     /// <summary> Gets the event emitted after the final build payload has been built. </summary>
-    public const string Completed = "build.completed";
+    public const string Completed = "build.run.completed";
 }

--- a/src/Ucli.Contracts/Assurance/Build/BuildRunStartedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildRunStartedEntry.cs
@@ -1,6 +1,6 @@
 namespace MackySoft.Ucli.Contracts.Assurance;
 
-/// <summary> Represents the <c>build.started</c> stream payload. </summary>
+/// <summary> Represents the <c>build.run.started</c> stream payload. </summary>
 public sealed record BuildRunStartedEntry (
     string RunId,
     string ProjectFingerprint,

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildRunProgressEventNamesTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildRunProgressEventNamesTests.cs
@@ -1,0 +1,14 @@
+using MackySoft.Ucli.Contracts.Assurance;
+
+namespace MackySoft.Ucli.Contracts.Tests.Assurance.Build;
+
+public sealed class BuildRunProgressEventNamesTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Constants_ExposePublicBuildRunEventNames ()
+    {
+        Assert.Equal("build.run.started", BuildRunProgressEventNames.Started);
+        Assert.Equal("build.run.completed", BuildRunProgressEventNames.Completed);
+    }
+}

--- a/tests/Ucli.Tests/CliOutputGoldenContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputGoldenContractTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using MackySoft.Ucli.Application.Features.Assurance.Build.Catalog;
+using MackySoft.Ucli.Application.Features.Assurance.Build.Semantics;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Catalog;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Semantics;
 using MackySoft.Ucli.Application.Features.Assurance.Ready;
@@ -133,6 +135,7 @@ public sealed class CliOutputGoldenContractTests
     {
         return string.Equals(command, "ready", StringComparison.Ordinal)
             || string.Equals(command, "compile", StringComparison.Ordinal)
+            || string.Equals(command, "build.run", StringComparison.Ordinal)
             || string.Equals(command, "verify", StringComparison.Ordinal);
     }
 
@@ -143,6 +146,7 @@ public sealed class CliOutputGoldenContractTests
             [
                 new ReadyAssuranceSemanticInvariantRule(),
                 new CompileAssuranceSemanticInvariantRule(),
+                new BuildAssuranceSemanticInvariantRule(),
                 new VerifyAssuranceSemanticInvariantRule(),
             ]);
     }
@@ -155,6 +159,7 @@ public sealed class CliOutputGoldenContractTests
             new ApplicationCodeCatalogContributor(),
             new ReadyCodeCatalogContributor(),
             new CompileCodeCatalogContributor(),
+            new BuildCodeCatalogContributor(),
             new VerifyCodeCatalogContributor(),
         ]);
     }

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
@@ -1,0 +1,324 @@
+{
+  "protocolVersion": 1,
+  "command": "build.run",
+  "status": "ok",
+  "exitCode": 0,
+  "message": "Build completed.",
+  "payload": {
+    "verdict": "pass",
+    "project": {
+      "projectPath": "/workspace/UnityProject",
+      "projectFingerprint": "project-fingerprint",
+      "unityVersion": "6000.1.4f1"
+    },
+    "build": {
+      "runId": "build-run-1",
+      "profile": {
+        "path": "/workspace/.ucli/build/player.json",
+        "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "target": "standaloneLinux64",
+      "scenes": {
+        "source": "explicit",
+        "paths": [
+          "Assets/Scenes/Main.unity"
+        ]
+      },
+      "options": {
+        "development": true
+      },
+      "output": {
+        "kind": "ucliArtifact",
+        "artifactRoot": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
+        "outputRoot": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
+        "manifestRef": "buildOutputManifest",
+        "manifestDigest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "fileCount": 1,
+        "totalBytes": 4096
+      },
+      "generations": {
+        "before": {
+          "compileGeneration": "compile-before",
+          "domainReloadGeneration": "domain-before",
+          "assetRefreshGeneration": "asset-before"
+        },
+        "after": {
+          "compileGeneration": "compile-after",
+          "domainReloadGeneration": "domain-after",
+          "assetRefreshGeneration": "asset-after"
+        },
+        "validFor": {
+          "compileGeneration": "compile-after",
+          "domainReloadGeneration": "domain-after",
+          "assetRefreshGeneration": "asset-after"
+        }
+      },
+      "summary": {
+        "result": "succeeded",
+        "durationMilliseconds": 2500,
+        "errorCount": 0,
+        "warningCount": 1,
+        "reportRef": "buildReport"
+      },
+      "logs": {
+        "reportRef": "buildLog",
+        "entryCount": 3,
+        "errorCount": 0,
+        "warningCount": 1,
+        "completionReason": "completed",
+        "window": {
+          "startedAtUtc": "2026-06-12T00:00:00+00:00",
+          "completedAtUtc": "2026-06-12T00:00:03+00:00"
+        }
+      }
+    },
+    "verifiers": [
+      {
+        "id": "build",
+        "kind": "build",
+        "deterministic": false,
+        "required": true,
+        "primaryClaims": [
+          "UNITY_BUILD_PROFILE_RESOLVED",
+          "UNITY_READY_FOR_BUILD",
+          "UNITY_BUILD_INPUTS_RESOLVED",
+          "UNITY_BUILD_COMPLETED",
+          "UNITY_BUILD_SUCCEEDED",
+          "UNITY_BUILD_REPORT_ACCOUNTED",
+          "UNITY_BUILD_ARTIFACTS_ACCOUNTED",
+          "UNITY_BUILD_OUTPUT_DIGESTED",
+          "UNITY_BUILD_LOGS_ACCOUNTED",
+          "UNITY_BUILD_VALID_FOR_GENERATION"
+        ],
+        "effects": [
+          "unityLifecycleRead",
+          "unityBuildPipeline",
+          "unityBuildReportRead",
+          "unityLogWindowRead",
+          "ucliArtifactWrite",
+          "outputManifestWrite",
+          "generationSnapshot"
+        ],
+        "reportRef": "build"
+      }
+    ],
+    "claims": [
+      {
+        "id": "UNITY_BUILD_PROFILE_RESOLVED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build profile resolved.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "build"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_READY_FOR_BUILD",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Unity was ready for build.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "lifecycleSnapshot",
+            "data": {
+              "state": "ready"
+            }
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_INPUTS_RESOLVED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build inputs resolved.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "build"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_COMPLETED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "BuildPipeline completed.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "buildReport"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_SUCCEEDED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "BuildPipeline succeeded.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "buildReport"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_REPORT_ACCOUNTED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "BuildReport artifact accounted.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "buildReport"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_ARTIFACTS_ACCOUNTED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build artifacts accounted.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "build"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_OUTPUT_DIGESTED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build output digested.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "buildOutputManifest"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_LOGS_ACCOUNTED",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build logs accounted.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "buildLog"
+          }
+        ],
+        "residualRisks": []
+      },
+      {
+        "id": "UNITY_BUILD_VALID_FOR_GENERATION",
+        "status": "passed",
+        "coverage": "full",
+        "required": true,
+        "verifierRef": "build",
+        "statement": "Build generations captured.",
+        "subject": {
+          "kind": "build",
+          "runId": "build-run-1"
+        },
+        "evidence": [
+          {
+            "kind": "artifact",
+            "evidenceRef": "build"
+          }
+        ],
+        "residualRisks": []
+      }
+    ],
+    "reports": {
+      "build": {
+        "kind": "build",
+        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json",
+        "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "buildReport": {
+        "kind": "buildReport",
+        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+        "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      },
+      "buildOutputManifest": {
+        "kind": "buildOutputManifest",
+        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+        "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      "buildLog": {
+        "kind": "buildLog",
+        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+        "digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    },
+    "residualRisks": []
+  },
+  "errors": []
+}

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandResultFactoryTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandResultFactoryTests.cs
@@ -1,5 +1,4 @@
 using MackySoft.Ucli.Application.Features.Assurance.Build.Contracts;
-using MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Vocabulary;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -11,9 +10,41 @@ public sealed class BuildRunCommandResultFactoryTests
 {
     [Fact]
     [Trait("Size", "Small")]
+    public void Create_WithPassVerifierVerdict_ReturnsOkStatusAndExitCodeZero ()
+    {
+        var output = BuildRunTestData.CreateOutput();
+
+        var result = BuildRunCommandResultFactory.Create(BuildExecutionResult.Success(output));
+
+        Assert.Equal(IpcProtocol.StatusOk, result.Status);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        Assert.Empty(result.Errors);
+        Assert.Same(output, result.Payload);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Create_WithFailedVerifierVerdict_ReturnsOkStatusAndExitCodeOne ()
     {
-        var output = CreateOutput(ContractLiteralCodec.ToValue(BuildVerdict.Fail));
+        var output = BuildRunTestData.CreateOutput(
+            ContractLiteralCodec.ToValue(BuildVerdict.Fail),
+            ContractLiteralCodec.ToValue(IpcBuildReportResult.Failed),
+            ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Failed),
+            errorCount: 1);
+
+        var result = BuildRunCommandResultFactory.Create(BuildExecutionResult.Success(output));
+
+        Assert.Equal(IpcProtocol.StatusOk, result.Status);
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Errors);
+        Assert.Same(output, result.Payload);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Create_WithIncompleteVerifierVerdict_ReturnsOkStatusAndExitCodeOne ()
+    {
+        var output = BuildRunTestData.CreateOutput(ContractLiteralCodec.ToValue(BuildVerdict.Incomplete));
 
         var result = BuildRunCommandResultFactory.Create(BuildExecutionResult.Success(output));
 
@@ -53,58 +84,5 @@ public sealed class BuildRunCommandResultFactoryTests
         var payload = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(result.Payload);
         Assert.True(payload.ContainsKey("project"));
         Assert.Same(dirtyState, payload["dirtyState"]);
-    }
-
-    private static BuildExecutionOutput CreateOutput (string verdict)
-    {
-        var project = new ProjectIdentityInfo(
-            ProjectPath: "/workspace/UnityProject",
-            ProjectFingerprint: "project-fingerprint",
-            UnityVersion: "6000.1.4f1");
-        var build = new BuildOutput(
-            RunId: "build-run-1",
-            Profile: new BuildProfileOutput("/workspace/build.ucli.json", "profile-digest"),
-            Target: "standaloneLinux64",
-            Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
-            Options: new BuildOptionsOutput(Development: true),
-            Output: new BuildArtifactOutput(
-                Kind: "ucliArtifact",
-                ArtifactRoot: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
-                OutputRoot: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
-                ManifestRef: "buildOutputManifest",
-                ManifestDigest: "manifest-digest",
-                FileCount: 0,
-                TotalBytes: 0),
-            Generations: new BuildGenerationsOutput(
-                Before: new BuildGenerationSnapshotOutput("compile-before", "domain-before", "asset-before"),
-                After: new BuildGenerationSnapshotOutput("compile-after", "domain-after", "asset-after"),
-                ValidFor: new BuildGenerationSnapshotOutput("compile-after", "domain-after", "asset-after")),
-            Summary: new BuildSummaryOutput(
-                Result: ContractLiteralCodec.ToValue(IpcBuildReportResult.Failed),
-                DurationMilliseconds: 2500,
-                ErrorCount: 1,
-                WarningCount: 0,
-                ReportRef: "buildReport"),
-            Logs: new BuildLogsOutput(
-                ReportRef: "buildLog",
-                EntryCount: 1,
-                ErrorCount: 1,
-                WarningCount: 0,
-                CompletionReason: ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Failed),
-                Window: new BuildLogWindowOutput(DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch)));
-        return new BuildExecutionOutput(
-            Verdict: verdict,
-            Project: project,
-            Build: build,
-            Verifiers: [],
-            Claims: [],
-            Reports: new Dictionary<string, BuildReportOutput>(StringComparer.Ordinal)
-            {
-                ["build"] = new BuildReportOutput("build", "/workspace/build.json", "metadata-digest"),
-                ["buildReport"] = new BuildReportOutput("buildReport", "/workspace/build-report.json", "build-report-digest"),
-                ["buildOutputManifest"] = new BuildReportOutput("buildOutputManifest", "/workspace/output-manifest.json", "output-manifest-digest"),
-                ["buildLog"] = new BuildReportOutput("buildLog", "/workspace/build.log", "build-log-digest"),
-            },
-            ResidualRisks: []);
     }
 }

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
@@ -1,0 +1,306 @@
+using System.Text.Json;
+using MackySoft.Tests;
+using MackySoft.Ucli.Application.Features.Assurance.Build.Contracts;
+using MackySoft.Ucli.Application.Shared.Execution.Progress;
+using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
+using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Hosting.Cli.Assurance;
+using MackySoft.Ucli.Tests.Hosting.Cli.Common.Execution;
+
+namespace MackySoft.Ucli.Tests;
+
+public sealed class BuildRunCommandTests
+{
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Run_MapsOptionsToServiceInputAndCancellationToken ()
+    {
+        var service = new StubBuildService((_, _, _) => ValueTask.FromResult(BuildExecutionResult.Success(BuildRunTestData.CreateOutput())));
+        var command = new BuildRunCommand(service, CommandResultTestWriter.Create());
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await StandardOutputCapture.ExecuteAsync(() => command.RunAsync(
+            profilePath: "/repo/.ucli/build/player.json",
+            projectPath: "/repo/UnityProject",
+            mode: "daemon",
+            timeout: "120000",
+            format: "json",
+            cancellationToken: cancellationTokenSource.Token));
+
+        Assert.Equal(cancellationTokenSource.Token, service.CapturedCancellationToken);
+        var input = Assert.IsType<BuildCommandInput>(service.CapturedInput);
+        Assert.Equal("/repo/.ucli/build/player.json", input.ProfilePath);
+        Assert.Equal("/repo/UnityProject", input.ProjectPath);
+        Assert.Equal(UnityExecutionMode.Daemon, input.Mode);
+        Assert.Equal(120000, input.TimeoutMilliseconds);
+        Assert.NotNull(service.CapturedProgressSink);
+    }
+
+    [Theory]
+    [InlineData("unknown", null, null)]
+    [InlineData(null, "not-an-int", null)]
+    [InlineData(null, null, "xml")]
+    [Trait("Size", "Small")]
+    public async Task Run_WhenNormalizedOptionIsInvalid_ReturnsInvalidArgumentWithoutCallingService (
+        string? mode,
+        string? timeout,
+        string? format)
+    {
+        var service = new StubBuildService((_, _, _) => throw new InvalidOperationException("Service should not be called."));
+        var command = new BuildRunCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.RunAsync(
+            mode: mode,
+            timeout: timeout,
+            format: format,
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        Assert.Null(service.CapturedInput);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Run_WithPassOutput_MatchesGolden ()
+    {
+        var service = new StubBuildService((_, _, _) => ValueTask.FromResult(BuildExecutionResult.Success(BuildRunTestData.CreateOutput())));
+        var command = new BuildRunCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.RunAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        JsonGoldenFileAssert.Matches(
+            CliOutputGoldenFiles.GetPath("build", "pass-success.json"),
+            standardOutput);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Run_WithJsonFormat_WritesProgressEntryToStandardError ()
+    {
+        var service = new StubBuildService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                    BuildRunProgressEventNames.Completed,
+                    BuildRunTestData.CreateCompletedEntry(),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return BuildExecutionResult.Success(BuildRunTestData.CreateOutput());
+        });
+        var command = new BuildRunCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.RunAsync(
+            format: "json",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+
+        var line = Assert.Single(standardError.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries));
+        using var entryJson = JsonDocument.Parse(line);
+        AssertBuildStreamEnvelope(entryJson.RootElement, sequence: 1, BuildRunProgressEventNames.Completed);
+        Assert.Equal(BuildRunTestData.RunId, entryJson.RootElement.GetProperty("payload").GetProperty("runId").GetString());
+        Assert.Equal("pass", entryJson.RootElement.GetProperty("payload").GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Run_WithDefaultFormat_WritesTextProgressToStandardError ()
+    {
+        var service = new StubBuildService(async (_, progressSink, cancellationToken) =>
+        {
+            Assert.NotNull(progressSink);
+            await progressSink!.OnEntryAsync(
+                    BuildRunProgressEventNames.Started,
+                    BuildRunTestData.CreateStartedEntry(),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            await progressSink.OnEntryAsync(
+                    BuildRunProgressEventNames.Completed,
+                    BuildRunTestData.CreateCompletedEntry(),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return BuildExecutionResult.Success(BuildRunTestData.CreateOutput());
+        });
+        var command = new BuildRunCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.RunAsync(
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusOk,
+            (int)CliExitCode.Success);
+        Assert.Equal(
+            "build runId=build-run-1 target=standaloneLinux64 requestedMode=daemon resolvedMode=daemon sessionKind=daemon timeoutMs=120000 started" + Environment.NewLine
+                + "build runId=build-run-1 verdict=pass result=succeeded completionReason=completed errorCount=0 warningCount=1 completed" + Environment.NewLine,
+            standardError);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task BuildRun_WithHelpOutput_ExposesOnlySpecifiedBuildRunOptions ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Build,
+            UcliCommandNames.RunSubcommand,
+            "--help");
+
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        Assert.Contains(UcliContractConstants.CliOption.ProfilePath, result.StdOut, StringComparison.Ordinal);
+        Assert.Contains(UcliContractConstants.CliOption.ProjectPath, result.StdOut, StringComparison.Ordinal);
+        Assert.Contains("-p", result.StdOut, StringComparison.Ordinal);
+        Assert.Contains(UcliContractConstants.CliOption.Mode, result.StdOut, StringComparison.Ordinal);
+        Assert.Contains(UcliContractConstants.CliOption.Timeout, result.StdOut, StringComparison.Ordinal);
+        Assert.Contains("--format", result.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain(UcliContractConstants.CliOption.OutputPath, result.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain("profile init", result.StdOut, StringComparison.Ordinal);
+        Assert.DoesNotContain("allowDirty", result.StdOut, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(UcliContractConstants.CliOption.ProjectPath)]
+    [InlineData("-p")]
+    [Trait("Size", "Medium")]
+    public async Task BuildRun_WithPublicOptions_ReachesProjectPathValidation (string projectPathOption)
+    {
+        using var scope = TestDirectories.CreateTempScope(
+            nameof(BuildRunCommandTests),
+            nameof(BuildRun_WithPublicOptions_ReachesProjectPathValidation));
+        var missingProfilePath = scope.GetPath("missing-build-profile.json");
+        var missingProjectPath = scope.GetPath("missing-unity-project");
+
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Build,
+            UcliCommandNames.RunSubcommand,
+            UcliContractConstants.CliOption.ProfilePath,
+            missingProfilePath,
+            projectPathOption,
+            missingProjectPath,
+            UcliContractConstants.CliOption.Mode,
+            "daemon",
+            UcliContractConstants.CliOption.Timeout,
+            "1",
+            "--format",
+            "json");
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.True(string.IsNullOrEmpty(result.StdErr), result.StdErr);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, ProjectContextErrorCodes.ProjectPathNotFound);
+    }
+
+    [Theory]
+    [InlineData(UcliContractConstants.CliOption.Mode, "unsupported")]
+    [InlineData(UcliContractConstants.CliOption.Timeout, "abc")]
+    [InlineData("--format", "xml")]
+    [Trait("Size", "Medium")]
+    public async Task BuildRun_ProcessWithInvalidNormalizedOption_ReturnsJsonInvalidArgument (
+        string option,
+        string value)
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Build,
+            UcliCommandNames.RunSubcommand,
+            option,
+            value);
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.True(string.IsNullOrEmpty(result.StdErr), result.StdErr);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task BuildRun_WithUnspecifiedBuildOption_ReturnsJsonInvalidArgument ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Build,
+            UcliCommandNames.RunSubcommand,
+            UcliContractConstants.CliOption.OutputPath,
+            "/tmp/output");
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.Contains("Argument '--outputPath' is not recognized.", result.StdErr, StringComparison.Ordinal);
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.BuildRun,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
+    }
+
+    private static void AssertBuildStreamEnvelope (
+        JsonElement root,
+        int sequence,
+        string eventName)
+    {
+        Assert.Equal(1, root.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(UcliCommandNames.BuildRun, root.GetProperty("command").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("streamId").GetString()));
+        Assert.Equal(sequence, root.GetProperty("sequence").GetInt32());
+        Assert.True(DateTimeOffset.TryParse(root.GetProperty("timestamp").GetString(), out _));
+        Assert.Equal(eventName, root.GetProperty("event").GetString());
+        Assert.Equal(JsonValueKind.Object, root.GetProperty("payload").ValueKind);
+    }
+
+    private sealed class StubBuildService : IBuildService
+    {
+        private readonly Func<BuildCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<BuildExecutionResult>> execute;
+
+        public StubBuildService (
+            Func<BuildCommandInput, ICommandProgressSink?, CancellationToken, ValueTask<BuildExecutionResult>> execute)
+        {
+            this.execute = execute;
+        }
+
+        public BuildCommandInput? CapturedInput { get; private set; }
+
+        public ICommandProgressSink? CapturedProgressSink { get; private set; }
+
+        public CancellationToken CapturedCancellationToken { get; private set; }
+
+        public ValueTask<BuildExecutionResult> ExecuteAsync (
+            BuildCommandInput input,
+            ICommandProgressSink? progressSink = null,
+            CancellationToken cancellationToken = default)
+        {
+            CapturedInput = input;
+            CapturedProgressSink = progressSink;
+            CapturedCancellationToken = cancellationToken;
+            return execute(input, progressSink, cancellationToken);
+        }
+    }
+}

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
@@ -1,0 +1,186 @@
+using MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
+using MackySoft.Ucli.Application.Features.Assurance.Build.Vocabulary;
+using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Tests;
+
+internal static class BuildRunTestData
+{
+    public const string RunId = "build-run-1";
+
+    public const string ProjectFingerprint = "project-fingerprint";
+
+    public static BuildExecutionOutput CreateOutput (
+        string? verdict = null,
+        string? reportResult = null,
+        string? completionReason = null,
+        int errorCount = 0)
+    {
+        var normalizedReportResult = reportResult ?? ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded);
+        var normalizedCompletionReason = completionReason ?? ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed);
+        var normalizedVerdict = verdict ?? ContractLiteralCodec.ToValue(BuildVerdict.Pass);
+        var project = CreateProject();
+        var build = CreateBuild(normalizedReportResult, normalizedCompletionReason, errorCount);
+
+        return new BuildExecutionOutput(
+            Verdict: normalizedVerdict,
+            Project: project,
+            Build: build,
+            Verifiers:
+            [
+                new BuildVerifierOutput(
+                    Id: BuildReportRefs.Build,
+                    Kind: BuildReportRefs.Build,
+                    Deterministic: false,
+                    Required: true,
+                    PrimaryClaims: BuildClaimCodes.All.Select(static code => code.Value).ToArray(),
+                    Effects: ContractLiteralCodec.GetLiterals<BuildEffect>(),
+                    ReportRef: BuildReportRefs.Build),
+            ],
+            Claims: CreateClaims(normalizedReportResult),
+            Reports: CreateReports(),
+            ResidualRisks: []);
+    }
+
+    public static BuildRunStartedEntry CreateStartedEntry ()
+    {
+        return new BuildRunStartedEntry(
+            RunId: RunId,
+            ProjectFingerprint: ProjectFingerprint,
+            RequestedMode: "daemon",
+            ResolvedMode: "daemon",
+            SessionKind: "daemon",
+            TimeoutMilliseconds: 120000,
+            Target: "standaloneLinux64",
+            OutputPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output");
+    }
+
+    public static BuildRunCompletedEntry CreateCompletedEntry ()
+    {
+        return new BuildRunCompletedEntry(
+            RunId: RunId,
+            Verdict: ContractLiteralCodec.ToValue(BuildVerdict.Pass),
+            Result: ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+            CompletionReason: ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
+            ErrorCount: 0,
+            WarningCount: 1,
+            BuildJsonPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json",
+            BuildReportPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+            BuildLogPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+            OutputManifestPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json");
+    }
+
+    private static ProjectIdentityInfo CreateProject ()
+    {
+        return new ProjectIdentityInfo(
+            ProjectPath: "/workspace/UnityProject",
+            ProjectFingerprint: ProjectFingerprint,
+            UnityVersion: "6000.1.4f1");
+    }
+
+    private static BuildOutput CreateBuild (
+        string reportResult,
+        string completionReason,
+        int errorCount)
+    {
+        return new BuildOutput(
+            RunId: RunId,
+            Profile: new BuildProfileOutput("/workspace/.ucli/build/player.json", Repeat('a')),
+            Target: "standaloneLinux64",
+            Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
+            Options: new BuildOptionsOutput(Development: true),
+            Output: new BuildArtifactOutput(
+                Kind: "ucliArtifact",
+                ArtifactRoot: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
+                OutputRoot: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
+                ManifestRef: BuildReportRefs.BuildOutputManifest,
+                ManifestDigest: Repeat('b'),
+                FileCount: 1,
+                TotalBytes: 4096),
+            Generations: new BuildGenerationsOutput(
+                Before: new BuildGenerationSnapshotOutput("compile-before", "domain-before", "asset-before"),
+                After: new BuildGenerationSnapshotOutput("compile-after", "domain-after", "asset-after"),
+                ValidFor: new BuildGenerationSnapshotOutput("compile-after", "domain-after", "asset-after")),
+            Summary: new BuildSummaryOutput(
+                Result: reportResult,
+                DurationMilliseconds: 2500,
+                ErrorCount: errorCount,
+                WarningCount: 1,
+                ReportRef: BuildReportRefs.BuildReport),
+            Logs: new BuildLogsOutput(
+                ReportRef: BuildReportRefs.BuildLog,
+                EntryCount: 3,
+                ErrorCount: errorCount,
+                WarningCount: 1,
+                CompletionReason: completionReason,
+                Window: new BuildLogWindowOutput(
+                    DateTimeOffset.Parse("2026-06-12T00:00:00+00:00"),
+                    DateTimeOffset.Parse("2026-06-12T00:00:03+00:00"))));
+    }
+
+    private static IReadOnlyList<BuildClaimOutput> CreateClaims (string reportResult)
+    {
+        var passed = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
+        var succeededStatus = string.Equals(reportResult, ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded), StringComparison.Ordinal)
+            ? passed
+            : ContractLiteralCodec.ToValue(BuildClaimStatus.Failed);
+
+        return
+        [
+            CreateClaim(BuildClaimCodes.UnityBuildProfileResolved, passed, "Build profile resolved.", BuildReportRefs.Build),
+            CreateClaim(BuildClaimCodes.UnityReadyForBuild, passed, "Unity was ready for build.", null),
+            CreateClaim(BuildClaimCodes.UnityBuildInputsResolved, passed, "Build inputs resolved.", BuildReportRefs.Build),
+            CreateClaim(BuildClaimCodes.UnityBuildCompleted, passed, "BuildPipeline completed.", BuildReportRefs.BuildReport),
+            CreateClaim(BuildClaimCodes.UnityBuildSucceeded, succeededStatus, "BuildPipeline succeeded.", BuildReportRefs.BuildReport),
+            CreateClaim(BuildClaimCodes.UnityBuildReportAccounted, passed, "BuildReport artifact accounted.", BuildReportRefs.BuildReport),
+            CreateClaim(BuildClaimCodes.UnityBuildArtifactsAccounted, passed, "Build artifacts accounted.", BuildReportRefs.Build),
+            CreateClaim(BuildClaimCodes.UnityBuildOutputDigested, passed, "Build output digested.", BuildReportRefs.BuildOutputManifest),
+            CreateClaim(BuildClaimCodes.UnityBuildLogsAccounted, passed, "Build logs accounted.", BuildReportRefs.BuildLog),
+            CreateClaim(BuildClaimCodes.UnityBuildValidForGeneration, passed, "Build generations captured.", BuildReportRefs.Build),
+        ];
+    }
+
+    private static BuildClaimOutput CreateClaim (
+        UcliCode code,
+        string status,
+        string statement,
+        string? evidenceRef)
+    {
+        return new BuildClaimOutput(
+            Id: code.Value,
+            Status: status,
+            Coverage: ContractLiteralCodec.ToValue(BuildCoverage.Full),
+            Required: true,
+            VerifierRef: BuildReportRefs.Build,
+            Statement: statement,
+            Subject: new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["kind"] = BuildReportRefs.Build,
+                ["runId"] = RunId,
+            },
+            Evidence:
+            [
+                evidenceRef == null
+                    ? new BuildEvidenceOutput("lifecycleSnapshot", Data: new { state = "ready" })
+                    : new BuildEvidenceOutput("artifact", evidenceRef),
+            ],
+            ResidualRisks: []);
+    }
+
+    private static IReadOnlyDictionary<string, BuildReportOutput> CreateReports ()
+    {
+        return new Dictionary<string, BuildReportOutput>(StringComparer.Ordinal)
+        {
+            [BuildReportRefs.Build] = new(BuildReportRefs.Build, "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json", Repeat('c')),
+            [BuildReportRefs.BuildReport] = new(BuildReportRefs.BuildReport, "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json", Repeat('d')),
+            [BuildReportRefs.BuildOutputManifest] = new(BuildReportRefs.BuildOutputManifest, "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json", Repeat('e')),
+            [BuildReportRefs.BuildLog] = new(BuildReportRefs.BuildLog, "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log", Repeat('f')),
+        };
+    }
+
+    private static string Repeat (char value)
+    {
+        return new string(value, 64);
+    }
+}

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -42,6 +42,7 @@ public sealed class CliOutputSchemaArtifactTests
         Assert.Contains("status", commandEntries.Keys);
         Assert.Contains("ready", commandEntries.Keys);
         Assert.Contains("compile", commandEntries.Keys);
+        Assert.Contains("build.run", commandEntries.Keys);
         Assert.Contains("verify", commandEntries.Keys);
         Assert.Contains("plan", commandEntries.Keys);
         Assert.Contains("call", commandEntries.Keys);

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using MackySoft.Ucli.Contracts;
+using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Daemon;
 using MackySoft.Ucli.Contracts.Ipc;
@@ -95,6 +96,7 @@ internal static class Program
             CreatePayloadSchema(UcliCommandIds.Status.Name, CreateStatusPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.Ready.Name, CreateReadyPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.Compile.Name, CreateCompilePayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.BuildRun.Name, CreateBuildRunPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.Verify.Name, CreateVerifyPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.Init.Name, CreateInitPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.Validate.Name, CreateValidatePayloadSchema()),
@@ -614,6 +616,135 @@ internal static class Program
                 Required("observedAtUtc", NullableStringSchema()),
                 Required("actionRequired", NullableStringSchema()),
                 Required("primaryDiagnostic", CreatePrimaryDiagnosticSchema()))));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunPayloadSchema ()
+    {
+        var schema = ObjectSchema(
+            additionalProperties: false,
+            Required("verdict", EnumSchema("pass", "fail", "incomplete")),
+            Required("project", ReferenceSchema("../defs/project.schema.json")),
+            Required("build", CreateBuildRunBuildSchema()),
+            Required("verifiers", ArraySchema(ReferenceSchema("../defs/verifier.schema.json"))),
+            Required("claims", ArraySchema(CreateBuildRunClaimSchema())),
+            Required("reports", CreateBuildRunReportsSchema()),
+            Required("residualRisks", ArraySchema(CreateBuildRunResidualRiskSchema())));
+
+        schema["$defs"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["generation"] = CreateBuildRunGenerationSnapshotSchema(),
+        };
+        return schema;
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunBuildSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("runId", StringSchema()),
+            Required("profile", ObjectSchema(
+                additionalProperties: false,
+                Required("path", StringSchema()),
+                Required("digest", Sha256LowerHexSchema()))),
+            Required("target", StringSchema()),
+            Required("scenes", ObjectSchema(
+                additionalProperties: false,
+                Required(
+                    "source",
+                    EnumSchema(
+                        Literal(BuildProfileSceneSource.EditorBuildSettings),
+                        Literal(BuildProfileSceneSource.Explicit))),
+                Required("paths", ArraySchema(StringSchema())))),
+            Required("options", ObjectSchema(
+                additionalProperties: false,
+                Required("development", BooleanSchema()))),
+            Required("output", ObjectSchema(
+                additionalProperties: false,
+                Required("kind", ConstString("ucliArtifact")),
+                Required("artifactRoot", StringSchema()),
+                Required("outputRoot", StringSchema()),
+                Required("manifestRef", ConstString("buildOutputManifest")),
+                Required("manifestDigest", Sha256LowerHexSchema()),
+                Required("fileCount", IntegerSchema()),
+                Required("totalBytes", IntegerSchema()))),
+            Required("generations", ObjectSchema(
+                additionalProperties: false,
+                Required("before", ReferenceSchema("#/$defs/generation")),
+                Required("after", ReferenceSchema("#/$defs/generation")),
+                Required("validFor", ReferenceSchema("#/$defs/generation")))),
+            Required("summary", ObjectSchema(
+                additionalProperties: false,
+                Required(
+                    "result",
+                    EnumSchema(
+                        Literal(IpcBuildReportResult.Succeeded),
+                        Literal(IpcBuildReportResult.Failed),
+                        Literal(IpcBuildReportResult.Canceled),
+                        Literal(IpcBuildReportResult.Unknown))),
+                Required("durationMilliseconds", IntegerSchema()),
+                Required("errorCount", IntegerSchema()),
+                Required("warningCount", IntegerSchema()),
+                Required("reportRef", ConstString("buildReport")))),
+            Required("logs", ObjectSchema(
+                additionalProperties: false,
+                Required("reportRef", ConstString("buildLog")),
+                Required("entryCount", IntegerSchema()),
+                Required("errorCount", IntegerSchema()),
+                Required("warningCount", IntegerSchema()),
+                Required(
+                    "completionReason",
+                    EnumSchema(
+                        Literal(IpcBuildLogCompletionReason.Completed),
+                        Literal(IpcBuildLogCompletionReason.Failed),
+                        Literal(IpcBuildLogCompletionReason.Canceled))),
+                Required("window", ObjectSchema(
+                    additionalProperties: false,
+                    Required("startedAtUtc", StringSchema()),
+                    Required("completedAtUtc", StringSchema()))))));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunClaimSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: true,
+            Required("id", StringSchema()),
+            Required("status", EnumSchema("passed", "failed", "indeterminate")),
+            Required("coverage", EnumSchema("full", "none")),
+            Required("required", BooleanSchema()),
+            Required("verifierRef", StringSchema()),
+            Required("statement", StringSchema()),
+            Required("subject", ObjectSchema(additionalProperties: true)),
+            Required("evidence", ArraySchema(ReferenceSchema("../defs/evidence.schema.json"))),
+            Required("residualRisks", ArraySchema(CreateBuildRunResidualRiskSchema())));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunReportsSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("build", ReferenceSchema("../defs/report-ref.schema.json")),
+            Required("buildReport", ReferenceSchema("../defs/report-ref.schema.json")),
+            Required("buildOutputManifest", ReferenceSchema("../defs/report-ref.schema.json")),
+            Required("buildLog", ReferenceSchema("../defs/report-ref.schema.json")));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunResidualRiskSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("id", StringSchema()),
+            Required("severity", StringSchema()),
+            Required("blocking", BooleanSchema()),
+            Required("statement", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunGenerationSnapshotSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("compileGeneration", StringSchema()),
+            Required("domainReloadGeneration", StringSchema()),
+            Required("assetRefreshGeneration", StringSchema()));
     }
 
     private static Dictionary<string, object?> CreateVerifyPayloadSchema ()


### PR DESCRIPTION
## Summary
- Exposes the public `ucli build run` contract for Issue #385.
- Publishes the `build.run.started` / `build.run.completed` stream event names and generated `build.run` payload schema.
- Locks the CLI parser, progress stream, exit code, JSON envelope, payload, and stable report-key behavior with contract tests.

## Scope
- `src/Ucli.Contracts/Assurance/Build`: public build run stream event literals and XML comments.
- `tools/Ucli.SchemaGenerator` and `schemas/v1`: generated `build.run` payload schema and manifest registration.
- `tests/Ucli.Tests/Hosting/Cli` and golden/schema contract tests: public option surface, rejected unspecified options, invalid argument envelopes, progress output formats, success payload, and verdict exit codes.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format --include ...`)
- Tests: PASS (`bash scripts/verify.sh`, 1660 tests)
- Coverage: N/A

## Risks / Rollback
- Risk: downstream consumers relying on the pre-public `build.started` / `build.completed` event literals must update to the Issue #385 public names.
- Rollback: revert the two commits in this PR to restore the previous event names, schema manifest, and test expectations.

## Checklist
- [x] `build run --help` exposes only the specified public options.
- [x] `--outputPath` and unsupported normalized option values return `INVALID_ARGUMENT` for `build.run`.
- [x] JSON and text progress entries are covered, including `build.run.completed`.
- [x] Success, failed verdict, and command error exit-code behavior is covered.

Closes #385
