### PR TITLE
fix(timeout): complete command timeout coverage

### DIFF
--- a/src/Ucli.Application/Features/Daemon/Observability/Logs/Common/LogsDaemonServiceRequest.cs
+++ b/src/Ucli.Application/Features/Daemon/Observability/Logs/Common/LogsDaemonServiceRequest.cs
@@ -25,4 +25,8 @@ internal sealed record LogsDaemonServiceRequest (
     string? Category,
     bool Stream,
     int? PollIntervalMilliseconds,
-    int? IdleTimeoutMilliseconds);
+    int? IdleTimeoutMilliseconds)
+{
+    /// <summary> Gets the optional normalized command timeout in milliseconds. </summary>
+    public int? TimeoutMilliseconds { get; init; }
+}

--- a/src/Ucli.Application/Features/Daemon/Observability/Logs/Common/LogsUnityServiceRequest.cs
+++ b/src/Ucli.Application/Features/Daemon/Observability/Logs/Common/LogsUnityServiceRequest.cs
@@ -31,4 +31,8 @@ internal sealed record LogsUnityServiceRequest (
     int? StackTraceMaxChars,
     bool Stream,
     int? PollIntervalMilliseconds,
-    int? IdleTimeoutMilliseconds);
+    int? IdleTimeoutMilliseconds)
+{
+    /// <summary> Gets the optional normalized command timeout in milliseconds. </summary>
+    public int? TimeoutMilliseconds { get; init; }
+}

--- a/src/Ucli.Application/Features/Daemon/Observability/Logs/Daemon/LogsDaemonService.cs
+++ b/src/Ucli.Application/Features/Daemon/Observability/Logs/Daemon/LogsDaemonService.cs
@@ -53,6 +53,7 @@ internal sealed class LogsDaemonService : ILogsDaemonService
             daemonCommandExecutionContextResolver,
             UcliCommandIds.LogsDaemonRead,
             request.ProjectPath,
+            request.TimeoutMilliseconds,
             query!,
             request.Stream,
             streamOptions!,

--- a/src/Ucli.Application/Features/Daemon/Observability/Logs/Streaming/LogsStreamPollingExecutor.cs
+++ b/src/Ucli.Application/Features/Daemon/Observability/Logs/Streaming/LogsStreamPollingExecutor.cs
@@ -12,6 +12,7 @@ internal static class LogsStreamPollingExecutor
         IDaemonCommandExecutionContextResolver daemonCommandExecutionContextResolver,
         UcliCommand commandId,
         string? projectPath,
+        int? timeoutMilliseconds,
         TQuery initialQuery,
         bool stream,
         LogsStreamRuntimeOptions streamOptions,
@@ -46,7 +47,7 @@ internal static class LogsStreamPollingExecutor
         var contextResolutionResult = await daemonCommandExecutionContextResolver.ResolveAsync(
                 commandId,
                 projectPath,
-                timeoutMilliseconds: null,
+                timeoutMilliseconds,
                 cancellationToken)
             .ConfigureAwait(false);
         if (!contextResolutionResult.IsSuccess)

--- a/src/Ucli.Application/Features/Daemon/Observability/Logs/Unity/LogsUnityService.cs
+++ b/src/Ucli.Application/Features/Daemon/Observability/Logs/Unity/LogsUnityService.cs
@@ -49,6 +49,7 @@ internal sealed class LogsUnityService : ILogsUnityService
             daemonCommandExecutionContextResolver,
             UcliCommandIds.LogsUnityRead,
             request.ProjectPath,
+            request.TimeoutMilliseconds,
             query!,
             request.Stream,
             streamOptions!,

--- a/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateCommandInput.cs
+++ b/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateCommandInput.cs
@@ -9,4 +9,8 @@ namespace MackySoft.Ucli.Application.Features.Requests.Validate.UseCases.Validat
 internal sealed record ValidateCommandInput (
     string? ProjectPath,
     ReadIndexMode? ReadIndexMode,
-    string RequestJson);
+    string RequestJson)
+{
+    /// <summary> Gets the optional normalized <c>--timeout</c> value in milliseconds. </summary>
+    public int? TimeoutMilliseconds { get; init; }
+}

--- a/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateService.cs
+++ b/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateService.cs
@@ -50,9 +50,21 @@ internal sealed class ValidateService : IValidateService
                 output: null);
         }
 
+        var preparedRequest = requestPreparationResult.PreparedRequest!;
+        var timeoutResolutionResult = IpcCommandTimeoutResolver.ResolveNormalized(
+            input.TimeoutMilliseconds,
+            UcliCommandIds.Validate,
+            preparedRequest.ProjectContext.Config);
+        if (!timeoutResolutionResult.IsSuccess)
+        {
+            var error = timeoutResolutionResult.Error!;
+            return ValidateServiceResult.Failure(
+                error.Message,
+                ExecutionErrorCodeMapper.ToCode(error));
+        }
+
         if (input.ReadIndexMode == ReadIndexMode.Disabled)
         {
-            var preparedRequest = requestPreparationResult.PreparedRequest!;
             var disabledOutput = new ValidateExecutionOutput(
                 Project: ProjectIdentityInfo.From(preparedRequest.ProjectContext.UnityProject),
                 ReadIndex: CreateReadIndexDisabledOutput());
@@ -82,13 +94,13 @@ internal sealed class ValidateService : IValidateService
         }
 
         var requestStaticValidationPreflightResult = await requestStaticValidationPreflightService.PrepareAsync(
-                requestPreparationResult.PreparedRequest!,
+                preparedRequest,
                 input.ReadIndexMode,
                 cancellationToken)
             .ConfigureAwait(false);
         var output = requestStaticValidationPreflightResult.ReadIndex != null
             ? new ValidateExecutionOutput(
-                Project: ProjectIdentityInfo.From(requestPreparationResult.PreparedRequest!.ProjectContext.UnityProject),
+                Project: ProjectIdentityInfo.From(preparedRequest.ProjectContext.UnityProject),
                 ReadIndex: requestStaticValidationPreflightResult.ReadIndex)
             : null;
         if (requestStaticValidationPreflightResult.Error != null)

--- a/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateService.cs
+++ b/src/Ucli.Application/Features/Requests/Validate/UseCases/Validate/ValidateService.cs
@@ -14,18 +14,23 @@ internal sealed class ValidateService : IValidateService
 
     private readonly IRequestStaticValidationPreflightService requestStaticValidationPreflightService;
 
+    private readonly TimeProvider timeProvider;
+
     /// <summary> Initializes a new instance of the <see cref="ValidateService" /> class. </summary>
     /// <param name="requestPreparationService"> The shared request-preparation dependency. </param>
     /// <param name="requestStaticValidator"> The static-validator dependency. </param>
     /// <param name="requestStaticValidationPreflightService"> The shared static-validation preflight dependency. </param>
+    /// <param name="timeProvider"> The time provider used for timeout cancellation. </param>
     public ValidateService (
         IRequestPreparationService requestPreparationService,
         IRequestStaticValidator requestStaticValidator,
-        IRequestStaticValidationPreflightService requestStaticValidationPreflightService)
+        IRequestStaticValidationPreflightService requestStaticValidationPreflightService,
+        TimeProvider? timeProvider = null)
     {
         this.requestPreparationService = requestPreparationService ?? throw new ArgumentNullException(nameof(requestPreparationService));
         this.requestStaticValidator = requestStaticValidator ?? throw new ArgumentNullException(nameof(requestStaticValidator));
         this.requestStaticValidationPreflightService = requestStaticValidationPreflightService ?? throw new ArgumentNullException(nameof(requestStaticValidationPreflightService));
+        this.timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <inheritdoc />
@@ -63,17 +68,55 @@ internal sealed class ValidateService : IValidateService
                 ExecutionErrorCodeMapper.ToCode(error));
         }
 
+        var timeout = timeoutResolutionResult.Timeout!.Value;
+        var deadline = ExecutionDeadline.Start(timeout, timeProvider);
         if (input.ReadIndexMode == ReadIndexMode.Disabled)
         {
             var disabledOutput = new ValidateExecutionOutput(
                 Project: ProjectIdentityInfo.From(preparedRequest.ProjectContext.UnityProject),
                 ReadIndex: CreateReadIndexDisabledOutput());
-            var disabledValidationResult = await requestStaticValidator.ValidateAsync(
-                    preparedRequest.Request,
-                    RequestStaticValidationCatalog.Unavailable,
-                    preparedRequest.ProjectContext.Config,
-                    cancellationToken)
-                .ConfigureAwait(false);
+            if (!deadline.TryGetRemainingTimeout(out var validationTimeout))
+            {
+                return ValidateServiceResult.Failure(
+                    CreateTimeoutFailureMessage(timeout),
+                    ExecutionErrorCodes.IpcTimeout,
+                    disabledOutput);
+            }
+
+            ValidationResult disabledValidationResult;
+            using (var timeoutCancellationScope = TimeProviderCancellationScope.CreateLinked(cancellationToken, validationTimeout, timeProvider))
+            {
+                try
+                {
+                    disabledValidationResult = await requestStaticValidator.ValidateAsync(
+                            preparedRequest.Request,
+                            RequestStaticValidationCatalog.Unavailable,
+                            preparedRequest.ProjectContext.Config,
+                            timeoutCancellationScope.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (OperationCanceledException) when (timeoutCancellationScope.HasTimedOut
+                    && !cancellationToken.IsCancellationRequested)
+                {
+                    return ValidateServiceResult.Failure(
+                        CreateTimeoutFailureMessage(timeout),
+                        ExecutionErrorCodes.IpcTimeout,
+                        disabledOutput);
+                }
+            }
+
+            if (deadline.IsExpired)
+            {
+                return ValidateServiceResult.Failure(
+                    CreateTimeoutFailureMessage(timeout),
+                    ExecutionErrorCodes.IpcTimeout,
+                    disabledOutput);
+            }
+
             if (disabledValidationResult.Error != null)
             {
                 return ValidateServiceResult.Failure(
@@ -93,11 +136,44 @@ internal sealed class ValidateService : IValidateService
             return ValidateServiceResult.Success(disabledOutput, "Static validation passed.");
         }
 
-        var requestStaticValidationPreflightResult = await requestStaticValidationPreflightService.PrepareAsync(
-                preparedRequest,
-                input.ReadIndexMode,
-                cancellationToken)
-            .ConfigureAwait(false);
+        if (!deadline.TryGetRemainingTimeout(out var preflightTimeout))
+        {
+            return ValidateServiceResult.Failure(
+                CreateTimeoutFailureMessage(timeout),
+                ExecutionErrorCodes.IpcTimeout);
+        }
+
+        RequestStaticValidationPreflightResult requestStaticValidationPreflightResult;
+        using (var timeoutCancellationScope = TimeProviderCancellationScope.CreateLinked(cancellationToken, preflightTimeout, timeProvider))
+        {
+            try
+            {
+                requestStaticValidationPreflightResult = await requestStaticValidationPreflightService.PrepareAsync(
+                        preparedRequest,
+                        input.ReadIndexMode,
+                        timeoutCancellationScope.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException) when (timeoutCancellationScope.HasTimedOut
+                && !cancellationToken.IsCancellationRequested)
+            {
+                return ValidateServiceResult.Failure(
+                    CreateTimeoutFailureMessage(timeout),
+                    ExecutionErrorCodes.IpcTimeout);
+            }
+        }
+
+        if (deadline.IsExpired)
+        {
+            return ValidateServiceResult.Failure(
+                CreateTimeoutFailureMessage(timeout),
+                ExecutionErrorCodes.IpcTimeout);
+        }
+
         var output = requestStaticValidationPreflightResult.ReadIndex != null
             ? new ValidateExecutionOutput(
                 Project: ProjectIdentityInfo.From(preparedRequest.ProjectContext.UnityProject),
@@ -120,6 +196,11 @@ internal sealed class ValidateService : IValidateService
         }
 
         return ValidateServiceResult.Success(output!, "Static validation passed.");
+    }
+
+    private static string CreateTimeoutFailureMessage (TimeSpan timeout)
+    {
+        return $"Validate timed out after {timeout.TotalMilliseconds:0} milliseconds.";
     }
 
     private static ReadIndexInfo CreateReadIndexDisabledOutput ()

--- a/src/Ucli.Application/Shared/Configuration/IpcTimeoutDefaults.cs
+++ b/src/Ucli.Application/Shared/Configuration/IpcTimeoutDefaults.cs
@@ -10,6 +10,8 @@ internal static class IpcTimeoutDefaults
     [
         (UcliCommandIds.Test, 300000),
         (UcliCommandIds.Ready, 10000),
+        (UcliCommandIds.Compile, 120000),
+        (UcliCommandIds.BuildRun, 1800000),
         (UcliCommandIds.Verify, 120000),
         (UcliCommandIds.Status, 5000),
         (UcliCommandIds.Validate, 10000),

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsDaemonReadCommand.cs
@@ -40,6 +40,7 @@ internal sealed class LogsDaemonReadCommand
     /// <param name="stream"> Enables stream polling mode until canceled or timeout conditions are met. </param>
     /// <param name="pollIntervalMilliseconds"> --pollIntervalMilliseconds, The optional polling interval in milliseconds used when stream is enabled. </param>
     /// <param name="idleTimeoutMilliseconds"> --idleTimeoutMilliseconds, The optional idle timeout in milliseconds used when stream is enabled. </param>
+    /// <param name="timeout"> Timeout in milliseconds. </param>
     /// <param name="format"> The output format (text|json). </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The command exit code. </returns>
@@ -57,14 +58,16 @@ internal sealed class LogsDaemonReadCommand
         bool stream = false,
         int? pollIntervalMilliseconds = null,
         int? idleTimeoutMilliseconds = null,
+        string? timeout = null,
         string? format = null,
         CancellationToken cancellationToken = default)
     {
         return await LogsReadCommandExecutor.ExecuteAsync<IpcDaemonLogEvent, JsonLinePayload>(
                 UcliCommandNames.LogsDaemonRead,
                 format,
+                timeout,
                 commandResultWriter,
-                (onLogEvent, executeCancellationToken) => logsDaemonService.ExecuteAsync(
+                (timeoutMilliseconds, onLogEvent, executeCancellationToken) => logsDaemonService.ExecuteAsync(
                     new LogsDaemonServiceRequest(
                         ProjectPath: projectPath,
                         Tail: tail,
@@ -77,7 +80,10 @@ internal sealed class LogsDaemonReadCommand
                         Category: category,
                         Stream: stream,
                         PollIntervalMilliseconds: pollIntervalMilliseconds,
-                        IdleTimeoutMilliseconds: idleTimeoutMilliseconds),
+                        IdleTimeoutMilliseconds: idleTimeoutMilliseconds)
+                    {
+                        TimeoutMilliseconds = timeoutMilliseconds,
+                    },
                     onLogEvent,
                     executeCancellationToken),
                 CreateProgressEntry,

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandExecutor.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsReadCommandExecutor.cs
@@ -15,6 +15,7 @@ internal static class LogsReadCommandExecutor
     /// <typeparam name="TPayload"> The emitted CLI progress payload type. </typeparam>
     /// <param name="commandName"> The command name used in emitted error envelopes. </param>
     /// <param name="format"> The requested output format. </param>
+    /// <param name="timeout"> The requested command timeout in milliseconds. </param>
     /// <param name="commandResultWriter"> The command-result writer dependency. </param>
     /// <param name="executeAsync"> The service execution delegate. </param>
     /// <param name="createProgressEntry"> The output projection for one log event. </param>
@@ -24,8 +25,9 @@ internal static class LogsReadCommandExecutor
     public static async Task<int> ExecuteAsync<TLogEvent, TPayload> (
         string commandName,
         string? format,
+        string? timeout,
         ICommandResultWriter commandResultWriter,
-        Func<Func<TLogEvent, string, CancellationToken, ValueTask>, CancellationToken, ValueTask<LogsReadServiceResult>> executeAsync,
+        Func<int?, Func<TLogEvent, string, CancellationToken, ValueTask>, CancellationToken, ValueTask<LogsReadServiceResult>> executeAsync,
         Func<TLogEvent, string, CliCommandProgressEntry<TPayload>> createProgressEntry,
         ICliCommandProgressTextProjector textProjector,
         CancellationToken cancellationToken)
@@ -55,11 +57,22 @@ internal static class LogsReadCommandExecutor
                 return invalidFormatResult.ExitCode;
             }
 
+            var timeoutResult = TimeoutOptionNormalizer.Normalize(timeout);
+            if (!timeoutResult.IsSuccess)
+            {
+                var invalidTimeoutResult = LogsReadCommandResultFactory.Create(
+                    commandName,
+                    LogsReadServiceResult.Failure(timeoutResult.Error!));
+                commandResultWriter.WriteToStandardOutput(invalidTimeoutResult);
+                return invalidTimeoutResult.ExitCode;
+            }
+
             var progressSink = new CliCommandProgressSink(
                 formatResult.Format,
                 new CliStreamEntryWriter(commandName),
                 textProjector);
             var serviceResult = await executeAsync(
+                    timeoutResult.TimeoutMilliseconds,
                     async (logEvent, nextCursor, callbackCancellationToken) =>
                     {
                         callbackCancellationToken.ThrowIfCancellationRequested();

--- a/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
+++ b/src/Ucli/Hosting/Cli/Daemon/Logs/LogsUnityReadCommand.cs
@@ -43,6 +43,7 @@ internal sealed class LogsUnityReadCommand
     /// <param name="stream"> Enables stream polling mode until canceled or timeout conditions are met. </param>
     /// <param name="pollIntervalMilliseconds"> --pollIntervalMilliseconds, The optional polling interval in milliseconds used when stream is enabled. </param>
     /// <param name="idleTimeoutMilliseconds"> --idleTimeoutMilliseconds, The optional idle timeout in milliseconds used when stream is enabled. </param>
+    /// <param name="timeout"> Timeout in milliseconds. </param>
     /// <param name="format"> The output format (text|json). </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The command exit code. </returns>
@@ -63,14 +64,16 @@ internal sealed class LogsUnityReadCommand
         bool stream = false,
         int? pollIntervalMilliseconds = null,
         int? idleTimeoutMilliseconds = null,
+        string? timeout = null,
         string? format = null,
         CancellationToken cancellationToken = default)
     {
         return await LogsReadCommandExecutor.ExecuteAsync<IpcUnityLogEvent, JsonLinePayload>(
                 UcliCommandNames.LogsUnityRead,
                 format,
+                timeout,
                 commandResultWriter,
-                (onLogEvent, executeCancellationToken) => logsUnityService.ExecuteAsync(
+                (timeoutMilliseconds, onLogEvent, executeCancellationToken) => logsUnityService.ExecuteAsync(
                     new LogsUnityServiceRequest(
                         ProjectPath: projectPath,
                         Tail: tail,
@@ -86,7 +89,10 @@ internal sealed class LogsUnityReadCommand
                         StackTraceMaxChars: stackTraceMaxChars,
                         Stream: stream,
                         PollIntervalMilliseconds: pollIntervalMilliseconds,
-                        IdleTimeoutMilliseconds: idleTimeoutMilliseconds),
+                        IdleTimeoutMilliseconds: idleTimeoutMilliseconds)
+                    {
+                        TimeoutMilliseconds = timeoutMilliseconds,
+                    },
                     onLogEvent,
                     executeCancellationToken),
                 CreateProgressEntry,

--- a/src/Ucli/Hosting/Cli/Requests/ValidateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Requests/ValidateCommand.cs
@@ -32,17 +32,27 @@ internal sealed class ValidateCommand
 
     /// <summary> Executes the validate command and emits the JSON result contract. </summary>
     /// <param name="projectPath">-p|--projectPath, Optional target Unity project path.</param>
+    /// <param name="timeout">Timeout in milliseconds.</param>
     /// <param name="readIndexMode">--readIndexMode, readIndex mode (disabled|allowStale|requireFresh).</param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.Validate)]
     public async Task<int> ValidateAsync (
         string? projectPath = null,
+        string? timeout = null,
         string? readIndexMode = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         CommandExecutionState.MarkStarted();
+
+        var normalizedTimeoutResult = TimeoutOptionNormalizer.Normalize(timeout);
+        if (!normalizedTimeoutResult.IsSuccess)
+        {
+            var errorResult = ValidateCommandResultFactory.CreateExecutionError(normalizedTimeoutResult.Error!);
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
 
         var normalizedReadIndexModeResult = ReadIndexModeOptionNormalizer.Normalize(readIndexMode);
         if (!normalizedReadIndexModeResult.IsSuccess)
@@ -64,7 +74,10 @@ internal sealed class ValidateCommand
                 new ValidateCommandInput(
                     ProjectPath: projectPath,
                     ReadIndexMode: normalizedReadIndexModeResult.Mode,
-                    RequestJson: requestInputReadResult.Json!),
+                    RequestJson: requestInputReadResult.Json!)
+                {
+                    TimeoutMilliseconds = normalizedTimeoutResult.TimeoutMilliseconds,
+                },
                 cancellationToken)
             .ConfigureAwait(false);
         var commandResult = ValidateCommandResultFactory.Create(serviceResult);

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Catalog;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Contracts;
@@ -159,6 +160,35 @@ public sealed class BuildServiceTests
         Assert.Equal(artifactStore.PreparedPaths!.OutputDirectory, requestPayload.OutputPath);
         Assert.Equal(artifactStore.PreparedPaths.BuildReportJsonPath, requestPayload.BuildReportPath);
         Assert.Equal(artifactStore.PreparedPaths.BuildLogPath, requestPayload.BuildLogPath);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithoutTimeoutOption_UsesBuildRunConfigOverride ()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var timeoutOverrides = new Dictionary<string, int?>(UcliConfig.CreateDefault().IpcTimeoutMillisecondsByCommand, StringComparer.Ordinal)
+        {
+            [UcliCommandIds.BuildRun.Name] = 432100,
+        };
+        var config = UcliConfig.CreateDefault() with
+        {
+            IpcTimeoutMillisecondsByCommand = timeoutOverrides,
+        };
+        var requestExecutor = CreateBuildResponseExecutor(
+            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+            ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
+            errorCount: 0);
+        var service = CreateService(
+            projectContextResolver: new StubProjectContextResolver(ProjectContextResolutionResult.Success(CreateProjectContext(config))),
+            requestExecutor: requestExecutor,
+            artifactStore: new StubBuildRunArtifactStore(tempDirectory.Path),
+            timeProvider: new ManualTimeProvider());
+
+        var result = await service.ExecuteAsync(CreateInput(timeoutMilliseconds: null));
+
+        Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
+        Assert.Equal(TimeSpan.FromMilliseconds(432100), requestExecutor.CapturedTimeout);
     }
 
     [Fact]
@@ -615,7 +645,7 @@ public sealed class BuildServiceTests
     }
 
     private static BuildCommandInput CreateInput (
-        int timeoutMilliseconds = 10000,
+        int? timeoutMilliseconds = 10000,
         string? buildTarget = null)
     {
         return new BuildCommandInput(
@@ -626,7 +656,7 @@ public sealed class BuildServiceTests
             TimeoutMilliseconds: timeoutMilliseconds);
     }
 
-    private static ProjectContext CreateProjectContext ()
+    private static ProjectContext CreateProjectContext (UcliConfig? config = null)
     {
         var unityProject = new ResolvedUnityProjectContext(
             UnityProjectRoot: "/workspace/UnityProject",
@@ -637,7 +667,7 @@ public sealed class BuildServiceTests
             UnityVersion: "6000.1.4f1");
         return new ProjectContext(
             unityProject,
-            UcliConfig.CreateDefault(),
+            config ?? UcliConfig.CreateDefault(),
             ConfigSource.Default);
     }
 
@@ -910,6 +940,8 @@ public sealed class BuildServiceTests
 
         public UnityRequestPayload? CapturedPayload { get; private set; }
 
+        public TimeSpan? CapturedTimeout { get; private set; }
+
         public ValueTask<UnityRequestExecutionResult> ExecuteAsync (
             UcliCommand command,
             UnityExecutionMode mode,
@@ -921,6 +953,7 @@ public sealed class BuildServiceTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             CapturedPayload = payload;
+            CapturedTimeout = timeout;
             return ValueTask.FromResult(resultFactory(payload));
         }
     }

--- a/tests/Ucli.Application.Tests/Features/Assurance/Compile/CompileServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Compile/CompileServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Artifacts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Contracts;
 using MackySoft.Ucli.Application.Features.Assurance.Compile.Execution;
@@ -58,6 +59,33 @@ public sealed class CompileServiceTests
         var completedEntry = Assert.IsType<CompileCompletedEntry>(progressSink.Entries[2].Payload);
         Assert.Equal(CompileVerdictValues.Pass, completedEntry.Verdict);
         Assert.Equal(0, completedEntry.ErrorCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithoutTimeoutOption_UsesCompileConfigOverride ()
+    {
+        var timeoutOverrides = new Dictionary<string, int?>(UcliConfig.CreateDefault().IpcTimeoutMillisecondsByCommand, StringComparer.Ordinal)
+        {
+            [UcliCommandIds.Compile.Name] = 4321,
+        };
+        var config = UcliConfig.CreateDefault() with
+        {
+            IpcTimeoutMillisecondsByCommand = timeoutOverrides,
+        };
+        var unityRequestExecutor = new StubUnityRequestExecutor(CreateCompileResponseResult(CreateSummary()));
+        var service = CreateService(
+            projectContextResolver: new StubProjectContextResolver(ProjectContextResolutionResult.Success(CreateProjectContext(config))),
+            unityRequestExecutor: unityRequestExecutor,
+            timeProvider: new ManualTimeProvider());
+
+        var result = await service.ExecuteAsync(new CompileCommandInput(
+            ProjectPath: null,
+            Mode: UnityExecutionMode.Auto,
+            TimeoutMilliseconds: null));
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TimeSpan.FromMilliseconds(4321), unityRequestExecutor.CapturedTimeout);
     }
 
     [Fact]
@@ -267,7 +295,7 @@ public sealed class CompileServiceTests
             timeProvider ?? TimeProvider.System);
     }
 
-    private static ProjectContext CreateProjectContext ()
+    private static ProjectContext CreateProjectContext (UcliConfig? config = null)
     {
         var unityProject = new ResolvedUnityProjectContext(
             UnityProjectRoot: "/workspace/UnityProject",
@@ -278,7 +306,7 @@ public sealed class CompileServiceTests
             UnityVersion: "6000.1.4f1");
         return new ProjectContext(
             unityProject,
-            UcliConfig.CreateDefault(),
+            config ?? UcliConfig.CreateDefault(),
             ConfigSource.Default);
     }
 
@@ -497,6 +525,8 @@ public sealed class CompileServiceTests
 
         public UnityRequestPayload? CapturedPayload { get; private set; }
 
+        public TimeSpan? CapturedTimeout { get; private set; }
+
         public ValueTask<UnityRequestExecutionResult> ExecuteAsync (
             UcliCommand command,
             UnityExecutionMode mode,
@@ -508,6 +538,7 @@ public sealed class CompileServiceTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             CapturedPayload = payload;
+            CapturedTimeout = timeout;
             return ValueTask.FromResult(result);
         }
     }

--- a/tests/Ucli.Application.Tests/Features/Requests/Validate/UseCases/Validate/ValidateServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Requests/Validate/UseCases/Validate/ValidateServiceTests.cs
@@ -1,3 +1,4 @@
+using MackySoft.Tests;
 using MackySoft.Ucli.Application.Features.Requests.Shared.OperationMetadata;
 using MackySoft.Ucli.Application.Features.Requests.Shared.Preparation;
 using MackySoft.Ucli.Application.Features.Requests.Validate.UseCases.Validate;
@@ -97,6 +98,121 @@ public sealed class ValidateServiceTests
         var error = Assert.Single(result.Errors);
         Assert.Equal(UcliCoreErrorCodes.InvalidArgument, error.Code);
         Assert.Contains("ipcTimeoutMillisecondsByCommand[validate]", error.Message, StringComparison.Ordinal);
+        Assert.Equal(0, preflightService.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenExplicitTimeoutElapsesDuringSharedPreflight_ReturnsTimeoutFailure ()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var preflightService = new StubRequestStaticValidationPreflightService(
+            RequestStaticValidationPreflightResult.Success(
+                CreatePreparedRequestContext(),
+                CreateReadIndexInfo(
+                    used: true,
+                    hit: true,
+                    freshness: IndexFreshness.Probable)),
+            cancellationToken =>
+            {
+                timeProvider.Advance(TimeSpan.FromMilliseconds(101));
+                cancellationToken.ThrowIfCancellationRequested();
+            });
+        var service = new ValidateService(
+            new StubRequestPreparationService(RequestPreparationResult.Success(CreatePreparedRequestContext())),
+            new StubRequestStaticValidator(ValidationResult.Success()),
+            preflightService,
+            timeProvider);
+
+        var result = await service.ExecuteAsync(
+            new ValidateCommandInput("/tmp/project", null, """{"steps":[]}""")
+            {
+                TimeoutMilliseconds = 100,
+            },
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(ApplicationFailureKind.Timeout, error.Kind);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, error.Code);
+        Assert.Equal(1, preflightService.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenConfigTimeoutElapsesDuringSharedPreflight_ReturnsTimeoutFailure ()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var config = CreateConfigWithValidateTimeout(timeoutMilliseconds: 100);
+        var preparedRequest = CreatePreparedRequestContext(config);
+        var preflightService = new StubRequestStaticValidationPreflightService(
+            RequestStaticValidationPreflightResult.Success(
+                preparedRequest,
+                CreateReadIndexInfo(
+                    used: true,
+                    hit: true,
+                    freshness: IndexFreshness.Probable)),
+            cancellationToken =>
+            {
+                timeProvider.Advance(TimeSpan.FromMilliseconds(101));
+                cancellationToken.ThrowIfCancellationRequested();
+            });
+        var service = new ValidateService(
+            new StubRequestPreparationService(RequestPreparationResult.Success(preparedRequest)),
+            new StubRequestStaticValidator(ValidationResult.Success()),
+            preflightService,
+            timeProvider);
+
+        var result = await service.ExecuteAsync(
+            new ValidateCommandInput("/tmp/project", null, """{"steps":[]}"""),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(ApplicationFailureKind.Timeout, error.Kind);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, error.Code);
+        Assert.Equal(1, preflightService.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WhenReadIndexDisabledValidationTimesOut_ReturnsTimeoutFailureWithDisabledOutput ()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var validator = new StubRequestStaticValidator(
+            ValidationResult.Success(),
+            cancellationToken =>
+            {
+                timeProvider.Advance(TimeSpan.FromMilliseconds(101));
+                cancellationToken.ThrowIfCancellationRequested();
+            });
+        var preflightService = new StubRequestStaticValidationPreflightService(RequestStaticValidationPreflightResult.Success(
+            CreatePreparedRequestContext(),
+            CreateReadIndexInfo(
+                used: true,
+                hit: true,
+                freshness: IndexFreshness.Probable)));
+        var service = new ValidateService(
+            new StubRequestPreparationService(RequestPreparationResult.Success(CreatePreparedRequestContext())),
+            validator,
+            preflightService,
+            timeProvider);
+
+        var result = await service.ExecuteAsync(
+            new ValidateCommandInput("/tmp/project", ReadIndexMode.Disabled, """{"steps":[]}""")
+            {
+                TimeoutMilliseconds = 100,
+            },
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.NotNull(result.Output);
+        Assert.False(result.Output!.ReadIndex.Used);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(ApplicationFailureKind.Timeout, error.Kind);
+        Assert.Equal(ExecutionErrorCodes.IpcTimeout, error.Code);
         Assert.Equal(0, preflightService.CallCount);
     }
 
@@ -221,6 +337,19 @@ public sealed class ValidateServiceTests
                 ConfigSource.Default));
     }
 
+    private static UcliConfig CreateConfigWithValidateTimeout (int? timeoutMilliseconds)
+    {
+        var timeoutOverrides = new Dictionary<string, int?>(UcliConfig.CreateDefault().IpcTimeoutMillisecondsByCommand, StringComparer.Ordinal)
+        {
+            [UcliCommandIds.Validate.Name] = timeoutMilliseconds,
+        };
+
+        return UcliConfig.CreateDefault() with
+        {
+            IpcTimeoutMillisecondsByCommand = timeoutOverrides,
+        };
+    }
+
     private static ReadIndexInfo CreateReadIndexInfo (
         bool used,
         bool hit,
@@ -298,9 +427,14 @@ public sealed class ValidateServiceTests
     {
         private readonly RequestStaticValidationPreflightResult result;
 
-        public StubRequestStaticValidationPreflightService (RequestStaticValidationPreflightResult result)
+        private readonly Action<CancellationToken>? onPrepare;
+
+        public StubRequestStaticValidationPreflightService (
+            RequestStaticValidationPreflightResult result,
+            Action<CancellationToken>? onPrepare = null)
         {
             this.result = result ?? throw new ArgumentNullException(nameof(result));
+            this.onPrepare = onPrepare;
         }
 
         public int CallCount { get; private set; }
@@ -312,6 +446,7 @@ public sealed class ValidateServiceTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             CallCount++;
+            onPrepare?.Invoke(cancellationToken);
             return ValueTask.FromResult(result);
         }
     }
@@ -320,9 +455,14 @@ public sealed class ValidateServiceTests
     {
         private readonly ValidationResult result;
 
-        public StubRequestStaticValidator (ValidationResult result)
+        private readonly Action<CancellationToken>? onValidate;
+
+        public StubRequestStaticValidator (
+            ValidationResult result,
+            Action<CancellationToken>? onValidate = null)
         {
             this.result = result ?? throw new ArgumentNullException(nameof(result));
+            this.onValidate = onValidate;
         }
 
         public ValueTask<ValidationResult> ValidateAsync (
@@ -332,6 +472,7 @@ public sealed class ValidateServiceTests
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            onValidate?.Invoke(cancellationToken);
             return ValueTask.FromResult(result);
         }
     }

--- a/tests/Ucli.Application.Tests/Features/Requests/Validate/UseCases/Validate/ValidateServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Requests/Validate/UseCases/Validate/ValidateServiceTests.cs
@@ -67,6 +67,41 @@ public sealed class ValidateServiceTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Execute_WhenValidateTimeoutConfigIsInvalid_ReturnsFailureWithoutSharedPreflight ()
+    {
+        var timeoutOverrides = new Dictionary<string, int?>(UcliConfig.CreateDefault().IpcTimeoutMillisecondsByCommand, StringComparer.Ordinal)
+        {
+            [UcliCommandIds.Validate.Name] = 0,
+        };
+        var config = UcliConfig.CreateDefault() with
+        {
+            IpcTimeoutMillisecondsByCommand = timeoutOverrides,
+        };
+        var preflightService = new StubRequestStaticValidationPreflightService(RequestStaticValidationPreflightResult.Success(
+            CreatePreparedRequestContext(),
+            CreateReadIndexInfo(
+                used: true,
+                hit: true,
+                freshness: IndexFreshness.Probable)));
+        var service = new ValidateService(
+            new StubRequestPreparationService(RequestPreparationResult.Success(CreatePreparedRequestContext(config))),
+            new StubRequestStaticValidator(ValidationResult.Success()),
+            preflightService);
+
+        var result = await service.ExecuteAsync(
+            new ValidateCommandInput("/tmp/project", null, """{"steps":[]}"""),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Output);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(UcliCoreErrorCodes.InvalidArgument, error.Code);
+        Assert.Contains("ipcTimeoutMillisecondsByCommand[validate]", error.Message, StringComparison.Ordinal);
+        Assert.Equal(0, preflightService.CallCount);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Execute_WhenSharedPreflightHasValidationErrors_ReturnsValidationFailure ()
     {
         ValidationError[] validationErrors =
@@ -168,7 +203,7 @@ public sealed class ValidateServiceTests
                 Steps: Array.Empty<ValidateRequestStep?>()));
     }
 
-    private static PreparedRequestContext CreatePreparedRequestContext ()
+    private static PreparedRequestContext CreatePreparedRequestContext (UcliConfig? config = null)
     {
         return new PreparedRequestContext(
             RequestJson: """{"protocolVersion":1,"requestId":"9b0e6d1e-3f55-4a6b-8c66-5b9a3a7c9c62","steps":[]}""",
@@ -182,7 +217,7 @@ public sealed class ValidateServiceTests
                     RepositoryRoot: "/tmp/repository",
                     ProjectFingerprint: "project-fingerprint",
                     PathSource: UnityProjectPathSource.CommandOption),
-                UcliConfig.CreateDefault(),
+                config ?? UcliConfig.CreateDefault(),
                 ConfigSource.Default));
     }
 

--- a/tests/Ucli.Application.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Shared/Execution/Timeout/IpcCommandTimeoutResolverTests.cs
@@ -68,6 +68,32 @@ public sealed class IpcCommandTimeoutResolverTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Resolve_WithoutOption_UsesDefaultCompileOverride ()
+    {
+        var config = UcliConfig.CreateDefault();
+
+        var result = IpcCommandTimeoutResolver.ResolveNormalized(null, UcliCommandIds.Compile, config);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TimeSpan.FromMilliseconds(120000), result.Timeout);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Resolve_WithoutOption_UsesDefaultBuildRunOverride ()
+    {
+        var config = UcliConfig.CreateDefault();
+
+        var result = IpcCommandTimeoutResolver.ResolveNormalized(null, UcliCommandIds.BuildRun, config);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(TimeSpan.FromMilliseconds(1800000), result.Timeout);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Resolve_WithoutOption_UsesConfigDefaultWhenCommandOverrideIsNull ()
     {
         var config = CreateConfig(

--- a/tests/Ucli.Tests/CliOutputContractTests.cs
+++ b/tests/Ucli.Tests/CliOutputContractTests.cs
@@ -344,6 +344,8 @@ public sealed class CliOutputContractTests
         var timeoutByCommand = configJson.RootElement.GetProperty("ipcTimeoutMillisecondsByCommand");
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultTestMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandTest).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultReadyMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandReady).GetInt32());
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultCompileMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandCompile).GetInt32());
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultBuildRunMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandBuildRun).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultStatusMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandStatus).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultValidateMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandValidate).GetInt32());
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultPlanMilliseconds, timeoutByCommand.GetProperty(UcliContractConstants.Config.IpcTimeoutCommandPlan).GetInt32());

--- a/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
+++ b/tests/Ucli.Tests/Contracts/UcliContractConstants.cs
@@ -77,6 +77,10 @@ internal static class UcliContractConstants
 
         public const int IpcTimeoutDefaultReadyMilliseconds = 10000;
 
+        public const int IpcTimeoutDefaultCompileMilliseconds = 120000;
+
+        public const int IpcTimeoutDefaultBuildRunMilliseconds = 1800000;
+
         public const int IpcTimeoutDefaultVerifyMilliseconds = 120000;
 
         public const int IpcTimeoutDefaultStatusMilliseconds = 5000;
@@ -122,6 +126,10 @@ internal static class UcliContractConstants
         public const string IpcTimeoutCommandTest = "test";
 
         public const string IpcTimeoutCommandReady = "ready";
+
+        public const string IpcTimeoutCommandCompile = "compile";
+
+        public const string IpcTimeoutCommandBuildRun = "build.run";
 
         public const string IpcTimeoutCommandVerify = "verify";
 

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonReadCommandTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonReadCommandTests.cs
@@ -86,6 +86,44 @@ public sealed class LogsDaemonReadCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Read_WithTimeoutOption_PassesTimeoutToServiceRequest ()
+    {
+        var service = new StubLogsDaemonService(static (_, _, _) =>
+        {
+            return ValueTask.FromResult(LogsReadServiceResult.Success(count: 0, nextCursor: "stream-1:1"));
+        });
+        var command = new LogsDaemonReadCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, _, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.ReadAsync(timeout: "1234"));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        Assert.Equal(1234, service.CapturedRequest!.TimeoutMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Read_WhenTimeoutIsInvalid_WritesInvalidArgumentResultWithoutCallingService ()
+    {
+        var service = new StubLogsDaemonService((_, _, _) => throw new InvalidOperationException("service must not be called"));
+        var command = new LogsDaemonReadCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.ReadAsync(timeout: "0"));
+
+        Assert.Equal(3, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        Assert.Equal(0, service.CallCount);
+        using var commandResult = JsonDocument.Parse(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            commandResult.RootElement,
+            UcliCommandNames.LogsDaemonRead,
+            "error",
+            3);
+        CommandResultAssert.HasSingleError(commandResult.RootElement, UcliCoreErrorCodes.InvalidArgument);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Read_WhenFormatIsInvalid_WritesInvalidArgumentResultWithoutCallingService ()
     {
         var service = new StubLogsDaemonService((_, _, _) => throw new InvalidOperationException("service must not be called"));
@@ -296,12 +334,15 @@ public sealed class LogsDaemonReadCommandTests
 
         public int CallCount { get; private set; }
 
+        public LogsDaemonServiceRequest? CapturedRequest { get; private set; }
+
         public ValueTask<LogsReadServiceResult> ExecuteAsync (
             LogsDaemonServiceRequest request,
             Func<IpcDaemonLogEvent, string, CancellationToken, ValueTask> onEvent,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
+            CapturedRequest = request;
             return handler(request, onEvent, cancellationToken);
         }
     }

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Daemon/LogsDaemonServiceTests.cs
@@ -51,7 +51,10 @@ public sealed class LogsDaemonServiceTests
                 Category: null,
                 Stream: true,
                 PollIntervalMilliseconds: 50,
-                IdleTimeoutMilliseconds: 1),
+                IdleTimeoutMilliseconds: 1)
+            {
+                TimeoutMilliseconds = 4321,
+            },
             (daemonLogEvent, _, _) =>
             {
                 emittedMessages.Add(daemonLogEvent.Message);
@@ -61,6 +64,7 @@ public sealed class LogsDaemonServiceTests
 
         Assert.True(result.IsSuccess, result.Error?.Message);
         Assert.Equal(UcliCommandIds.LogsDaemonRead, resolver.LastTimeoutCommand);
+        Assert.Equal(4321, resolver.LastTimeoutMilliseconds);
         Assert.Equal(["alpha", "bravo"], emittedMessages);
         Assert.Equal(["stream-1:1", "stream-1:2", "stream-1:3"], daemonLogsClient.CapturedAfterValues);
     }

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityReadCommandTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityReadCommandTests.cs
@@ -120,6 +120,23 @@ public sealed class LogsUnityReadCommandTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task Read_WithTimeoutOption_PassesTimeoutToServiceRequest ()
+    {
+        var service = new StubLogsUnityService(static (_, _, _) =>
+        {
+            return ValueTask.FromResult(LogsReadServiceResult.Success(count: 0, nextCursor: "stream-1:1"));
+        });
+        var command = new LogsUnityReadCommand(service, CommandResultTestWriter.Create());
+
+        var (exitCode, _, standardError) = await StandardOutputCapture.ExecuteWithErrorAsync(() => command.ReadAsync(timeout: "1234"));
+
+        Assert.Equal((int)CliExitCode.Success, exitCode);
+        Assert.Equal(string.Empty, standardError);
+        Assert.Equal(1234, service.CapturedRequest!.TimeoutMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task Read_WhenFormatIsInvalid_WritesInvalidArgumentResultWithoutCallingService ()
     {
         var service = new StubLogsUnityService((_, _, _) => throw new InvalidOperationException("service must not be called"));
@@ -256,12 +273,15 @@ public sealed class LogsUnityReadCommandTests
 
         public int CallCount { get; private set; }
 
+        public LogsUnityServiceRequest? CapturedRequest { get; private set; }
+
         public ValueTask<LogsReadServiceResult> ExecuteAsync (
             LogsUnityServiceRequest request,
             Func<IpcUnityLogEvent, string, CancellationToken, ValueTask> onEvent,
             CancellationToken cancellationToken = default)
         {
             CallCount++;
+            CapturedRequest = request;
             return handler(request, onEvent, cancellationToken);
         }
     }

--- a/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityServiceTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Observability/Logs/Unity/LogsUnityServiceTests.cs
@@ -108,7 +108,10 @@ public sealed class LogsUnityServiceTests
                 StackTraceMaxChars: null,
                 Stream: true,
                 PollIntervalMilliseconds: 50,
-                IdleTimeoutMilliseconds: 1),
+                IdleTimeoutMilliseconds: 1)
+            {
+                TimeoutMilliseconds = 4321,
+            },
             (unityLogEvent, _, _) =>
             {
                 emittedMessages.Add(unityLogEvent.Message);
@@ -118,6 +121,7 @@ public sealed class LogsUnityServiceTests
 
         Assert.True(result.IsSuccess, result.Error?.Message);
         Assert.Equal(UcliCommandIds.LogsUnityRead, resolver.LastTimeoutCommand);
+        Assert.Equal(4321, resolver.LastTimeoutMilliseconds);
         Assert.Equal(["alpha", "bravo"], emittedMessages);
         Assert.Equal(["stream-1:1", "stream-1:2", "stream-1:3"], unityLogsClient.CapturedAfterValues);
     }

--- a/tests/Ucli.Tests/Hosting/Cli/ValidateCommandTests.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/ValidateCommandTests.cs
@@ -32,12 +32,14 @@ public sealed class ValidateCommandTests
 
         var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ValidateAsync(
             projectPath: "/repo/UnityProject",
+            timeout: "1234",
             readIndexMode: "disabled",
             cancellationToken: CancellationToken.None));
 
         Assert.Equal((int)CliExitCode.Success, exitCode);
         Assert.NotNull(service.CapturedInput);
         Assert.Equal("/repo/UnityProject", service.CapturedInput!.ProjectPath);
+        Assert.Equal(1234, service.CapturedInput.TimeoutMilliseconds);
         Assert.Equal(ReadIndexMode.Disabled, service.CapturedInput.ReadIndexMode);
         Assert.Equal(DefaultRequestJson, service.CapturedInput.RequestJson);
 
@@ -47,6 +49,29 @@ public sealed class ValidateCommandTests
             UcliCommandNames.Validate,
             IpcProtocol.StatusOk,
             (int)CliExitCode.Success);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Validate_WhenTimeoutIsInvalid_ReturnsInvalidArgumentWithoutCallingService ()
+    {
+        var service = new StubValidateService((_, _) => throw new InvalidOperationException("Service should not be called."));
+        var command = new ValidateCommand(service, new StubRequestInputReader(RequestInputReadResult.Success(DefaultRequestJson)), CommandResultTestWriter.Create());
+
+        var (exitCode, standardOutput) = await StandardOutputCapture.ExecuteAsync(() => command.ValidateAsync(
+            timeout: "0",
+            cancellationToken: CancellationToken.None));
+
+        Assert.Equal((int)CliExitCode.InvalidArgument, exitCode);
+        Assert.Null(service.CapturedInput);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(standardOutput);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            UcliCommandNames.Validate,
+            IpcProtocol.StatusError,
+            (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, UcliCoreErrorCodes.InvalidArgument);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/LogsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/LogsCliOutputContractTests.cs
@@ -51,6 +51,33 @@ public sealed class LogsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task LogsDaemonRead_WithInvalidTimeoutOption_ReturnsJsonEnvelopeError ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Logs,
+            UcliCommandNames.Daemon,
+            UcliCommandNames.ReadSubcommand,
+            UcliContractConstants.CliOption.Timeout,
+            "0");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.LogsDaemonRead,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(
+            outputJson.RootElement,
+            expectedCode: "INVALID_ARGUMENT");
+        Assert.Contains(
+            "timeout must be a positive integer milliseconds value. Actual: 0.",
+            outputJson.RootElement.GetProperty("message").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task LogsUnityRead_WithInvalidStackTrace_ReturnsJsonEnvelopeError ()
     {
         var result = await CliProcessRunner.RunCommandAsync(
@@ -74,6 +101,33 @@ public sealed class LogsCliOutputContractTests
             expectedCode: "INVALID_ARGUMENT");
         Assert.Contains(
             "stackTrace must be one of: none, error, all. Actual: unsupported.",
+            outputJson.RootElement.GetProperty("message").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task LogsUnityRead_WithInvalidTimeoutOption_ReturnsJsonEnvelopeError ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Logs,
+            UcliCommandNames.UnitySubcommand,
+            UcliCommandNames.ReadSubcommand,
+            UcliContractConstants.CliOption.Timeout,
+            "0");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.LogsUnityRead,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(
+            outputJson.RootElement,
+            expectedCode: "INVALID_ARGUMENT");
+        Assert.Contains(
+            "timeout must be a positive integer milliseconds value. Actual: 0.",
             outputJson.RootElement.GetProperty("message").GetString(),
             StringComparison.Ordinal);
     }

--- a/tests/Ucli.Tests/UcliConfigStoreTests.cs
+++ b/tests/Ucli.Tests/UcliConfigStoreTests.cs
@@ -574,9 +574,11 @@ public sealed class UcliConfigStoreTests
 
     private static void AssertDefaultIpcTimeouts (IReadOnlyDictionary<string, int?> actual)
     {
-        Assert.Equal(23, actual.Count);
+        Assert.Equal(25, actual.Count);
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandTest));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandReady));
+        Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandCompile));
+        Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandBuildRun));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandVerify));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandStatus));
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandValidate));
@@ -600,6 +602,8 @@ public sealed class UcliConfigStoreTests
         Assert.True(actual.ContainsKey(UcliContractConstants.Config.IpcTimeoutCommandPlayExit));
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultTestMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandTest]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultReadyMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandReady]);
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultCompileMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandCompile]);
+        Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultBuildRunMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandBuildRun]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultVerifyMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandVerify]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultStatusMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandStatus]);
         Assert.Equal(UcliContractConstants.Config.IpcTimeoutDefaultValidateMilliseconds, actual[UcliContractConstants.Config.IpcTimeoutCommandValidate]);

--- a/tests/Ucli.Tests/ValidateCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/ValidateCliOutputContractTests.cs
@@ -32,6 +32,31 @@ public sealed class ValidateCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
+    public async Task Validate_WithInvalidTimeoutOption_ReturnsInvalidArgumentErrorAsSingleJson ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Validate,
+            UcliContractConstants.CliOption.Timeout,
+            "0");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.Validate,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(
+            outputJson.RootElement,
+            expectedCode: "INVALID_ARGUMENT");
+        Assert.Contains(
+            "timeout must be a positive integer milliseconds value. Actual: 0.",
+            outputJson.RootElement.GetProperty("message").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
     public async Task Validate_WithPreseededReadIndex_ReturnsJsonEnvelopeSuccess ()
     {
         using var scope = TestDirectories.CreateTempScope("validate-cli-output-contract", "success");


### PR DESCRIPTION
## Summary
- Completes timeout coverage for Unity-backed commands that either missed config defaults or command-line overrides.
- Adds default `ipcTimeoutMillisecondsByCommand` entries for `compile` and `build.run` so omitted `--timeout` no longer falls back to the global 3000 ms value.
- Adds `--timeout` handling for `validate`, `logs daemon read`, and `logs unity read`.
- Enforces the resolved `validate` timeout during static validation and read-index preflight, returning `IPC_TIMEOUT` on deadline expiry.

## Scope
- `src/Ucli.Application/Shared/Configuration`: adds missing per-command timeout defaults.
- `src/Ucli/Hosting/Cli/Requests` and `src/Ucli.Application/Features/Requests/Validate`: normalizes, resolves, and applies validate timeout input.
- `src/Ucli/Hosting/Cli/Daemon/Logs` and `src/Ucli.Application/Features/Daemon/Observability/Logs`: threads log read timeout overrides into daemon execution context resolution.
- `tests`: updates config/output contracts and adds resolver, service, CLI, and real-process contract tests for the corrected timeout paths.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`, `bash scripts/code-quality.sh verify --include ...`)
- Targeted tests: PASS (`ValidateServiceTests` 9 passed; logs/validate CLI contract focus 23 passed)
- Final gate: PASS (`bash scripts/verify.sh`; build 0 warnings / 0 errors; .NET tests passed)
- Coverage: N/A

## Risks / Rollback
- Risk is limited to timeout option/default resolution and validate static-validation timeout enforcement for the affected commands.
- Rollback is the PR branch commits if any command option binding or timeout default needs to be reverted.

## Checklist
- [x] Timeout defaults include the long-running compile and build run commands.
- [x] Affected CLI commands normalize invalid timeout input before service execution.
- [x] `validate` applies resolved timeout to static validation/read-index preflight.
- [x] Service tests cover config fallback and override propagation.
- [x] Real-process CLI contract tests cover the new public `--timeout` options.

Issue: none (ad-hoc task)