### PR TITLE
[build] Resolve BuildPipeline runner output layout from command contract

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
@@ -8,7 +8,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <param name="BuildReportJsonPath"> The absolute <c>build-report.json</c> path. </param>
 /// <param name="BuildLogPath"> The absolute <c>build.log</c> path. </param>
 /// <param name="OutputManifestJsonPath"> The absolute <c>output-manifest.json</c> path. </param>
-/// <param name="OutputDirectory"> The absolute player output directory path. </param>
+/// <param name="OutputDirectory"> The absolute runner working output root path. </param>
 internal sealed record BuildRunArtifactPaths (
     string RepositoryRoot,
     string RunId,

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunMetadataDocument.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunMetadataDocument.cs
@@ -7,6 +7,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <param name="RunId"> The build run identifier. </param>
 /// <param name="Project"> The project identity section. </param>
 /// <param name="Profile"> The profile metadata section. </param>
+/// <param name="Runner"> The resolved runner metadata section. </param>
 /// <param name="Input"> The resolved build inputs section. </param>
 /// <param name="Lifecycle"> The lifecycle evidence section. </param>
 /// <param name="Generations"> The Unity generation evidence section. </param>
@@ -19,6 +20,7 @@ internal sealed record BuildRunMetadataDocument (
     string RunId,
     JsonElement Project,
     JsonElement Profile,
+    JsonElement Runner,
     JsonElement Input,
     JsonElement Lifecycle,
     JsonElement Generations,

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/IBuildRunArtifactStore.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/IBuildRunArtifactStore.cs
@@ -1,12 +1,20 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 
 /// <summary> Prepares, accounts, and writes build-run artifacts under local uCLI storage. </summary>
 internal interface IBuildRunArtifactStore
 {
-    /// <summary> Prepares the build-run artifact directory and player output directory. </summary>
+    /// <summary> Prepares the build-run artifact directory and runner working output root. </summary>
     BuildRunArtifactPreparationResult Prepare (
         ResolvedUnityProjectContext unityProject,
         string runId);
+
+    /// <summary> Prepares the command-derived BuildPipeline output layout before runner invocation. </summary>
+    BuildRunArtifactPreparationResult PrepareBuildPipelineOutputLayout (
+        BuildRunArtifactPaths paths,
+        string buildTarget,
+        IpcBuildOutputLayout outputLayout);
 
     /// <summary> Accounts Unity-generated artifacts and writes the output manifest. </summary>
     ValueTask<BuildRunArtifactAccountingOperationResult> AccountArtifactsAsync (

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -8,6 +8,7 @@ using MackySoft.Ucli.Application.Features.Assurance.Build.Vocabulary;
 using MackySoft.Ucli.Application.Features.Assurance.Semantics;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.Progress;
+using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Text;
@@ -22,6 +23,12 @@ internal sealed class BuildService : IBuildService
 
     private static readonly IReadOnlyList<BuildResidualRiskOutput> EmptyResidualRisks =
         Array.Empty<BuildResidualRiskOutput>();
+
+    private static readonly IReadOnlyDictionary<string, JsonElement> EmptyRunnerArguments =
+        new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+    private static readonly IReadOnlyList<string> EmptyRunnerEnvironment =
+        Array.Empty<string>();
 
     private readonly IProjectContextResolver projectContextResolver;
 
@@ -141,6 +148,22 @@ internal sealed class BuildService : IBuildService
 
         var profile = profileResolutionResult.Profile!;
         var paths = prepareResult.Paths!;
+        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, profile.BuildTarget.StableName, out var outputLayout))
+        {
+            return BuildExecutionResult.Failure(ExecutionError.InvalidArgument(
+                $"BuildPipeline output layout could not be resolved for build target: {profile.BuildTarget.StableName}.",
+                BuildErrorCodes.BuildInputsInvalid), project);
+        }
+
+        var outputLayoutPrepareResult = artifactStore.PrepareBuildPipelineOutputLayout(
+            paths,
+            profile.BuildTarget.StableName,
+            outputLayout!);
+        if (!outputLayoutPrepareResult.IsSuccess)
+        {
+            return BuildExecutionResult.Failure(outputLayoutPrepareResult.Error!, project);
+        }
+
         await EmitStartedAsync(
                 resolvedProgressSink,
                 runId,
@@ -153,7 +176,7 @@ internal sealed class BuildService : IBuildService
                 cancellationToken)
             .ConfigureAwait(false);
 
-        var request = CreateBuildRunRequest(profile, paths, runId);
+        var request = CreateBuildRunRequest(profile, paths, outputLayout!, runId);
         var executionResult = await unityRequestExecutor.ExecuteAsync(
                 UcliCommandIds.BuildRun,
                 ResolveExecutionMode(executionTarget),
@@ -225,7 +248,9 @@ internal sealed class BuildService : IBuildService
             var metadata = CreateMetadataDocument(
                 project,
                 output,
-                buildResponse);
+                buildResponse,
+                profile,
+                outputLayout!);
             var metadataWriteResult = await artifactStore.WriteMetadataAsync(
                     new BuildRunMetadataWriteRequest(
                         paths,
@@ -309,6 +334,7 @@ internal sealed class BuildService : IBuildService
     private static UnityRequestPayload.BuildRun CreateBuildRunRequest (
         ResolvedBuildProfile profile,
         BuildRunArtifactPaths paths,
+        IpcBuildOutputLayout outputLayout,
         string runId)
     {
         return new UnityRequestPayload.BuildRun(
@@ -319,6 +345,7 @@ internal sealed class BuildService : IBuildService
             ScenePaths: profile.Scenes.Paths,
             Development: profile.Options.Development,
             OutputPath: paths.OutputDirectory,
+            OutputLayout: outputLayout,
             BuildReportPath: paths.BuildReportJsonPath,
             BuildLogPath: paths.BuildLogPath);
     }
@@ -575,13 +602,22 @@ internal sealed class BuildService : IBuildService
     private static BuildRunMetadataDocument CreateMetadataDocument (
         ProjectIdentityInfo project,
         BuildExecutionOutput output,
-        IpcBuildRunResponse response)
+        IpcBuildRunResponse response,
+        ResolvedBuildProfile profile,
+        IpcBuildOutputLayout outputLayout)
     {
         return new BuildRunMetadataDocument(
             SchemaVersion: BuildMetadataSchemaVersion,
             RunId: output.Build.RunId,
             Project: SerializeMetadataElement(project),
             Profile: SerializeMetadataElement(output.Build.Profile),
+            Runner: SerializeMetadataElement(new BuildRunRunnerMetadata(
+                Kind: ContractLiteralCodec.ToValue(profile.Runner.Kind),
+                Method: null,
+                Invocation: new BuildRunRunnerInvocationMetadata(
+                    Arguments: EmptyRunnerArguments,
+                    Environment: EmptyRunnerEnvironment),
+                OutputLayout: outputLayout)),
             Input: SerializeMetadataElement(new BuildRunInputMetadata(
                 BuildTarget: output.Build.BuildTarget,
                 UnityBuildTarget: response.Input.UnityBuildTarget,

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunRunnerInvocationMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunRunnerInvocationMetadata.cs
@@ -1,0 +1,8 @@
+using System.Text.Json;
+
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
+
+/// <summary> Represents the runner invocation summary persisted in <c>build.json</c>. </summary>
+internal sealed record BuildRunRunnerInvocationMetadata (
+    IReadOnlyDictionary<string, JsonElement> Arguments,
+    IReadOnlyList<string> Environment);

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunRunnerMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunRunnerMetadata.cs
@@ -1,0 +1,10 @@
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
+
+/// <summary> Represents the resolved runner metadata persisted in <c>build.json</c>. </summary>
+internal sealed record BuildRunRunnerMetadata (
+    string Kind,
+    string? Method,
+    BuildRunRunnerInvocationMetadata Invocation,
+    IpcBuildOutputLayout? OutputLayout);

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
@@ -1,3 +1,4 @@
+using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/BuildTargetStableNameCodec.cs
@@ -17,7 +17,7 @@ internal static class BuildTargetStableNameCodec
             return false;
         }
 
-        if (!TryGetUnityBuildTargetLiteral(stableNameValue, out var unityBuildTargetLiteral))
+        if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableNameValue, out var unityBuildTargetLiteral))
         {
             target = null!;
             return false;
@@ -28,74 +28,5 @@ internal static class BuildTargetStableNameCodec
             StableName: ContractLiteralCodec.ToValue(stableNameValue),
             UnityBuildTargetLiteral: unityBuildTargetLiteral);
         return true;
-    }
-
-    private static bool TryGetUnityBuildTargetLiteral (
-        BuildTargetStableName stableName,
-        out string unityBuildTargetLiteral)
-    {
-        switch (stableName)
-        {
-            case BuildTargetStableName.StandaloneOsx:
-                unityBuildTargetLiteral = "StandaloneOSX";
-                return true;
-            case BuildTargetStableName.StandaloneWindows:
-                unityBuildTargetLiteral = "StandaloneWindows";
-                return true;
-            case BuildTargetStableName.StandaloneWindows64:
-                unityBuildTargetLiteral = "StandaloneWindows64";
-                return true;
-            case BuildTargetStableName.StandaloneLinux64:
-                unityBuildTargetLiteral = "StandaloneLinux64";
-                return true;
-            case BuildTargetStableName.Ios:
-                unityBuildTargetLiteral = "iOS";
-                return true;
-            case BuildTargetStableName.Android:
-                unityBuildTargetLiteral = "Android";
-                return true;
-            case BuildTargetStableName.Webgl:
-                unityBuildTargetLiteral = "WebGL";
-                return true;
-            case BuildTargetStableName.WsaPlayer:
-                unityBuildTargetLiteral = "WSAPlayer";
-                return true;
-            case BuildTargetStableName.Tvos:
-                unityBuildTargetLiteral = "tvOS";
-                return true;
-            case BuildTargetStableName.Switch:
-                unityBuildTargetLiteral = "Switch";
-                return true;
-            case BuildTargetStableName.LinuxHeadlessSimulation:
-                unityBuildTargetLiteral = "LinuxHeadlessSimulation";
-                return true;
-            case BuildTargetStableName.GameCoreXboxSeries:
-                unityBuildTargetLiteral = "GameCoreXboxSeries";
-                return true;
-            case BuildTargetStableName.GameCoreXboxOne:
-                unityBuildTargetLiteral = "GameCoreXboxOne";
-                return true;
-            case BuildTargetStableName.Ps4:
-                unityBuildTargetLiteral = "PS4";
-                return true;
-            case BuildTargetStableName.Ps5:
-                unityBuildTargetLiteral = "PS5";
-                return true;
-            case BuildTargetStableName.XboxOne:
-                unityBuildTargetLiteral = "XboxOne";
-                return true;
-            case BuildTargetStableName.EmbeddedLinux:
-                unityBuildTargetLiteral = "EmbeddedLinux";
-                return true;
-            case BuildTargetStableName.Qnx:
-                unityBuildTargetLiteral = "QNX";
-                return true;
-            case BuildTargetStableName.VisionOs:
-                unityBuildTargetLiteral = "VisionOS";
-                return true;
-            default:
-                unityBuildTargetLiteral = null!;
-                return false;
-        }
     }
 }

--- a/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildTarget.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Profiles/ResolvedBuildTarget.cs
@@ -1,3 +1,5 @@
+using MackySoft.Ucli.Contracts.Assurance.Build;
+
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 
 /// <summary> Represents one resolved buildTarget stable name. </summary>

--- a/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
+++ b/src/Ucli.Application/Shared/Execution/UnityRequest/UnityRequestPayload.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MackySoft.Ucli.Contracts.Ipc;
 
 namespace MackySoft.Ucli.Application.Shared.Execution.UnityRequest;
 
@@ -28,6 +29,7 @@ internal abstract record UnityRequestPayload
         IReadOnlyList<string> ScenePaths,
         bool Development,
         string OutputPath,
+        IpcBuildOutputLayout OutputLayout,
         string BuildReportPath,
         string BuildLogPath) : UnityRequestPayload;
 

--- a/src/Ucli.Contracts/Assurance/Build/BuildTargetStableName.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildTargetStableName.cs
@@ -1,9 +1,9 @@
 using MackySoft.Ucli.Contracts.Text;
 
-namespace MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
+namespace MackySoft.Ucli.Contracts.Assurance.Build;
 
 /// <summary> Defines uCLI buildTarget stable-name literals. </summary>
-internal enum BuildTargetStableName
+public enum BuildTargetStableName
 {
     /// <summary> macOS standalone player build target. </summary>
     [UcliContractLiteral("standaloneOSX")]

--- a/src/Ucli.Contracts/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolver.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolver.cs
@@ -1,0 +1,91 @@
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Assurance.Build;
+
+/// <summary> Resolves uCLI buildTarget stable names to Unity BuildTarget literals. </summary>
+internal static class BuildTargetStableNameUnityBuildTargetResolver
+{
+    /// <summary> Tries to resolve one buildTarget stable-name literal to its Unity BuildTarget literal. </summary>
+    public static bool TryResolve (
+        string stableName,
+        out string unityBuildTargetLiteral)
+    {
+        if (!ContractLiteralCodec.TryParse<BuildTargetStableName>(stableName, out var stableNameValue))
+        {
+            unityBuildTargetLiteral = null!;
+            return false;
+        }
+
+        return TryResolve(stableNameValue, out unityBuildTargetLiteral);
+    }
+
+    /// <summary> Tries to resolve one buildTarget stable name to its Unity BuildTarget literal. </summary>
+    public static bool TryResolve (
+        BuildTargetStableName stableName,
+        out string unityBuildTargetLiteral)
+    {
+        switch (stableName)
+        {
+            case BuildTargetStableName.StandaloneOsx:
+                unityBuildTargetLiteral = "StandaloneOSX";
+                return true;
+            case BuildTargetStableName.StandaloneWindows:
+                unityBuildTargetLiteral = "StandaloneWindows";
+                return true;
+            case BuildTargetStableName.StandaloneWindows64:
+                unityBuildTargetLiteral = "StandaloneWindows64";
+                return true;
+            case BuildTargetStableName.StandaloneLinux64:
+                unityBuildTargetLiteral = "StandaloneLinux64";
+                return true;
+            case BuildTargetStableName.Ios:
+                unityBuildTargetLiteral = "iOS";
+                return true;
+            case BuildTargetStableName.Android:
+                unityBuildTargetLiteral = "Android";
+                return true;
+            case BuildTargetStableName.Webgl:
+                unityBuildTargetLiteral = "WebGL";
+                return true;
+            case BuildTargetStableName.WsaPlayer:
+                unityBuildTargetLiteral = "WSAPlayer";
+                return true;
+            case BuildTargetStableName.Tvos:
+                unityBuildTargetLiteral = "tvOS";
+                return true;
+            case BuildTargetStableName.Switch:
+                unityBuildTargetLiteral = "Switch";
+                return true;
+            case BuildTargetStableName.LinuxHeadlessSimulation:
+                unityBuildTargetLiteral = "LinuxHeadlessSimulation";
+                return true;
+            case BuildTargetStableName.GameCoreXboxSeries:
+                unityBuildTargetLiteral = "GameCoreXboxSeries";
+                return true;
+            case BuildTargetStableName.GameCoreXboxOne:
+                unityBuildTargetLiteral = "GameCoreXboxOne";
+                return true;
+            case BuildTargetStableName.Ps4:
+                unityBuildTargetLiteral = "PS4";
+                return true;
+            case BuildTargetStableName.Ps5:
+                unityBuildTargetLiteral = "PS5";
+                return true;
+            case BuildTargetStableName.XboxOne:
+                unityBuildTargetLiteral = "XboxOne";
+                return true;
+            case BuildTargetStableName.EmbeddedLinux:
+                unityBuildTargetLiteral = "EmbeddedLinux";
+                return true;
+            case BuildTargetStableName.Qnx:
+                unityBuildTargetLiteral = "QNX";
+                return true;
+            case BuildTargetStableName.VisionOs:
+                unityBuildTargetLiteral = "VisionOS";
+                return true;
+            default:
+                unityBuildTargetLiteral = null!;
+                return false;
+        }
+    }
+}

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayout.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayout.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Represents the command-derived BuildPipeline output layout for one <c>build.run</c> request. </summary>
+/// <param name="Shape"> The BuildPipeline output shape literal. </param>
+/// <param name="LocationPathName"> The absolute path passed to <c>BuildPlayerOptions.locationPathName</c>. </param>
+public sealed record IpcBuildOutputLayout (
+    string Shape,
+    string LocationPathName);

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutResolver.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutResolver.cs
@@ -4,7 +4,7 @@ using MackySoft.Ucli.Contracts.Text;
 namespace MackySoft.Ucli.Contracts.Ipc;
 
 /// <summary> Resolves command-owned BuildPipeline output layouts from stable build target names. </summary>
-public static class IpcBuildOutputLayoutResolver
+internal static class IpcBuildOutputLayoutResolver
 {
     private const string PlayerDirectoryName = "player";
     private const string PlayerFileName = "Player";

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutResolver.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutResolver.cs
@@ -1,0 +1,100 @@
+using MackySoft.Ucli.Contracts.Assurance.Build;
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Resolves command-owned BuildPipeline output layouts from stable build target names. </summary>
+public static class IpcBuildOutputLayoutResolver
+{
+    private const string PlayerDirectoryName = "player";
+    private const string PlayerFileName = "Player";
+    private const string PlayerAppBundleName = "Player.app";
+    private const string WindowsPlayerFileName = "Player.exe";
+    private const string AndroidPlayerFileName = "Player.apk";
+
+    /// <summary> Tries to resolve the BuildPipeline output layout for the target. </summary>
+    /// <param name="outputDirectory"> The absolute runner working output root. </param>
+    /// <param name="buildTarget"> The uCLI build target stable name. </param>
+    /// <param name="layout"> The resolved output layout when successful. </param>
+    /// <returns> <see langword="true" /> when the target has a deterministic output layout; otherwise <see langword="false" />. </returns>
+    public static bool TryResolve (
+        string outputDirectory,
+        string buildTarget,
+        out IpcBuildOutputLayout? layout)
+    {
+        layout = null;
+        if (string.IsNullOrWhiteSpace(outputDirectory) || string.IsNullOrWhiteSpace(buildTarget))
+        {
+            return false;
+        }
+
+        if (!ContractLiteralCodec.TryParse<BuildTargetStableName>(buildTarget, out var stableName)
+            || !TryResolveShapeAndFileName(stableName, out var shape, out var fileName))
+        {
+            return false;
+        }
+
+        layout = new IpcBuildOutputLayout(
+            Shape: shape,
+            LocationPathName: CombineProtocolPath(outputDirectory, PlayerDirectoryName, fileName));
+        return true;
+    }
+
+    private static string CombineProtocolPath (string root, string firstSegment, string secondSegment)
+    {
+        return string.Concat(TrimTrailingDirectorySeparators(root), "/", firstSegment, "/", secondSegment);
+    }
+
+    private static string TrimTrailingDirectorySeparators (string value)
+    {
+        var length = value.Length;
+        while (length > 0 && IsDirectorySeparator(value[length - 1]))
+        {
+            length--;
+        }
+
+        return length == value.Length ? value : value[..length];
+    }
+
+    private static bool IsDirectorySeparator (char value)
+    {
+        return value == '/' || value == '\\';
+    }
+
+    private static bool TryResolveShapeAndFileName (
+        BuildTargetStableName buildTarget,
+        out string shape,
+        out string fileName)
+    {
+        switch (buildTarget)
+        {
+            case BuildTargetStableName.StandaloneOsx:
+                shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.AppBundle);
+                fileName = PlayerAppBundleName;
+                return true;
+            case BuildTargetStableName.StandaloneWindows:
+            case BuildTargetStableName.StandaloneWindows64:
+                shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File);
+                fileName = WindowsPlayerFileName;
+                return true;
+            case BuildTargetStableName.StandaloneLinux64:
+                shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File);
+                fileName = PlayerFileName;
+                return true;
+            case BuildTargetStableName.Android:
+                shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File);
+                fileName = AndroidPlayerFileName;
+                return true;
+            case BuildTargetStableName.Ios:
+            case BuildTargetStableName.Tvos:
+            case BuildTargetStableName.Webgl:
+                shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.Directory);
+                fileName = PlayerFileName;
+                return true;
+            default:
+                shape = null!;
+                fileName = null!;
+                return false;
+        }
+    }
+}

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutShape.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildOutputLayoutShape.cs
@@ -1,0 +1,19 @@
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Ipc;
+
+/// <summary> Defines BuildPipeline output layout shape literals. </summary>
+public enum IpcBuildOutputLayoutShape
+{
+    /// <summary> BuildPipeline writes one file. </summary>
+    [UcliContractLiteral("file")]
+    File = 0,
+
+    /// <summary> BuildPipeline writes one directory. </summary>
+    [UcliContractLiteral("directory")]
+    Directory = 1,
+
+    /// <summary> BuildPipeline writes one macOS application bundle. </summary>
+    [UcliContractLiteral("appBundle")]
+    AppBundle = 2,
+}

--- a/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildRunRequest.cs
+++ b/src/Ucli.Contracts/Ipc/Methods/Build/IpcBuildRunRequest.cs
@@ -9,7 +9,8 @@ namespace MackySoft.Ucli.Contracts.Ipc;
 /// <param name="SceneSource"> The resolved scene source literal. </param>
 /// <param name="ScenePaths"> The explicit scene paths, or an empty list when scene source is Editor Build Settings. </param>
 /// <param name="Development"> Whether the development build option is enabled. </param>
-/// <param name="OutputPath"> The absolute output path passed to Unity BuildPipeline. </param>
+/// <param name="OutputPath"> The absolute runner working output root. </param>
+/// <param name="OutputLayout"> The command-derived BuildPipeline output layout. </param>
 /// <param name="BuildReportPath"> The absolute path where Unity writes the normalized BuildReport artifact. </param>
 /// <param name="BuildLogPath"> The absolute path where Unity writes the build log artifact. </param>
 public sealed record IpcBuildRunRequest (
@@ -20,6 +21,7 @@ public sealed record IpcBuildRunRequest (
     IReadOnlyList<string> ScenePaths,
     bool Development,
     string OutputPath,
+    IpcBuildOutputLayout OutputLayout,
     string BuildReportPath,
     string BuildLogPath)
 {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildPlayerOptionsFactory.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline/UnityBuildPlayerOptionsFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using MackySoft.Ucli.Contracts.Ipc;
 using UnityEditor;
 
@@ -25,31 +24,23 @@ namespace MackySoft.Ucli.Unity.Build
                 throw new ArgumentNullException(nameof(resolvedInput));
             }
 
+            if (request.OutputLayout == null)
+            {
+                throw new ArgumentException("BuildPipeline outputLayout must be specified.", nameof(request));
+            }
+
+            if (string.IsNullOrWhiteSpace(request.OutputLayout.LocationPathName))
+            {
+                throw new ArgumentException("BuildPipeline outputLayout.locationPathName must not be empty.", nameof(request));
+            }
+
             return new BuildPlayerOptions
             {
                 scenes = resolvedInput.ScenePaths,
                 target = resolvedInput.UnityBuildTarget,
                 targetGroup = resolvedInput.UnityBuildTargetGroup,
                 options = resolvedInput.Options,
-                locationPathName = ResolveLocationPathName(request.OutputPath, resolvedInput.UnityBuildTarget),
-            };
-        }
-
-        private static string ResolveLocationPathName (
-            string outputDirectory,
-            BuildTarget unityBuildTarget)
-        {
-            return unityBuildTarget switch
-            {
-                BuildTarget.StandaloneOSX => Path.Combine(outputDirectory, "build.app"),
-                BuildTarget.StandaloneWindows => Path.Combine(outputDirectory, "build.exe"),
-                BuildTarget.StandaloneWindows64 => Path.Combine(outputDirectory, "build.exe"),
-                BuildTarget.StandaloneLinux64 => Path.Combine(outputDirectory, "build"),
-                BuildTarget.Android => Path.Combine(outputDirectory, "build.apk"),
-                BuildTarget.WebGL => outputDirectory,
-                BuildTarget.iOS => outputDirectory,
-                BuildTarget.tvOS => outputDirectory,
-                _ => Path.Combine(outputDirectory, "build"),
+                locationPathName = request.OutputLayout.LocationPathName,
             };
         }
     }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -426,7 +426,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             {
                 return string.Equals(
                     Path.GetFullPath(actualPath),
-                    expectedPath,
+                    Path.GetFullPath(expectedPath),
                     Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
             }
             catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts;
+using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Contracts.Text;
@@ -294,6 +295,18 @@ namespace MackySoft.Ucli.Unity.Ipc
                 || string.IsNullOrWhiteSpace(request.SceneSource))
             {
                 errorMessage = "BuildTarget and scene source values must not be empty.";
+                return false;
+            }
+
+            if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolve(request.BuildTarget, out var expectedUnityBuildTarget))
+            {
+                errorMessage = $"Build buildTarget stable name is unsupported: {request.BuildTarget}.";
+                return false;
+            }
+
+            if (!string.Equals(request.UnityBuildTarget, expectedUnityBuildTarget, StringComparison.Ordinal))
+            {
+                errorMessage = $"Build UnityBuildTarget must match buildTarget. Expected={expectedUnityBuildTarget}, Actual={request.UnityBuildTarget}.";
                 return false;
             }
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -100,6 +100,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 }
 
                 FileSystemAccessBoundary.EnsureSecureDirectory(buildRunRequest.OutputPath);
+                EnsureBuildPipelineOutputLayoutReady(buildRunRequest.OutputLayout);
                 var logSourcePath = Application.consoleLogPath;
                 var logStartOffset = GetLogLength(logSourcePath);
                 var startedAtUtc = DateTimeOffset.UtcNow;
@@ -307,11 +308,25 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
+            if (request.OutputLayout == null)
+            {
+                errorMessage = "Build outputLayout must match the expected uCLI build artifact layout.";
+                return false;
+            }
+
+            if (!IpcBuildOutputLayoutResolver.TryResolve(expectedOutputPath!, request.BuildTarget, out var expectedOutputLayout))
+            {
+                errorMessage = $"Build outputLayout could not be resolved for build target: {request.BuildTarget}.";
+                return false;
+            }
+
             if (!PathEquals(request.OutputPath, expectedOutputPath!)
+                || !string.Equals(request.OutputLayout.Shape, expectedOutputLayout!.Shape, StringComparison.Ordinal)
+                || !PathEquals(request.OutputLayout.LocationPathName, expectedOutputLayout.LocationPathName)
                 || !PathEquals(request.BuildReportPath, expectedBuildReportPath!)
                 || !PathEquals(request.BuildLogPath, expectedBuildLogPath!))
             {
-                errorMessage = "Build output and artifact paths must match the expected uCLI build artifact layout.";
+                errorMessage = "Build output, outputLayout, and artifact paths must match the expected uCLI build artifact layout.";
                 return false;
             }
 
@@ -442,6 +457,40 @@ namespace MackySoft.Ucli.Unity.Ipc
         private static bool IsDirectorySeparator (char value)
         {
             return value == '\\' || value == '/';
+        }
+
+        private static void EnsureBuildPipelineOutputLayoutReady (IpcBuildOutputLayout outputLayout)
+        {
+            if (outputLayout == null)
+            {
+                throw new InvalidOperationException("BuildPipeline outputLayout must be specified.");
+            }
+
+            var parentDirectory = Path.GetDirectoryName(outputLayout.LocationPathName);
+            if (string.IsNullOrWhiteSpace(parentDirectory))
+            {
+                throw new InvalidOperationException(
+                    $"BuildPipeline output parent directory could not be resolved: {outputLayout.LocationPathName}");
+            }
+
+            FileSystemAccessBoundary.EnsureSecureDirectory(parentDirectory);
+            EnsureBuildPipelineOutputTargetDoesNotExist(outputLayout.LocationPathName);
+        }
+
+        private static void EnsureBuildPipelineOutputTargetDoesNotExist (string locationPathName)
+        {
+            if (!File.Exists(locationPathName) && !Directory.Exists(locationPathName))
+            {
+                return;
+            }
+
+            var attributes = File.GetAttributes(locationPathName);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                throw new IOException($"BuildPipeline output target must not be a reparse point: {locationPathName}");
+            }
+
+            throw new IOException($"BuildPipeline output target already exists: {locationPathName}");
         }
 
         private static long GetLogLength (string path)

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPipeline/UnityBuildReportNormalizerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildPipeline/UnityBuildReportNormalizerTests.cs
@@ -105,6 +105,7 @@ namespace MackySoft.Ucli.Unity.Tests
         public void Create_WithStandaloneLinuxTarget_CreatesBuildPlayerOptions ()
         {
             var outputPath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "ucli", "output"));
+            var locationPathName = Path.Combine(outputPath, "player", "Player");
             var request = new IpcBuildRunRequest(
                 RunId: "build-run-1",
                 BuildTarget: "standaloneLinux64",
@@ -113,6 +114,9 @@ namespace MackySoft.Ucli.Unity.Tests
                 ScenePaths: new[] { "Assets/Scenes/Main.unity" },
                 Development: true,
                 OutputPath: outputPath,
+                OutputLayout: new IpcBuildOutputLayout(
+                    Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+                    LocationPathName: locationPathName),
                 BuildReportPath: "/tmp/ucli/build-report.json",
                 BuildLogPath: "/tmp/ucli/build.log");
             var resolvedInput = new UnityBuildResolvedInput(
@@ -127,7 +131,7 @@ namespace MackySoft.Ucli.Unity.Tests
             Assert.That(options.target, Is.EqualTo(BuildTarget.StandaloneLinux64));
             Assert.That(options.targetGroup, Is.EqualTo(BuildTargetGroup.Standalone));
             Assert.That(options.options, Is.EqualTo(BuildOptions.Development));
-            Assert.That(options.locationPathName, Is.EqualTo(Path.Combine(outputPath, "build")));
+            Assert.That(options.locationPathName, Is.EqualTo(locationPathName));
         }
     }
 }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
@@ -42,6 +42,27 @@ namespace MackySoft.Ucli.Unity.Tests
             }
         }
 
+        [Test]
+        [Category("Size.Small")]
+        public void TryValidateRequest_WithOutputLayoutOutsideExpectedLayout_ReturnsFalse ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var request = CreateRequest(scope.ProjectPath, identity) with
+                {
+                    OutputLayout = new IpcBuildOutputLayout(
+                        Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+                        LocationPathName: Path.Combine(scope.RootPath, "outside", "Player")),
+                };
+
+                var result = BuildRunUnityIpcMethodHandler.TryValidateRequest(request, identity, out var errorMessage);
+
+                Assert.That(result, Is.False);
+                Assert.That(errorMessage, Does.Contain("outputLayout"));
+            }
+        }
+
         [TestCase("output")]
         [TestCase("report")]
         [TestCase("log")]
@@ -125,6 +146,40 @@ namespace MackySoft.Ucli.Unity.Tests
             }
         }
 
+        [Test]
+        [Category("Size.Small")]
+        public async Task HandleAsync_WithExistingOutputLayoutTarget_ReturnsBuildArtifactWriteFailedWithoutRunningBuild ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var readinessGate = new CountingReadinessGate();
+                var buildPipelineRunner = new CountingBuildPipelineRunner();
+                var logRangeExporter = new CountingEditorLogRangeExporter();
+                var handler = new BuildRunUnityIpcMethodHandler(
+                    new UnityBuildPreconditionProbe(
+                        readinessGate,
+                        identity,
+                        new StubServerVersionProvider("1.2.3"),
+                        new CountingBuildTargetSupportProbe()),
+                    buildPipelineRunner,
+                    logRangeExporter,
+                    identity,
+                    new CountingTimeoutScopeFactory());
+                var payload = CreateRequest(scope.ProjectPath, identity);
+                Directory.CreateDirectory(Path.GetDirectoryName(payload.OutputLayout.LocationPathName)!);
+                File.WriteAllText(payload.OutputLayout.LocationPathName, "existing player");
+
+                var response = await handler.HandleAsync(CreateIpcRequest(payload), CancellationToken.None);
+
+                Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+                Assert.That(response.Errors.Count, Is.EqualTo(1));
+                Assert.That(response.Errors[0].Code, Is.EqualTo(BuildErrorCodes.BuildArtifactWriteFailed));
+                Assert.That(buildPipelineRunner.CallCount, Is.EqualTo(0));
+                Assert.That(logRangeExporter.CallCount, Is.EqualTo(0));
+            }
+        }
+
         [TestCase(IpcBuildReportResult.Succeeded, IpcBuildLogCompletionReason.Completed, 0, 9)]
         [TestCase(IpcBuildReportResult.Failed, IpcBuildLogCompletionReason.Failed, 1, 2)]
         [TestCase(IpcBuildReportResult.Canceled, IpcBuildLogCompletionReason.Canceled, 0, 0)]
@@ -146,7 +201,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 Directory.CreateDirectory(requestPayload.OutputPath);
                 var reportArtifact = CreateReportArtifact(
                     ContractLiteralCodec.ToValue(reportResult),
-                    Path.Combine(requestPayload.OutputPath, "build"),
+                    requestPayload.OutputLayout.LocationPathName,
                     reportErrorCount,
                     reportWarningCount);
                 var buildPipelineRunner = new CountingBuildPipelineRunner(reportArtifact);
@@ -181,7 +236,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 Assert.That(payload.Logs.ErrorCount, Is.EqualTo(1));
                 Assert.That(payload.Logs.WarningCount, Is.EqualTo(1));
                 Assert.That(buildPipelineRunner.CallCount, Is.EqualTo(1));
-                Assert.That(buildPipelineRunner.LastOptions.locationPathName, Is.EqualTo(Path.Combine(requestPayload.OutputPath, "build")));
+                Assert.That(buildPipelineRunner.LastOptions.locationPathName, Is.EqualTo(requestPayload.OutputLayout.LocationPathName));
                 Assert.That(logRangeExporter.CallCount, Is.EqualTo(1));
                 Assert.That(File.Exists(requestPayload.BuildReportPath), Is.True);
                 Assert.That(File.Exists(requestPayload.BuildLogPath), Is.True);
@@ -258,6 +313,12 @@ namespace MackySoft.Ucli.Unity.Tests
                 storageRoot,
                 identity.ProjectFingerprint,
                 RunId);
+            var outputPath = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName);
+            if (!IpcBuildOutputLayoutResolver.TryResolve(outputPath, "standaloneLinux64", out var outputLayout))
+            {
+                throw new InvalidOperationException("Test build target must resolve a BuildPipeline output layout.");
+            }
+
             return new IpcBuildRunRequest(
                 RunId: RunId,
                 BuildTarget: "standaloneLinux64",
@@ -265,7 +326,8 @@ namespace MackySoft.Ucli.Unity.Tests
                 SceneSource: "explicit",
                 ScenePaths: new[] { "Assets/Scenes/SampleScene.unity" },
                 Development: true,
-                OutputPath: Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName),
+                OutputPath: outputPath,
+                OutputLayout: outputLayout!,
                 BuildReportPath: Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildReportFileName),
                 BuildLogPath: Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildLogFileName));
         }

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
@@ -63,6 +63,83 @@ namespace MackySoft.Ucli.Unity.Tests
             }
         }
 
+        [TestCase("missing")]
+        [TestCase("shapeMismatch")]
+        [TestCase("unsupportedTarget")]
+        [Category("Size.Small")]
+        public void TryValidateRequest_WithInvalidOutputLayout_ReturnsFalse (string scenario)
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var request = CreateRequest(scope.ProjectPath, identity);
+                request = scenario switch
+                {
+                    "missing" => request with
+                    {
+                        OutputLayout = null!,
+                    },
+                    "shapeMismatch" => request with
+                    {
+                        OutputLayout = request.OutputLayout with
+                        {
+                            Shape = ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.Directory),
+                        },
+                    },
+                    "unsupportedTarget" => request with
+                    {
+                        BuildTarget = "switch",
+                        UnityBuildTarget = "Switch",
+                    },
+                    _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, "Unsupported output layout validation scenario."),
+                };
+
+                var result = BuildRunUnityIpcMethodHandler.TryValidateRequest(request, identity, out var errorMessage);
+
+                Assert.That(result, Is.False);
+                Assert.That(errorMessage, Does.Contain("outputLayout"));
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void TryValidateRequest_WithUnknownBuildTarget_ReturnsFalse ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var request = CreateRequest(scope.ProjectPath, identity) with
+                {
+                    BuildTarget = "unknownTarget",
+                    UnityBuildTarget = "UnknownTarget",
+                };
+
+                var result = BuildRunUnityIpcMethodHandler.TryValidateRequest(request, identity, out var errorMessage);
+
+                Assert.That(result, Is.False);
+                Assert.That(errorMessage, Does.Contain("buildTarget"));
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public void TryValidateRequest_WithMismatchedUnityBuildTarget_ReturnsFalse ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var request = CreateRequest(scope.ProjectPath, identity) with
+                {
+                    UnityBuildTarget = "StandaloneWindows64",
+                };
+
+                var result = BuildRunUnityIpcMethodHandler.TryValidateRequest(request, identity, out var errorMessage);
+
+                Assert.That(result, Is.False);
+                Assert.That(errorMessage, Does.Contain("UnityBuildTarget"));
+            }
+        }
+
         [TestCase("output")]
         [TestCase("report")]
         [TestCase("log")]
@@ -134,6 +211,85 @@ namespace MackySoft.Ucli.Unity.Tests
                 var ipcRequest = CreateIpcRequest(payload);
 
                 var response = await handler.HandleAsync(ipcRequest, CancellationToken.None);
+
+                Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+                Assert.That(response.Errors.Count, Is.EqualTo(1));
+                Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
+                Assert.That(readinessGate.EnsureExecutionReadyCallCount, Is.EqualTo(0));
+                Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
+                Assert.That(buildPipelineRunner.CallCount, Is.EqualTo(0));
+                Assert.That(logRangeExporter.CallCount, Is.EqualTo(0));
+                Assert.That(timeoutScopeFactory.CallCount, Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task HandleAsync_WithMismatchedUnityBuildTarget_ReturnsInvalidArgumentWithoutSideEffects ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var readinessGate = new CountingReadinessGate();
+                var buildPipelineRunner = new CountingBuildPipelineRunner();
+                var logRangeExporter = new CountingEditorLogRangeExporter();
+                var timeoutScopeFactory = new CountingTimeoutScopeFactory();
+                var handler = new BuildRunUnityIpcMethodHandler(
+                    new UnityBuildPreconditionProbe(
+                        readinessGate,
+                        identity,
+                        new StubServerVersionProvider("1.2.3"),
+                        new CountingBuildTargetSupportProbe()),
+                    buildPipelineRunner,
+                    logRangeExporter,
+                    identity,
+                    timeoutScopeFactory);
+                var payload = CreateRequest(scope.ProjectPath, identity) with
+                {
+                    UnityBuildTarget = "StandaloneWindows64",
+                };
+
+                var response = await handler.HandleAsync(CreateIpcRequest(payload), CancellationToken.None);
+
+                Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
+                Assert.That(response.Errors.Count, Is.EqualTo(1));
+                Assert.That(response.Errors[0].Code, Is.EqualTo(UcliCoreErrorCodes.InvalidArgument));
+                Assert.That(readinessGate.EnsureExecutionReadyCallCount, Is.EqualTo(0));
+                Assert.That(readinessGate.CaptureSnapshotCallCount, Is.EqualTo(0));
+                Assert.That(buildPipelineRunner.CallCount, Is.EqualTo(0));
+                Assert.That(logRangeExporter.CallCount, Is.EqualTo(0));
+                Assert.That(timeoutScopeFactory.CallCount, Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        [Category("Size.Small")]
+        public async Task HandleAsync_WithUnknownBuildTarget_ReturnsInvalidArgumentWithoutSideEffects ()
+        {
+            using (var scope = TemporaryDirectoryScope.Create())
+            {
+                var identity = CreateProjectIdentity(scope.ProjectPath);
+                var readinessGate = new CountingReadinessGate();
+                var buildPipelineRunner = new CountingBuildPipelineRunner();
+                var logRangeExporter = new CountingEditorLogRangeExporter();
+                var timeoutScopeFactory = new CountingTimeoutScopeFactory();
+                var handler = new BuildRunUnityIpcMethodHandler(
+                    new UnityBuildPreconditionProbe(
+                        readinessGate,
+                        identity,
+                        new StubServerVersionProvider("1.2.3"),
+                        new CountingBuildTargetSupportProbe()),
+                    buildPipelineRunner,
+                    logRangeExporter,
+                    identity,
+                    timeoutScopeFactory);
+                var payload = CreateRequest(scope.ProjectPath, identity) with
+                {
+                    BuildTarget = "unknownTarget",
+                    UnityBuildTarget = "UnknownTarget",
+                };
+
+                var response = await handler.HandleAsync(CreateIpcRequest(payload), CancellationToken.None);
 
                 Assert.That(response.Status, Is.EqualTo(IpcProtocol.StatusError));
                 Assert.That(response.Errors.Count, Is.EqualTo(1));

--- a/src/Ucli/Features/Assurance/Build/BuildRunMetadataDocumentWriter.cs
+++ b/src/Ucli/Features/Assurance/Build/BuildRunMetadataDocumentWriter.cs
@@ -32,6 +32,7 @@ internal sealed class BuildRunMetadataDocumentWriter
             writer.WriteString("runId", document.RunId);
             WriteElement(writer, "project", document.Project);
             WriteElement(writer, "profile", document.Profile);
+            WriteElement(writer, "runner", document.Runner);
             WriteElement(writer, "input", document.Input);
             WriteElement(writer, "lifecycle", document.Lifecycle);
             WriteElement(writer, "generations", document.Generations);

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -6,6 +6,7 @@ using MackySoft.Ucli.Application.Shared.Context.Project;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Cryptography;
+using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Infrastructure.Cryptography;
 using MackySoft.Ucli.Infrastructure.Paths;
@@ -73,6 +74,59 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         {
             return BuildRunArtifactPreparationResult.Failure(ExecutionError.InternalError(
                 $"Failed to prepare build artifact directory. {exception.Message}",
+                BuildErrorCodes.BuildArtifactWriteFailed));
+        }
+    }
+
+    /// <inheritdoc />
+    public BuildRunArtifactPreparationResult PrepareBuildPipelineOutputLayout (
+        BuildRunArtifactPaths paths,
+        string buildTarget,
+        IpcBuildOutputLayout outputLayout)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        ArgumentException.ThrowIfNullOrWhiteSpace(buildTarget);
+        ArgumentNullException.ThrowIfNull(outputLayout);
+
+        try
+        {
+            EnsureExpectedPathLayout(paths);
+            EnsureExpectedBuildPipelineOutputLayout(paths, buildTarget, outputLayout);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return BuildRunArtifactPreparationResult.Failure(ExecutionError.InvalidArgument(
+                $"BuildPipeline output layout path is invalid. {exception.Message}"));
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BuildRunArtifactPreparationResult.Failure(ExecutionError.InvalidArgument(
+                $"BuildPipeline output layout is invalid. {exception.Message}",
+                BuildErrorCodes.BuildInputsInvalid));
+        }
+
+        try
+        {
+            var parentDirectory = Path.GetDirectoryName(outputLayout.LocationPathName);
+            if (string.IsNullOrWhiteSpace(parentDirectory))
+            {
+                throw new InvalidOperationException(
+                    $"BuildPipeline output parent directory could not be resolved: {outputLayout.LocationPathName}");
+            }
+
+            FileSystemAccessBoundary.EnsureSecureDirectory(parentDirectory);
+            EnsureBuildPipelineOutputTargetDoesNotExist(outputLayout.LocationPathName);
+            return BuildRunArtifactPreparationResult.Success(paths);
+        }
+        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
+        {
+            return BuildRunArtifactPreparationResult.Failure(ExecutionError.InvalidArgument(
+                $"BuildPipeline output layout path is invalid. {exception.Message}"));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            return BuildRunArtifactPreparationResult.Failure(ExecutionError.InternalError(
+                $"Failed to prepare BuildPipeline output layout. {exception.Message}",
                 BuildErrorCodes.BuildArtifactWriteFailed));
         }
     }
@@ -321,6 +375,47 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
             artifactsDirectory,
             paths.OutputDirectory,
             UcliStoragePathNames.BuildOutputDirectoryName);
+    }
+
+    private static void EnsureExpectedBuildPipelineOutputLayout (
+        BuildRunArtifactPaths paths,
+        string buildTarget,
+        IpcBuildOutputLayout outputLayout)
+    {
+        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, buildTarget, out var expectedLayout))
+        {
+            throw new InvalidOperationException($"Build target does not have a deterministic BuildPipeline output layout: {buildTarget}");
+        }
+
+        if (!string.Equals(outputLayout.Shape, expectedLayout!.Shape, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"BuildPipeline output layout shape must be {expectedLayout.Shape}: {outputLayout.Shape}");
+        }
+
+        var actualLocationPathName = Path.GetFullPath(outputLayout.LocationPathName);
+        var expectedLocationPathName = Path.GetFullPath(expectedLayout.LocationPathName);
+        if (!string.Equals(actualLocationPathName, expectedLocationPathName, GetPathComparison()))
+        {
+            throw new InvalidOperationException(
+                $"BuildPipeline output locationPathName must be {expectedLocationPathName}: {outputLayout.LocationPathName}");
+        }
+    }
+
+    private static void EnsureBuildPipelineOutputTargetDoesNotExist (string locationPathName)
+    {
+        if (!File.Exists(locationPathName) && !Directory.Exists(locationPathName))
+        {
+            return;
+        }
+
+        var attributes = File.GetAttributes(locationPathName);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException($"BuildPipeline output target must not be a reparse point: {locationPathName}");
+        }
+
+        throw new IOException($"BuildPipeline output target already exists: {locationPathName}");
     }
 
     private static void EnsureExpectedArtifactsDirectory (

--- a/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
@@ -46,6 +46,7 @@ internal sealed class UnityIpcRequestBuilder
                     ScenePaths: buildRun.ScenePaths,
                     Development: buildRun.Development,
                     OutputPath: buildRun.OutputPath,
+                    OutputLayout: buildRun.OutputLayout,
                     BuildReportPath: buildRun.BuildReportPath,
                     BuildLogPath: buildRun.BuildLogPath)),
                 dispatchTimeoutPayloadTransformer: ApplyBuildRunDispatchTimeout),

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildProfileResolverTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildProfileResolverTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Cryptography;
 
 namespace MackySoft.Ucli.Application.Tests.Features.Assurance.Build;

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -136,7 +136,7 @@ public sealed class BuildServiceTests
         Assert.Equal(0, artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("environment").GetArrayLength());
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("shape").GetString());
         Assert.Equal(
-            Path.Combine(preparedPaths.OutputDirectory, "player", "Player"),
+            CreateExpectedPlayerLocationPathName(preparedPaths.OutputDirectory),
             artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal(output.Build.Summary.ReportRef, artifactStore.WrittenMetadata.Summary.GetProperty("reportRef").GetString());
         Assert.Equal(output.Build.Logs.ReportRef, artifactStore.WrittenMetadata.Logs.GetProperty("reportRef").GetString());
@@ -185,7 +185,7 @@ public sealed class BuildServiceTests
         Assert.True(requestPayload.Development);
         Assert.Equal(preparedPaths.OutputDirectory, requestPayload.OutputPath);
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), requestPayload.OutputLayout.Shape);
-        Assert.Equal(Path.Combine(preparedPaths.OutputDirectory, "player", "Player"), requestPayload.OutputLayout.LocationPathName);
+        Assert.Equal(CreateExpectedPlayerLocationPathName(preparedPaths.OutputDirectory), requestPayload.OutputLayout.LocationPathName);
         Assert.Equal(preparedPaths.BuildReportJsonPath, requestPayload.BuildReportPath);
         Assert.Equal(preparedPaths.BuildLogPath, requestPayload.BuildLogPath);
     }
@@ -866,6 +866,13 @@ public sealed class BuildServiceTests
         return new AssuranceSemanticInvariantValidator(
             new CodeCatalogModel([new BuildCodeCatalogContributor()]),
             [new BuildAssuranceSemanticInvariantRule()]);
+    }
+
+    private static string CreateExpectedPlayerLocationPathName (string outputDirectory)
+    {
+        return string.Concat(
+            outputDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            "/player/Player");
     }
 
     private static void AssertProgressEvents (

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -130,6 +130,14 @@ public sealed class BuildServiceTests
             artifactStore.WrittenMetadata!.Summary.GetProperty("result").GetString());
         Assert.Equal(output.Build.Profile.Path, artifactStore.WrittenMetadata.Profile.GetProperty("path").GetString());
         Assert.Equal(expectedProfileDigest, artifactStore.WrittenMetadata.Profile.GetProperty("digest").GetString());
+        Assert.Equal("buildPipeline", artifactStore.WrittenMetadata.Runner.GetProperty("kind").GetString());
+        Assert.Equal(JsonValueKind.Null, artifactStore.WrittenMetadata.Runner.GetProperty("method").ValueKind);
+        Assert.Equal("{}", artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("arguments").GetRawText());
+        Assert.Equal(0, artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("environment").GetArrayLength());
+        Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("shape").GetString());
+        Assert.Equal(
+            Path.Combine(preparedPaths.OutputDirectory, "player", "Player"),
+            artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal(output.Build.Summary.ReportRef, artifactStore.WrittenMetadata.Summary.GetProperty("reportRef").GetString());
         Assert.Equal(output.Build.Logs.ReportRef, artifactStore.WrittenMetadata.Logs.GetProperty("reportRef").GetString());
         Assert.Equal(output.Build.Output.ManifestRef, artifactStore.WrittenMetadata.Output.GetProperty("manifestRef").GetString());
@@ -176,6 +184,8 @@ public sealed class BuildServiceTests
         Assert.Equal(["Assets/Scenes/Main.unity"], requestPayload.ScenePaths);
         Assert.True(requestPayload.Development);
         Assert.Equal(preparedPaths.OutputDirectory, requestPayload.OutputPath);
+        Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), requestPayload.OutputLayout.Shape);
+        Assert.Equal(Path.Combine(preparedPaths.OutputDirectory, "player", "Player"), requestPayload.OutputLayout.LocationPathName);
         Assert.Equal(preparedPaths.BuildReportJsonPath, requestPayload.BuildReportPath);
         Assert.Equal(preparedPaths.BuildLogPath, requestPayload.BuildLogPath);
     }
@@ -588,6 +598,62 @@ public sealed class BuildServiceTests
         Assert.Null(result.Output);
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithBuildTargetWithoutDeterministicBuildPipelineOutputLayout_ReturnsBuildInputsInvalid ()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        const string profileJson = """
+            {
+              "schemaVersion": 1,
+              "inputs": {
+                "kind": "explicit",
+                "buildTarget": "switch",
+                "scenes": {
+                  "source": "explicit",
+                  "paths": [
+                    "Assets/Scenes/Main.unity"
+                  ]
+                },
+                "options": {
+                  "development": true
+                }
+              },
+              "runner": {
+                "kind": "buildPipeline"
+              },
+              "policy": {
+                "runtime": {
+                  "allowedExecutionModes": [
+                    "daemon",
+                    "oneshot"
+                  ],
+                  "allowedEditorModes": [
+                    "batchmode",
+                    "gui"
+                  ]
+                },
+                "projectMutationMode": "forbid"
+              }
+            }
+            """;
+        var requestExecutor = CreateBuildResponseExecutor(
+            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+            ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
+            errorCount: 0);
+        var service = CreateService(
+            profileFileReader: new StubBuildProfileFileReader(BuildProfileFileReadResult.Success(profileJson, "/workspace/build.ucli.json")),
+            requestExecutor: requestExecutor,
+            artifactStore: new StubBuildRunArtifactStore(tempDirectory.Path));
+
+        var result = await service.ExecuteAsync(CreateInput());
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(BuildErrorCodes.BuildInputsInvalid, error.Code);
+        Assert.Null(requestExecutor.CapturedPayload);
+    }
+
     private static BuildService CreateService (
         IBuildRunArtifactStore artifactStore,
         IProjectContextResolver? projectContextResolver = null,
@@ -666,7 +732,7 @@ public sealed class BuildServiceTests
                 buildOptions,
                 lifecycleBefore,
                 lifecycleAfter,
-                reportOutputPath: reportOutputPath ?? Path.Combine(buildRunPayload.OutputPath, "build"));
+                reportOutputPath: reportOutputPath ?? buildRunPayload.OutputLayout.LocationPathName);
         });
     }
 
@@ -695,7 +761,7 @@ public sealed class BuildServiceTests
                     SchemaVersion: 1,
                     Result: reportResult,
                     UnityBuildTarget: unityBuildTarget ?? "StandaloneLinux64",
-                    OutputPath: reportOutputPath ?? "/workspace/.ucli/output/build",
+                    OutputPath: reportOutputPath ?? "/workspace/.ucli/output/player/Player",
                     DurationMilliseconds: 2500,
                     TotalSizeBytes: 4096,
                     ErrorCount: errorCount,
@@ -961,6 +1027,8 @@ public sealed class BuildServiceTests
 
         public BuildRunArtifactAccountingRequest? AccountingRequest { get; private set; }
 
+        public IpcBuildOutputLayout? PreparedOutputLayout { get; private set; }
+
         public BuildRunArtifactPreparationResult Prepare (
             ResolvedUnityProjectContext unityProject,
             string runId)
@@ -978,6 +1046,15 @@ public sealed class BuildServiceTests
                 OutputManifestJsonPath: Path.Combine(runDirectory, "output-manifest.json"),
                 OutputDirectory: outputDirectory);
             return BuildRunArtifactPreparationResult.Success(PreparedPaths);
+        }
+
+        public BuildRunArtifactPreparationResult PrepareBuildPipelineOutputLayout (
+            BuildRunArtifactPaths paths,
+            string buildTarget,
+            IpcBuildOutputLayout outputLayout)
+        {
+            PreparedOutputLayout = outputLayout;
+            return BuildRunArtifactPreparationResult.Success(paths);
         }
 
         public ValueTask<BuildRunArtifactAccountingOperationResult> AccountArtifactsAsync (

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildTargetStableNameCodecTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildTargetStableNameCodecTests.cs
@@ -5,23 +5,18 @@ namespace MackySoft.Ucli.Application.Tests.Features.Assurance.Build;
 
 public sealed class BuildTargetStableNameCodecTests
 {
-    [Theory]
-    [MemberData(nameof(SupportedTargetCases))]
+    [Fact]
     [Trait("Size", "Small")]
-    public void TryResolve_WithSupportedTarget_ReturnsResolvedTarget (
-        string stableName,
-        string expectedStableNameValueName,
-        string expectedUnityBuildTargetLiteral)
+    public void TryResolve_WithSupportedTarget_ReturnsResolvedTarget ()
     {
-        var expectedStableNameValue = Enum.Parse<BuildTargetStableName>(expectedStableNameValueName);
+        const string stableName = "standaloneLinux64";
 
         var resolved = BuildTargetStableNameCodec.TryResolve(stableName, out var target);
 
         Assert.True(resolved);
-        Assert.Equal(expectedStableNameValue, target.StableNameValue);
+        Assert.Equal(BuildTargetStableName.StandaloneLinux64, target.StableNameValue);
         Assert.Equal(stableName, target.StableName);
-        Assert.Equal(ContractLiteralCodec.ToValue(expectedStableNameValue), target.StableName);
-        Assert.Equal(expectedUnityBuildTargetLiteral, target.UnityBuildTargetLiteral);
+        Assert.Equal("StandaloneLinux64", target.UnityBuildTargetLiteral);
     }
 
     [Fact]
@@ -30,36 +25,25 @@ public sealed class BuildTargetStableNameCodecTests
     {
         foreach (var stableName in ContractLiteralCodec.GetLiterals<BuildTargetStableName>())
         {
+            var expectedStableNameValueResolved = ContractLiteralCodec.TryParse<BuildTargetStableName>(stableName, out var expectedStableNameValue);
+
             var resolved = BuildTargetStableNameCodec.TryResolve(stableName, out var target);
 
+            Assert.True(expectedStableNameValueResolved);
             Assert.True(resolved, $"Build target stable name '{stableName}' must resolve.");
+            Assert.Equal(expectedStableNameValue, target.StableNameValue);
             Assert.Equal(stableName, target.StableName);
+            Assert.False(string.IsNullOrWhiteSpace(target.UnityBuildTargetLiteral));
         }
     }
 
-    public static TheoryData<string, string, string> SupportedTargetCases ()
+    [Fact]
+    [Trait("Size", "Small")]
+    public void TryResolve_WithUnsupportedTarget_ReturnsFalse ()
     {
-        return new TheoryData<string, string, string>
-        {
-            { "standaloneOSX", nameof(BuildTargetStableName.StandaloneOsx), "StandaloneOSX" },
-            { "standaloneWindows", nameof(BuildTargetStableName.StandaloneWindows), "StandaloneWindows" },
-            { "standaloneWindows64", nameof(BuildTargetStableName.StandaloneWindows64), "StandaloneWindows64" },
-            { "standaloneLinux64", nameof(BuildTargetStableName.StandaloneLinux64), "StandaloneLinux64" },
-            { "ios", nameof(BuildTargetStableName.Ios), "iOS" },
-            { "android", nameof(BuildTargetStableName.Android), "Android" },
-            { "webgl", nameof(BuildTargetStableName.Webgl), "WebGL" },
-            { "wsaPlayer", nameof(BuildTargetStableName.WsaPlayer), "WSAPlayer" },
-            { "tvos", nameof(BuildTargetStableName.Tvos), "tvOS" },
-            { "switch", nameof(BuildTargetStableName.Switch), "Switch" },
-            { "linuxHeadlessSimulation", nameof(BuildTargetStableName.LinuxHeadlessSimulation), "LinuxHeadlessSimulation" },
-            { "gameCoreXboxSeries", nameof(BuildTargetStableName.GameCoreXboxSeries), "GameCoreXboxSeries" },
-            { "gameCoreXboxOne", nameof(BuildTargetStableName.GameCoreXboxOne), "GameCoreXboxOne" },
-            { "ps4", nameof(BuildTargetStableName.Ps4), "PS4" },
-            { "ps5", nameof(BuildTargetStableName.Ps5), "PS5" },
-            { "xboxOne", nameof(BuildTargetStableName.XboxOne), "XboxOne" },
-            { "embeddedLinux", nameof(BuildTargetStableName.EmbeddedLinux), "EmbeddedLinux" },
-            { "qnx", nameof(BuildTargetStableName.Qnx), "QNX" },
-            { "visionOS", nameof(BuildTargetStableName.VisionOs), "VisionOS" },
-        };
+        var resolved = BuildTargetStableNameCodec.TryResolve("unknownTarget", out var target);
+
+        Assert.False(resolved);
+        Assert.Null(target);
     }
 }

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildTargetStableNameCodecTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildTargetStableNameCodecTests.cs
@@ -1,4 +1,5 @@
 using MackySoft.Ucli.Application.Features.Assurance.Build.Profiles;
+using MackySoft.Ucli.Contracts.Assurance.Build;
 
 namespace MackySoft.Ucli.Application.Tests.Features.Assurance.Build;
 

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolverTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolverTests.cs
@@ -1,0 +1,75 @@
+using MackySoft.Ucli.Contracts.Assurance.Build;
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Tests.Assurance.Build;
+
+public sealed class BuildTargetStableNameUnityBuildTargetResolverTests
+{
+    [Theory]
+    [MemberData(nameof(SupportedTargetCases))]
+    [Trait("Size", "Small")]
+    public void TryResolve_WithSupportedStableName_ReturnsUnityBuildTargetLiteral (
+        string stableName,
+        BuildTargetStableName stableNameValue,
+        string expectedUnityBuildTargetLiteral)
+    {
+        var stringResolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var stringLiteral);
+        var enumResolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableNameValue, out var enumLiteral);
+
+        Assert.True(stringResolved);
+        Assert.Equal(expectedUnityBuildTargetLiteral, stringLiteral);
+        Assert.True(enumResolved);
+        Assert.Equal(expectedUnityBuildTargetLiteral, enumLiteral);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void TryResolve_SupportsEveryBuildTargetStableNameLiteral ()
+    {
+        foreach (var stableName in ContractLiteralCodec.GetLiterals<BuildTargetStableName>())
+        {
+            var resolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var unityBuildTargetLiteral);
+
+            Assert.True(resolved, $"Build target stable name '{stableName}' must resolve.");
+            Assert.False(string.IsNullOrWhiteSpace(unityBuildTargetLiteral));
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("unknownTarget")]
+    [Trait("Size", "Small")]
+    public void TryResolve_WithUnsupportedStableName_ReturnsFalse (string stableName)
+    {
+        var resolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var unityBuildTargetLiteral);
+
+        Assert.False(resolved);
+        Assert.Null(unityBuildTargetLiteral);
+    }
+
+    public static TheoryData<string, BuildTargetStableName, string> SupportedTargetCases ()
+    {
+        return new TheoryData<string, BuildTargetStableName, string>
+        {
+            { "standaloneOSX", BuildTargetStableName.StandaloneOsx, "StandaloneOSX" },
+            { "standaloneWindows", BuildTargetStableName.StandaloneWindows, "StandaloneWindows" },
+            { "standaloneWindows64", BuildTargetStableName.StandaloneWindows64, "StandaloneWindows64" },
+            { "standaloneLinux64", BuildTargetStableName.StandaloneLinux64, "StandaloneLinux64" },
+            { "ios", BuildTargetStableName.Ios, "iOS" },
+            { "android", BuildTargetStableName.Android, "Android" },
+            { "webgl", BuildTargetStableName.Webgl, "WebGL" },
+            { "wsaPlayer", BuildTargetStableName.WsaPlayer, "WSAPlayer" },
+            { "tvos", BuildTargetStableName.Tvos, "tvOS" },
+            { "switch", BuildTargetStableName.Switch, "Switch" },
+            { "linuxHeadlessSimulation", BuildTargetStableName.LinuxHeadlessSimulation, "LinuxHeadlessSimulation" },
+            { "gameCoreXboxSeries", BuildTargetStableName.GameCoreXboxSeries, "GameCoreXboxSeries" },
+            { "gameCoreXboxOne", BuildTargetStableName.GameCoreXboxOne, "GameCoreXboxOne" },
+            { "ps4", BuildTargetStableName.Ps4, "PS4" },
+            { "ps5", BuildTargetStableName.Ps5, "PS5" },
+            { "xboxOne", BuildTargetStableName.XboxOne, "XboxOne" },
+            { "embeddedLinux", BuildTargetStableName.EmbeddedLinux, "EmbeddedLinux" },
+            { "qnx", BuildTargetStableName.Qnx, "QNX" },
+            { "visionOS", BuildTargetStableName.VisionOs, "VisionOS" },
+        };
+    }
+}

--- a/tests/Ucli.Contracts.Tests/Ipc/Methods/Build/IpcBuildOutputLayoutResolverTests.cs
+++ b/tests/Ucli.Contracts.Tests/Ipc/Methods/Build/IpcBuildOutputLayoutResolverTests.cs
@@ -1,0 +1,48 @@
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Tests.Ipc;
+
+public sealed class IpcBuildOutputLayoutResolverTests
+{
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("standaloneOSX", IpcBuildOutputLayoutShape.AppBundle, "Player.app")]
+    [InlineData("standaloneWindows", IpcBuildOutputLayoutShape.File, "Player.exe")]
+    [InlineData("standaloneWindows64", IpcBuildOutputLayoutShape.File, "Player.exe")]
+    [InlineData("standaloneLinux64", IpcBuildOutputLayoutShape.File, "Player")]
+    [InlineData("android", IpcBuildOutputLayoutShape.File, "Player.apk")]
+    [InlineData("ios", IpcBuildOutputLayoutShape.Directory, "Player")]
+    [InlineData("tvos", IpcBuildOutputLayoutShape.Directory, "Player")]
+    [InlineData("webgl", IpcBuildOutputLayoutShape.Directory, "Player")]
+    public void TryResolve_WithSupportedTarget_ReturnsCommandDerivedPlayerLayout (
+        string buildTarget,
+        IpcBuildOutputLayoutShape expectedShape,
+        string expectedFileName)
+    {
+        var outputDirectory = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "ucli", "output"));
+
+        var resolved = IpcBuildOutputLayoutResolver.TryResolve(outputDirectory, buildTarget, out var layout);
+
+        Assert.True(resolved);
+        Assert.NotNull(layout);
+        Assert.Equal(ContractLiteralCodec.ToValue(expectedShape), layout!.Shape);
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(outputDirectory, "player", expectedFileName)),
+            Path.GetFullPath(layout.LocationPathName));
+    }
+
+    [Theory]
+    [InlineData("switch")]
+    [InlineData("unknownTarget")]
+    [Trait("Size", "Small")]
+    public void TryResolve_WithUnsupportedTarget_ReturnsFalse (string buildTarget)
+    {
+        var outputDirectory = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "ucli", "output"));
+
+        var resolved = IpcBuildOutputLayoutResolver.TryResolve(outputDirectory, buildTarget, out var layout);
+
+        Assert.False(resolved);
+        Assert.Null(layout);
+    }
+}

--- a/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
+++ b/tests/Ucli.Contracts.Tests/Ipc/Protocol/IpcContractSerializationTests.cs
@@ -274,6 +274,9 @@ public sealed class IpcContractSerializationTests
                 ScenePaths: ["Assets/Scenes/Main.unity"],
                 Development: true,
                 OutputPath: "/tmp/ucli/output",
+                OutputLayout: new IpcBuildOutputLayout(
+                    Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+                    LocationPathName: "/tmp/ucli/output/player/Player"),
                 BuildReportPath: "/tmp/ucli/build-report.json",
                 BuildLogPath: "/tmp/ucli/build.log")
             {
@@ -337,6 +340,9 @@ public sealed class IpcContractSerializationTests
                 .HasString("Assets/Scenes/Main.unity"))
             .HasBoolean("development", true)
             .HasString("outputPath", "/tmp/ucli/output")
+            .HasProperty("outputLayout", outputLayout => outputLayout
+                .HasString("shape", ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File))
+                .HasString("locationPathName", "/tmp/ucli/output/player/Player"))
             .HasString("buildReportPath", "/tmp/ucli/build-report.json")
             .HasString("buildLogPath", "/tmp/ucli/build.log")
             .HasInt32("timeoutMilliseconds", 1234);

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -124,6 +124,26 @@ public sealed class FileBuildRunArtifactStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void PrepareBuildPipelineOutputLayout_WhenPlayerParentCannotBeCreated_ReturnsBuildArtifactWriteFailed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "prepare-player-parent-blocked");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
+        WriteUtf8(Path.Combine(paths.OutputDirectory, "player"), "blocking file");
+
+        var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout!);
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildArtifactWriteFailed, error.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void PrepareBuildPipelineOutputLayout_WhenTargetLayoutIsUnsupported_ReturnsBuildInputsInvalid ()
     {
         using var scope = TestDirectories.CreateTempScope("build-artifact-store", "prepare-player-unsupported");

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -6,6 +6,7 @@ using MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Cryptography;
+using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
 using MackySoft.Ucli.Features.Assurance.Build;
 using MackySoft.Ucli.Infrastructure.Paths;
@@ -80,6 +81,66 @@ public sealed class FileBuildRunArtifactStoreTests
         var error = Assert.IsType<ExecutionError>(result.Error);
         Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
         Assert.Equal(BuildErrorCodes.BuildArtifactWriteFailed, error.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void PrepareBuildPipelineOutputLayout_WithResolvedLayout_CreatesPlayerParentDirectory ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "prepare-player-layout");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
+
+        var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout!);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(Directory.Exists(Path.GetDirectoryName(layout!.LocationPathName)));
+        Assert.False(File.Exists(layout.LocationPathName));
+        Assert.False(Directory.Exists(layout.LocationPathName));
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void PrepareBuildPipelineOutputLayout_WhenLocationPathNameAlreadyExists_ReturnsBuildArtifactWriteFailed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "prepare-player-collision");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
+        WriteUtf8(layout!.LocationPathName, "existing player");
+
+        var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout);
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildArtifactWriteFailed, error.Code);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void PrepareBuildPipelineOutputLayout_WhenTargetLayoutIsUnsupported_ReturnsBuildInputsInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "prepare-player-unsupported");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        var layout = new IpcBuildOutputLayout(
+            Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+            LocationPathName: Path.Combine(paths.OutputDirectory, "player", "Player"));
+
+        var result = store.PrepareBuildPipelineOutputLayout(paths, "switch", layout);
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(result.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildInputsInvalid, error.Code);
     }
 
     [Fact]
@@ -174,6 +235,11 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.False(buildRoot.GetProperty("output").TryGetProperty("kind", out _));
         Assert.False(buildRoot.GetProperty("output").TryGetProperty("artifactRoot", out _));
         Assert.False(buildRoot.GetProperty("output").TryGetProperty("outputRoot", out _));
+        Assert.Equal("buildPipeline", buildRoot.GetProperty("runner").GetProperty("kind").GetString());
+        Assert.Equal("file", buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("shape").GetString());
+        Assert.Equal(
+            "/repo/.ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output/player/Player",
+            buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal("standaloneLinux64", buildRoot.GetProperty("input").GetProperty("buildTarget").GetProperty("stableName").GetString());
 
         var artifacts = buildRoot.GetProperty("artifacts");
@@ -441,6 +507,7 @@ public sealed class FileBuildRunArtifactStoreTests
             runId,
             ParseJsonElement("""{"projectPath":"/repo/UnityProject","projectFingerprint":"fingerprint","unityVersion":"6000.1.4f1"}"""),
             ParseJsonElement("""{"path":"/repo/.ucli/build/player.json","digest":"profile-digest"}"""),
+            ParseJsonElement("""{"kind":"buildPipeline","method":null,"invocation":{"arguments":{},"environment":[]},"outputLayout":{"shape":"file","locationPathName":"/repo/.ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output/player/Player"}}"""),
             ParseJsonElement("""{"buildTarget":{"stableName":"standaloneLinux64"}}"""),
             ParseJsonElement("""{"state":"completed"}"""),
             ParseJsonElement("""{"compile":"42","domainReload":"7"}"""),

--- a/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
+++ b/tests/Ucli.Tests/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilderTests.cs
@@ -72,6 +72,9 @@ public sealed class UnityIpcRequestBuilderTests
             ScenePaths: ["Assets/Scenes/Main.unity"],
             Development: true,
             OutputPath: "/tmp/ucli/output",
+            OutputLayout: new IpcBuildOutputLayout(
+                Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+                LocationPathName: "/tmp/ucli/output/player/Player"),
             BuildReportPath: "/tmp/ucli/build-report.json",
             BuildLogPath: "/tmp/ucli/build.log"));
 
@@ -85,6 +88,8 @@ public sealed class UnityIpcRequestBuilderTests
         Assert.Equal(["Assets/Scenes/Main.unity"], payload.ScenePaths);
         Assert.True(payload.Development);
         Assert.Equal("/tmp/ucli/output", payload.OutputPath);
+        Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), payload.OutputLayout.Shape);
+        Assert.Equal("/tmp/ucli/output/player/Player", payload.OutputLayout.LocationPathName);
         Assert.Equal("/tmp/ucli/build-report.json", payload.BuildReportPath);
         Assert.Equal("/tmp/ucli/build.log", payload.BuildLogPath);
         Assert.Null(payload.TimeoutMilliseconds);
@@ -188,6 +193,9 @@ public sealed class UnityIpcRequestBuilderTests
             ScenePaths: ["Assets/Scenes/Main.unity"],
             Development: false,
             OutputPath: "/tmp/ucli/output",
+            OutputLayout: new IpcBuildOutputLayout(
+                Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
+                LocationPathName: "/tmp/ucli/output/player/Player"),
             BuildReportPath: "/tmp/ucli/build-report.json",
             BuildLogPath: "/tmp/ucli/build.log"));
 


### PR DESCRIPTION
## Summary
- Resolves BuildPipeline output layout on the CLI side from the command contract instead of relying on Unity-side inference.
- Sends the same `outputLayout` through IPC and persists it under `build.json.runner.outputLayout`.
- Keeps BuildPipeline output under the runner working output root at `output/player/...` and rejects unsupported deterministic layouts before Unity invocation.

## Scope
- Contracts: added `IpcBuildOutputLayout`, `IpcBuildOutputLayoutShape`, `IpcBuildOutputLayoutResolver`, and moved `BuildTargetStableName` into the contract vocabulary so layout resolution uses `ContractLiteralCodec` for both target and shape literals.
- CLI application and artifact store: resolves output layout, prepares the output parent directory, maps target collisions to `BUILD_ARTIFACT_WRITE_FAILED`, and writes runner metadata to `build.json`.
- Unity editor integration: validates the requested output layout and passes `request.OutputLayout.LocationPathName` directly into `BuildPlayerOptions.locationPathName`.
- Tests: added and updated .NET and Unity editor coverage for resolver mappings, IPC serialization, BuildService propagation, artifact preparation failures, Unity request validation, and BuildPlayerOptions creation.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh`; `bash scripts/verify.sh --include-unity --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`)
- Coverage: N/A

## Risks / Rollback
- Risk: BuildPipeline output paths now reject targets without a deterministic command-derived layout; this is intentional and maps to `BUILD_INPUTS_INVALID`.
- Risk: Existing files or directories at the resolved `output/player/...` target now fail before the build with `BUILD_ARTIFACT_WRITE_FAILED`.
- Rollback: revert the two commits in this PR to restore the previous Unity-side layout inference behavior.

## Checklist
- [x] CLI-derived output layout is sent over IPC.
- [x] `build.json.runner.outputLayout` stores the resolved layout.
- [x] Unity uses the request layout for `BuildPlayerOptions.locationPathName`.
- [x] .NET and Unity editor verification passed.

Closes #401
