### PR TITLE
Use buildTarget for build runs and CI player build

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -218,6 +218,22 @@ jobs:
             --result-dir "artifacts/unity/${{ matrix.os_name }}"
         shell: bash
 
+      - name: Run uCLI player build
+        if: ${{ runner.os == 'Linux' && steps.unity_test.outputs.exit_code == '0' }}
+        run: |
+          set -euo pipefail
+
+          bash scripts/run-ucli-unity-build.sh \
+            --project-path "src/Ucli.Unity" \
+            --profile-path ".ucli/build/player.json" \
+            --buildTarget "standaloneLinux64" \
+            --unity-editor-path "${{ steps.unity_setup.outputs.unity-editor-path }}" \
+            --result-dir "artifacts/unity/${{ matrix.os_name }}/build-run" \
+            --no-restore \
+            --no-build \
+            --no-package-restore
+        shell: bash
+
       - name: Upload Unity artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.ucli/build/player.json
+++ b/.ucli/build/player.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "buildTarget": "standaloneLinux64",
+  "scenes": {
+    "source": "editorBuildSettings"
+  },
+  "output": {
+    "kind": "ucliArtifact"
+  },
+  "options": {
+    "development": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ ucli build run \
   --buildTarget standaloneLinux64
 ```
 
-The build profile defines the default BuildTarget, scenes, options, and output policy. Pass `--buildTarget` to override the profile BuildTarget for one run. `ucli build run` writes the final JSON result to standard output, and may write progress entries to standard error before that final result.
+The build profile defines the default `buildTarget`, scenes, options, and output policy. Pass `--buildTarget` to override the profile `buildTarget` for one run. `ucli build run` writes the final JSON result to standard output, and may write progress entries to standard error before that final result.
 
 Build artifacts are written under `.ucli/local/fingerprints/<projectFingerprint>/artifacts/build/<runId>/`.
 

--- a/README.md
+++ b/README.md
@@ -403,10 +403,12 @@ Use normal edit steps for planned, reviewable Unity changes.
 Use `ucli build run` to run Unity BuildPipeline from a build profile and collect machine-readable build results:
 
 ```bash
-ucli build run --profilePath .ucli/build/player.json
+ucli build run \
+  --profilePath .ucli/build/player.json \
+  --buildTarget standaloneLinux64
 ```
 
-The build profile defines the target, scenes, options, and output policy. `ucli build run` writes the final JSON result to standard output, and may write progress entries to standard error before that final result.
+The build profile defines the default BuildTarget, scenes, options, and output policy. Pass `--buildTarget` to override the profile BuildTarget for one run. `ucli build run` writes the final JSON result to standard output, and may write progress entries to standard error before that final result.
 
 Build artifacts are written under `.ucli/local/fingerprints/<projectFingerprint>/artifacts/build/<runId>/`.
 

--- a/schemas/v1/cli-output/payload/build.run.schema.json
+++ b/schemas/v1/cli-output/payload/build.run.schema.json
@@ -41,7 +41,7 @@
                 "digest"
               ]
             },
-            "target": {
+            "buildTarget": {
               "type": "string"
             },
             "scenes": {
@@ -228,7 +228,7 @@
           "required": [
             "runId",
             "profile",
-            "target",
+            "buildTarget",
             "scenes",
             "options",
             "output",

--- a/scripts/detect-verify-scopes.sh
+++ b/scripts/detect-verify-scopes.sh
@@ -95,7 +95,7 @@ is_unity_input() {
   local file="$1"
 
   case "${file}" in
-    .editorconfig|.gitattributes|.github/workflows/verify.yaml|scripts/detect-verify-scopes.sh|scripts/setup-nuget-cli.sh|scripts/test-unity.sh|scripts/update-local-shared-packages.sh|scripts/verify.sh|src/Ucli.Unity/Ucli.Unity.slnx|src/Ucli.Unity/*.csproj|src/Ucli.Unity/Assets/*|src/Ucli.Unity/Packages/*|src/Ucli.Unity/ProjectSettings/*)
+    .editorconfig|.gitattributes|.github/workflows/verify.yaml|.ucli/build/*|scripts/detect-verify-scopes.sh|scripts/run-ucli-unity-build.sh|scripts/setup-nuget-cli.sh|scripts/test-unity.sh|scripts/update-local-shared-packages.sh|scripts/verify.sh|src/Ucli.Unity/Ucli.Unity.slnx|src/Ucli.Unity/*.csproj|src/Ucli.Unity/Assets/*|src/Ucli.Unity/Packages/*|src/Ucli.Unity/ProjectSettings/*)
       return 0
       ;;
   esac

--- a/scripts/run-ucli-unity-build.sh
+++ b/scripts/run-ucli-unity-build.sh
@@ -10,7 +10,7 @@ Options:
   --repo-root <path>          Repository root. Defaults to git root.
   --project-path <path>       Unity project root. Required unless UCLI_UNITY_PROJECT_PATH is set.
   --profile-path <path>       uCLI build profile JSON path. Required unless UCLI_BUILD_PROFILE_PATH is set.
-  --buildTarget <value>       BuildTarget stable name. Defaults to UCLI_BUILD_TARGET when set.
+  --buildTarget <value>       buildTarget stable name. Defaults to UCLI_BUILD_TARGET when set.
   --mode <mode>               uCLI execution mode. Defaults to oneshot.
   --unity-editor-path <path>  Unity editor executable or directory path.
   --timeout <milliseconds>    Build timeout. Defaults to 900000.

--- a/scripts/run-ucli-unity-build.sh
+++ b/scripts/run-ucli-unity-build.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/run-ucli-unity-build.sh [options]
+
+Options:
+  --repo-root <path>          Repository root. Defaults to git root.
+  --project-path <path>       Unity project root. Required unless UCLI_UNITY_PROJECT_PATH is set.
+  --profile-path <path>       uCLI build profile JSON path. Required unless UCLI_BUILD_PROFILE_PATH is set.
+  --buildTarget <value>       BuildTarget stable name. Defaults to UCLI_BUILD_TARGET when set.
+  --mode <mode>               uCLI execution mode. Defaults to oneshot.
+  --unity-editor-path <path>  Unity editor executable or directory path.
+  --timeout <milliseconds>    Build timeout. Defaults to 900000.
+  --configuration <name>      .NET build configuration. Defaults to Release.
+  --result-dir <path>         Output directory. Defaults to a temporary directory.
+  --no-restore                Skip dotnet restore for the ucli project build.
+  --no-build                  Skip dotnet build for the ucli project.
+  --no-package-restore        Skip Unity local package restore.
+  --no-prune                  Do not prune restored Unity package assets.
+EOF
+}
+
+repository_root=""
+project_path="${UCLI_UNITY_PROJECT_PATH:-}"
+profile_path="${UCLI_BUILD_PROFILE_PATH:-}"
+buildTarget="${UCLI_BUILD_TARGET:-}"
+execution_mode="oneshot"
+unity_editor_path=""
+timeout_milliseconds="900000"
+configuration="Release"
+result_dir=""
+restore=true
+build=true
+package_restore=true
+prune=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      repository_root="$2"
+      shift 2
+      ;;
+    --repo-root=*)
+      repository_root="${1#--repo-root=}"
+      shift
+      ;;
+    --project-path)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      project_path="$2"
+      shift 2
+      ;;
+    --project-path=*)
+      project_path="${1#--project-path=}"
+      shift
+      ;;
+    --profile-path)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      profile_path="$2"
+      shift 2
+      ;;
+    --profile-path=*)
+      profile_path="${1#--profile-path=}"
+      shift
+      ;;
+    --buildTarget)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      buildTarget="$2"
+      shift 2
+      ;;
+    --buildTarget=*)
+      buildTarget="${1#--buildTarget=}"
+      shift
+      ;;
+    --mode)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      execution_mode="$2"
+      shift 2
+      ;;
+    --mode=*)
+      execution_mode="${1#--mode=}"
+      shift
+      ;;
+    --unity-editor-path)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      unity_editor_path="$2"
+      shift 2
+      ;;
+    --unity-editor-path=*)
+      unity_editor_path="${1#--unity-editor-path=}"
+      shift
+      ;;
+    --timeout)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      timeout_milliseconds="$2"
+      shift 2
+      ;;
+    --timeout=*)
+      timeout_milliseconds="${1#--timeout=}"
+      shift
+      ;;
+    --configuration)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      configuration="$2"
+      shift 2
+      ;;
+    --configuration=*)
+      configuration="${1#--configuration=}"
+      shift
+      ;;
+    --result-dir)
+      [[ $# -ge 2 ]] || { print_usage; exit 2; }
+      result_dir="$2"
+      shift 2
+      ;;
+    --result-dir=*)
+      result_dir="${1#--result-dir=}"
+      shift
+      ;;
+    --no-restore)
+      restore=false
+      shift
+      ;;
+    --no-build)
+      build=false
+      shift
+      ;;
+    --no-package-restore)
+      package_restore=false
+      shift
+      ;;
+    --no-prune)
+      prune=false
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      print_usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${repository_root}" ]]; then
+  repository_root="$(git rev-parse --show-toplevel)"
+fi
+
+if [[ ! -d "${repository_root}" ]]; then
+  echo "ERROR: Repository root not found: ${repository_root}" >&2
+  exit 1
+fi
+
+if [[ -z "${configuration}" ]]; then
+  echo "ERROR: --configuration must not be empty." >&2
+  exit 2
+fi
+
+if [[ -z "${project_path}" ]]; then
+  echo "ERROR: --project-path or UCLI_UNITY_PROJECT_PATH is required." >&2
+  exit 2
+fi
+
+if [[ -z "${profile_path}" ]]; then
+  echo "ERROR: --profile-path or UCLI_BUILD_PROFILE_PATH is required." >&2
+  exit 2
+fi
+
+if [[ ! "${timeout_milliseconds}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --timeout must be a positive integer. Actual: ${timeout_milliseconds}" >&2
+  exit 2
+fi
+
+cd "${repository_root}"
+
+to_absolute_path() {
+  case "$1" in
+    /*|[A-Za-z]:/*|[A-Za-z]:\\*)
+      printf '%s\n' "${1//\\//}"
+      ;;
+    *)
+      printf '%s/%s\n' "${repository_root}" "$1"
+      ;;
+  esac
+}
+
+is_supported_unity_editor_executable_file_name() {
+  local file_name
+  file_name="$(basename "${1//\\//}")"
+  [[ "${file_name}" == "Unity" || "${file_name}" == "Unity.exe" ]]
+}
+
+resolve_unity_editor_executable_path() {
+  local preferred_path="$1"
+  local normalized_path
+  normalized_path="$(to_absolute_path "${preferred_path}")"
+
+  if [[ -f "${normalized_path}" ]]; then
+    if ! is_supported_unity_editor_executable_file_name "${normalized_path}"; then
+      echo "ERROR: --unity-editor-path must point to a Unity executable (Unity or Unity.exe): ${normalized_path}" >&2
+      return 2
+    fi
+
+    printf '%s\n' "${normalized_path}"
+    return 0
+  fi
+
+  if [[ ! -d "${normalized_path}" ]]; then
+    echo "ERROR: --unity-editor-path does not exist: ${normalized_path}" >&2
+    return 2
+  fi
+
+  local executable_relative_paths=(
+    "Contents/MacOS/Unity"
+    "Unity.app/Contents/MacOS/Unity"
+    "Editor/Unity.exe"
+    "Editor/Unity"
+    "Unity.exe"
+    "Unity"
+  )
+
+  local relative_path
+  local executable_path
+  for relative_path in "${executable_relative_paths[@]}"; do
+    executable_path="${normalized_path}/${relative_path}"
+    if [[ ! -f "${executable_path}" ]]; then
+      continue
+    fi
+
+    if ! is_supported_unity_editor_executable_file_name "${executable_path}"; then
+      continue
+    fi
+
+    printf '%s\n' "${executable_path}"
+    return 0
+  done
+
+  echo "ERROR: --unity-editor-path does not contain a Unity executable: ${normalized_path}" >&2
+  return 2
+}
+
+resolve_unity_editor_root_path() {
+  local executable_path="$1"
+
+  case "${executable_path}" in
+    */Editor/Unity)
+      printf '%s\n' "${executable_path%/Editor/Unity}"
+      ;;
+    */Editor/Unity.exe)
+      printf '%s\n' "${executable_path%/Editor/Unity.exe}"
+      ;;
+    */Unity.app/Contents/MacOS/Unity)
+      printf '%s\n' "${executable_path%/Unity.app/Contents/MacOS/Unity}"
+      ;;
+    *)
+      echo "ERROR: Unsupported Unity editor executable path: ${executable_path}" >&2
+      return 2
+      ;;
+  esac
+}
+
+ensure_unity_hub_editor_path() {
+  local editor_path="$1"
+  local unity_version
+  unity_version="$(
+    sed -nE 's/^m_EditorVersion: (.+)$/\1/p' \
+      "${project_path}/ProjectSettings/ProjectVersion.txt" \
+      | head -n 1
+  )"
+  if [[ -z "${unity_version}" ]]; then
+    echo "ERROR: Failed to resolve Unity version from ProjectVersion.txt." >&2
+    return 1
+  fi
+
+  local executable_path
+  executable_path="$(resolve_unity_editor_executable_path "${editor_path}")" || return $?
+
+  local editor_root
+  editor_root="$(resolve_unity_editor_root_path "${executable_path}")" || return $?
+
+  local hub_root="${HOME}/Unity/Hub/Editor"
+  local expected_editor_root="${hub_root}/${unity_version}"
+  mkdir -p "${hub_root}"
+
+  if [[ ! -e "${expected_editor_root}" ]]; then
+    ln -s "${editor_root}" "${expected_editor_root}"
+  fi
+}
+
+project_path="$(to_absolute_path "${project_path}")"
+profile_path="$(to_absolute_path "${profile_path}")"
+
+temporary_result_dir=""
+if [[ -z "${result_dir}" ]]; then
+  temporary_result_dir="$(mktemp -d "${TMPDIR:-/tmp}/ucli-unity-build.XXXXXX")"
+  result_dir="${temporary_result_dir}"
+else
+  result_dir="$(to_absolute_path "${result_dir}")"
+fi
+
+command_result_path="${result_dir}/command-result.json"
+command_stderr_path="${result_dir}/command-stderr.ndjson"
+ucli_project_path="${repository_root}/src/Ucli/Ucli.csproj"
+ucli_dll_path="${repository_root}/src/Ucli/bin/${configuration}/net8.0/MackySoft.Ucli.dll"
+
+cleanup_temporary_result_dir() {
+  if [[ -n "${temporary_result_dir}" && -d "${temporary_result_dir}" ]]; then
+    rm -rf "${temporary_result_dir}"
+  fi
+}
+
+trap cleanup_temporary_result_dir EXIT
+
+if [[ ! -d "${project_path}" ]]; then
+  echo "ERROR: Unity project path not found: ${project_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${profile_path}" ]]; then
+  echo "ERROR: uCLI build profile not found: ${profile_path}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${ucli_project_path}" ]]; then
+  echo "ERROR: uCLI project file not found: ${ucli_project_path}" >&2
+  exit 1
+fi
+
+if [[ -n "${unity_editor_path}" ]]; then
+  ensure_unity_hub_editor_path "${unity_editor_path}"
+fi
+
+if [[ "${restore}" == "true" ]]; then
+  dotnet restore "${ucli_project_path}"
+fi
+
+if [[ "${build}" == "true" ]]; then
+  dotnet build "${ucli_project_path}" --configuration "${configuration}" --no-restore
+fi
+
+if [[ "${package_restore}" == "true" ]]; then
+  unity_package_restore_args=(--repo-root "${repository_root}")
+  if [[ "${prune}" == "true" ]]; then
+    unity_package_restore_args+=(--prune)
+  fi
+
+  bash scripts/update-local-shared-packages.sh "${unity_package_restore_args[@]}"
+fi
+
+if [[ ! -f "${ucli_dll_path}" ]]; then
+  echo "ERROR: uCLI executable assembly not found: ${ucli_dll_path}" >&2
+  exit 1
+fi
+
+mkdir -p "${result_dir}"
+
+ucli_build_args=(
+  build
+  run
+  --projectPath "${project_path}"
+  --profilePath "${profile_path}"
+  --mode "${execution_mode}"
+  --timeout "${timeout_milliseconds}"
+  --format json
+)
+
+if [[ -n "${buildTarget}" ]]; then
+  ucli_build_args+=(--buildTarget "${buildTarget}")
+fi
+
+set +e
+dotnet "${ucli_dll_path}" "${ucli_build_args[@]}" > "${command_result_path}" 2> >(tee "${command_stderr_path}" >&2)
+exit_code=$?
+set -e
+
+if [[ -s "${command_result_path}" ]]; then
+  cat "${command_result_path}"
+else
+  echo "ERROR: uCLI build run did not write a command result." >&2
+  if [[ "${exit_code}" -ne 0 ]]; then
+    exit "${exit_code}"
+  fi
+
+  exit 1
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "exit_code=${exit_code}"
+    if [[ -z "${temporary_result_dir}" ]]; then
+      echo "command_result_path=${command_result_path}"
+      echo "command_stderr_path=${command_stderr_path}"
+    fi
+  } >> "${GITHUB_OUTPUT}"
+fi
+
+if ! jq -e '
+  .status == "ok"
+  and .exitCode == 0
+  and .payload.verdict == "pass"
+  and .payload.build.summary.result == "succeeded"
+  and .payload.build.output.fileCount > 0
+' "${command_result_path}" > /dev/null; then
+  if [[ "${exit_code}" -ne 0 ]]; then
+    exit "${exit_code}"
+  fi
+
+  exit 1
+fi
+
+if [[ "${exit_code}" -ne 0 ]]; then
+  echo "ERROR: uCLI build run exited with ${exit_code}." >&2
+  exit "${exit_code}"
+fi

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
@@ -3,8 +3,8 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <summary> Represents inputs needed to account non-metadata build-run artifacts. </summary>
 /// <param name="Paths"> The prepared artifact layout. </param>
 /// <param name="ReportedOutputPath"> The output path reported by Unity's normalized BuildReport. </param>
-/// <param name="TargetStableName"> The resolved build target stable name. </param>
+/// <param name="BuildTarget"> The resolved build target stable name. </param>
 internal sealed record BuildRunArtifactAccountingRequest (
     BuildRunArtifactPaths Paths,
     string ReportedOutputPath,
-    string TargetStableName);
+    string BuildTarget);

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
@@ -3,7 +3,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <summary> Represents inputs needed to account non-metadata build-run artifacts. </summary>
 /// <param name="Paths"> The prepared artifact layout. </param>
 /// <param name="ReportedOutputPath"> The output path reported by Unity's normalized BuildReport. </param>
-/// <param name="BuildTarget"> The resolved build target stable name. </param>
+/// <param name="BuildTarget"> The resolved buildTarget stable name. </param>
 internal sealed record BuildRunArtifactAccountingRequest (
     BuildRunArtifactPaths Paths,
     string ReportedOutputPath,

--- a/src/Ucli.Application/Features/Assurance/Build/Contracts/BuildCommandInput.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Contracts/BuildCommandInput.cs
@@ -4,5 +4,6 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Contracts;
 internal sealed record BuildCommandInput (
     string? ProfilePath,
     string? ProjectPath,
+    string? BuildTarget,
     UnityExecutionMode? Mode,
     int? TimeoutMilliseconds);

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -8,6 +8,7 @@ using MackySoft.Ucli.Application.Features.Assurance.Build.Vocabulary;
 using MackySoft.Ucli.Application.Features.Assurance.Semantics;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.Progress;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Text;
@@ -90,6 +91,12 @@ internal sealed class BuildService : IBuildService
             return BuildExecutionResult.Failure(profileResolutionResult.Error!, project);
         }
 
+        var profileOverrideResult = ApplyCommandOverrides(profileResolutionResult.Profile!, input);
+        if (!profileOverrideResult.IsSuccess)
+        {
+            return BuildExecutionResult.Failure(profileOverrideResult.Error!, project);
+        }
+
         var timeoutResult = IpcCommandTimeoutResolver.ResolveNormalized(
             input.TimeoutMilliseconds,
             UcliCommandIds.BuildRun,
@@ -139,7 +146,7 @@ internal sealed class BuildService : IBuildService
             return BuildExecutionResult.Failure(prepareResult.Error!, project);
         }
 
-        var profile = profileResolutionResult.Profile!;
+        var profile = profileOverrideResult.Profile!;
         var paths = prepareResult.Paths!;
         await EmitStartedAsync(
                 resolvedProgressSink,
@@ -148,7 +155,7 @@ internal sealed class BuildService : IBuildService
                 requestedMode,
                 executionTarget,
                 timeout,
-                profile.Target.StableName,
+                profile.BuildTarget.StableName,
                 paths.OutputDirectory,
                 cancellationToken)
             .ConfigureAwait(false);
@@ -205,7 +212,7 @@ internal sealed class BuildService : IBuildService
                     new BuildRunArtifactAccountingRequest(
                         paths,
                         buildResponse.Report.OutputPath,
-                        profile.Target.StableName),
+                        profile.BuildTarget.StableName),
                     artifactCancellationToken)
                 .ConfigureAwait(false);
             if (!accountingResult.IsSuccess)
@@ -259,6 +266,41 @@ internal sealed class BuildService : IBuildService
         }
     }
 
+    private static BuildProfileResolutionResult ApplyCommandOverrides (
+        ResolvedBuildProfile profile,
+        BuildCommandInput input)
+    {
+        if (input.BuildTarget is null)
+        {
+            return BuildProfileResolutionResult.Success(profile);
+        }
+
+        if (string.IsNullOrWhiteSpace(input.BuildTarget))
+        {
+            return BuildProfileResolutionResult.Failure(ExecutionError.InvalidArgument(
+                "buildTarget must not be empty.",
+                BuildErrorCodes.BuildTargetUnsupported));
+        }
+
+        if (!BuildTargetStableNameCodec.TryResolve(input.BuildTarget, out var buildTarget))
+        {
+            return BuildProfileResolutionResult.Failure(ExecutionError.InvalidArgument(
+                $"buildTarget is unsupported: {input.BuildTarget}.",
+                BuildErrorCodes.BuildTargetUnsupported));
+        }
+
+        return BuildProfileResolutionResult.Success(profile with
+        {
+            BuildTarget = buildTarget,
+            Digest = BuildProfileDigestCalculator.Calculate(
+                profile.SchemaVersion,
+                buildTarget,
+                profile.Scenes,
+                profile.Output,
+                profile.Options),
+        });
+    }
+
     private static ValueTask EmitStartedAsync (
         ICommandProgressSink progressSink,
         string runId,
@@ -266,7 +308,7 @@ internal sealed class BuildService : IBuildService
         UnityExecutionMode requestedMode,
         UnityExecutionTarget executionTarget,
         TimeSpan timeout,
-        string target,
+        string buildTarget,
         string outputPath,
         CancellationToken cancellationToken)
     {
@@ -279,7 +321,7 @@ internal sealed class BuildService : IBuildService
                 ResolvedMode: AssuranceExecutionModeCodec.ToResolvedModeValue(executionTarget),
                 SessionKind: AssuranceExecutionModeCodec.ToSessionKindValue(executionTarget),
                 TimeoutMilliseconds: checked((int)timeout.TotalMilliseconds),
-                Target: target,
+                BuildTarget: buildTarget,
                 OutputPath: outputPath),
             cancellationToken);
     }
@@ -313,8 +355,8 @@ internal sealed class BuildService : IBuildService
     {
         return new UnityRequestPayload.BuildRun(
             RunId: runId,
-            TargetStableName: profile.Target.StableName,
-            UnityBuildTarget: profile.Target.UnityBuildTargetLiteral,
+            BuildTarget: profile.BuildTarget.StableName,
+            UnityBuildTarget: profile.BuildTarget.UnityBuildTargetLiteral,
             SceneSource: ContractLiteralCodec.ToValue(profile.Scenes.Source),
             ScenePaths: profile.Scenes.Paths,
             Development: profile.Options.Development,
@@ -380,16 +422,16 @@ internal sealed class BuildService : IBuildService
                 $"Unity build response projectFingerprint mismatch. Requested={expectedProjectFingerprint}, Actual={response.ProjectFingerprint}.");
         }
 
-        if (!string.Equals(response.Input.TargetStableName, expectedProfile.Target.StableName, StringComparison.Ordinal))
+        if (!string.Equals(response.Input.BuildTarget, expectedProfile.BuildTarget.StableName, StringComparison.Ordinal))
         {
             return ApplicationFailure.InternalError(
-                $"Unity build response target mismatch. Requested={expectedProfile.Target.StableName}, Actual={response.Input.TargetStableName}.");
+                $"Unity build response buildTarget mismatch. Requested={expectedProfile.BuildTarget.StableName}, Actual={response.Input.BuildTarget}.");
         }
 
-        if (!string.Equals(response.Input.UnityBuildTarget, expectedProfile.Target.UnityBuildTargetLiteral, StringComparison.Ordinal))
+        if (!string.Equals(response.Input.UnityBuildTarget, expectedProfile.BuildTarget.UnityBuildTargetLiteral, StringComparison.Ordinal))
         {
             return ApplicationFailure.InternalError(
-                $"Unity build response Unity target mismatch. Requested={expectedProfile.Target.UnityBuildTargetLiteral}, Actual={response.Input.UnityBuildTarget}.");
+                $"Unity build response Unity BuildTarget mismatch. Requested={expectedProfile.BuildTarget.UnityBuildTargetLiteral}, Actual={response.Input.UnityBuildTarget}.");
         }
 
         var expectedSceneSource = ContractLiteralCodec.ToValue(expectedProfile.Scenes.Source);
@@ -447,10 +489,10 @@ internal sealed class BuildService : IBuildService
             return ApplicationFailure.InternalError("Unity build response resolved scenes do not match the requested explicit build scenes.");
         }
 
-        if (!string.Equals(response.Report.Target, response.Input.UnityBuildTarget, StringComparison.Ordinal))
+        if (!string.Equals(response.Report.UnityBuildTarget, response.Input.UnityBuildTarget, StringComparison.Ordinal))
         {
             return ApplicationFailure.InternalError(
-                $"Unity build report target mismatch. Input={response.Input.UnityBuildTarget}, Report={response.Report.Target}.");
+                $"Unity BuildReport BuildTarget mismatch. Input={response.Input.UnityBuildTarget}, Report={response.Report.UnityBuildTarget}.");
         }
 
         return null;
@@ -523,7 +565,7 @@ internal sealed class BuildService : IBuildService
         var build = new BuildOutput(
             RunId: runId,
             Profile: new BuildProfileOutput(profilePath, profile.Digest),
-            Target: profile.Target.StableName,
+            BuildTarget: profile.BuildTarget.StableName,
             Scenes: new BuildScenesOutput(
                 Source: response.Input.SceneSource,
                 Paths: response.Input.Scenes),
@@ -585,7 +627,7 @@ internal sealed class BuildService : IBuildService
             Project: SerializeMetadataElement(project),
             Profile: SerializeMetadataElement(output.Build.Profile),
             Input: SerializeMetadataElement(new BuildRunInputMetadata(
-                Target: output.Build.Target,
+                BuildTarget: output.Build.BuildTarget,
                 UnityBuildTarget: response.Input.UnityBuildTarget,
                 Scenes: output.Build.Scenes,
                 Options: output.Build.Options)),
@@ -663,10 +705,10 @@ internal sealed class BuildService : IBuildService
             CreateClaim(
                 BuildClaimCodes.UnityBuildInputsResolved,
                 BuildClaimStatus.Passed,
-                "Unity resolved BuildPipeline target and scenes.",
+                "Unity resolved BuildPipeline BuildTarget and scenes.",
                 new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
-                    ["target"] = build.Target,
+                    ["buildTarget"] = build.BuildTarget,
                     ["sceneCount"] = build.Scenes.Paths.Count,
                 },
                 [new BuildEvidenceOutput(Kind: ContractLiteralCodec.ToValue(BuildEvidenceKind.BuildInput), EvidenceRef: BuildReportRefs.Build, Data: response.Input)]),

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
 
 /// <summary> Represents the resolved BuildPipeline input persisted in <c>build.json</c>. </summary>
 internal sealed record BuildRunInputMetadata (
-    string Target,
+    string BuildTarget,
     string UnityBuildTarget,
     BuildScenesOutput Scenes,
     BuildOptionsOutput Options);

--- a/src/Ucli.Application/Features/Assurance/Build/Payload/BuildOutput.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Payload/BuildOutput.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
 internal sealed record BuildOutput (
     string RunId,
     BuildProfileOutput Profile,
-    string Target,
+    string BuildTarget,
     BuildScenesOutput Scenes,
     BuildOptionsOutput Options,
     BuildArtifactOutput Output,

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildProfileDigestCalculator.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildProfileDigestCalculator.cs
@@ -19,19 +19,19 @@ internal static class BuildProfileDigestCalculator
     /// <summary> Calculates the canonical digest for one resolved build profile content. </summary>
     public static string Calculate (
         int schemaVersion,
-        ResolvedBuildTarget target,
+        ResolvedBuildTarget buildTarget,
         ResolvedBuildScenes scenes,
         ResolvedBuildOutputPolicy output,
         ResolvedBuildOptions options)
     {
-        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(buildTarget);
         ArgumentNullException.ThrowIfNull(scenes);
         ArgumentNullException.ThrowIfNull(output);
         ArgumentNullException.ThrowIfNull(options);
 
         var canonical = new CanonicalBuildProfile(
             SchemaVersion: schemaVersion,
-            Target: target.StableName,
+            BuildTarget: buildTarget.StableName,
             Scenes: CanonicalBuildScenes.From(scenes),
             Output: new CanonicalBuildOutputPolicy(ContractLiteralCodec.ToValue(output.Kind)),
             Options: new CanonicalBuildOptions(options.Development));
@@ -42,7 +42,7 @@ internal static class BuildProfileDigestCalculator
 
     private sealed record CanonicalBuildProfile (
         int SchemaVersion,
-        string Target,
+        string BuildTarget,
         CanonicalBuildScenes Scenes,
         CanonicalBuildOutputPolicy Output,
         CanonicalBuildOptions Options);

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildProfileResolver.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildProfileResolver.cs
@@ -14,7 +14,7 @@ internal static class BuildProfileResolver
     private static readonly HashSet<string> AllowedRootProperties = new(StringComparer.Ordinal)
     {
         "schemaVersion",
-        "target",
+        "buildTarget",
         "scenes",
         "output",
         "options",
@@ -72,7 +72,7 @@ internal static class BuildProfileResolver
             return error!;
         }
 
-        if (!TryReadTarget(root, out var target, out error)
+        if (!TryReadBuildTarget(root, out var buildTarget, out error)
             || !TryReadScenes(root, out var scenes, out error)
             || !TryReadOutput(root, out var output, out error)
             || !TryReadOptions(root, out var options, out error))
@@ -82,13 +82,13 @@ internal static class BuildProfileResolver
 
         var digest = BuildProfileDigestCalculator.Calculate(
             schemaVersion,
-            target!,
+            buildTarget!,
             scenes!,
             output!,
             options!);
         return BuildProfileResolutionResult.Success(new ResolvedBuildProfile(
             SchemaVersion: schemaVersion,
-            Target: target!,
+            BuildTarget: buildTarget!,
             Scenes: scenes!,
             Output: output!,
             Options: options!,
@@ -123,15 +123,15 @@ internal static class BuildProfileResolver
         return true;
     }
 
-    private static bool TryReadTarget (
+    private static bool TryReadBuildTarget (
         JsonElement root,
-        out ResolvedBuildTarget? target,
+        out ResolvedBuildTarget? buildTarget,
         out BuildProfileResolutionResult? error)
     {
-        target = null;
+        buildTarget = null;
         if (!JsonObjectPropertyReader.TryReadRequiredString(
             root,
-            "target",
+            "buildTarget",
             CreateMissingRequiredPropertyError,
             CreateStringTypeMismatchError,
             noError: null,
@@ -144,19 +144,19 @@ internal static class BuildProfileResolver
 
         if (string.IsNullOrWhiteSpace(stableName))
         {
-            error = InvalidProfile("Build profile target must not be empty.");
+            error = InvalidProfile("Build profile buildTarget must not be empty.");
             return false;
         }
 
         if (!BuildTargetStableNameCodec.TryResolve(stableName, out var resolvedTarget))
         {
             error = BuildProfileResolutionResult.Failure(ExecutionError.InvalidArgument(
-                $"Build profile target is unsupported: {stableName}.",
+                $"Build profile buildTarget is unsupported: {stableName}.",
                 BuildErrorCodes.BuildTargetUnsupported));
             return false;
         }
 
-        target = resolvedTarget;
+        buildTarget = resolvedTarget;
         error = null;
         return true;
     }

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableName.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableName.cs
@@ -2,7 +2,7 @@ using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 
-/// <summary> Defines uCLI build target stable-name literals. </summary>
+/// <summary> Defines uCLI buildTarget stable-name literals. </summary>
 internal enum BuildTargetStableName
 {
     /// <summary> macOS standalone player build target. </summary>

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
@@ -2,10 +2,10 @@ using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 
-/// <summary> Resolves uCLI build target stable names to Unity BuildTarget literals. </summary>
+/// <summary> Resolves uCLI buildTarget stable names to Unity BuildTarget literals. </summary>
 internal static class BuildTargetStableNameCodec
 {
-    /// <summary> Tries to resolve one build target stable name. </summary>
+    /// <summary> Tries to resolve one buildTarget stable name. </summary>
     public static bool TryResolve (
         string stableName,
         out ResolvedBuildTarget target)

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildProfile.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildProfile.cs
@@ -3,7 +3,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 /// <summary> Represents one resolved build profile consumed by build execution. </summary>
 internal sealed record ResolvedBuildProfile (
     int SchemaVersion,
-    ResolvedBuildTarget Target,
+    ResolvedBuildTarget BuildTarget,
     ResolvedBuildScenes Scenes,
     ResolvedBuildOutputPolicy Output,
     ResolvedBuildOptions Options,

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildTarget.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildTarget.cs
@@ -1,6 +1,6 @@
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 
-/// <summary> Represents one resolved build target stable name. </summary>
+/// <summary> Represents one resolved buildTarget stable name. </summary>
 internal sealed record ResolvedBuildTarget (
     BuildTargetStableName StableNameValue,
     string StableName,

--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -39,6 +39,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
 
         ValidateReports(payload, violations);
+        ValidateBuildInput(buildElement, violations);
         ValidateBuildProfile(buildElement, violations);
         ValidateBuildOutput(payload, violations);
         ValidateBuildSummary(buildElement, violations);
@@ -117,6 +118,16 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         else if (!IsSha256LowerHex(digest))
         {
             AddViolation(violations, BuildPropertyPath(reportPath, "digest"), $"Build report {expectedKind} digest must be lowercase SHA-256 hex.");
+        }
+    }
+
+    private static void ValidateBuildInput (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!TryReadString(buildElement, "buildTarget", out _))
+        {
+            AddViolation(violations, "$.build.buildTarget", "Build payload must declare buildTarget.");
         }
     }
 

--- a/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
+++ b/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
@@ -22,7 +22,7 @@ internal abstract record UnityRequestPayload
     /// <summary> Represents a build assurance request prepared by application orchestration. </summary>
     internal sealed record BuildRun (
         string RunId,
-        string TargetStableName,
+        string BuildTarget,
         string UnityBuildTarget,
         string SceneSource,
         IReadOnlyList<string> ScenePaths,

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestContentJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestContentJsonContract.cs
@@ -3,14 +3,14 @@ namespace MackySoft.Ucli.Contracts.Assurance.Build;
 /// <summary> Represents the digest source fields of <c>output-manifest.json</c>. </summary>
 /// <param name="SchemaVersion"> The output-manifest schema version. </param>
 /// <param name="OutputRoot"> The build output root path. </param>
-/// <param name="Target"> The resolved build target stable name. </param>
+/// <param name="BuildTarget"> The resolved canonical buildTarget literal. </param>
 /// <param name="FileCount"> The number of regular files included in the manifest. </param>
 /// <param name="TotalBytes"> The total byte count for manifest files. </param>
 /// <param name="Files"> The manifest file entries in canonical order. </param>
 internal sealed record BuildOutputManifestContentJsonContract (
     int SchemaVersion,
     string OutputRoot,
-    string Target,
+    string BuildTarget,
     int FileCount,
     long TotalBytes,
     IReadOnlyList<BuildOutputManifestFileJsonContract> Files);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContract.cs
@@ -3,7 +3,7 @@ namespace MackySoft.Ucli.Contracts.Assurance.Build;
 /// <summary> Represents the persisted <c>output-manifest.json</c> contract. </summary>
 /// <param name="SchemaVersion"> The output-manifest schema version. </param>
 /// <param name="OutputRoot"> The build output root path. </param>
-/// <param name="Target"> The resolved build target stable name. </param>
+/// <param name="BuildTarget"> The resolved canonical buildTarget literal. </param>
 /// <param name="FileCount"> The number of regular files included in the manifest. </param>
 /// <param name="TotalBytes"> The total byte count for manifest files. </param>
 /// <param name="Files"> The manifest file entries in canonical order. </param>
@@ -11,7 +11,7 @@ namespace MackySoft.Ucli.Contracts.Assurance.Build;
 internal sealed record BuildOutputManifestJsonContract (
     int SchemaVersion,
     string OutputRoot,
-    string Target,
+    string BuildTarget,
     int FileCount,
     long TotalBytes,
     IReadOnlyList<BuildOutputManifestFileJsonContract> Files,
@@ -27,7 +27,7 @@ internal sealed record BuildOutputManifestJsonContract (
         return new BuildOutputManifestContentJsonContract(
             SchemaVersion,
             OutputRoot,
-            Target,
+            BuildTarget,
             FileCount,
             TotalBytes,
             Files);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContractWriter.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContractWriter.cs
@@ -79,7 +79,7 @@ internal sealed class BuildOutputManifestJsonContractWriter : IJsonContractWrite
             writer.WriteStartObject();
             writer.WriteNumber("schemaVersion", content.SchemaVersion);
             writer.WriteString("outputRoot", content.OutputRoot);
-            writer.WriteString("target", content.Target);
+            writer.WriteString("buildTarget", content.BuildTarget);
             writer.WriteNumber("fileCount", content.FileCount);
             writer.WriteNumber("totalBytes", content.TotalBytes);
             writer.WritePropertyName("files");

--- a/src/Ucli.Contracts/Assurance/Build/BuildRunStartedEntry.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildRunStartedEntry.cs
@@ -8,5 +8,5 @@ public sealed record BuildRunStartedEntry (
     string ResolvedMode,
     string SessionKind,
     int TimeoutMilliseconds,
-    string Target,
+    string BuildTarget,
     string OutputPath);

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildInputProbe.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildInputProbe.cs
@@ -1,14 +1,14 @@
 namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Represents the Unity BuildPipeline inputs resolved by the build precondition probe. </summary>
-/// <param name="TargetStableName"> The uCLI build target stable name from the resolved build profile. </param>
+/// <param name="BuildTarget"> The uCLI buildTarget stable name from the resolved build profile. </param>
 /// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> enum literal. </param>
 /// <param name="UnityBuildTargetGroup"> The Unity <c>BuildTargetGroup</c> enum literal. </param>
 /// <param name="SceneSource"> The resolved scene source literal. </param>
 /// <param name="Scenes"> The project-relative scene paths passed to BuildPipeline. </param>
 /// <param name="BuildOptions"> The Unity <c>BuildOptions</c> flags literal. </param>
 public sealed record IpcBuildInputProbe (
-    string TargetStableName,
+    string BuildTarget,
     string UnityBuildTarget,
     string UnityBuildTargetGroup,
     string SceneSource,

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildReportArtifact.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildReportArtifact.cs
@@ -3,7 +3,7 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 /// <summary> Represents the normalized Unity BuildReport artifact. </summary>
 /// <param name="SchemaVersion"> The artifact schema version. </param>
 /// <param name="Result"> The normalized BuildReport result literal. </param>
-/// <param name="Target"> The Unity <c>BuildTarget</c> literal. </param>
+/// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> literal. </param>
 /// <param name="OutputPath"> The BuildPipeline output path. </param>
 /// <param name="DurationMilliseconds"> The BuildPipeline duration in milliseconds. </param>
 /// <param name="TotalSizeBytes"> The BuildReport total output size in bytes. </param>
@@ -14,7 +14,7 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 public sealed record IpcBuildReportArtifact (
     int SchemaVersion,
     string Result,
-    string Target,
+    string UnityBuildTarget,
     string OutputPath,
     long DurationMilliseconds,
     long TotalSizeBytes,

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildRunRequest.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildRunRequest.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Represents a <c>build.run</c> IPC request payload. </summary>
 /// <param name="RunId"> The CLI-generated build run identifier. </param>
-/// <param name="TargetStableName"> The uCLI build target stable name from the resolved build profile. </param>
+/// <param name="BuildTarget"> The uCLI buildTarget stable name from the resolved build profile. </param>
 /// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> enum literal. </param>
 /// <param name="SceneSource"> The resolved scene source literal. </param>
 /// <param name="ScenePaths"> The explicit scene paths, or an empty list when scene source is Editor Build Settings. </param>
@@ -14,7 +14,7 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 /// <param name="BuildLogPath"> The absolute path where Unity writes the build log artifact. </param>
 public sealed record IpcBuildRunRequest (
     string RunId,
-    string TargetStableName,
+    string BuildTarget,
     string UnityBuildTarget,
     string SceneSource,
     IReadOnlyList<string> ScenePaths,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildPlayerOptionsFactory.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildPlayerOptionsFactory.cs
@@ -28,18 +28,18 @@ namespace MackySoft.Ucli.Unity.Build
             return new BuildPlayerOptions
             {
                 scenes = resolvedInput.ScenePaths,
-                target = resolvedInput.Target,
-                targetGroup = resolvedInput.TargetGroup,
+                target = resolvedInput.UnityBuildTarget,
+                targetGroup = resolvedInput.UnityBuildTargetGroup,
                 options = resolvedInput.Options,
-                locationPathName = ResolveLocationPathName(request.OutputPath, resolvedInput.Target),
+                locationPathName = ResolveLocationPathName(request.OutputPath, resolvedInput.UnityBuildTarget),
             };
         }
 
         private static string ResolveLocationPathName (
             string outputDirectory,
-            BuildTarget target)
+            BuildTarget unityBuildTarget)
         {
-            return target switch
+            return unityBuildTarget switch
             {
                 BuildTarget.StandaloneOSX => Path.Combine(outputDirectory, "build.app"),
                 BuildTarget.StandaloneWindows => Path.Combine(outputDirectory, "build.exe"),

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildReportNormalizer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildReportNormalizer.cs
@@ -22,7 +22,7 @@ namespace MackySoft.Ucli.Unity.Build
             var summary = report.summary;
             return Normalize(new BuildReportSnapshot(
                 Result: ToIpcResult(summary.result),
-                Target: summary.platform.ToString(),
+                UnityBuildTarget: summary.platform.ToString(),
                 OutputPath: summary.outputPath ?? string.Empty,
                 Duration: summary.totalTime,
                 TotalSizeBytes: checked((long)summary.totalSize),
@@ -43,7 +43,7 @@ namespace MackySoft.Ucli.Unity.Build
             return new IpcBuildReportArtifact(
                 SchemaVersion: BuildReportSchemaVersion,
                 Result: ContractLiteralCodec.ToValue(snapshot.Result),
-                Target: snapshot.Target ?? string.Empty,
+                UnityBuildTarget: snapshot.UnityBuildTarget ?? string.Empty,
                 OutputPath: snapshot.OutputPath ?? string.Empty,
                 DurationMilliseconds: ToMilliseconds(snapshot.Duration),
                 TotalSizeBytes: snapshot.TotalSizeBytes,
@@ -165,7 +165,7 @@ namespace MackySoft.Ucli.Unity.Build
 
         internal sealed record BuildReportSnapshot (
             IpcBuildReportResult Result,
-            string Target,
+            string UnityBuildTarget,
             string OutputPath,
             TimeSpan Duration,
             long TotalSizeBytes,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionInput.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionInput.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 namespace MackySoft.Ucli.Unity.Build
 {
     /// <summary> Represents build inputs resolved before Unity BuildPipeline precondition probing. </summary>
-    /// <param name="TargetStableName"> The uCLI build target stable name. </param>
+    /// <param name="BuildTarget"> The uCLI buildTarget stable name. </param>
     /// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> enum literal. </param>
     /// <param name="SceneSource"> The build profile scene source literal. </param>
     /// <param name="ScenePaths"> The explicit scene paths, or an empty list when scene source is Editor Build Settings. </param>
     /// <param name="Development"> Whether the development build option is enabled. </param>
     internal sealed record UnityBuildPreconditionInput (
-        string TargetStableName,
+        string BuildTarget,
         string UnityBuildTarget,
         string SceneSource,
         IReadOnlyList<string> ScenePaths,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
@@ -93,7 +93,7 @@ namespace MackySoft.Ucli.Unity.Build
                     CreateInputProbe(input, targetSupport, Array.Empty<string>(), BuildOptions.None),
                     new IpcError(
                         BuildErrorCodes.BuildTargetModuleMissing,
-                        $"Unity build target module is not installed or not supported: {targetSupport.Target}.",
+                        $"Unity buildTarget module is not installed or not supported: {targetSupport.UnityBuildTarget}.",
                         null));
             }
 
@@ -130,8 +130,8 @@ namespace MackySoft.Ucli.Unity.Build
                 dirtyState,
                 resolvedInputProbe,
                 new UnityBuildResolvedInput(
-                    targetSupport.Target,
-                    targetSupport.TargetGroup,
+                    targetSupport.UnityBuildTarget,
+                    targetSupport.UnityBuildTargetGroup,
                     scenePaths,
                     buildOptions));
         }
@@ -342,9 +342,9 @@ namespace MackySoft.Ucli.Unity.Build
             BuildOptions buildOptions)
         {
             return new IpcBuildInputProbe(
-                TargetStableName: input.TargetStableName,
-                UnityBuildTarget: targetSupport.Target.ToString(),
-                UnityBuildTargetGroup: targetSupport.TargetGroup.ToString(),
+                BuildTarget: input.BuildTarget,
+                UnityBuildTarget: targetSupport.UnityBuildTarget.ToString(),
+                UnityBuildTargetGroup: targetSupport.UnityBuildTargetGroup.ToString(),
                 SceneSource: input.SceneSource,
                 Scenes: scenePaths,
                 BuildOptions: buildOptions.ToString());

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildResolvedInput.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildResolvedInput.cs
@@ -5,13 +5,13 @@ using UnityEditor;
 namespace MackySoft.Ucli.Unity.Build
 {
     /// <summary> Represents the Unity BuildPipeline input resolved after build preconditions pass. </summary>
-    /// <param name="Target"> The Unity build target. </param>
-    /// <param name="TargetGroup"> The Unity build target group. </param>
+    /// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> value. </param>
+    /// <param name="UnityBuildTargetGroup"> The Unity <c>BuildTargetGroup</c> value. </param>
     /// <param name="ScenePaths"> The project-relative scene paths passed to BuildPipeline. </param>
     /// <param name="Options"> The Unity build options. </param>
     internal sealed record UnityBuildResolvedInput (
-        BuildTarget Target,
-        BuildTargetGroup TargetGroup,
+        BuildTarget UnityBuildTarget,
+        BuildTargetGroup UnityBuildTargetGroup,
         string[] ScenePaths,
         BuildOptions Options);
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildTargetSupportProbeResult.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildTargetSupportProbeResult.cs
@@ -6,13 +6,13 @@ namespace MackySoft.Ucli.Unity.Build
 {
     /// <summary> Represents a Unity build target support probe result. </summary>
     /// <param name="IsValidTarget"> Whether the Unity build target literal could be parsed. </param>
-    /// <param name="Target"> The parsed Unity build target. </param>
-    /// <param name="TargetGroup"> The Unity build target group. </param>
+    /// <param name="UnityBuildTarget"> The parsed Unity <c>BuildTarget</c> value. </param>
+    /// <param name="UnityBuildTargetGroup"> The Unity <c>BuildTargetGroup</c> value. </param>
     /// <param name="IsSupported"> Whether the current Unity installation supports the target. </param>
     internal sealed record UnityBuildTargetSupportProbeResult (
         bool IsValidTarget,
-        BuildTarget Target,
-        BuildTargetGroup TargetGroup,
+        BuildTarget UnityBuildTarget,
+        BuildTargetGroup UnityBuildTargetGroup,
         bool IsSupported)
     {
         /// <summary> Creates a result for an invalid target literal. </summary>
@@ -27,14 +27,14 @@ namespace MackySoft.Ucli.Unity.Build
 
         /// <summary> Creates a result for a parsed target literal. </summary>
         public static UnityBuildTargetSupportProbeResult Resolved (
-            BuildTarget target,
-            BuildTargetGroup targetGroup,
+            BuildTarget unityBuildTarget,
+            BuildTargetGroup unityBuildTargetGroup,
             bool isSupported)
         {
             return new UnityBuildTargetSupportProbeResult(
                 true,
-                target,
-                targetGroup,
+                unityBuildTarget,
+                unityBuildTargetGroup,
                 isSupported);
         }
     }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -88,7 +88,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 var executionCancellationToken = requestTimeoutScope.Token;
                 precondition = await preconditionProbe.ProbeBeforeBuildAsync(
                     new UnityBuildPreconditionInput(
-                        TargetStableName: buildRunRequest.TargetStableName,
+                        BuildTarget: buildRunRequest.BuildTarget,
                         UnityBuildTarget: buildRunRequest.UnityBuildTarget,
                         SceneSource: buildRunRequest.SceneSource,
                         ScenePaths: buildRunRequest.ScenePaths,
@@ -288,11 +288,11 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
-            if (string.IsNullOrWhiteSpace(request.TargetStableName)
+            if (string.IsNullOrWhiteSpace(request.BuildTarget)
                 || string.IsNullOrWhiteSpace(request.UnityBuildTarget)
                 || string.IsNullOrWhiteSpace(request.SceneSource))
             {
-                errorMessage = "Build target and scene source values must not be empty.";
+                errorMessage = "BuildTarget and scene source values must not be empty.";
                 return false;
             }
 

--- a/src/Ucli.Unity/Assets/Settings/URP-Balanced.asset
+++ b/src/Ucli.Unity/Assets/Settings/URP-Balanced.asset
@@ -100,33 +100,33 @@ MonoBehaviour:
     hasProbeVolumes:
       m_Keys: []
       m_Values: 
-  m_PrefilteringModeMainLightShadows: 1
-  m_PrefilteringModeAdditionalLight: 4
-  m_PrefilteringModeAdditionalLightShadows: 1
-  m_PrefilterXRKeywords: 0
-  m_PrefilteringModeForwardPlus: 1
-  m_PrefilteringModeDeferredRendering: 1
-  m_PrefilteringModeScreenSpaceOcclusion: 1
-  m_PrefilterDebugKeywords: 0
-  m_PrefilterWriteRenderingLayers: 0
-  m_PrefilterHDROutput: 0
-  m_PrefilterSSAODepthNormals: 0
+  m_PrefilteringModeMainLightShadows: 3
+  m_PrefilteringModeAdditionalLight: 3
+  m_PrefilteringModeAdditionalLightShadows: 0
+  m_PrefilterXRKeywords: 1
+  m_PrefilteringModeForwardPlus: 0
+  m_PrefilteringModeDeferredRendering: 0
+  m_PrefilteringModeScreenSpaceOcclusion: 2
+  m_PrefilterDebugKeywords: 1
+  m_PrefilterWriteRenderingLayers: 1
+  m_PrefilterHDROutput: 1
+  m_PrefilterSSAODepthNormals: 1
   m_PrefilterSSAOSourceDepthLow: 0
-  m_PrefilterSSAOSourceDepthMedium: 0
-  m_PrefilterSSAOSourceDepthHigh: 0
+  m_PrefilterSSAOSourceDepthMedium: 1
+  m_PrefilterSSAOSourceDepthHigh: 1
   m_PrefilterSSAOInterleaved: 0
-  m_PrefilterSSAOBlueNoise: 0
+  m_PrefilterSSAOBlueNoise: 1
   m_PrefilterSSAOSampleCountLow: 0
-  m_PrefilterSSAOSampleCountMedium: 0
-  m_PrefilterSSAOSampleCountHigh: 0
-  m_PrefilterDBufferMRT1: 0
-  m_PrefilterDBufferMRT2: 0
-  m_PrefilterDBufferMRT3: 0
-  m_PrefilterSoftShadowsQualityLow: 0
-  m_PrefilterSoftShadowsQualityMedium: 0
-  m_PrefilterSoftShadowsQualityHigh: 0
+  m_PrefilterSSAOSampleCountMedium: 1
+  m_PrefilterSSAOSampleCountHigh: 1
+  m_PrefilterDBufferMRT1: 1
+  m_PrefilterDBufferMRT2: 1
+  m_PrefilterDBufferMRT3: 1
+  m_PrefilterSoftShadowsQualityLow: 1
+  m_PrefilterSoftShadowsQualityMedium: 1
+  m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 0
-  m_PrefilterScreenCoord: 0
-  m_PrefilterNativeRenderPass: 0
+  m_PrefilterScreenCoord: 1
+  m_PrefilterNativeRenderPass: 1
   m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0

--- a/src/Ucli.Unity/Assets/Settings/URP-HighFidelity.asset
+++ b/src/Ucli.Unity/Assets/Settings/URP-HighFidelity.asset
@@ -100,33 +100,33 @@ MonoBehaviour:
     hasProbeVolumes:
       m_Keys: []
       m_Values: 
-  m_PrefilteringModeMainLightShadows: 1
-  m_PrefilteringModeAdditionalLight: 4
-  m_PrefilteringModeAdditionalLightShadows: 1
-  m_PrefilterXRKeywords: 0
-  m_PrefilteringModeForwardPlus: 1
-  m_PrefilteringModeDeferredRendering: 1
-  m_PrefilteringModeScreenSpaceOcclusion: 1
-  m_PrefilterDebugKeywords: 0
-  m_PrefilterWriteRenderingLayers: 0
-  m_PrefilterHDROutput: 0
+  m_PrefilteringModeMainLightShadows: 3
+  m_PrefilteringModeAdditionalLight: 3
+  m_PrefilteringModeAdditionalLightShadows: 2
+  m_PrefilterXRKeywords: 1
+  m_PrefilteringModeForwardPlus: 0
+  m_PrefilteringModeDeferredRendering: 0
+  m_PrefilteringModeScreenSpaceOcclusion: 2
+  m_PrefilterDebugKeywords: 1
+  m_PrefilterWriteRenderingLayers: 1
+  m_PrefilterHDROutput: 1
   m_PrefilterSSAODepthNormals: 0
-  m_PrefilterSSAOSourceDepthLow: 0
-  m_PrefilterSSAOSourceDepthMedium: 0
-  m_PrefilterSSAOSourceDepthHigh: 0
+  m_PrefilterSSAOSourceDepthLow: 1
+  m_PrefilterSSAOSourceDepthMedium: 1
+  m_PrefilterSSAOSourceDepthHigh: 1
   m_PrefilterSSAOInterleaved: 0
-  m_PrefilterSSAOBlueNoise: 0
-  m_PrefilterSSAOSampleCountLow: 0
-  m_PrefilterSSAOSampleCountMedium: 0
+  m_PrefilterSSAOBlueNoise: 1
+  m_PrefilterSSAOSampleCountLow: 1
+  m_PrefilterSSAOSampleCountMedium: 1
   m_PrefilterSSAOSampleCountHigh: 0
-  m_PrefilterDBufferMRT1: 0
-  m_PrefilterDBufferMRT2: 0
-  m_PrefilterDBufferMRT3: 0
-  m_PrefilterSoftShadowsQualityLow: 0
-  m_PrefilterSoftShadowsQualityMedium: 0
-  m_PrefilterSoftShadowsQualityHigh: 0
+  m_PrefilterDBufferMRT1: 1
+  m_PrefilterDBufferMRT2: 1
+  m_PrefilterDBufferMRT3: 1
+  m_PrefilterSoftShadowsQualityLow: 1
+  m_PrefilterSoftShadowsQualityMedium: 1
+  m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 0
-  m_PrefilterScreenCoord: 0
-  m_PrefilterNativeRenderPass: 0
+  m_PrefilterScreenCoord: 1
+  m_PrefilterNativeRenderPass: 1
   m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 1

--- a/src/Ucli.Unity/Assets/Settings/URP-Performant.asset
+++ b/src/Ucli.Unity/Assets/Settings/URP-Performant.asset
@@ -100,33 +100,33 @@ MonoBehaviour:
     hasProbeVolumes:
       m_Keys: []
       m_Values: 
-  m_PrefilteringModeMainLightShadows: 1
-  m_PrefilteringModeAdditionalLight: 4
-  m_PrefilteringModeAdditionalLightShadows: 1
-  m_PrefilterXRKeywords: 0
-  m_PrefilteringModeForwardPlus: 1
-  m_PrefilteringModeDeferredRendering: 1
-  m_PrefilteringModeScreenSpaceOcclusion: 1
-  m_PrefilterDebugKeywords: 0
-  m_PrefilterWriteRenderingLayers: 0
-  m_PrefilterHDROutput: 0
-  m_PrefilterSSAODepthNormals: 0
-  m_PrefilterSSAOSourceDepthLow: 0
-  m_PrefilterSSAOSourceDepthMedium: 0
-  m_PrefilterSSAOSourceDepthHigh: 0
-  m_PrefilterSSAOInterleaved: 0
-  m_PrefilterSSAOBlueNoise: 0
-  m_PrefilterSSAOSampleCountLow: 0
-  m_PrefilterSSAOSampleCountMedium: 0
-  m_PrefilterSSAOSampleCountHigh: 0
-  m_PrefilterDBufferMRT1: 0
-  m_PrefilterDBufferMRT2: 0
-  m_PrefilterDBufferMRT3: 0
-  m_PrefilterSoftShadowsQualityLow: 0
-  m_PrefilterSoftShadowsQualityMedium: 0
-  m_PrefilterSoftShadowsQualityHigh: 0
+  m_PrefilteringModeMainLightShadows: 0
+  m_PrefilteringModeAdditionalLight: 0
+  m_PrefilteringModeAdditionalLightShadows: 0
+  m_PrefilterXRKeywords: 1
+  m_PrefilteringModeForwardPlus: 0
+  m_PrefilteringModeDeferredRendering: 0
+  m_PrefilteringModeScreenSpaceOcclusion: 0
+  m_PrefilterDebugKeywords: 1
+  m_PrefilterWriteRenderingLayers: 1
+  m_PrefilterHDROutput: 1
+  m_PrefilterSSAODepthNormals: 1
+  m_PrefilterSSAOSourceDepthLow: 1
+  m_PrefilterSSAOSourceDepthMedium: 1
+  m_PrefilterSSAOSourceDepthHigh: 1
+  m_PrefilterSSAOInterleaved: 1
+  m_PrefilterSSAOBlueNoise: 1
+  m_PrefilterSSAOSampleCountLow: 1
+  m_PrefilterSSAOSampleCountMedium: 1
+  m_PrefilterSSAOSampleCountHigh: 1
+  m_PrefilterDBufferMRT1: 1
+  m_PrefilterDBufferMRT2: 1
+  m_PrefilterDBufferMRT3: 1
+  m_PrefilterSoftShadowsQualityLow: 1
+  m_PrefilterSoftShadowsQualityMedium: 1
+  m_PrefilterSoftShadowsQualityHigh: 1
   m_PrefilterSoftShadows: 0
-  m_PrefilterScreenCoord: 0
-  m_PrefilterNativeRenderPass: 0
+  m_PrefilterScreenCoord: 1
+  m_PrefilterNativeRenderPass: 1
   m_ShaderVariantLogLevel: 0
   m_ShadowCascades: 0

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPipeline/UnityBuildReportNormalizerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPipeline/UnityBuildReportNormalizerTests.cs
@@ -16,7 +16,7 @@ namespace MackySoft.Ucli.Unity.Tests
         {
             var snapshot = new UnityBuildReportNormalizer.BuildReportSnapshot(
                 Result: IpcBuildReportResult.Succeeded,
-                Target: "StandaloneLinux64",
+                UnityBuildTarget: "StandaloneLinux64",
                 OutputPath: "/tmp/ucli/output/build",
                 Duration: TimeSpan.FromMilliseconds(1234.6),
                 TotalSizeBytes: 4096,
@@ -40,7 +40,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             Assert.That(artifact.SchemaVersion, Is.EqualTo(1));
             Assert.That(artifact.Result, Is.EqualTo(ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded)));
-            Assert.That(artifact.Target, Is.EqualTo("StandaloneLinux64"));
+            Assert.That(artifact.UnityBuildTarget, Is.EqualTo("StandaloneLinux64"));
             Assert.That(artifact.OutputPath, Is.EqualTo("/tmp/ucli/output/build"));
             Assert.That(artifact.DurationMilliseconds, Is.EqualTo(1235));
             Assert.That(artifact.TotalSizeBytes, Is.EqualTo(4096));
@@ -62,7 +62,7 @@ namespace MackySoft.Ucli.Unity.Tests
         {
             var snapshot = new UnityBuildReportNormalizer.BuildReportSnapshot(
                 Result: IpcBuildReportResult.Failed,
-                Target: "StandaloneLinux64",
+                UnityBuildTarget: "StandaloneLinux64",
                 OutputPath: "/tmp/ucli/output/build",
                 Duration: TimeSpan.FromMilliseconds(10),
                 TotalSizeBytes: 0,
@@ -107,7 +107,7 @@ namespace MackySoft.Ucli.Unity.Tests
             var outputPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "ucli", "output"));
             var request = new IpcBuildRunRequest(
                 RunId: "build-run-1",
-                TargetStableName: "standaloneLinux64",
+                BuildTarget: "standaloneLinux64",
                 UnityBuildTarget: "StandaloneLinux64",
                 SceneSource: "explicit",
                 ScenePaths: new[] { "Assets/Scenes/Main.unity" },
@@ -116,8 +116,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 BuildReportPath: "/tmp/ucli/build-report.json",
                 BuildLogPath: "/tmp/ucli/build.log");
             var resolvedInput = new UnityBuildResolvedInput(
-                Target: BuildTarget.StandaloneLinux64,
-                TargetGroup: BuildTargetGroup.Standalone,
+                UnityBuildTarget: BuildTarget.StandaloneLinux64,
+                UnityBuildTargetGroup: BuildTargetGroup.Standalone,
                 ScenePaths: new[] { "Assets/Scenes/Main.unity" },
                 Options: BuildOptions.Development);
 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPreconditions/UnityBuildPreconditionProbeTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPreconditions/UnityBuildPreconditionProbeTests.cs
@@ -38,8 +38,8 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(result.DirtyState.Dirty, Is.False);
             Assert.That(result.DirtyState.Items, Is.Empty);
             Assert.That(result.ResolvedInput, Is.Not.Null);
-            Assert.That(result.ResolvedInput!.Target, Is.EqualTo(BuildTarget.StandaloneLinux64));
-            Assert.That(result.ResolvedInput.TargetGroup, Is.EqualTo(BuildTargetGroup.Standalone));
+            Assert.That(result.ResolvedInput!.UnityBuildTarget, Is.EqualTo(BuildTarget.StandaloneLinux64));
+            Assert.That(result.ResolvedInput.UnityBuildTargetGroup, Is.EqualTo(BuildTargetGroup.Standalone));
             Assert.That(result.ResolvedInput.ScenePaths, Is.EqualTo(new[] { scenePath }));
             Assert.That(result.ResolvedInput.Options, Is.EqualTo(BuildOptions.None));
             Assert.That(result.InputProbe, Is.Not.Null);
@@ -118,7 +118,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             var result = await probe.ProbeBeforeBuildAsync(
                 new UnityBuildPreconditionInput(
-                    TargetStableName: "standaloneLinux64",
+                    BuildTarget: "standaloneLinux64",
                     UnityBuildTarget: "StandaloneLinux64",
                     SceneSource: SceneSourceLiteral(BuildProfileSceneSource.EditorBuildSettings),
                     ScenePaths: Array.Empty<string>(),
@@ -141,7 +141,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             var result = await probe.ProbeBeforeBuildAsync(
                 new UnityBuildPreconditionInput(
-                    TargetStableName: "standaloneLinux64",
+                    BuildTarget: "standaloneLinux64",
                     UnityBuildTarget: "StandaloneLinux64",
                     SceneSource: "unsupported",
                     ScenePaths: Array.Empty<string>(),
@@ -161,7 +161,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             var result = await probe.ProbeBeforeBuildAsync(
                 new UnityBuildPreconditionInput(
-                    TargetStableName: "standaloneLinux64",
+                    BuildTarget: "standaloneLinux64",
                     UnityBuildTarget: "StandaloneLinux64",
                     SceneSource: SceneSourceLiteral(BuildProfileSceneSource.Explicit),
                     ScenePaths: Array.Empty<string>(),
@@ -183,7 +183,7 @@ namespace MackySoft.Ucli.Unity.Tests
 
             var result = await probe.ProbeBeforeBuildAsync(
                 new UnityBuildPreconditionInput(
-                    TargetStableName: "standaloneLinux64",
+                    BuildTarget: "standaloneLinux64",
                     UnityBuildTarget: "StandaloneLinux64",
                     SceneSource: SceneSourceLiteral(BuildProfileSceneSource.EditorBuildSettings),
                     ScenePaths: Array.Empty<string>(),
@@ -275,8 +275,8 @@ namespace MackySoft.Ucli.Unity.Tests
             var result = new UnityBuildTargetSupportProbe().Probe("StandaloneLinux64");
 
             Assert.That(result.IsValidTarget, Is.True);
-            Assert.That(result.Target, Is.EqualTo(BuildTarget.StandaloneLinux64));
-            Assert.That(result.TargetGroup, Is.EqualTo(BuildTargetGroup.Standalone));
+            Assert.That(result.UnityBuildTarget, Is.EqualTo(BuildTarget.StandaloneLinux64));
+            Assert.That(result.UnityBuildTargetGroup, Is.EqualTo(BuildTargetGroup.Standalone));
         }
 
         [Test]
@@ -393,7 +393,7 @@ namespace MackySoft.Ucli.Unity.Tests
         private static UnityBuildPreconditionInput CreateExplicitInput (params string[] scenePaths)
         {
             return new UnityBuildPreconditionInput(
-                TargetStableName: "standaloneLinux64",
+                BuildTarget: "standaloneLinux64",
                 UnityBuildTarget: "StandaloneLinux64",
                 SceneSource: SceneSourceLiteral(BuildProfileSceneSource.Explicit),
                 ScenePaths: scenePaths,

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
@@ -260,7 +260,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 RunId);
             return new IpcBuildRunRequest(
                 RunId: RunId,
-                TargetStableName: "standaloneLinux64",
+                BuildTarget: "standaloneLinux64",
                 UnityBuildTarget: "StandaloneLinux64",
                 SceneSource: "explicit",
                 ScenePaths: new[] { "Assets/Scenes/SampleScene.unity" },
@@ -360,7 +360,7 @@ namespace MackySoft.Ucli.Unity.Tests
             return new IpcBuildReportArtifact(
                 SchemaVersion: 1,
                 Result: result,
-                Target: "StandaloneLinux64",
+                UnityBuildTarget: "StandaloneLinux64",
                 OutputPath: outputPath,
                 DurationMilliseconds: 1234,
                 TotalSizeBytes: 4096,

--- a/src/Ucli.Unity/ProjectSettings/BurstAotSettings_StandaloneOSX.json
+++ b/src/Ucli.Unity/ProjectSettings/BurstAotSettings_StandaloneOSX.json
@@ -1,0 +1,17 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "DebugDataKind": 1,
+    "EnableArmv9SecurityFeatures": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -85,7 +85,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.Paths);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.ReportedOutputPath);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.TargetStableName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.BuildTarget);
         cancellationToken.ThrowIfCancellationRequested();
 
         try
@@ -125,7 +125,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         {
             outputManifestArtifacts = await CreateOutputManifestArtifactsAsync(
                     request.Paths,
-                    request.TargetStableName,
+                    request.BuildTarget,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -391,7 +391,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
     private async ValueTask<OutputManifestArtifacts> CreateOutputManifestArtifactsAsync (
         BuildRunArtifactPaths paths,
-        string targetStableName,
+        string buildTarget,
         CancellationToken cancellationToken)
     {
         var outputRoot = NormalizeRepositoryRelativePath(paths.RepositoryRoot, paths.OutputDirectory);
@@ -420,7 +420,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         var content = new BuildOutputManifestContentJsonContract(
             BuildOutputManifestJsonContract.CurrentSchemaVersion,
             outputRoot,
-            targetStableName,
+            buildTarget,
             files.Count,
             totalBytes,
             files);
@@ -428,7 +428,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         var contract = new BuildOutputManifestJsonContract(
             content.SchemaVersion,
             content.OutputRoot,
-            content.Target,
+            content.BuildTarget,
             content.FileCount,
             content.TotalBytes,
             content.Files,

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
@@ -24,9 +24,9 @@ internal sealed class BuildRunCommand
     }
 
     /// <summary> Runs Unity BuildPipeline from a build profile and emits final JSON with build artifacts: build.json, build-report.json, build.log, output-manifest.json, output/. </summary>
-    /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines the default BuildTarget, scenes, options, and output policy. </param>
+    /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines the default buildTarget, scenes, options, and output policy. </param>
     /// <param name="projectPath"> -p|--projectPath, optional target Unity project path. </param>
-    /// <param name="buildTarget"> --buildTarget, optional BuildTarget stable name that overrides the profile BuildTarget. </param>
+    /// <param name="buildTarget"> --buildTarget, optional buildTarget stable name that overrides the profile buildTarget. </param>
     /// <param name="mode"> Unity execution mode (auto|daemon|oneshot). </param>
     /// <param name="timeout"> Timeout in milliseconds. </param>
     /// <param name="format"> Progress entry format (text|json) for entries written to standard error. </param>

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunCommand.cs
@@ -24,8 +24,9 @@ internal sealed class BuildRunCommand
     }
 
     /// <summary> Runs Unity BuildPipeline from a build profile and emits final JSON with build artifacts: build.json, build-report.json, build.log, output-manifest.json, output/. </summary>
-    /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines target, scenes, options, and output policy. </param>
+    /// <param name="profilePath"> --profilePath, path to the build profile JSON that defines the default BuildTarget, scenes, options, and output policy. </param>
     /// <param name="projectPath"> -p|--projectPath, optional target Unity project path. </param>
+    /// <param name="buildTarget"> --buildTarget, optional BuildTarget stable name that overrides the profile BuildTarget. </param>
     /// <param name="mode"> Unity execution mode (auto|daemon|oneshot). </param>
     /// <param name="timeout"> Timeout in milliseconds. </param>
     /// <param name="format"> Progress entry format (text|json) for entries written to standard error. </param>
@@ -35,6 +36,7 @@ internal sealed class BuildRunCommand
     public async Task<int> RunAsync (
         string? profilePath = null,
         string? projectPath = null,
+        string? buildTarget = null,
         string? mode = null,
         string? timeout = null,
         string? format = null,
@@ -76,6 +78,7 @@ internal sealed class BuildRunCommand
                 new BuildCommandInput(
                     ProfilePath: profilePath,
                     ProjectPath: projectPath,
+                    BuildTarget: buildTarget,
                     Mode: modeResult.Mode,
                     TimeoutMilliseconds: timeoutResult.TimeoutMilliseconds),
                 progressSink,

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunProgressTextProjector.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunProgressTextProjector.cs
@@ -31,7 +31,7 @@ internal sealed class BuildRunProgressTextProjector : ICliCommandProgressTextPro
     private static string CreateStartedText (BuildRunStartedEntry entry)
     {
         const string Prefix = "build runId=";
-        const string TargetLabel = " target=";
+        const string BuildTargetLabel = " buildTarget=";
         const string RequestedModeLabel = " requestedMode=";
         const string ResolvedModeLabel = " resolvedMode=";
         const string SessionKindLabel = " sessionKind=";
@@ -41,8 +41,8 @@ internal sealed class BuildRunProgressTextProjector : ICliCommandProgressTextPro
         var timeoutLength = SpanTextLength.GetInvariantInt64Length(entry.TimeoutMilliseconds);
         var length = checked(Prefix.Length
             + entry.RunId.Length
-            + TargetLabel.Length
-            + entry.Target.Length
+            + BuildTargetLabel.Length
+            + entry.BuildTarget.Length
             + RequestedModeLabel.Length
             + entry.RequestedMode.Length
             + ResolvedModeLabel.Length
@@ -60,8 +60,8 @@ internal sealed class BuildRunProgressTextProjector : ICliCommandProgressTextPro
                 var writer = new SpanTextWriter(destination);
                 writer.Append(Prefix);
                 writer.Append(state.RunId);
-                writer.Append(TargetLabel);
-                writer.Append(state.Target);
+                writer.Append(BuildTargetLabel);
+                writer.Append(state.BuildTarget);
                 writer.Append(RequestedModeLabel);
                 writer.Append(state.RequestedMode);
                 writer.Append(ResolvedModeLabel);

--- a/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
@@ -40,7 +40,7 @@ internal sealed class UnityIpcRequestBuilder
                 IpcMethodNames.BuildRun,
                 IpcPayloadCodec.SerializeToElement(new IpcBuildRunRequest(
                     RunId: buildRun.RunId,
-                    TargetStableName: buildRun.TargetStableName,
+                    BuildTarget: buildRun.BuildTarget,
                     UnityBuildTarget: buildRun.UnityBuildTarget,
                     SceneSource: buildRun.SceneSource,
                     ScenePaths: buildRun.ScenePaths,

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildProfileResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildProfileResolverTests.cs
@@ -16,7 +16,7 @@ public sealed class BuildProfileResolverTests
             """
             {
               "schemaVersion": 1,
-              "target": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "scenes": {
                 "source": "explicit",
                 "paths": [
@@ -36,9 +36,9 @@ public sealed class BuildProfileResolverTests
         Assert.True(result.IsSuccess);
         var profile = result.Profile!;
         Assert.Equal(1, profile.SchemaVersion);
-        Assert.Equal(BuildTargetStableName.StandaloneLinux64, profile.Target.StableNameValue);
-        Assert.Equal("standaloneLinux64", profile.Target.StableName);
-        Assert.Equal("StandaloneLinux64", profile.Target.UnityBuildTargetLiteral);
+        Assert.Equal(BuildTargetStableName.StandaloneLinux64, profile.BuildTarget.StableNameValue);
+        Assert.Equal("standaloneLinux64", profile.BuildTarget.StableName);
+        Assert.Equal("StandaloneLinux64", profile.BuildTarget.UnityBuildTargetLiteral);
         Assert.Equal(BuildProfileSceneSource.Explicit, profile.Scenes.Source);
         Assert.Equal("explicit", ContractLiteralCodec.ToValue(profile.Scenes.Source));
         Assert.Equal(
@@ -62,7 +62,7 @@ public sealed class BuildProfileResolverTests
             """
             {
               "schemaVersion": 1,
-              "target": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "scenes": {
                 "source": "editorBuildSettings"
               },
@@ -97,13 +97,13 @@ public sealed class BuildProfileResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void ResolveJson_WithUnsupportedTarget_ReturnsBuildTargetUnsupported ()
+    public void ResolveJson_WithUnsupportedBuildTarget_ReturnsBuildTargetUnsupported ()
     {
         var result = BuildProfileResolver.ResolveJson(
             """
             {
               "schemaVersion": 1,
-              "target": "StandaloneWindows64",
+              "buildTarget": "StandaloneWindows64",
               "scenes": {
                 "source": "editorBuildSettings"
               },
@@ -125,7 +125,7 @@ public sealed class BuildProfileResolverTests
     [Trait("Size", "Small")]
     public void ResolveJson_ComputesStableCanonicalDigest ()
     {
-        const string CompactJson = "{\"schemaVersion\":1,\"target\":\"standaloneLinux64\",\"scenes\":{\"source\":\"explicit\",\"paths\":[\"Assets/Scenes/Main.unity\"]},\"output\":{\"kind\":\"ucliArtifact\"},\"options\":{\"development\":false}}";
+        const string CompactJson = "{\"schemaVersion\":1,\"buildTarget\":\"standaloneLinux64\",\"scenes\":{\"source\":\"explicit\",\"paths\":[\"Assets/Scenes/Main.unity\"]},\"output\":{\"kind\":\"ucliArtifact\"},\"options\":{\"development\":false}}";
         const string ReorderedJson = """
             {
               "options": {
@@ -140,7 +140,7 @@ public sealed class BuildProfileResolverTests
                 ],
                 "source": "explicit"
               },
-              "target": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "schemaVersion": 1
             }
             """;
@@ -162,35 +162,35 @@ public sealed class BuildProfileResolverTests
             """not-json""",
             """ """,
             """[]""",
-            """{"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":2,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false},"legacy":true}""",
-            """{"schemaVersion":1,"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":[],"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings","legacy":true},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings","source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"unknown"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings","paths":["Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":"Assets/Scenes/Main.unity"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":[]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":[" "]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":["/Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":["C:/Project/Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets/Scenes/../Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets\\Scenes\\Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets/Scenes/Main.scene"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":[" Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"explicit","paths":[1]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":[],"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact","legacy":true},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact","kind":"ucliArtifact"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"fileSystem"},"options":{"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":[]}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false,"legacy":true}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false,"development":false}}""",
-            """{"schemaVersion":1,"target":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":"false"}}""",
+            """{"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":2,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false},"legacy":true}""",
+            """{"schemaVersion":1,"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":[],"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings","legacy":true},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings","source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"unknown"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings","paths":["Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":"Assets/Scenes/Main.unity"},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":[]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":[" "]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":["/Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":["C:/Project/Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets/Scenes/../Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets\\Scenes\\Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":["Assets/Scenes/Main.scene"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":[" Assets/Scenes/Main.unity"]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"explicit","paths":[1]},"output":{"kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":[],"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact","legacy":true},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact","kind":"ucliArtifact"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"fileSystem"},"options":{"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":[]}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false,"legacy":true}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":false,"development":false}}""",
+            """{"schemaVersion":1,"buildTarget":"standaloneLinux64","scenes":{"source":"editorBuildSettings"},"output":{"kind":"ucliArtifact"},"options":{"development":"false"}}""",
         ];
     }
 

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class BuildServiceTests
     private const string ProfileJson = """
         {
           "schemaVersion": 1,
-          "target": "standaloneLinux64",
+          "buildTarget": "standaloneLinux64",
           "scenes": {
             "source": "explicit",
             "paths": [
@@ -70,7 +70,10 @@ public sealed class BuildServiceTests
 
         var result = await service.ExecuteAsync(CreateInput(), progressSink);
 
-        Assert.True(result.IsSuccess);
+        if (!result.IsSuccess)
+        {
+            Assert.Fail(string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
+        }
         var output = result.Output!;
         Assert.Equal(ContractLiteralCodec.ToValue(BuildVerdict.Pass), output.Verdict);
         Assert.Equal(RunId, output.Build.RunId);
@@ -127,7 +130,7 @@ public sealed class BuildServiceTests
         Assert.Equal("oneshot", startedEntry.ResolvedMode);
         Assert.Equal("transientProbe", startedEntry.SessionKind);
         Assert.Equal(10000, startedEntry.TimeoutMilliseconds);
-        Assert.Equal("standaloneLinux64", startedEntry.Target);
+        Assert.Equal("standaloneLinux64", startedEntry.BuildTarget);
         Assert.Equal(artifactStore.PreparedPaths.OutputDirectory, startedEntry.OutputPath);
         var completedEntry = Assert.IsType<BuildRunCompletedEntry>(progressSink.Entries[1].Payload);
         Assert.Equal(RunId, completedEntry.RunId);
@@ -148,7 +151,7 @@ public sealed class BuildServiceTests
 
         var requestPayload = Assert.IsType<UnityRequestPayload.BuildRun>(requestExecutor.CapturedPayload);
         Assert.Equal(RunId, requestPayload.RunId);
-        Assert.Equal("standaloneLinux64", requestPayload.TargetStableName);
+        Assert.Equal("standaloneLinux64", requestPayload.BuildTarget);
         Assert.Equal("StandaloneLinux64", requestPayload.UnityBuildTarget);
         Assert.Equal("explicit", requestPayload.SceneSource);
         Assert.Equal(["Assets/Scenes/Main.unity"], requestPayload.ScenePaths);
@@ -173,7 +176,7 @@ public sealed class BuildServiceTests
 
         var result = await service.ExecuteAsync(CreateInput());
 
-        Assert.True(result.IsSuccess);
+        Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
     }
 
     [Fact]
@@ -184,7 +187,7 @@ public sealed class BuildServiceTests
         const string profileJson = """
             {
               "schemaVersion": 1,
-              "target": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "scenes": {
                 "source": "editorBuildSettings"
               },
@@ -210,7 +213,7 @@ public sealed class BuildServiceTests
 
         var result = await service.ExecuteAsync(CreateInput());
 
-        Assert.True(result.IsSuccess);
+        Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
         Assert.Equal("editorBuildSettings", result.Output!.Build.Scenes.Source);
         Assert.Equal(["Assets/Scenes/FromSettings.unity"], result.Output.Build.Scenes.Paths);
         var metadataScenePaths = artifactStore.WrittenMetadata!.Input
@@ -223,6 +226,70 @@ public sealed class BuildServiceTests
         var payload = Assert.IsType<UnityRequestPayload.BuildRun>(requestExecutor.CapturedPayload);
         Assert.Equal("editorBuildSettings", payload.SceneSource);
         Assert.Empty(payload.ScenePaths);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithBuildTargetOverride_UsesCommandBuildTarget ()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var artifactStore = new StubBuildRunArtifactStore(tempDirectory.Path);
+        var requestExecutor = CreateBuildResponseExecutor(
+            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+            ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
+            errorCount: 0,
+            buildTarget: "standaloneOSX",
+            unityBuildTarget: "StandaloneOSX");
+        var progressSink = new CollectingProgressSink();
+        var service = CreateService(
+            requestExecutor: requestExecutor,
+            artifactStore: artifactStore);
+
+        var result = await service.ExecuteAsync(CreateInput(buildTarget: "standaloneOSX"), progressSink);
+
+        if (!result.IsSuccess)
+        {
+            Assert.Fail(string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
+        }
+        var output = result.Output!;
+        Assert.Equal("standaloneOSX", output.Build.BuildTarget);
+        Assert.Equal("standaloneOSX", artifactStore.AccountingRequest!.BuildTarget);
+        var startedEntry = Assert.IsType<BuildRunStartedEntry>(progressSink.Entries[0].Payload);
+        Assert.Equal("standaloneOSX", startedEntry.BuildTarget);
+        var requestPayload = Assert.IsType<UnityRequestPayload.BuildRun>(requestExecutor.CapturedPayload);
+        Assert.Equal("standaloneOSX", requestPayload.BuildTarget);
+        Assert.Equal("StandaloneOSX", requestPayload.UnityBuildTarget);
+
+        var profile = BuildProfileResolver.ResolveJson(ProfileJson).Profile!;
+        Assert.True(BuildTargetStableNameCodec.TryResolve("standaloneOSX", out var buildTarget));
+        var expectedDigest = BuildProfileDigestCalculator.Calculate(
+            profile.SchemaVersion,
+            buildTarget,
+            profile.Scenes,
+            profile.Output,
+            profile.Options);
+        Assert.Equal(expectedDigest, output.Build.Profile.Digest);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithUnsupportedBuildTargetOverride_ReturnsBuildTargetUnsupported ()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var requestExecutor = CreateBuildResponseExecutor(
+            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+            ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
+            errorCount: 0);
+        var service = CreateService(
+            requestExecutor: requestExecutor,
+            artifactStore: new StubBuildRunArtifactStore(tempDirectory.Path));
+
+        var result = await service.ExecuteAsync(CreateInput(buildTarget: "unsupportedTarget"));
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(BuildErrorCodes.BuildTargetUnsupported, error.Code);
+        Assert.Null(requestExecutor.CapturedPayload);
     }
 
     [Fact]
@@ -429,7 +496,7 @@ public sealed class BuildServiceTests
     [InlineData("standaloneLinux64", "StandaloneOSX", "Development")]
     [InlineData("standaloneLinux64", "StandaloneLinux64", "None")]
     public async Task Execute_WithMismatchedResolvedInputResponse_ReturnsCommandFailure (
-        string targetStableName,
+        string buildTarget,
         string unityBuildTarget,
         string buildOptions)
     {
@@ -439,7 +506,7 @@ public sealed class BuildServiceTests
                 ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
                 ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
                 errorCount: 0,
-                targetStableName: targetStableName,
+                buildTarget: buildTarget,
                 unityBuildTarget: unityBuildTarget,
                 buildOptions: buildOptions),
             artifactStore: new StubBuildRunArtifactStore(tempDirectory.Path));
@@ -548,11 +615,13 @@ public sealed class BuildServiceTests
     }
 
     private static BuildCommandInput CreateInput (
-        int timeoutMilliseconds = 10000)
+        int timeoutMilliseconds = 10000,
+        string? buildTarget = null)
     {
         return new BuildCommandInput(
             ProfilePath: null,
             ProjectPath: null,
+            BuildTarget: buildTarget,
             Mode: UnityExecutionMode.Auto,
             TimeoutMilliseconds: timeoutMilliseconds);
     }
@@ -578,7 +647,7 @@ public sealed class BuildServiceTests
         int errorCount,
         string? sceneSource = null,
         IReadOnlyList<string>? scenes = null,
-        string? targetStableName = null,
+        string? buildTarget = null,
         string? unityBuildTarget = null,
         string? buildOptions = null,
         IpcBuildLifecycleSnapshot? lifecycleBefore = null,
@@ -594,7 +663,7 @@ public sealed class BuildServiceTests
                 errorCount,
                 sceneSource,
                 scenes,
-                targetStableName,
+                buildTarget,
                 unityBuildTarget,
                 buildOptions,
                 lifecycleBefore,
@@ -609,7 +678,7 @@ public sealed class BuildServiceTests
         int errorCount,
         string? sceneSource = null,
         IReadOnlyList<string>? scenes = null,
-        string? targetStableName = null,
+        string? buildTarget = null,
         string? unityBuildTarget = null,
         string? buildOptions = null,
         IpcBuildLifecycleSnapshot? lifecycleBefore = null,
@@ -623,11 +692,11 @@ public sealed class BuildServiceTests
                 LifecycleBefore: lifecycleBefore ?? CreateLifecycleSnapshot("before", canAcceptExecutionRequests: true),
                 LifecycleAfter: lifecycleAfter ?? CreateLifecycleSnapshot("after", canAcceptExecutionRequests: true),
                 DirtyState: new IpcBuildDirtyState(Checked: true, Dirty: false, Items: []),
-                Input: CreateInputProbe(sceneSource, scenes, targetStableName, unityBuildTarget, buildOptions),
+                Input: CreateInputProbe(sceneSource, scenes, buildTarget, unityBuildTarget, buildOptions),
                 Report: new IpcBuildReportArtifact(
                     SchemaVersion: 1,
                     Result: reportResult,
-                    Target: "StandaloneLinux64",
+                    UnityBuildTarget: unityBuildTarget ?? "StandaloneLinux64",
                     OutputPath: reportOutputPath ?? "/workspace/.ucli/output/build",
                     DurationMilliseconds: 2500,
                     TotalSizeBytes: 4096,
@@ -690,12 +759,12 @@ public sealed class BuildServiceTests
     private static IpcBuildInputProbe CreateInputProbe (
         string? sceneSource = null,
         IReadOnlyList<string>? scenes = null,
-        string? targetStableName = null,
+        string? buildTarget = null,
         string? unityBuildTarget = null,
         string? buildOptions = null)
     {
         return new IpcBuildInputProbe(
-            TargetStableName: targetStableName ?? "standaloneLinux64",
+            BuildTarget: buildTarget ?? "standaloneLinux64",
             UnityBuildTarget: unityBuildTarget ?? "StandaloneLinux64",
             UnityBuildTargetGroup: "Standalone",
             SceneSource: sceneSource ?? ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit),
@@ -889,6 +958,8 @@ public sealed class BuildServiceTests
 
         public BuildRunMetadataDocument? WrittenMetadata { get; private set; }
 
+        public BuildRunArtifactAccountingRequest? AccountingRequest { get; private set; }
+
         public BuildRunArtifactPreparationResult Prepare (
             ResolvedUnityProjectContext unityProject,
             string runId)
@@ -913,6 +984,7 @@ public sealed class BuildServiceTests
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            AccountingRequest = request;
             if (accountArtifactsOverride != null)
             {
                 return accountArtifactsOverride(request, cancellationToken);

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -1123,6 +1123,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             verdict,
             build = new
             {
+                buildTarget = "standaloneLinux64",
                 profile,
                 output = new
                 {

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
@@ -31,7 +31,7 @@ public sealed class BuildOutputManifestJsonContractWriterTests
             [
                 "schemaVersion",
                 "outputRoot",
-                "target",
+                "buildTarget",
                 "fileCount",
                 "totalBytes",
                 "files",
@@ -68,9 +68,9 @@ public sealed class BuildOutputManifestJsonContractWriterTests
         var digest = writer.CalculateManifestDigest(content);
 
         Assert.Equal(
-            "{\"schemaVersion\":1,\"outputRoot\":\".ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output\",\"target\":\"standaloneLinux64\",\"fileCount\":1,\"totalBytes\":12,\"files\":[{\"path\":\"Game.x86_64\",\"sizeBytes\":12,\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}",
+            "{\"schemaVersion\":1,\"outputRoot\":\".ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output\",\"buildTarget\":\"standaloneLinux64\",\"fileCount\":1,\"totalBytes\":12,\"files\":[{\"path\":\"Game.x86_64\",\"sizeBytes\":12,\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}",
             digestSource);
-        Assert.Equal("a853dad0d38bd6ae09f37d3dc13c77616975011bc81076765bc274f41b9beebd", digest);
+        Assert.Equal("0b6ea568d0262e545935b9a5a573e52a86fb1cc1576aae647fc1b7c9c8606404", digest);
         Assert.DoesNotContain("manifestDigest", digestSource, StringComparison.Ordinal);
         Assert.All(digest, static c => Assert.True(
             (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),

--- a/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
@@ -171,7 +171,7 @@ public sealed class IpcContractSerializationTests
             SerializerOptions));
         using var inputProbe = JsonDocument.Parse(JsonSerializer.Serialize(
             new IpcBuildInputProbe(
-                TargetStableName: "standaloneLinux64",
+                BuildTarget: "standaloneLinux64",
                 UnityBuildTarget: "StandaloneLinux64",
                 UnityBuildTargetGroup: "Standalone",
                 SceneSource: ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit),
@@ -216,7 +216,7 @@ public sealed class IpcContractSerializationTests
                 .HasString("kind", ContractLiteralCodec.ToValue(IpcBuildDirtyStateItemKind.Scene))
                 .HasString("path", "Assets/Scenes/Main.unity"));
         JsonAssert.For(inputProbe.RootElement)
-            .HasString("targetStableName", "standaloneLinux64")
+            .HasString("buildTarget", "standaloneLinux64")
             .HasString("unityBuildTarget", "StandaloneLinux64")
             .HasString("unityBuildTargetGroup", "Standalone")
             .HasString("sceneSource", ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit))
@@ -268,7 +268,7 @@ public sealed class IpcContractSerializationTests
         using var request = JsonDocument.Parse(JsonSerializer.Serialize(
             new IpcBuildRunRequest(
                 RunId: "build-run-1",
-                TargetStableName: "standaloneLinux64",
+                BuildTarget: "standaloneLinux64",
                 UnityBuildTarget: "StandaloneLinux64",
                 SceneSource: ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit),
                 ScenePaths: ["Assets/Scenes/Main.unity"],
@@ -288,7 +288,7 @@ public sealed class IpcContractSerializationTests
                 LifecycleAfter: CreateBuildLifecycleSnapshot("after", canAcceptExecutionRequests: true),
                 DirtyState: new IpcBuildDirtyState(Checked: true, Dirty: false, Items: []),
                 Input: new IpcBuildInputProbe(
-                    TargetStableName: "standaloneLinux64",
+                    BuildTarget: "standaloneLinux64",
                     UnityBuildTarget: "StandaloneLinux64",
                     UnityBuildTargetGroup: "Standalone",
                     SceneSource: ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit),
@@ -297,7 +297,7 @@ public sealed class IpcContractSerializationTests
                 Report: new IpcBuildReportArtifact(
                     SchemaVersion: 1,
                     Result: ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
-                    Target: "StandaloneLinux64",
+                    UnityBuildTarget: "StandaloneLinux64",
                     OutputPath: "/tmp/ucli/output/build",
                     DurationMilliseconds: 2500,
                     TotalSizeBytes: 4096,
@@ -329,7 +329,7 @@ public sealed class IpcContractSerializationTests
 
         JsonAssert.For(request.RootElement)
             .HasString("runId", "build-run-1")
-            .HasString("targetStableName", "standaloneLinux64")
+            .HasString("buildTarget", "standaloneLinux64")
             .HasString("unityBuildTarget", "StandaloneLinux64")
             .HasString("sceneSource", ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit))
             .HasArrayLength("scenePaths", 1)
@@ -357,12 +357,12 @@ public sealed class IpcContractSerializationTests
                 .HasBoolean("dirty", false)
                 .HasArrayLength("items", 0))
             .HasProperty("input", input => input
-                .HasString("targetStableName", "standaloneLinux64")
+                .HasString("buildTarget", "standaloneLinux64")
                 .HasString("sceneSource", ContractLiteralCodec.ToValue(BuildProfileSceneSource.Explicit)))
             .HasProperty("report", report => report
                 .HasInt32("schemaVersion", 1)
                 .HasString("result", ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded))
-                .HasString("target", "StandaloneLinux64")
+                .HasString("unityBuildTarget", "StandaloneLinux64")
                 .HasString("outputPath", "/tmp/ucli/output/build")
                 .HasInt32("durationMilliseconds", 2500)
                 .HasInt32("totalSizeBytes", 4096)

--- a/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
@@ -22,8 +22,8 @@ public sealed class BuildRunCliOutputContractTests
     private const string BuildArtifactFixtureRoot = "tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts";
     private const string ArtifactRoot = "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1";
     private const string OutputRoot = ArtifactRoot + "/output";
-    private const string SuccessManifestDigest = "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6";
-    private const string FailedManifestDigest = "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314";
+    private const string SuccessManifestDigest = "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1";
+    private const string FailedManifestDigest = "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444";
 
     private static readonly string RepositoryRoot = FindRepositoryRoot();
     private static readonly string BuildDigest = new('a', 64);
@@ -194,9 +194,9 @@ public sealed class BuildRunCliOutputContractTests
         yield return ["success.json", "success"];
         yield return ["build-report-failed.json", "build-report-failed"];
         yield return ["invalid-profile.json", "invalid-profile"];
-        yield return ["unsupported-target.json", "unsupported-target"];
+        yield return ["unsupported-buildTarget.json", "unsupported-buildTarget"];
         yield return ["dirty-scene.json", "dirty-scene"];
-        yield return ["target-module-missing.json", "target-module-missing"];
+        yield return ["buildTarget-module-missing.json", "buildTarget-module-missing"];
         yield return ["artifact-write-failed.json", "artifact-write-failed"];
         yield return ["output-manifest-failed.json", "output-manifest-failed"];
     }
@@ -210,15 +210,15 @@ public sealed class BuildRunCliOutputContractTests
             "invalid-profile" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
                 ExecutionError.InvalidArgument("Build profile is invalid: /workspace/UnityProject/.ucli/build/player.json.", BuildErrorCodes.BuildProfileInvalid),
                 CreateProject())),
-            "unsupported-target" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
-                ExecutionError.InvalidArgument("Build target is unsupported: webgl.", BuildErrorCodes.BuildTargetUnsupported),
+            "unsupported-buildTarget" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
+                ExecutionError.InvalidArgument("buildTarget is unsupported: webgl.", BuildErrorCodes.BuildTargetUnsupported),
                 CreateProject())),
             "dirty-scene" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
                 ApplicationFailure.FromCode(BuildErrorCodes.BuildDirtyStatePresent, "Dirty scene state is present."),
                 CreateProject(),
                 CreateDirtyState())),
-            "target-module-missing" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
-                ApplicationFailure.FromCode(BuildErrorCodes.BuildTargetModuleMissing, "Build target module is missing: standaloneLinux64."),
+            "buildTarget-module-missing" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
+                ApplicationFailure.FromCode(BuildErrorCodes.BuildTargetModuleMissing, "buildTarget module is missing: standaloneLinux64."),
                 CreateProject())),
             "artifact-write-failed" => BuildRunCommandResultFactory.Create(BuildExecutionResult.Failure(
                 ExecutionError.InternalError("Build artifacts could not be written.", BuildErrorCodes.BuildArtifactWriteFailed),
@@ -243,7 +243,7 @@ public sealed class BuildRunCliOutputContractTests
         var build = new BuildOutput(
             RunId: "build-run-1",
             Profile: new BuildProfileOutput("/workspace/UnityProject/.ucli/build/player.json", ProfileDigest),
-            Target: "standaloneLinux64",
+            BuildTarget: "standaloneLinux64",
             Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
             Options: new BuildOptionsOutput(Development: true),
             Output: new BuildArtifactOutput(
@@ -346,7 +346,7 @@ public sealed class BuildRunCliOutputContractTests
 
         if (BuildClaimCodes.UnityBuildInputsResolved == code)
         {
-            return "Unity resolved BuildPipeline target and scenes.";
+            return "Unity resolved BuildPipeline BuildTarget and scenes.";
         }
 
         if (BuildClaimCodes.UnityBuildCompleted == code)
@@ -407,7 +407,7 @@ public sealed class BuildRunCliOutputContractTests
         {
             return new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["target"] = build.Target,
+                ["buildTarget"] = build.BuildTarget,
                 ["sceneCount"] = build.Scenes.Paths.Count,
             };
         }
@@ -510,7 +510,7 @@ public sealed class BuildRunCliOutputContractTests
                     BuildReportRefs.Build,
                     new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["targetStableName"] = build.Target,
+                        ["buildTarget"] = build.BuildTarget,
                         ["unityBuildTarget"] = "StandaloneLinux64",
                         ["sceneSource"] = build.Scenes.Source,
                         ["scenes"] = build.Scenes.Paths,
@@ -678,7 +678,7 @@ public sealed class BuildRunCliOutputContractTests
         return new BuildOutputManifestContentJsonContract(
             root.GetProperty("schemaVersion").GetInt32(),
             root.GetProperty("outputRoot").GetString()!,
-            root.GetProperty("target").GetString()!,
+            root.GetProperty("buildTarget").GetString()!,
             root.GetProperty("fileCount").GetInt32(),
             root.GetProperty("totalBytes").GetInt64(),
             files);

--- a/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
+++ b/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
@@ -16,6 +16,8 @@ internal static class UcliContractConstants
 
         public const string Timeout = "--timeout";
 
+        public const string BuildTarget = "--buildTarget";
+
         public const string Mode = "--mode";
 
         public const string TestPlatform = "--testPlatform";

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -144,7 +144,7 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal(
             ToRepositoryRelativeSlashPath(scope.FullPath, paths.OutputDirectory),
             outputRoot.GetProperty("outputRoot").GetString());
-        Assert.Equal("standaloneLinux64", outputRoot.GetProperty("target").GetString());
+        Assert.Equal("standaloneLinux64", outputRoot.GetProperty("buildTarget").GetString());
         Assert.Equal(2, outputRoot.GetProperty("fileCount").GetInt32());
         Assert.Equal(configBytes.Length + playerBytes.Length, outputRoot.GetProperty("totalBytes").GetInt64());
         Assert.Equal(result.OutputManifest.ManifestDigest, outputRoot.GetProperty("manifestDigest").GetString());
@@ -170,7 +170,7 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal(1, buildRoot.GetProperty("schemaVersion").GetInt32());
         Assert.Equal("run-1", buildRoot.GetProperty("runId").GetString());
         Assert.Equal("ucliArtifact", buildRoot.GetProperty("profile").GetProperty("output").GetProperty("kind").GetString());
-        Assert.Equal("standaloneLinux64", buildRoot.GetProperty("input").GetProperty("target").GetProperty("stableName").GetString());
+        Assert.Equal("standaloneLinux64", buildRoot.GetProperty("input").GetProperty("buildTarget").GetProperty("stableName").GetString());
 
         var artifacts = buildRoot.GetProperty("artifacts");
         Assert.Equal(
@@ -440,7 +440,7 @@ public sealed class FileBuildRunArtifactStoreTests
             runId,
             ParseJsonElement("""{"projectPath":"/repo/UnityProject","projectFingerprint":"fingerprint","unityVersion":"6000.1.4f1"}"""),
             ParseJsonElement("""{"digest":"profile-digest","output":{"kind":"ucliArtifact"}}"""),
-            ParseJsonElement("""{"target":{"stableName":"standaloneLinux64"}}"""),
+            ParseJsonElement("""{"buildTarget":{"stableName":"standaloneLinux64"}}"""),
             ParseJsonElement("""{"state":"completed"}"""),
             ParseJsonElement("""{"compile":"42","domainReload":"7"}"""),
             ParseJsonElement("""{"result":"succeeded"}"""),
@@ -471,7 +471,7 @@ public sealed class FileBuildRunArtifactStoreTests
         return new BuildOutputManifestContentJsonContract(
             root.GetProperty("schemaVersion").GetInt32(),
             root.GetProperty("outputRoot").GetString()!,
-            root.GetProperty("target").GetString()!,
+            root.GetProperty("buildTarget").GetString()!,
             root.GetProperty("fileCount").GetInt32(),
             root.GetProperty("totalBytes").GetInt64(),
             files);

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
@@ -11,7 +11,7 @@
     "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   },
   "input": {
-    "target": "standaloneLinux64",
+    "buildTarget": "standaloneLinux64",
     "unityBuildTarget": "StandaloneLinux64",
     "scenes": {
       "source": "explicit",
@@ -77,7 +77,7 @@
     "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
     "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
     "manifestRef": "buildOutputManifest",
-    "manifestDigest": "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314",
+    "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
     "fileCount": 0,
     "totalBytes": 0
   },

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/output-manifest.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/output-manifest.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
-  "target": "standaloneLinux64",
+  "buildTarget": "standaloneLinux64",
   "fileCount": 0,
   "totalBytes": 0,
   "files": [],
-  "manifestDigest": "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314"
+  "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444"
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
@@ -11,7 +11,7 @@
     "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   },
   "input": {
-    "target": "standaloneLinux64",
+    "buildTarget": "standaloneLinux64",
     "unityBuildTarget": "StandaloneLinux64",
     "scenes": {
       "source": "explicit",
@@ -77,7 +77,7 @@
     "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
     "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
     "manifestRef": "buildOutputManifest",
-    "manifestDigest": "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6",
+    "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
     "fileCount": 2,
     "totalBytes": 33
   },

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/output-manifest.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/output-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
-  "target": "standaloneLinux64",
+  "buildTarget": "standaloneLinux64",
   "fileCount": 2,
   "totalBytes": 33,
   "files": [
@@ -16,5 +16,5 @@
       "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
     }
   ],
-  "manifestDigest": "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6"
+  "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1"
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
@@ -17,7 +17,7 @@
         "path": "/workspace/UnityProject/.ucli/build/player.json",
         "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       },
-      "target": "standaloneLinux64",
+      "buildTarget": "standaloneLinux64",
       "scenes": {
         "source": "explicit",
         "paths": [
@@ -32,7 +32,7 @@
         "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
         "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
         "manifestRef": "buildOutputManifest",
-        "manifestDigest": "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314",
+        "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
         "fileCount": 0,
         "totalBytes": 0
       },
@@ -153,9 +153,9 @@
         "coverage": "full",
         "required": true,
         "verifierRef": "build",
-        "statement": "Unity resolved BuildPipeline target and scenes.",
+        "statement": "Unity resolved BuildPipeline BuildTarget and scenes.",
         "subject": {
-          "target": "standaloneLinux64",
+          "buildTarget": "standaloneLinux64",
           "sceneCount": 1
         },
         "evidence": [
@@ -163,7 +163,7 @@
             "kind": "buildInput",
             "evidenceRef": "build",
             "data": {
-              "targetStableName": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "unityBuildTarget": "StandaloneLinux64",
               "sceneSource": "explicit",
               "scenes": [
@@ -264,7 +264,7 @@
               "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
               "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
               "manifestRef": "buildOutputManifest",
-              "manifestDigest": "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314",
+              "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
               "fileCount": 0,
               "totalBytes": 0
             }
@@ -280,7 +280,7 @@
         "verifierRef": "build",
         "statement": "Build output manifest digest was verified against the written artifact.",
         "subject": {
-          "manifestDigest": "ea4ff87cdded978e946d73668e5626dd3fb06b2e65cba15e1d1ecbc78d5ae314"
+          "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444"
         },
         "evidence": [
           {

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/buildTarget-module-missing.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/buildTarget-module-missing.json
@@ -2,8 +2,8 @@
   "protocolVersion": 1,
   "command": "build.run",
   "status": "error",
-  "exitCode": 3,
-  "message": "Build target is unsupported: webgl.",
+  "exitCode": 4,
+  "message": "buildTarget module is missing: standaloneLinux64.",
   "payload": {
     "project": {
       "projectPath": "/workspace/UnityProject",
@@ -13,8 +13,8 @@
   },
   "errors": [
     {
-      "code": "BUILD_TARGET_UNSUPPORTED",
-      "message": "Build target is unsupported: webgl.",
+      "code": "BUILD_TARGET_MODULE_MISSING",
+      "message": "buildTarget module is missing: standaloneLinux64.",
       "opId": null
     }
   ]

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
@@ -17,7 +17,7 @@
         "path": "/workspace/UnityProject/.ucli/build/player.json",
         "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       },
-      "target": "standaloneLinux64",
+      "buildTarget": "standaloneLinux64",
       "scenes": {
         "source": "explicit",
         "paths": [
@@ -32,7 +32,7 @@
         "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
         "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
         "manifestRef": "buildOutputManifest",
-        "manifestDigest": "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6",
+        "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
         "fileCount": 2,
         "totalBytes": 33
       },
@@ -153,9 +153,9 @@
         "coverage": "full",
         "required": true,
         "verifierRef": "build",
-        "statement": "Unity resolved BuildPipeline target and scenes.",
+        "statement": "Unity resolved BuildPipeline BuildTarget and scenes.",
         "subject": {
-          "target": "standaloneLinux64",
+          "buildTarget": "standaloneLinux64",
           "sceneCount": 1
         },
         "evidence": [
@@ -163,7 +163,7 @@
             "kind": "buildInput",
             "evidenceRef": "build",
             "data": {
-              "targetStableName": "standaloneLinux64",
+              "buildTarget": "standaloneLinux64",
               "unityBuildTarget": "StandaloneLinux64",
               "sceneSource": "explicit",
               "scenes": [
@@ -264,7 +264,7 @@
               "artifactRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1",
               "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
               "manifestRef": "buildOutputManifest",
-              "manifestDigest": "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6",
+              "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
               "fileCount": 2,
               "totalBytes": 33
             }
@@ -280,7 +280,7 @@
         "verifierRef": "build",
         "statement": "Build output manifest digest was verified against the written artifact.",
         "subject": {
-          "manifestDigest": "e167d441934ca84452ea2cb52619e5240ec485c46facd6f921b83459dc3ea6f6"
+          "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1"
         },
         "evidence": [
           {

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/unsupported-buildTarget.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/unsupported-buildTarget.json
@@ -2,8 +2,8 @@
   "protocolVersion": 1,
   "command": "build.run",
   "status": "error",
-  "exitCode": 4,
-  "message": "Build target module is missing: standaloneLinux64.",
+  "exitCode": 3,
+  "message": "buildTarget is unsupported: webgl.",
   "payload": {
     "project": {
       "projectPath": "/workspace/UnityProject",
@@ -13,8 +13,8 @@
   },
   "errors": [
     {
-      "code": "BUILD_TARGET_MODULE_MISSING",
-      "message": "Build target module is missing: standaloneLinux64.",
+      "code": "BUILD_TARGET_UNSUPPORTED",
+      "message": "buildTarget is unsupported: webgl.",
       "opId": null
     }
   ]

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
@@ -17,7 +17,7 @@
         "path": "/workspace/.ucli/build/player.json",
         "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       },
-      "target": "standaloneLinux64",
+      "buildTarget": "standaloneLinux64",
       "scenes": {
         "source": "explicit",
         "paths": [

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunCommandTests.cs
@@ -32,6 +32,7 @@ public sealed class BuildRunCommandTests
         await StandardOutputCapture.ExecuteAsync(() => command.RunAsync(
             profilePath: "/repo/.ucli/build/player.json",
             projectPath: "/repo/UnityProject",
+            buildTarget: "standaloneOSX",
             mode: "daemon",
             timeout: "120000",
             format: "json",
@@ -41,6 +42,7 @@ public sealed class BuildRunCommandTests
         var input = Assert.IsType<BuildCommandInput>(service.CapturedInput);
         Assert.Equal("/repo/.ucli/build/player.json", input.ProfilePath);
         Assert.Equal("/repo/UnityProject", input.ProjectPath);
+        Assert.Equal("standaloneOSX", input.BuildTarget);
         Assert.Equal(UnityExecutionMode.Daemon, input.Mode);
         Assert.Equal(120000, input.TimeoutMilliseconds);
         Assert.NotNull(service.CapturedProgressSink);
@@ -161,7 +163,7 @@ public sealed class BuildRunCommandTests
             IpcProtocol.StatusOk,
             (int)CliExitCode.Success);
         Assert.Equal(
-            "build runId=build-run-1 target=standaloneLinux64 requestedMode=daemon resolvedMode=daemon sessionKind=daemon timeoutMs=120000 started" + Environment.NewLine
+            "build runId=build-run-1 buildTarget=standaloneLinux64 requestedMode=daemon resolvedMode=daemon sessionKind=daemon timeoutMs=120000 started" + Environment.NewLine
                 + "build runId=build-run-1 verdict=pass result=succeeded completionReason=completed errorCount=0 warningCount=1 completed" + Environment.NewLine,
             standardError);
     }
@@ -178,6 +180,7 @@ public sealed class BuildRunCommandTests
         Assert.Equal((int)CliExitCode.Success, result.ExitCode);
         Assert.Contains(UcliContractConstants.CliOption.ProfilePath, result.StdOut, StringComparison.Ordinal);
         Assert.Contains(UcliContractConstants.CliOption.ProjectPath, result.StdOut, StringComparison.Ordinal);
+        Assert.Contains(UcliContractConstants.CliOption.BuildTarget, result.StdOut, StringComparison.Ordinal);
         Assert.Contains("-p", result.StdOut, StringComparison.Ordinal);
         Assert.Contains(UcliContractConstants.CliOption.Mode, result.StdOut, StringComparison.Ordinal);
         Assert.Contains(UcliContractConstants.CliOption.Timeout, result.StdOut, StringComparison.Ordinal);

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
@@ -52,7 +52,7 @@ internal static class BuildRunTestData
             ResolvedMode: "daemon",
             SessionKind: "daemon",
             TimeoutMilliseconds: 120000,
-            Target: "standaloneLinux64",
+            BuildTarget: "standaloneLinux64",
             OutputPath: "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output");
     }
 
@@ -87,7 +87,7 @@ internal static class BuildRunTestData
         return new BuildOutput(
             RunId: RunId,
             Profile: new BuildProfileOutput("/workspace/.ucli/build/player.json", Repeat('a')),
-            Target: "standaloneLinux64",
+            BuildTarget: "standaloneLinux64",
             Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
             Options: new BuildOptionsOutput(Development: true),
             Output: new BuildArtifactOutput(

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
@@ -66,7 +66,7 @@ public sealed class UnityIpcRequestBuilderTests
 
         var request = builder.Build(new UnityRequestPayload.BuildRun(
             RunId: "build-run-1",
-            TargetStableName: "standaloneLinux64",
+            BuildTarget: "standaloneLinux64",
             UnityBuildTarget: "StandaloneLinux64",
             SceneSource: "explicit",
             ScenePaths: ["Assets/Scenes/Main.unity"],
@@ -79,7 +79,7 @@ public sealed class UnityIpcRequestBuilderTests
         Assert.False(request.IsRecoverable);
         Assert.True(IpcPayloadCodec.TryDeserialize(request.Payload, out IpcBuildRunRequest payload, out _));
         Assert.Equal("build-run-1", payload.RunId);
-        Assert.Equal("standaloneLinux64", payload.TargetStableName);
+        Assert.Equal("standaloneLinux64", payload.BuildTarget);
         Assert.Equal("StandaloneLinux64", payload.UnityBuildTarget);
         Assert.Equal("explicit", payload.SceneSource);
         Assert.Equal(["Assets/Scenes/Main.unity"], payload.ScenePaths);
@@ -182,7 +182,7 @@ public sealed class UnityIpcRequestBuilderTests
     {
         var dispatchRequest = new UnityIpcRequestBuilder().Build(new UnityRequestPayload.BuildRun(
             RunId: "build-run-1",
-            TargetStableName: "standaloneLinux64",
+            BuildTarget: "standaloneLinux64",
             UnityBuildTarget: "StandaloneLinux64",
             SceneSource: "explicit",
             ScenePaths: ["Assets/Scenes/Main.unity"],

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -666,7 +666,7 @@ internal static class Program
                 additionalProperties: false,
                 Required("path", StringSchema()),
                 Required("digest", Sha256LowerHexSchema()))),
-            Required("target", StringSchema()),
+            Required("buildTarget", StringSchema()),
             Required("scenes", ObjectSchema(
                 additionalProperties: false,
                 Required(


### PR DESCRIPTION
## Summary
- Replaces build run `target` vocabulary with `buildTarget` across CLI input, profile resolution, IPC payloads, manifests, schemas, and golden outputs.
- Adds a reusable local `uCLI build run` script and runs the player build in Unity CI after EditMode tests pass.
- Includes Unity objects updated by the local player build verification as build side effects.

## Scope
- Build run contract: `buildTarget` override, output payload, manifest JSON, IPC build request/report fields, schema, and golden files.
- CI/local execution: `.ucli/build/player.json`, `scripts/run-ucli-unity-build.sh`, verification scope detection, and the Unity workflow player build step.
- Build side effects: `URP-Balanced.asset`, `URP-HighFidelity.asset`, `URP-Performant.asset`, and `BurstAotSettings_StandaloneOSX.json`.
- Documentation: README build run example and buildTarget wording normalization.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh --no-restore verify`)
- Tests: PASS (`bash scripts/verify.sh --no-restore`, 1714 tests)
- Unity: PASS (`bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`)
- uCLI player build: PASS (`bash scripts/run-ucli-unity-build.sh --project-path "src/Ucli.Unity" --profile-path ".ucli/build/player.json" --buildTarget "standaloneOSX" --result-dir "/tmp/ucli-pr-build-run" --no-restore --no-build --no-package-restore`)
- Build result: `status=ok`, `exitCode=0`, `verdict=pass`, `result=succeeded`, `fileCount=179`
- Coverage: N/A

## Risks / Rollback
- The CI player build depends on Unity build support for `standaloneLinux64`; rollback is removing the CI build step, profile, and helper script.
- The committed Unity asset changes are generated side effects from player build verification and can be reverted independently if the project should not persist them.

## Checklist
- [x] Removed old build run `target` vocabulary from the build feature surface.
- [x] Added CI and local player build entry point.
- [x] Included observed build side effects in the PR.

Issue: none (ad-hoc task)