### PR TITLE
[build] Implement final build output artifact accounting

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildOutputSourceEntry.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildOutputSourceEntry.cs
@@ -1,0 +1,6 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
+
+/// <summary> Represents one resolved runner output source candidate for artifact-store ingestion. </summary>
+/// <param name="SourcePath"> The absolute source file or directory path before artifact-store ingestion. </param>
+internal sealed record BuildOutputSourceEntry (
+    string SourcePath);

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactAccountingRequest.cs
@@ -2,9 +2,13 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 
 /// <summary> Represents inputs needed to account non-metadata build-run artifacts. </summary>
 /// <param name="Paths"> The prepared artifact layout. </param>
-/// <param name="ReportedOutputPath"> The output path reported by Unity's normalized BuildReport. </param>
 /// <param name="BuildTarget"> The resolved buildTarget stable name. </param>
+/// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> enum member name. </param>
+/// <param name="OutputSources"> The output source entries to ingest into the artifact store. </param>
+/// <param name="AllowEmptyOutputManifest"> Whether no existing output sources may produce a valid empty manifest. </param>
 internal sealed record BuildRunArtifactAccountingRequest (
     BuildRunArtifactPaths Paths,
-    string ReportedOutputPath,
-    string BuildTarget);
+    string BuildTarget,
+    string UnityBuildTarget,
+    IReadOnlyList<BuildOutputSourceEntry> OutputSources,
+    bool AllowEmptyOutputManifest);

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
@@ -8,7 +8,8 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <param name="BuildReportJsonPath"> The absolute <c>build-report.json</c> path. </param>
 /// <param name="BuildLogPath"> The absolute <c>build.log</c> path. </param>
 /// <param name="OutputManifestJsonPath"> The absolute <c>output-manifest.json</c> path. </param>
-/// <param name="OutputDirectory"> The absolute runner working output root path. </param>
+/// <param name="RunnerOutputDirectory"> The absolute runner working output root path. </param>
+/// <param name="ArtifactOutputDirectory"> The absolute artifact-store output root path. </param>
 internal sealed record BuildRunArtifactPaths (
     string RepositoryRoot,
     string RunId,
@@ -17,4 +18,5 @@ internal sealed record BuildRunArtifactPaths (
     string BuildReportJsonPath,
     string BuildLogPath,
     string OutputManifestJsonPath,
-    string OutputDirectory);
+    string RunnerOutputDirectory,
+    string ArtifactOutputDirectory);

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -231,16 +231,14 @@ internal sealed class BuildService : IBuildService
         var artifactCancellationToken = artifactAccountingCancellationTokenSource.Token;
         try
         {
+            var reportResult = ResolveTerminalBuildReportResult(buildResponse.Report.Result);
             var accountingResult = await artifactStore.AccountArtifactsAsync(
                     new BuildRunArtifactAccountingRequest(
                         paths,
                         profile.BuildTarget.StableName,
                         profile.BuildTarget.UnityBuildTargetLiteral,
                         [new BuildOutputSourceEntry(outputLayout!.LocationPathName)],
-                        !string.Equals(
-                            buildResponse.Report.Result,
-                            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
-                            StringComparison.Ordinal)),
+                        CanWriteEmptyOutputManifest(reportResult)),
                     artifactCancellationToken)
                 .ConfigureAwait(false);
             if (!accountingResult.IsSuccess)
@@ -467,6 +465,11 @@ internal sealed class BuildService : IBuildService
             return ApplicationFailure.InternalError($"Unity build response contains unsupported report result: {response.Report.Result}.");
         }
 
+        if (!IsTerminalBuildReportResult(reportResult))
+        {
+            return ApplicationFailure.InternalError($"Unity build response contains non-terminal report result: {response.Report.Result}.");
+        }
+
         if (!ContractLiteralCodec.TryParse<IpcBuildLogCompletionReason>(response.Logs.CompletionReason, out var completionReason))
         {
             return ApplicationFailure.InternalError($"Unity build response contains unsupported log completionReason: {response.Logs.CompletionReason}.");
@@ -581,6 +584,27 @@ internal sealed class BuildService : IBuildService
         }
 
         return null;
+    }
+
+    private static IpcBuildReportResult ResolveTerminalBuildReportResult (string result)
+    {
+        if (!ContractLiteralCodec.TryParse<IpcBuildReportResult>(result, out var reportResult)
+            || !IsTerminalBuildReportResult(reportResult))
+        {
+            throw new InvalidOperationException($"Build report result is not terminal: {result}");
+        }
+
+        return reportResult;
+    }
+
+    private static bool CanWriteEmptyOutputManifest (IpcBuildReportResult reportResult)
+    {
+        return reportResult is IpcBuildReportResult.Failed or IpcBuildReportResult.Canceled;
+    }
+
+    private static bool IsTerminalBuildReportResult (IpcBuildReportResult reportResult)
+    {
+        return reportResult is IpcBuildReportResult.Succeeded or IpcBuildReportResult.Failed or IpcBuildReportResult.Canceled;
     }
 
     private static ApplicationFailure? ValidateProjectMutationAuditItem (

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -154,7 +154,7 @@ internal sealed class BuildService : IBuildService
         }
 
         var paths = prepareResult.Paths!;
-        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, profile.BuildTarget.StableName, out var outputLayout))
+        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.RunnerOutputDirectory, profile.BuildTarget.StableName, out var outputLayout))
         {
             return BuildExecutionResult.Failure(ExecutionError.InvalidArgument(
                 $"BuildPipeline output layout could not be resolved for build target: {profile.BuildTarget.StableName}.",
@@ -178,7 +178,7 @@ internal sealed class BuildService : IBuildService
                 executionTarget,
                 timeout,
                 profile.BuildTarget.StableName,
-                paths.OutputDirectory,
+                paths.RunnerOutputDirectory,
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -234,8 +234,13 @@ internal sealed class BuildService : IBuildService
             var accountingResult = await artifactStore.AccountArtifactsAsync(
                     new BuildRunArtifactAccountingRequest(
                         paths,
-                        buildResponse.Report.OutputPath,
-                        profile.BuildTarget.StableName),
+                        profile.BuildTarget.StableName,
+                        profile.BuildTarget.UnityBuildTargetLiteral,
+                        [new BuildOutputSourceEntry(outputLayout!.LocationPathName)],
+                        !string.Equals(
+                            buildResponse.Report.Result,
+                            ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
+                            StringComparison.Ordinal)),
                     artifactCancellationToken)
                 .ConfigureAwait(false);
             if (!accountingResult.IsSuccess)
@@ -360,7 +365,7 @@ internal sealed class BuildService : IBuildService
             SceneSource: ContractLiteralCodec.ToValue(profile.Scenes.Source),
             ScenePaths: profile.Scenes.Paths,
             Development: profile.Options.Development,
-            OutputPath: paths.OutputDirectory,
+            OutputPath: paths.RunnerOutputDirectory,
             OutputLayout: outputLayout,
             BuildReportPath: paths.BuildReportJsonPath,
             BuildLogPath: paths.BuildLogPath,

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestContentJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestContentJsonContract.cs
@@ -2,15 +2,17 @@ namespace MackySoft.Ucli.Contracts.Assurance.Build;
 
 /// <summary> Represents the digest source fields of <c>output-manifest.json</c>. </summary>
 /// <param name="SchemaVersion"> The output-manifest schema version. </param>
-/// <param name="OutputRoot"> The build output root path. </param>
-/// <param name="BuildTarget"> The resolved canonical buildTarget literal. </param>
+/// <param name="Target"> The resolved build target identity. </param>
+/// <param name="Entries"> The output source entries in resolved ordinal order. </param>
+/// <param name="EntryCount"> The number of output source entries included in the manifest. </param>
 /// <param name="FileCount"> The number of regular files included in the manifest. </param>
 /// <param name="TotalBytes"> The total byte count for manifest files. </param>
 /// <param name="Files"> The manifest file entries in canonical order. </param>
 internal sealed record BuildOutputManifestContentJsonContract (
     int SchemaVersion,
-    string OutputRoot,
-    string BuildTarget,
+    BuildOutputManifestTargetJsonContract Target,
+    IReadOnlyList<BuildOutputManifestEntryJsonContract> Entries,
+    int EntryCount,
     int FileCount,
     long TotalBytes,
     IReadOnlyList<BuildOutputManifestFileJsonContract> Files);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestEntryJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestEntryJsonContract.cs
@@ -1,0 +1,10 @@
+namespace MackySoft.Ucli.Contracts.Assurance.Build;
+
+/// <summary> Represents one output source entry in <c>output-manifest.json</c>. </summary>
+/// <param name="Id"> The manifest entry id. </param>
+/// <param name="Kind"> The resolved output source filesystem shape. </param>
+/// <param name="SourcePath"> The normalized absolute source path before artifact-store ingestion. </param>
+internal sealed record BuildOutputManifestEntryJsonContract (
+    string Id,
+    string Kind,
+    string SourcePath);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestEntryKind.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestEntryKind.cs
@@ -1,0 +1,15 @@
+using MackySoft.Ucli.Contracts.Text;
+
+namespace MackySoft.Ucli.Contracts.Assurance.Build;
+
+/// <summary> Defines output source entry kind literals in <c>output-manifest.json</c>. </summary>
+internal enum BuildOutputManifestEntryKind
+{
+    /// <summary> The source entry was a regular file. </summary>
+    [UcliContractLiteral("file")]
+    File = 0,
+
+    /// <summary> The source entry was a directory. </summary>
+    [UcliContractLiteral("directory")]
+    Directory = 1,
+}

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestFileJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestFileJsonContract.cs
@@ -1,10 +1,16 @@
 namespace MackySoft.Ucli.Contracts.Assurance.Build;
 
 /// <summary> Represents one regular file entry in <c>output-manifest.json</c>. </summary>
-/// <param name="Path"> The output-root-relative slash-separated file path. </param>
+/// <param name="EntryId"> The referenced output source entry id. </param>
+/// <param name="LogicalPath"> The manifest-local slash-separated file path. </param>
+/// <param name="SourcePath"> The normalized absolute source file path before artifact-store ingestion. </param>
+/// <param name="ArtifactPath"> The artifact-root-relative slash-separated output file path. </param>
 /// <param name="SizeBytes"> The file size in bytes. </param>
 /// <param name="Sha256"> The lowercase SHA-256 digest for the file content. </param>
 internal sealed record BuildOutputManifestFileJsonContract (
-    string Path,
+    string EntryId,
+    string LogicalPath,
+    string SourcePath,
+    string ArtifactPath,
     long SizeBytes,
     string Sha256);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContract.cs
@@ -2,16 +2,18 @@ namespace MackySoft.Ucli.Contracts.Assurance.Build;
 
 /// <summary> Represents the persisted <c>output-manifest.json</c> contract. </summary>
 /// <param name="SchemaVersion"> The output-manifest schema version. </param>
-/// <param name="OutputRoot"> The build output root path. </param>
-/// <param name="BuildTarget"> The resolved canonical buildTarget literal. </param>
+/// <param name="Target"> The resolved build target identity. </param>
+/// <param name="Entries"> The output source entries in resolved ordinal order. </param>
+/// <param name="EntryCount"> The number of output source entries included in the manifest. </param>
 /// <param name="FileCount"> The number of regular files included in the manifest. </param>
 /// <param name="TotalBytes"> The total byte count for manifest files. </param>
 /// <param name="Files"> The manifest file entries in canonical order. </param>
 /// <param name="ManifestDigest"> The lowercase SHA-256 digest of canonical manifest content excluding this field. </param>
 internal sealed record BuildOutputManifestJsonContract (
     int SchemaVersion,
-    string OutputRoot,
-    string BuildTarget,
+    BuildOutputManifestTargetJsonContract Target,
+    IReadOnlyList<BuildOutputManifestEntryJsonContract> Entries,
+    int EntryCount,
     int FileCount,
     long TotalBytes,
     IReadOnlyList<BuildOutputManifestFileJsonContract> Files,
@@ -26,8 +28,9 @@ internal sealed record BuildOutputManifestJsonContract (
     {
         return new BuildOutputManifestContentJsonContract(
             SchemaVersion,
-            OutputRoot,
-            BuildTarget,
+            Target,
+            Entries,
+            EntryCount,
             FileCount,
             TotalBytes,
             Files);

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContractWriter.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestJsonContractWriter.cs
@@ -78,8 +78,25 @@ internal sealed class BuildOutputManifestJsonContractWriter : IJsonContractWrite
         {
             writer.WriteStartObject();
             writer.WriteNumber("schemaVersion", content.SchemaVersion);
-            writer.WriteString("outputRoot", content.OutputRoot);
-            writer.WriteString("buildTarget", content.BuildTarget);
+            writer.WritePropertyName("target");
+            writer.WriteStartObject();
+            writer.WriteString("stableName", content.Target.StableName);
+            writer.WriteString("unityBuildTarget", content.Target.UnityBuildTarget);
+            writer.WriteEndObject();
+            writer.WritePropertyName("entries");
+            writer.WriteStartArray();
+            for (var i = 0; i < content.Entries.Count; i++)
+            {
+                var entry = content.Entries[i];
+                writer.WriteStartObject();
+                writer.WriteString("id", entry.Id);
+                writer.WriteString("kind", entry.Kind);
+                writer.WriteString("sourcePath", entry.SourcePath);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteNumber("entryCount", content.EntryCount);
             writer.WriteNumber("fileCount", content.FileCount);
             writer.WriteNumber("totalBytes", content.TotalBytes);
             writer.WritePropertyName("files");
@@ -88,7 +105,10 @@ internal sealed class BuildOutputManifestJsonContractWriter : IJsonContractWrite
             {
                 var file = content.Files[i];
                 writer.WriteStartObject();
-                writer.WriteString("path", file.Path);
+                writer.WriteString("entryId", file.EntryId);
+                writer.WriteString("logicalPath", file.LogicalPath);
+                writer.WriteString("sourcePath", file.SourcePath);
+                writer.WriteString("artifactPath", file.ArtifactPath);
                 writer.WriteNumber("sizeBytes", file.SizeBytes);
                 writer.WriteString("sha256", file.Sha256);
                 writer.WriteEndObject();

--- a/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestTargetJsonContract.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildOutputManifestTargetJsonContract.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Contracts.Assurance.Build;
+
+/// <summary> Represents the resolved build target identity recorded in <c>output-manifest.json</c>. </summary>
+/// <param name="StableName"> The uCLI build target stable name. </param>
+/// <param name="UnityBuildTarget"> The Unity <c>BuildTarget</c> enum member name. </param>
+internal sealed record BuildOutputManifestTargetJsonContract (
+    string StableName,
+    string UnityBuildTarget);

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/BuildErrorCodeDescriptors.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/BuildErrorCodeDescriptors.cs
@@ -199,16 +199,54 @@ internal static class BuildErrorCodeDescriptors
             relatedCodes: [BuildErrorCodes.BuildArtifactWriteFailed]),
 
         UcliErrorDescriptorFactory.Create(
-            code: BuildErrorCodes.BuildOutputDigestMismatch,
+            code: BuildErrorCodes.BuildOutputPathInvalid,
+            category: "build",
+            summary: "Build output path violates output path policy.",
+            meaning: "A build output source path was empty, malformed, or resolved inside the artifact root.",
+            appliesTo: AppliesToBuildRun,
+            possiblePhases: ["outputSourceResolution", "outputManifest"],
+            impliesNotApplied: false,
+            mayBeIndeterminate: false,
+            safeToRetry: UcliErrorRetryClassValues.No,
+            inspect: ["errors[].code", "errors[].message", "payload.build.output"],
+            nextActions:
+            [
+                new UcliErrorNextActionDescriptor(
+                    When: null,
+                    Action: "Ensure build output source entries are absolute runner output paths and are not artifact-store paths."),
+            ],
+            relatedCodes: [BuildErrorCodes.BuildOutputManifestFailed]),
+
+        UcliErrorDescriptorFactory.Create(
+            code: BuildErrorCodes.BuildOutputManifestDigestMismatch,
             category: "build",
             summary: "Build output manifest digest mismatch.",
-            meaning: "The persisted output manifest digest did not match the digest recalculated from manifest content.",
+            meaning: "The output-manifest.json manifestDigest value did not match the digest recalculated from canonical manifest content.",
             appliesTo: AppliesToBuildRun,
             possiblePhases: ["outputManifest", "artifactAccounting"],
             impliesNotApplied: false,
             mayBeIndeterminate: true,
             safeToRetry: UcliErrorRetryClassValues.Yes,
             inspect: ["errors[].code", "errors[].message", "payload.build.output.manifestDigest"],
+            nextActions:
+            [
+                new UcliErrorNextActionDescriptor(
+                    When: null,
+                    Action: "Rerun the build and inspect concurrent writes to the build artifact directory if the mismatch repeats."),
+            ],
+            relatedCodes: [BuildErrorCodes.BuildOutputManifestFailed]),
+
+        UcliErrorDescriptorFactory.Create(
+            code: BuildErrorCodes.BuildOutputManifestArtifactDigestMismatch,
+            category: "build",
+            summary: "Build output manifest artifact digest mismatch.",
+            meaning: "The reports.buildOutputManifest digest did not match the bytes stored in output-manifest.json.",
+            appliesTo: AppliesToBuildRun,
+            possiblePhases: ["outputManifest", "artifactAccounting"],
+            impliesNotApplied: false,
+            mayBeIndeterminate: true,
+            safeToRetry: UcliErrorRetryClassValues.Yes,
+            inspect: ["errors[].code", "errors[].message", "payload.reports.buildOutputManifest.digest"],
             nextActions:
             [
                 new UcliErrorNextActionDescriptor(

--- a/src/Ucli.Contracts/Diagnostics/ErrorCodes/BuildErrorCodes.cs
+++ b/src/Ucli.Contracts/Diagnostics/ErrorCodes/BuildErrorCodes.cs
@@ -33,8 +33,14 @@ public static class BuildErrorCodes
     /// <summary> Gets the error code emitted when the build output manifest cannot be generated. </summary>
     public static readonly UcliCode BuildOutputManifestFailed = new("BUILD_OUTPUT_MANIFEST_FAILED");
 
-    /// <summary> Gets the error code emitted when the output manifest digest does not match persisted artifact content. </summary>
-    public static readonly UcliCode BuildOutputDigestMismatch = new("BUILD_OUTPUT_DIGEST_MISMATCH");
+    /// <summary> Gets the error code emitted when an output source path violates build output path policy. </summary>
+    public static readonly UcliCode BuildOutputPathInvalid = new("BUILD_OUTPUT_PATH_INVALID");
+
+    /// <summary> Gets the error code emitted when <c>output-manifest.json.manifestDigest</c> does not match manifest content. </summary>
+    public static readonly UcliCode BuildOutputManifestDigestMismatch = new("BUILD_OUTPUT_MANIFEST_DIGEST_MISMATCH");
+
+    /// <summary> Gets the error code emitted when the output manifest artifact digest does not match file bytes. </summary>
+    public static readonly UcliCode BuildOutputManifestArtifactDigestMismatch = new("BUILD_OUTPUT_MANIFEST_ARTIFACT_DIGEST_MISMATCH");
 
     /// <summary> Gets the error code emitted when project mutation is detected while mutation is forbidden. </summary>
     public static readonly UcliCode BuildProjectMutationForbidden = new("BUILD_PROJECT_MUTATION_FORBIDDEN");
@@ -52,7 +58,9 @@ public static class BuildErrorCodes
         BuildReportMissing,
         BuildArtifactWriteFailed,
         BuildOutputManifestFailed,
-        BuildOutputDigestMismatch,
+        BuildOutputPathInvalid,
+        BuildOutputManifestDigestMismatch,
+        BuildOutputManifestArtifactDigestMismatch,
         BuildProjectMutationForbidden,
     ];
 }

--- a/src/Ucli.Contracts/Storage/UcliStoragePathNames.cs
+++ b/src/Ucli.Contracts/Storage/UcliStoragePathNames.cs
@@ -24,6 +24,9 @@ public static class UcliStoragePathNames
     /// <summary> Gets the artifacts directory name under one fingerprint directory. </summary>
     public const string ArtifactsDirectoryName = "artifacts";
 
+    /// <summary> Gets the work directory name under one fingerprint directory. </summary>
+    public const string WorkDirectoryName = "work";
+
     /// <summary> Gets the read-index directory name under one fingerprint directory. </summary>
     public const string IndexDirectoryName = "index";
 
@@ -74,6 +77,9 @@ public static class UcliStoragePathNames
 
     /// <summary> Gets the build-artifacts directory name under one fingerprint artifacts directory. </summary>
     public const string BuildArtifactsDirectoryName = "build";
+
+    /// <summary> Gets the build-work directory name under one fingerprint work directory. </summary>
+    public const string BuildWorkDirectoryName = "build";
 
     /// <summary> Gets the recoverable IPC operation directory name under one fingerprint directory. </summary>
     public const string IpcOperationsDirectoryName = "ipc-operations";

--- a/src/Ucli.Infrastructure/Storage/UcliStoragePathResolver.cs
+++ b/src/Ucli.Infrastructure/Storage/UcliStoragePathResolver.cs
@@ -426,6 +426,20 @@ public static class UcliStoragePathResolver
             UcliStoragePathNames.ArtifactsDirectoryName);
     }
 
+    /// <summary> Resolves the absolute path to one fingerprint work directory under <c>.ucli/local/fingerprints/&lt;projectFingerprint&gt;/work</c>. </summary>
+    /// <param name="storageRoot"> The storage-root path. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <returns> The absolute fingerprint work directory path. </returns>
+    /// <exception cref="ArgumentException"> Thrown when any argument is <see langword="null" />, empty, or whitespace. </exception>
+    public static string ResolveWorkDirectory (
+        string storageRoot,
+        string projectFingerprint)
+    {
+        return Path.Combine(
+            ResolveFingerprintDirectory(storageRoot, projectFingerprint),
+            UcliStoragePathNames.WorkDirectoryName);
+    }
+
     /// <summary> Resolves the absolute path to one fingerprint test-artifacts directory under <c>.ucli/local/fingerprints/&lt;projectFingerprint&gt;/artifacts/test</c>. </summary>
     /// <param name="storageRoot"> The storage-root path. Must not be <see langword="null" />, empty, or whitespace. </param>
     /// <param name="projectFingerprint"> The project fingerprint value. Must not be <see langword="null" />, empty, or whitespace. </param>
@@ -466,6 +480,20 @@ public static class UcliStoragePathResolver
         return Path.Combine(
             ResolveArtifactsDirectory(storageRoot, projectFingerprint),
             UcliStoragePathNames.BuildArtifactsDirectoryName);
+    }
+
+    /// <summary> Resolves the absolute path to one fingerprint build-work directory under <c>.ucli/local/fingerprints/&lt;projectFingerprint&gt;/work/build</c>. </summary>
+    /// <param name="storageRoot"> The storage-root path. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <returns> The absolute fingerprint build-work directory path. </returns>
+    /// <exception cref="ArgumentException"> Thrown when any argument is <see langword="null" />, empty, or whitespace. </exception>
+    public static string ResolveBuildWorkDirectory (
+        string storageRoot,
+        string projectFingerprint)
+    {
+        return Path.Combine(
+            ResolveWorkDirectory(storageRoot, projectFingerprint),
+            UcliStoragePathNames.BuildWorkDirectoryName);
     }
 
     /// <summary> Resolves the absolute path to one mutation read-postcondition file under one fingerprint directory. </summary>
@@ -534,6 +562,25 @@ public static class UcliStoragePathResolver
         return Path.Combine(
             ResolveBuildArtifactsDirectory(storageRoot, projectFingerprint),
             normalizedRunId);
+    }
+
+    /// <summary> Resolves the absolute runner output directory for one build run under <c>.ucli/local/fingerprints/&lt;projectFingerprint&gt;/work/build/&lt;runId&gt;/output</c>. </summary>
+    /// <param name="storageRoot"> The storage-root path. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <param name="projectFingerprint"> The project fingerprint value. Must not be <see langword="null" />, empty, or whitespace. </param>
+    /// <param name="runId"> The run identifier value. Must not be <see langword="null" />, empty, whitespace, or contain path-segment/control tokens. </param>
+    /// <returns> The absolute runner output directory path. </returns>
+    /// <exception cref="ArgumentException"> Thrown when any argument is <see langword="null" />, empty, or whitespace. </exception>
+    public static string ResolveBuildRunOutputDirectory (
+        string storageRoot,
+        string projectFingerprint,
+        string runId)
+    {
+        var normalizedRunId = NormalizeRunId(runId);
+
+        return Path.Combine(
+            ResolveBuildWorkDirectory(storageRoot, projectFingerprint),
+            normalizedRunId,
+            UcliStoragePathNames.BuildOutputDirectoryName);
     }
 
     /// <summary> Resolves the absolute path to daemon <c>session.json</c>. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -437,9 +437,10 @@ namespace MackySoft.Ucli.Unity.Ipc
                     storageRoot,
                     projectIdentity.ProjectFingerprint,
                     runId);
-                expectedOutputPath = Path.GetFullPath(Path.Combine(
-                    expectedArtifactsDirectory,
-                    UcliStoragePathNames.BuildOutputDirectoryName));
+                expectedOutputPath = UcliStoragePathResolver.ResolveBuildRunOutputDirectory(
+                    storageRoot,
+                    projectIdentity.ProjectFingerprint,
+                    runId);
                 expectedBuildReportPath = Path.GetFullPath(Path.Combine(
                     expectedArtifactsDirectory,
                     UcliStoragePathNames.BuildReportFileName));

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Ipc/Methods/BuildRunUnityIpcMethodHandlerTests.cs
@@ -578,7 +578,10 @@ namespace MackySoft.Ucli.Unity.Tests
                 storageRoot,
                 identity.ProjectFingerprint,
                 RunId);
-            var outputPath = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName);
+            var outputPath = UcliStoragePathResolver.ResolveBuildRunOutputDirectory(
+                storageRoot,
+                identity.ProjectFingerprint,
+                RunId);
             if (!IpcBuildOutputLayoutResolver.TryResolve(outputPath, "standaloneLinux64", out var outputLayout))
             {
                 throw new InvalidOperationException("Test build target must resolve a BuildPipeline output layout.");

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -18,6 +18,9 @@ namespace MackySoft.Ucli.Features.Assurance.Build;
 internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 {
     private const int FileStreamBufferSize = 81920;
+    private const string OutputEntryIdPrefix = "output-";
+    private const string OutputEntryKindDirectory = "directory";
+    private const string OutputEntryKindFile = "file";
 
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
@@ -61,8 +64,15 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
                     BuildErrorCodes.BuildArtifactWriteFailed));
             }
 
+            if (File.Exists(paths.RunnerOutputDirectory) || Directory.Exists(paths.RunnerOutputDirectory))
+            {
+                return BuildRunArtifactPreparationResult.Failure(ExecutionError.InternalError(
+                    $"Build runner output directory already exists: {paths.RunnerOutputDirectory}.",
+                    BuildErrorCodes.BuildArtifactWriteFailed));
+            }
+
             FileSystemAccessBoundary.EnsureSecureDirectory(paths.ArtifactsDirectory);
-            FileSystemAccessBoundary.EnsureSecureDirectory(paths.OutputDirectory);
+            FileSystemAccessBoundary.EnsureSecureDirectory(paths.RunnerOutputDirectory);
             return BuildRunArtifactPreparationResult.Success(paths);
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
@@ -138,8 +148,9 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.Paths);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.ReportedOutputPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.BuildTarget);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.UnityBuildTarget);
+        ArgumentNullException.ThrowIfNull(request.OutputSources);
         cancellationToken.ThrowIfCancellationRequested();
 
         try
@@ -157,42 +168,35 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
                 $"Build artifact path layout is invalid. {exception.Message}"));
         }
 
-        try
-        {
-            EnsureReportedOutputPathUnderOutputDirectory(request.Paths, request.ReportedOutputPath);
-        }
-        catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
-        {
-            return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
-                $"Build report output path is invalid. {exception.Message}",
-                BuildErrorCodes.BuildOutputManifestFailed));
-        }
-        catch (InvalidOperationException exception)
-        {
-            return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
-                $"Build report output path must remain under the requested output directory. {exception.Message}",
-                BuildErrorCodes.BuildOutputManifestFailed));
-        }
-
         OutputManifestArtifacts outputManifestArtifacts;
         try
         {
             outputManifestArtifacts = await CreateOutputManifestArtifactsAsync(
                     request.Paths,
                     request.BuildTarget,
+                    request.UnityBuildTarget,
+                    request.OutputSources,
+                    request.AllowEmptyOutputManifest,
                     cancellationToken)
                 .ConfigureAwait(false);
         }
-        catch (OutputDigestMismatchException exception)
+        catch (OutputPathPolicyException exception)
+        {
+            return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InvalidArgument(
+                $"Build output path is invalid. {exception.Message}",
+                BuildErrorCodes.BuildOutputPathInvalid));
+        }
+        catch (OutputManifestDigestMismatchException exception)
         {
             return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
-                $"Build output digest accounting failed. {exception.Message}",
-                BuildErrorCodes.BuildOutputDigestMismatch));
+                $"Build output manifest digest mismatch. {exception.Message}",
+                BuildErrorCodes.BuildOutputManifestDigestMismatch));
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
         {
             return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InvalidArgument(
-                $"Build output manifest path is invalid. {exception.Message}"));
+                $"Build output path is invalid. {exception.Message}",
+                BuildErrorCodes.BuildOutputPathInvalid));
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or InvalidOperationException)
         {
@@ -233,17 +237,40 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         BuildArtifactRef outputManifestRef;
         try
         {
+            VerifyManifestDigest(outputManifestArtifacts.Contract);
             var outputManifestJson = outputManifestWriter.Write(outputManifestArtifacts.Contract);
             var outputManifestDigest = await WriteTextAtomicallyAsync(
                     request.Paths.OutputManifestJsonPath,
                     outputManifestJson,
                     cancellationToken)
                 .ConfigureAwait(false);
+            var persistedOutputManifestDigest = await ComputeExistingArtifactSha256Async(
+                    request.Paths.OutputManifestJsonPath,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (!string.Equals(outputManifestDigest, persistedOutputManifestDigest, StringComparison.Ordinal))
+            {
+                throw new OutputManifestArtifactDigestMismatchException(
+                    $"Expected={outputManifestDigest}, Actual={persistedOutputManifestDigest}.");
+            }
+
             outputManifestRef = CreateArtifactRef(
                 BuildArtifactKind.BuildOutputManifest,
                 request.Paths.RepositoryRoot,
                 request.Paths.OutputManifestJsonPath,
-                outputManifestDigest);
+                persistedOutputManifestDigest);
+        }
+        catch (OutputManifestDigestMismatchException exception)
+        {
+            return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
+                $"Build output manifest digest mismatch. {exception.Message}",
+                BuildErrorCodes.BuildOutputManifestDigestMismatch));
+        }
+        catch (OutputManifestArtifactDigestMismatchException exception)
+        {
+            return BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
+                $"Build output manifest artifact digest mismatch. {exception.Message}",
+                BuildErrorCodes.BuildOutputManifestArtifactDigestMismatch));
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
         {
@@ -334,6 +361,10 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
             unityProject.RepositoryRoot,
             unityProject.ProjectFingerprint,
             runId);
+        var runnerOutputDirectory = UcliStoragePathResolver.ResolveBuildRunOutputDirectory(
+            unityProject.RepositoryRoot,
+            unityProject.ProjectFingerprint,
+            runId);
 
         return new BuildRunArtifactPaths(
             unityProject.RepositoryRoot,
@@ -343,6 +374,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
             Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildReportFileName),
             Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildLogFileName),
             Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputManifestFileName),
+            runnerOutputDirectory,
             Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName));
     }
 
@@ -373,8 +405,10 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
             UcliStoragePathNames.BuildOutputManifestFileName);
         EnsureExpectedPath(
             artifactsDirectory,
-            paths.OutputDirectory,
+            paths.ArtifactOutputDirectory,
             UcliStoragePathNames.BuildOutputDirectoryName);
+        EnsureExpectedRunnerOutputDirectory(paths);
+        EnsureSeparatedOutputRoots(paths);
     }
 
     private static void EnsureExpectedBuildPipelineOutputLayout (
@@ -382,7 +416,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         string buildTarget,
         IpcBuildOutputLayout outputLayout)
     {
-        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, buildTarget, out var expectedLayout))
+        if (!IpcBuildOutputLayoutResolver.TryResolve(paths.RunnerOutputDirectory, buildTarget, out var expectedLayout))
         {
             throw new InvalidOperationException($"Build target does not have a deterministic BuildPipeline output layout: {buildTarget}");
         }
@@ -447,31 +481,56 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         if (!string.Equals(normalizedActualPath, expectedPath, GetPathComparison()))
         {
             throw new InvalidOperationException(
-            $"Artifact path must be {expectedPath}: {actualPath}");
+                $"Artifact path must be {expectedPath}: {actualPath}");
         }
     }
 
-    private static void EnsureReportedOutputPathUnderOutputDirectory (
-        BuildRunArtifactPaths paths,
-        string reportedOutputPath)
+    private static void EnsureExpectedRunnerOutputDirectory (BuildRunArtifactPaths paths)
     {
-        if (!Path.IsPathFullyQualified(reportedOutputPath))
+        var expectedRunnerOutputDirectory = UcliStoragePathResolver.ResolveBuildRunOutputDirectory(
+            paths.RepositoryRoot,
+            ResolveProjectFingerprintFromArtifactsDirectory(paths),
+            paths.RunId);
+        var normalizedActualPath = Path.GetFullPath(paths.RunnerOutputDirectory);
+        if (!string.Equals(normalizedActualPath, expectedRunnerOutputDirectory, GetPathComparison()))
         {
-            throw new InvalidOperationException($"Reported output path must be fully qualified: {reportedOutputPath}");
+            throw new InvalidOperationException(
+                $"Runner output directory must be {expectedRunnerOutputDirectory}: {paths.RunnerOutputDirectory}");
+        }
+    }
+
+    private static string ResolveProjectFingerprintFromArtifactsDirectory (BuildRunArtifactPaths paths)
+    {
+        var relativePath = NormalizeRepositoryRelativePath(paths.RepositoryRoot, paths.ArtifactsDirectory);
+        var segments = relativePath.Split('/');
+        if (segments.Length < 4)
+        {
+            throw new InvalidOperationException(
+                $"Artifact directory must include a project fingerprint segment: {paths.ArtifactsDirectory}");
         }
 
-        var outputDirectory = Path.GetFullPath(paths.OutputDirectory);
-        var normalizedReportedOutputPath = Path.GetFullPath(reportedOutputPath);
-        var relativePath = Path.GetRelativePath(outputDirectory, normalizedReportedOutputPath);
-        if (string.Equals(relativePath, ".", StringComparison.Ordinal))
-        {
-            return;
-        }
+        return segments[3];
+    }
 
-        if (Path.IsPathRooted(relativePath) || IsParentRelativePath(relativePath))
+    private static void EnsureSeparatedOutputRoots (BuildRunArtifactPaths paths)
+    {
+        var artifactOutputDirectory = Path.GetFullPath(paths.ArtifactOutputDirectory);
+        var runnerOutputDirectory = Path.GetFullPath(paths.RunnerOutputDirectory);
+        if (PathsAreSameOrNested(artifactOutputDirectory, runnerOutputDirectory)
+            || PathsAreSameOrNested(runnerOutputDirectory, artifactOutputDirectory))
         {
-            throw new InvalidOperationException($"Reported={reportedOutputPath}, ExpectedRoot={paths.OutputDirectory}.");
+            throw new InvalidOperationException(
+                "Runner output directory and artifact output directory must be separate non-nested paths.");
         }
+    }
+
+    private static bool PathsAreSameOrNested (
+        string ancestorPath,
+        string candidatePath)
+    {
+        var relativePath = Path.GetRelativePath(ancestorPath, candidatePath);
+        return string.Equals(relativePath, ".", StringComparison.Ordinal)
+            || (!Path.IsPathRooted(relativePath) && !IsParentRelativePath(relativePath));
     }
 
     private static bool IsParentRelativePath (string relativePath)
@@ -487,43 +546,56 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
     private async ValueTask<OutputManifestArtifacts> CreateOutputManifestArtifactsAsync (
         BuildRunArtifactPaths paths,
         string buildTarget,
+        string unityBuildTarget,
+        IReadOnlyList<BuildOutputSourceEntry> outputSources,
+        bool allowEmptyOutputManifest,
         CancellationToken cancellationToken)
     {
-        var outputRoot = NormalizeRepositoryRelativePath(paths.RepositoryRoot, paths.OutputDirectory);
-        var candidates = EnumerateOutputFileCandidates(paths.OutputDirectory);
-        candidates.Sort(static (left, right) => string.CompareOrdinal(left.RelativePath, right.RelativePath));
+        cancellationToken.ThrowIfCancellationRequested();
+        var sourceEntries = ResolveOutputSourceEntries(
+            paths,
+            outputSources,
+            allowEmptyOutputManifest);
 
-        var files = new List<BuildOutputManifestFileJsonContract>(candidates.Count);
+        FileSystemAccessBoundary.EnsureSecureDirectory(paths.ArtifactOutputDirectory);
+        var entries = new List<BuildOutputManifestEntryJsonContract>(sourceEntries.Count);
+        var files = new List<BuildOutputManifestFileJsonContract>();
         long totalBytes = 0;
-        for (var i = 0; i < candidates.Count; i++)
+        for (var i = 0; i < sourceEntries.Count; i++)
         {
-            var candidate = candidates[i];
-            var fileInfo = new FileInfo(candidate.FullPath);
-            var sizeBytes = fileInfo.Length;
-            var sha256 = await ComputeFileSha256Async(
-                    candidate.FullPath,
-                    sizeBytes,
+            var sourceEntry = sourceEntries[i];
+            var entryId = FormatOutputEntryId(i + 1);
+            entries.Add(new BuildOutputManifestEntryJsonContract(
+                entryId,
+                sourceEntry.Kind,
+                sourceEntry.SourcePath));
+
+            totalBytes += await IngestOutputSourceEntryAsync(
+                    paths,
+                    sourceEntry,
+                    entryId,
+                    files,
                     cancellationToken)
                 .ConfigureAwait(false);
-            totalBytes += sizeBytes;
-            files.Add(new BuildOutputManifestFileJsonContract(
-                candidate.RelativePath,
-                sizeBytes,
-                sha256));
         }
+
+        files.Sort(static (left, right) => string.CompareOrdinal(left.LogicalPath, right.LogicalPath));
+        EnsureUniqueLogicalPaths(files);
 
         var content = new BuildOutputManifestContentJsonContract(
             BuildOutputManifestJsonContract.CurrentSchemaVersion,
-            outputRoot,
-            buildTarget,
+            new BuildOutputManifestTargetJsonContract(buildTarget, unityBuildTarget),
+            entries,
+            entries.Count,
             files.Count,
             totalBytes,
             files);
         var manifestDigest = outputManifestWriter.CalculateManifestDigest(content);
         var contract = new BuildOutputManifestJsonContract(
             content.SchemaVersion,
-            content.OutputRoot,
-            content.BuildTarget,
+            content.Target,
+            content.Entries,
+            content.EntryCount,
             content.FileCount,
             content.TotalBytes,
             content.Files,
@@ -533,24 +605,161 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
             contract,
             new BuildOutputManifestSummary(
                 manifestDigest,
-                files.Count,
+                entries.Count,
                 files.Count,
                 totalBytes));
     }
 
-    private static List<OutputFileCandidate> EnumerateOutputFileCandidates (string outputDirectory)
+    private static List<ResolvedOutputSourceEntry> ResolveOutputSourceEntries (
+        BuildRunArtifactPaths paths,
+        IReadOnlyList<BuildOutputSourceEntry> outputSources,
+        bool allowEmptyOutputManifest)
     {
-        if (!Directory.Exists(outputDirectory))
+        if (outputSources.Count == 0)
         {
-            throw new DirectoryNotFoundException($"Build output directory was not found: {outputDirectory}");
+            if (allowEmptyOutputManifest)
+            {
+                return [];
+            }
+
+            throw new InvalidOperationException("Successful build output accounting requires at least one output source entry.");
         }
 
-        var outputRootFullPath = Path.GetFullPath(outputDirectory);
-        EnsureOutputDirectoryNode(outputRootFullPath);
+        var entries = new List<ResolvedOutputSourceEntry>(outputSources.Count);
+        var missingSourcePath = string.Empty;
+        for (var i = 0; i < outputSources.Count; i++)
+        {
+            var outputSource = outputSources[i];
+            if (outputSource == null || string.IsNullOrWhiteSpace(outputSource.SourcePath))
+            {
+                throw new OutputPathPolicyException("Output source path must not be empty.");
+            }
 
-        var files = new List<OutputFileCandidate>();
+            if (!Path.IsPathFullyQualified(outputSource.SourcePath))
+            {
+                throw new OutputPathPolicyException($"Output source path must be fully qualified: {outputSource.SourcePath}");
+            }
+
+            var sourcePath = Path.GetFullPath(outputSource.SourcePath);
+            EnsureOutputSourceOutsideArtifactRoot(paths, sourcePath);
+            if (!File.Exists(sourcePath) && !Directory.Exists(sourcePath))
+            {
+                missingSourcePath = sourcePath;
+                continue;
+            }
+
+            var kind = ResolveOutputSourceEntryKind(sourcePath);
+            entries.Add(new ResolvedOutputSourceEntry(sourcePath, kind));
+        }
+
+        if (entries.Count == 0 && !string.IsNullOrEmpty(missingSourcePath) && allowEmptyOutputManifest)
+        {
+            return [];
+        }
+
+        if (!string.IsNullOrEmpty(missingSourcePath))
+        {
+            throw new FileNotFoundException($"Build output source entry was not found: {missingSourcePath}", missingSourcePath);
+        }
+
+        if (entries.Count == 0)
+        {
+            throw new InvalidOperationException("Successful build output accounting requires at least one existing output source entry.");
+        }
+
+        return entries;
+    }
+
+    private static void EnsureOutputSourceOutsideArtifactRoot (
+        BuildRunArtifactPaths paths,
+        string sourcePath)
+    {
+        var artifactRoot = Path.GetFullPath(paths.ArtifactsDirectory);
+        if (PathsAreSameOrNested(artifactRoot, sourcePath))
+        {
+            throw new OutputPathPolicyException(
+                $"Output source path must not resolve inside the artifact root. Source={sourcePath}, ArtifactRoot={artifactRoot}.");
+        }
+    }
+
+    private static string ResolveOutputSourceEntryKind (string sourcePath)
+    {
+        var attributes = File.GetAttributes(sourcePath);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException($"Build output source entry must not be a reparse point: {sourcePath}");
+        }
+
+        if ((attributes & FileAttributes.Directory) != 0)
+        {
+            return OutputEntryKindDirectory;
+        }
+
+        if (!FileSystemNodeClassifier.IsRegularFile(sourcePath, attributes))
+        {
+            throw new IOException($"Build output source entry must be a regular file or directory: {sourcePath}");
+        }
+
+        return OutputEntryKindFile;
+    }
+
+    private async ValueTask<long> IngestOutputSourceEntryAsync (
+        BuildRunArtifactPaths paths,
+        ResolvedOutputSourceEntry sourceEntry,
+        string entryId,
+        List<BuildOutputManifestFileJsonContract> files,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var entryOutputDirectory = Path.Combine(paths.ArtifactOutputDirectory, entryId);
+        FileSystemAccessBoundary.EnsureSecureDirectory(entryOutputDirectory);
+
+        if (string.Equals(sourceEntry.Kind, OutputEntryKindFile, StringComparison.Ordinal))
+        {
+            var fileName = Path.GetFileName(sourceEntry.SourcePath);
+            EnsureSafeOutputRelativePath(fileName, sourceEntry.SourcePath);
+            var artifactFilePath = Path.Combine(entryOutputDirectory, fileName);
+            await CopyRegularFileAsync(sourceEntry.SourcePath, artifactFilePath, cancellationToken).ConfigureAwait(false);
+            return await AddArtifactFileEntryAsync(
+                    entryId,
+                    fileName,
+                    sourceEntry.SourcePath,
+                    artifactFilePath,
+                    files,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var candidates = EnumerateOutputSourceFileCandidates(sourceEntry.SourcePath);
+        candidates.Sort(static (left, right) => string.CompareOrdinal(left.RelativePath, right.RelativePath));
+
+        long totalBytes = 0;
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var candidate = candidates[i];
+            var artifactFilePath = CombineSlashRelativePath(entryOutputDirectory, candidate.RelativePath);
+            await CopyRegularFileAsync(candidate.FullPath, artifactFilePath, cancellationToken).ConfigureAwait(false);
+            totalBytes += await AddArtifactFileEntryAsync(
+                    entryId,
+                    candidate.RelativePath,
+                    candidate.FullPath,
+                    artifactFilePath,
+                    files,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return totalBytes;
+    }
+
+    private static List<OutputSourceFileCandidate> EnumerateOutputSourceFileCandidates (string sourceDirectory)
+    {
+        var sourceRootFullPath = Path.GetFullPath(sourceDirectory);
+        EnsureOutputDirectoryNode(sourceRootFullPath);
+
+        var files = new List<OutputSourceFileCandidate>();
         var pendingDirectories = new Stack<string>();
-        pendingDirectories.Push(outputRootFullPath);
+        pendingDirectories.Push(sourceRootFullPath);
         while (pendingDirectories.Count > 0)
         {
             var currentDirectory = pendingDirectories.Pop();
@@ -569,14 +778,143 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
                 }
 
                 var fullPath = Path.GetFullPath(entryPath);
-                var platformRelativePath = Path.GetRelativePath(outputRootFullPath, fullPath);
+                if (!FileSystemNodeClassifier.IsRegularFile(fullPath, attributes))
+                {
+                    throw new IOException($"Build output file must be a regular file: {fullPath}");
+                }
+
+                var platformRelativePath = Path.GetRelativePath(sourceRootFullPath, fullPath);
                 EnsureSafeOutputRelativePath(platformRelativePath, fullPath);
                 var relativePath = PathStringNormalizer.ToSlashSeparated(platformRelativePath);
-                files.Add(new OutputFileCandidate(fullPath, relativePath));
+                files.Add(new OutputSourceFileCandidate(fullPath, relativePath));
             }
         }
 
         return files;
+    }
+
+    private static async ValueTask CopyRegularFileAsync (
+        string sourcePath,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureReadableOutputFile(sourcePath);
+
+        var destinationDirectoryPath = Path.GetDirectoryName(destinationPath);
+        if (string.IsNullOrWhiteSpace(destinationDirectoryPath))
+        {
+            throw new InvalidOperationException($"Artifact output directory path could not be resolved: {destinationPath}");
+        }
+
+        FileSystemAccessBoundary.EnsureSecureDirectory(destinationDirectoryPath);
+        EnsureWritableArtifactPath(destinationPath);
+        var buffer = ArrayPool<byte>.Shared.Rent(FileStreamBufferSize);
+        try
+        {
+            using var sourceStream = new FileStream(
+                sourcePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                FileStreamBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            using var destinationStream = new FileStream(
+                destinationPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                FileStreamBufferSize,
+                FileOptions.Asynchronous);
+            while (true)
+            {
+                var bytesRead = await sourceStream
+                    .ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                    .ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                await destinationStream
+                    .WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        FileSystemAccessBoundary.EnsureSecureFile(destinationPath);
+    }
+
+    private static async ValueTask<long> AddArtifactFileEntryAsync (
+        string entryId,
+        string entryRelativePath,
+        string sourcePath,
+        string artifactFilePath,
+        List<BuildOutputManifestFileJsonContract> files,
+        CancellationToken cancellationToken)
+    {
+        var sizeBytes = new FileInfo(artifactFilePath).Length;
+        var sha256 = await ComputeFileSha256Async(
+                artifactFilePath,
+                sizeBytes,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var logicalPath = $"{entryId}/{entryRelativePath}";
+        files.Add(new BuildOutputManifestFileJsonContract(
+            entryId,
+            logicalPath,
+            sourcePath,
+            $"{UcliStoragePathNames.BuildOutputDirectoryName}/{logicalPath}",
+            sizeBytes,
+            sha256));
+        return sizeBytes;
+    }
+
+    private static string FormatOutputEntryId (int ordinal)
+    {
+        if (ordinal is < 1 or > 9999)
+        {
+            throw new InvalidOperationException($"Build output source entry ordinal is outside the manifest id range: {ordinal}");
+        }
+
+        return string.Create(
+            11,
+            ordinal,
+            static (destination, value) =>
+            {
+                OutputEntryIdPrefix.AsSpan().CopyTo(destination);
+                value.TryFormat(destination[7..], out _, "D4", null);
+            });
+    }
+
+    private static string CombineSlashRelativePath (
+        string root,
+        string relativePath)
+    {
+        var path = root;
+        var segments = relativePath.Split('/');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            path = Path.Combine(path, segments[i]);
+        }
+
+        return path;
+    }
+
+    private static void EnsureUniqueLogicalPaths (IReadOnlyList<BuildOutputManifestFileJsonContract> files)
+    {
+        var logicalPaths = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < files.Count; i++)
+        {
+            if (!logicalPaths.Add(files[i].LogicalPath))
+            {
+                throw new InvalidOperationException($"Build output manifest logicalPath is duplicated: {files[i].LogicalPath}");
+            }
+        }
     }
 
     private static void EnsureOutputDirectoryNode (string outputDirectory)
@@ -671,14 +1009,14 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
         if (totalBytesRead != expectedLength)
         {
-            throw new OutputDigestMismatchException(
+            throw new IOException(
                 $"Build output file length changed while hashing: {filePath}.");
         }
 
         var finalLength = new FileInfo(filePath).Length;
         if (finalLength != expectedLength)
         {
-            throw new OutputDigestMismatchException(
+            throw new IOException(
                 $"Build output file length changed after hashing: {filePath}.");
         }
 
@@ -949,7 +1287,21 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         }
     }
 
-    private sealed record OutputFileCandidate (
+    private void VerifyManifestDigest (BuildOutputManifestJsonContract contract)
+    {
+        var calculatedDigest = outputManifestWriter.CalculateManifestDigest(contract.ToContent());
+        if (!string.Equals(calculatedDigest, contract.ManifestDigest, StringComparison.Ordinal))
+        {
+            throw new OutputManifestDigestMismatchException(
+                $"Expected={contract.ManifestDigest}, Actual={calculatedDigest}.");
+        }
+    }
+
+    private sealed record ResolvedOutputSourceEntry (
+        string SourcePath,
+        string Kind);
+
+    private sealed record OutputSourceFileCandidate (
         string FullPath,
         string RelativePath);
 
@@ -976,9 +1328,25 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         }
     }
 
-    private sealed class OutputDigestMismatchException : Exception
+    private sealed class OutputPathPolicyException : Exception
     {
-        public OutputDigestMismatchException (string message)
+        public OutputPathPolicyException (string message)
+            : base(message)
+        {
+        }
+    }
+
+    private sealed class OutputManifestDigestMismatchException : Exception
+    {
+        public OutputManifestDigestMismatchException (string message)
+            : base(message)
+        {
+        }
+    }
+
+    private sealed class OutputManifestArtifactDigestMismatchException : Exception
+    {
+        public OutputManifestArtifactDigestMismatchException (string message)
             : base(message)
         {
         }

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
@@ -8,6 +9,7 @@ using MackySoft.Ucli.Contracts.Assurance.Build;
 using MackySoft.Ucli.Contracts.Cryptography;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Storage;
+using MackySoft.Ucli.Contracts.Text;
 using MackySoft.Ucli.Infrastructure.Cryptography;
 using MackySoft.Ucli.Infrastructure.Paths;
 using MackySoft.Ucli.Infrastructure.Storage;
@@ -19,9 +21,19 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 {
     private const int FileStreamBufferSize = 81920;
     private const string OutputEntryIdPrefix = "output-";
-    private const string OutputEntryKindDirectory = "directory";
-    private const string OutputEntryKindFile = "file";
+    private const int PosixFileStatusBufferSize = 256;
+    private const int PosixFileTypeMask = 0xF000;
+    private const int PosixRegularFileType = 0x8000;
+    private const int LinuxFileModeOffset = 24;
+    private const int LinuxArm64FileModeOffset = 16;
+    private const int LinuxDeviceOffset = 0;
+    private const int LinuxInodeOffset = 8;
+    private const int MacOsDeviceOffset = 0;
+    private const int MacOsFileModeOffset = 4;
+    private const int MacOsInodeOffset = 8;
 
+    private static readonly string OutputEntryKindDirectory = ContractLiteralCodec.ToValue(BuildOutputManifestEntryKind.Directory);
+    private static readonly string OutputEntryKindFile = ContractLiteralCodec.ToValue(BuildOutputManifestEntryKind.File);
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
     private readonly BuildOutputManifestJsonContractWriter outputManifestWriter;
@@ -642,12 +654,14 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
             var sourcePath = Path.GetFullPath(outputSource.SourcePath);
             EnsureOutputSourceOutsideArtifactRoot(paths, sourcePath);
+            EnsureOutputSourceInsideRunnerOutputRoot(paths, sourcePath);
             if (!File.Exists(sourcePath) && !Directory.Exists(sourcePath))
             {
                 missingSourcePath = sourcePath;
                 continue;
             }
 
+            EnsureOutputSourcePathHasNoReparsePoint(paths.RunnerOutputDirectory, sourcePath);
             var kind = ResolveOutputSourceEntryKind(sourcePath);
             entries.Add(new ResolvedOutputSourceEntry(sourcePath, kind));
         }
@@ -670,6 +684,18 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         return entries;
     }
 
+    private static void EnsureOutputSourceInsideRunnerOutputRoot (
+        BuildRunArtifactPaths paths,
+        string sourcePath)
+    {
+        var runnerOutputRoot = Path.GetFullPath(paths.RunnerOutputDirectory);
+        if (!PathsAreSameOrNested(runnerOutputRoot, sourcePath))
+        {
+            throw new OutputPathPolicyException(
+                $"Output source path must resolve inside the runner output root. Source={sourcePath}, RunnerOutputRoot={runnerOutputRoot}.");
+        }
+    }
+
     private static void EnsureOutputSourceOutsideArtifactRoot (
         BuildRunArtifactPaths paths,
         string sourcePath)
@@ -679,6 +705,38 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         {
             throw new OutputPathPolicyException(
                 $"Output source path must not resolve inside the artifact root. Source={sourcePath}, ArtifactRoot={artifactRoot}.");
+        }
+    }
+
+    private static void EnsureOutputSourcePathHasNoReparsePoint (
+        string runnerOutputRoot,
+        string sourcePath)
+    {
+        var rootPath = Path.GetFullPath(runnerOutputRoot);
+        var relativePath = Path.GetRelativePath(rootPath, sourcePath);
+        if (string.Equals(relativePath, ".", StringComparison.Ordinal))
+        {
+            EnsureOutputPathNodeIsNotReparsePoint(sourcePath);
+            return;
+        }
+
+        var currentPath = rootPath;
+        var segments = relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length; i++)
+        {
+            currentPath = Path.Combine(currentPath, segments[i]);
+            EnsureOutputPathNodeIsNotReparsePoint(currentPath);
+        }
+    }
+
+    private static void EnsureOutputPathNodeIsNotReparsePoint (string path)
+    {
+        var attributes = File.GetAttributes(path);
+        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        {
+            throw new IOException($"Build output path must not contain a reparse point: {path}");
         }
     }
 
@@ -800,6 +858,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
     {
         cancellationToken.ThrowIfCancellationRequested();
         EnsureReadableOutputFile(sourcePath);
+        var sourceIdentity = CaptureOutputFileIdentity(sourcePath);
 
         var destinationDirectoryPath = Path.GetDirectoryName(destinationPath);
         if (string.IsNullOrWhiteSpace(destinationDirectoryPath))
@@ -819,6 +878,8 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
                 FileShare.Read,
                 FileStreamBufferSize,
                 FileOptions.Asynchronous | FileOptions.SequentialScan);
+            EnsureOpenedOutputFileMatchesIdentity(sourcePath, sourceStream, sourceIdentity);
+
             using var destinationStream = new FileStream(
                 destinationPath,
                 FileMode.CreateNew,
@@ -847,6 +908,107 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         }
 
         FileSystemAccessBoundary.EnsureSecureFile(destinationPath);
+    }
+
+    private static OutputFileIdentity CaptureOutputFileIdentity (string sourcePath)
+    {
+        if (!CanCapturePosixFileIdentity())
+        {
+            return OutputFileIdentity.Unavailable;
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent(PosixFileStatusBufferSize);
+        try
+        {
+            if (LStat(sourcePath, buffer) != 0)
+            {
+                throw new IOException($"Build output file identity could not be inspected: {sourcePath}. errno={Marshal.GetLastWin32Error()}");
+            }
+
+            return ReadOutputFileIdentity(buffer);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void EnsureOpenedOutputFileMatchesIdentity (
+        string sourcePath,
+        FileStream sourceStream,
+        OutputFileIdentity expectedIdentity)
+    {
+        if (!expectedIdentity.IsAvailable)
+        {
+            EnsureReadableOutputFile(sourcePath);
+            return;
+        }
+
+        var actualIdentity = CaptureOpenedOutputFileIdentity(sourcePath, sourceStream);
+        if (!actualIdentity.IsRegularFile)
+        {
+            throw new IOException($"Build output file must be a regular file after opening: {sourcePath}");
+        }
+
+        if (actualIdentity.Device != expectedIdentity.Device || actualIdentity.Inode != expectedIdentity.Inode)
+        {
+            throw new IOException($"Build output file changed before it could be copied: {sourcePath}");
+        }
+    }
+
+    private static OutputFileIdentity CaptureOpenedOutputFileIdentity (
+        string sourcePath,
+        FileStream sourceStream)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(PosixFileStatusBufferSize);
+        try
+        {
+            if (FStat(sourceStream.SafeFileHandle.DangerousGetHandle(), buffer) != 0)
+            {
+                throw new IOException($"Opened build output file identity could not be inspected: {sourcePath}. errno={Marshal.GetLastWin32Error()}");
+            }
+
+            return ReadOutputFileIdentity(buffer);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static OutputFileIdentity ReadOutputFileIdentity (byte[] buffer)
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return new OutputFileIdentity(
+                IsAvailable: true,
+                Device: BitConverter.ToUInt64(buffer, LinuxDeviceOffset),
+                Inode: BitConverter.ToUInt64(buffer, LinuxInodeOffset),
+                Mode: BitConverter.ToInt32(buffer, GetLinuxFileModeOffset()));
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return new OutputFileIdentity(
+                IsAvailable: true,
+                Device: BitConverter.ToUInt32(buffer, MacOsDeviceOffset),
+                Inode: BitConverter.ToUInt64(buffer, MacOsInodeOffset),
+                Mode: BitConverter.ToUInt16(buffer, MacOsFileModeOffset));
+        }
+
+        return OutputFileIdentity.Unavailable;
+    }
+
+    private static int GetLinuxFileModeOffset ()
+    {
+        return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+            ? LinuxArm64FileModeOffset
+            : LinuxFileModeOffset;
+    }
+
+    private static bool CanCapturePosixFileIdentity ()
+    {
+        return OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
     }
 
     private static async ValueTask<long> AddArtifactFileEntryAsync (
@@ -1297,6 +1459,17 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         }
     }
 
+    private readonly record struct OutputFileIdentity (
+        bool IsAvailable,
+        ulong Device,
+        ulong Inode,
+        int Mode)
+    {
+        public static OutputFileIdentity Unavailable => default;
+
+        public bool IsRegularFile => (Mode & PosixFileTypeMask) == PosixRegularFileType;
+    }
+
     private sealed record ResolvedOutputSourceEntry (
         string SourcePath,
         string Kind);
@@ -1351,5 +1524,15 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         {
         }
     }
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "lstat")]
+    private static extern int LStat (
+        string path,
+        byte[] fileStatus);
+
+    [DllImport("libc", SetLastError = true, EntryPoint = "fstat")]
+    private static extern int FStat (
+        IntPtr fileDescriptor,
+        byte[] fileStatus);
 
 }

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -671,6 +671,28 @@ public sealed class BuildServiceTests
         Assert.Equal(UcliCoreErrorCodes.InternalError, error.Code);
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task Execute_WithUnknownBuildReportResult_ReturnsCommandFailureBeforeArtifactAccounting ()
+    {
+        using var tempDirectory = TemporaryDirectory.Create();
+        var artifactStore = new StubBuildRunArtifactStore(tempDirectory.Path);
+        var service = CreateService(
+            requestExecutor: CreateBuildResponseExecutor(
+                ContractLiteralCodec.ToValue(IpcBuildReportResult.Unknown),
+                ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Failed),
+                errorCount: 1),
+            artifactStore: artifactStore);
+
+        var result = await service.ExecuteAsync(CreateInput());
+
+        Assert.False(result.IsSuccess);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(UcliCoreErrorCodes.InternalError, error.Code);
+        Assert.Null(artifactStore.AccountingRequest);
+        Assert.Null(artifactStore.WrittenMetadata);
+    }
+
     [Theory]
     [Trait("Size", "Small")]
     [InlineData(IpcBuildReportResult.Failed, IpcBuildLogCompletionReason.Failed)]

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -13,7 +13,6 @@ using MackySoft.Ucli.Application.Shared.Configuration;
 using MackySoft.Ucli.Application.Shared.Context;
 using MackySoft.Ucli.Application.Shared.Execution.Progress;
 using MackySoft.Ucli.Application.Shared.Execution.UnityExecutionMode.Decision;
-using MackySoft.Ucli.Application.Shared.Foundation;
 using MackySoft.Ucli.Contracts.Assurance;
 using MackySoft.Ucli.Contracts.Ipc;
 using CodeCatalogModel = MackySoft.Ucli.Application.Features.CodeCatalog.Catalog.CodeCatalog;
@@ -136,7 +135,7 @@ public sealed class BuildServiceTests
         Assert.Equal(0, artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("environment").GetArrayLength());
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("shape").GetString());
         Assert.Equal(
-            CreateExpectedPlayerLocationPathName(preparedPaths.OutputDirectory),
+            CreateExpectedPlayerLocationPathName(preparedPaths.RunnerOutputDirectory),
             artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal(output.Build.Summary.ReportRef, artifactStore.WrittenMetadata.Summary.GetProperty("reportRef").GetString());
         Assert.Equal(output.Build.Logs.ReportRef, artifactStore.WrittenMetadata.Logs.GetProperty("reportRef").GetString());
@@ -160,7 +159,7 @@ public sealed class BuildServiceTests
         Assert.Equal("transientProbe", startedEntry.SessionKind);
         Assert.Equal(10000, startedEntry.TimeoutMilliseconds);
         Assert.Equal("standaloneLinux64", startedEntry.BuildTarget);
-        Assert.Equal(preparedPaths.OutputDirectory, startedEntry.OutputPath);
+        Assert.Equal(preparedPaths.RunnerOutputDirectory, startedEntry.OutputPath);
         var completedEntry = Assert.IsType<BuildRunCompletedEntry>(progressSink.Entries[1].Payload);
         Assert.Equal(RunId, completedEntry.RunId);
         Assert.Equal(ContractLiteralCodec.ToValue(BuildVerdict.Pass), completedEntry.Verdict);
@@ -185,13 +184,20 @@ public sealed class BuildServiceTests
         Assert.Equal("explicit", requestPayload.SceneSource);
         Assert.Equal(["Assets/Scenes/Main.unity"], requestPayload.ScenePaths);
         Assert.True(requestPayload.Development);
-        Assert.Equal(preparedPaths.OutputDirectory, requestPayload.OutputPath);
+        Assert.Equal(preparedPaths.RunnerOutputDirectory, requestPayload.OutputPath);
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File), requestPayload.OutputLayout.Shape);
-        Assert.Equal(CreateExpectedPlayerLocationPathName(preparedPaths.OutputDirectory), requestPayload.OutputLayout.LocationPathName);
+        Assert.Equal(CreateExpectedPlayerLocationPathName(preparedPaths.RunnerOutputDirectory), requestPayload.OutputLayout.LocationPathName);
         Assert.Equal(preparedPaths.BuildReportJsonPath, requestPayload.BuildReportPath);
         Assert.Equal(preparedPaths.BuildLogPath, requestPayload.BuildLogPath);
         Assert.Equal(["batchmode", "gui"], requestPayload.AllowedEditorModes);
         Assert.Equal("forbid", requestPayload.ProjectMutationMode);
+        Assert.NotEqual(preparedPaths.RunnerOutputDirectory, preparedPaths.ArtifactOutputDirectory);
+        var accountingRequest = Assert.IsType<BuildRunArtifactAccountingRequest>(artifactStore.AccountingRequest);
+        var outputSource = Assert.Single(accountingRequest.OutputSources);
+        Assert.Equal(requestPayload.OutputLayout.LocationPathName, outputSource.SourcePath);
+        Assert.Equal("standaloneLinux64", accountingRequest.BuildTarget);
+        Assert.Equal("StandaloneLinux64", accountingRequest.UnityBuildTarget);
+        Assert.False(accountingRequest.AllowEmptyOutputManifest);
     }
 
     [Fact]
@@ -665,35 +671,43 @@ public sealed class BuildServiceTests
         Assert.Equal(UcliCoreErrorCodes.InternalError, error.Code);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Small")]
-    public async Task Execute_WithReportOutputPathOutsideRequestedOutput_ReturnsCommandFailure ()
+    [InlineData(IpcBuildReportResult.Failed, IpcBuildLogCompletionReason.Failed)]
+    [InlineData(IpcBuildReportResult.Canceled, IpcBuildLogCompletionReason.Canceled)]
+    public async Task Execute_WithUnsuccessfulBuildResponse_AllowsEmptyOutputManifest (
+        IpcBuildReportResult reportResult,
+        IpcBuildLogCompletionReason completionReason)
     {
         using var tempDirectory = TemporaryDirectory.Create();
-        var reportOutputPath = System.IO.Path.Combine(tempDirectory.Path, "outside", "build");
         var artifactStore = new StubBuildRunArtifactStore(
             tempDirectory.Path,
             (request, _) =>
             {
-                Assert.Equal(reportOutputPath, request.ReportedOutputPath);
-                return ValueTask.FromResult(BuildRunArtifactAccountingOperationResult.Failure(ExecutionError.InternalError(
-                    "Build report output path must remain under the requested output directory.",
-                    BuildErrorCodes.BuildOutputManifestFailed)));
+                Assert.True(request.AllowEmptyOutputManifest);
+                return ValueTask.FromResult(BuildRunArtifactAccountingOperationResult.Success(new BuildRunArtifactAccountingResult(
+                    BuildReport: new BuildArtifactRef(BuildArtifactKind.BuildReport, "build-report.json", BuildReportArtifactDigest),
+                    BuildOutputManifest: new BuildArtifactRef(BuildArtifactKind.BuildOutputManifest, "output-manifest.json", BuildOutputManifestArtifactDigest),
+                    BuildLog: new BuildArtifactRef(BuildArtifactKind.BuildLog, "build.log", BuildLogArtifactDigest),
+                    OutputManifest: new BuildOutputManifestSummary(
+                        ManifestDigest: OutputManifestDigest,
+                        EntryCount: 0,
+                        FileCount: 0,
+                        TotalBytes: 0))));
             });
         var service = CreateService(
             requestExecutor: CreateBuildResponseExecutor(
-                ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
-                ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed),
-                errorCount: 0,
-                reportOutputPath: reportOutputPath),
+                ContractLiteralCodec.ToValue(reportResult),
+                ContractLiteralCodec.ToValue(completionReason),
+                errorCount: 1),
             artifactStore: artifactStore);
 
         var result = await service.ExecuteAsync(CreateInput());
 
-        Assert.False(result.IsSuccess);
-        var error = Assert.Single(result.Errors);
-        Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
-        Assert.Null(result.Output);
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, result.Output!.Build.Output.EntryCount);
+        Assert.Equal(0, result.Output.Build.Output.FileCount);
+        Assert.Equal(0, result.Output.Build.Output.TotalBytes);
     }
 
     [Fact]
@@ -1434,8 +1448,9 @@ public sealed class BuildServiceTests
             string runId)
         {
             var runDirectory = Path.Combine(rootPath, runId);
-            var outputDirectory = Path.Combine(runDirectory, "output");
-            Directory.CreateDirectory(outputDirectory);
+            var runnerOutputDirectory = Path.Combine(rootPath, "work", runId, "output");
+            var artifactOutputDirectory = Path.Combine(runDirectory, "output");
+            Directory.CreateDirectory(runnerOutputDirectory);
             PreparedPaths = new BuildRunArtifactPaths(
                 RepositoryRoot: rootPath,
                 RunId: runId,
@@ -1444,7 +1459,8 @@ public sealed class BuildServiceTests
                 BuildReportJsonPath: Path.Combine(runDirectory, "build-report.json"),
                 BuildLogPath: Path.Combine(runDirectory, "build.log"),
                 OutputManifestJsonPath: Path.Combine(runDirectory, "output-manifest.json"),
-                OutputDirectory: outputDirectory);
+                RunnerOutputDirectory: runnerOutputDirectory,
+                ArtifactOutputDirectory: artifactOutputDirectory);
             return BuildRunArtifactPreparationResult.Success(PreparedPaths);
         }
 

--- a/tests/Ucli.Application.Tests/Features/CodeCatalog/Catalog/CodeCatalogTests.cs
+++ b/tests/Ucli.Application.Tests/Features/CodeCatalog/Catalog/CodeCatalogTests.cs
@@ -154,7 +154,10 @@ public sealed class CodeCatalogTests
             ApplicationFailure.FromCode(BuildErrorCodes.BuildOutputManifestFailed, "Output manifest failed.").Outcome);
         Assert.Equal(
             ApplicationOutcome.ToolError,
-            ApplicationFailure.FromCode(BuildErrorCodes.BuildOutputDigestMismatch, "Digest mismatch.").Outcome);
+            ApplicationFailure.FromCode(BuildErrorCodes.BuildOutputManifestDigestMismatch, "Digest mismatch.").Outcome);
+        Assert.Equal(
+            ApplicationOutcome.ToolError,
+            ApplicationFailure.FromCode(BuildErrorCodes.BuildOutputManifestArtifactDigestMismatch, "Artifact digest mismatch.").Outcome);
     }
 
     [Fact]

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
@@ -1,10 +1,19 @@
 using System.Text.Json;
 using MackySoft.Ucli.Contracts.Assurance.Build;
+using MackySoft.Ucli.Contracts.Text;
 
 namespace MackySoft.Ucli.Contracts.Tests.Assurance.Build;
 
 public sealed class BuildOutputManifestJsonContractWriterTests
 {
+    [Fact]
+    [Trait("Size", "Small")]
+    public void BuildOutputManifestEntryKind_HasStableContractLiterals ()
+    {
+        Assert.Equal("file", ContractLiteralCodec.ToValue(BuildOutputManifestEntryKind.File));
+        Assert.Equal("directory", ContractLiteralCodec.ToValue(BuildOutputManifestEntryKind.Directory));
+    }
+
     [Fact]
     [Trait("Size", "Small")]
     public void Write_WritesStablePublicShapeWithTrailingNewline ()

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildOutputManifestJsonContractWriterTests.cs
@@ -12,13 +12,16 @@ public sealed class BuildOutputManifestJsonContractWriterTests
         var writer = new BuildOutputManifestJsonContractWriter();
         var contract = new BuildOutputManifestJsonContract(
             BuildOutputManifestJsonContract.CurrentSchemaVersion,
-            ".ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output",
-            "standaloneLinux64",
+            new BuildOutputManifestTargetJsonContract("standaloneLinux64", "StandaloneLinux64"),
+            [
+                new BuildOutputManifestEntryJsonContract("output-0001", "directory", "/workspace/build/player"),
+            ],
+            1,
             2,
             17,
             [
-                new BuildOutputManifestFileJsonContract("Data/config.json", 5, new string('a', 64)),
-                new BuildOutputManifestFileJsonContract("Game.x86_64", 12, new string('b', 64)),
+                new BuildOutputManifestFileJsonContract("output-0001", "output-0001/Data/config.json", "/workspace/build/player/Data/config.json", "output/output-0001/Data/config.json", 5, new string('a', 64)),
+                new BuildOutputManifestFileJsonContract("output-0001", "output-0001/Game.x86_64", "/workspace/build/player/Game.x86_64", "output/output-0001/Game.x86_64", 12, new string('b', 64)),
             ],
             new string('c', 64));
 
@@ -30,8 +33,9 @@ public sealed class BuildOutputManifestJsonContractWriterTests
         Assert.Equal(
             [
                 "schemaVersion",
-                "outputRoot",
-                "buildTarget",
+                "target",
+                "entries",
+                "entryCount",
                 "fileCount",
                 "totalBytes",
                 "files",
@@ -39,10 +43,30 @@ public sealed class BuildOutputManifestJsonContractWriterTests
             ],
             root.EnumerateObject().Select(static property => property.Name).ToArray());
 
+        var target = root.GetProperty("target");
+        Assert.Equal(
+            [
+                "stableName",
+                "unityBuildTarget",
+            ],
+            target.EnumerateObject().Select(static property => property.Name).ToArray());
+
+        var firstEntry = root.GetProperty("entries")[0];
+        Assert.Equal(
+            [
+                "id",
+                "kind",
+                "sourcePath",
+            ],
+            firstEntry.EnumerateObject().Select(static property => property.Name).ToArray());
+
         var firstFile = root.GetProperty("files")[0];
         Assert.Equal(
             [
-                "path",
+                "entryId",
+                "logicalPath",
+                "sourcePath",
+                "artifactPath",
                 "sizeBytes",
                 "sha256",
             ],
@@ -56,21 +80,24 @@ public sealed class BuildOutputManifestJsonContractWriterTests
         var writer = new BuildOutputManifestJsonContractWriter();
         var content = new BuildOutputManifestContentJsonContract(
             BuildOutputManifestJsonContract.CurrentSchemaVersion,
-            ".ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output",
-            "standaloneLinux64",
+            new BuildOutputManifestTargetJsonContract("standaloneLinux64", "StandaloneLinux64"),
+            [
+                new BuildOutputManifestEntryJsonContract("output-0001", "file", "/workspace/build/player/Player"),
+            ],
+            1,
             1,
             12,
             [
-                new BuildOutputManifestFileJsonContract("Game.x86_64", 12, new string('b', 64)),
+                new BuildOutputManifestFileJsonContract("output-0001", "output-0001/Player", "/workspace/build/player/Player", "output/output-0001/Player", 12, new string('b', 64)),
             ]);
 
         var digestSource = writer.WriteDigestSource(content);
         var digest = writer.CalculateManifestDigest(content);
 
         Assert.Equal(
-            "{\"schemaVersion\":1,\"outputRoot\":\".ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output\",\"buildTarget\":\"standaloneLinux64\",\"fileCount\":1,\"totalBytes\":12,\"files\":[{\"path\":\"Game.x86_64\",\"sizeBytes\":12,\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}",
+            "{\"schemaVersion\":1,\"target\":{\"stableName\":\"standaloneLinux64\",\"unityBuildTarget\":\"StandaloneLinux64\"},\"entries\":[{\"id\":\"output-0001\",\"kind\":\"file\",\"sourcePath\":\"/workspace/build/player/Player\"}],\"entryCount\":1,\"fileCount\":1,\"totalBytes\":12,\"files\":[{\"entryId\":\"output-0001\",\"logicalPath\":\"output-0001/Player\",\"sourcePath\":\"/workspace/build/player/Player\",\"artifactPath\":\"output/output-0001/Player\",\"sizeBytes\":12,\"sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\"}]}",
             digestSource);
-        Assert.Equal("0b6ea568d0262e545935b9a5a573e52a86fb1cc1576aae647fc1b7c9c8606404", digest);
+        Assert.Equal("d1280d23359f281aceca8d928adaca97dc3f9b940cdc30648fdf20edd4a216d3", digest);
         Assert.DoesNotContain("manifestDigest", digestSource, StringComparison.Ordinal);
         Assert.All(digest, static c => Assert.True(
             (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),

--- a/tests/Ucli.Infrastructure.Tests/Storage/UcliStoragePathResolverContractTests.cs
+++ b/tests/Ucli.Infrastructure.Tests/Storage/UcliStoragePathResolverContractTests.cs
@@ -519,6 +519,28 @@ public sealed class UcliStoragePathResolverContractTests
             resolvedPath);
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public void ResolveBuildRunOutputDirectory_ReturnsRunScopedWorkPath ()
+    {
+        var storageRoot = Path.Combine(Path.GetTempPath(), "ucli-infrastructure-storage-root");
+
+        var resolvedPath = UcliStoragePathResolver.ResolveBuildRunOutputDirectory(storageRoot, "abc123", "run-id");
+
+        Assert.Equal(
+            Path.Combine(
+                Path.GetFullPath(storageRoot),
+                UcliStoragePathNames.UcliDirectoryName,
+                UcliStoragePathNames.LocalDirectoryName,
+                UcliStoragePathNames.FingerprintsDirectoryName,
+                "abc123",
+                UcliStoragePathNames.WorkDirectoryName,
+                UcliStoragePathNames.BuildWorkDirectoryName,
+                "run-id",
+                UcliStoragePathNames.BuildOutputDirectoryName),
+            resolvedPath);
+    }
+
     [Theory]
     [Trait("Size", "Small")]
     [InlineData("../run-id")]
@@ -555,6 +577,26 @@ public sealed class UcliStoragePathResolverContractTests
 
         var exception = Assert.Throws<ArgumentException>(() =>
             UcliStoragePathResolver.ResolveBuildRunArtifactsDirectory(storageRoot, "abc123", runId));
+
+        Assert.Equal("runId", exception.ParamName);
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("../run-id")]
+    [InlineData("..\\run-id")]
+    [InlineData("run/id")]
+    [InlineData("run\\id")]
+    [InlineData("/absolute")]
+    [InlineData("C:\\absolute")]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void ResolveBuildRunOutputDirectory_WithPathSegmentOrTraversalRunId_ThrowsArgumentException (string runId)
+    {
+        var storageRoot = Path.Combine(Path.GetTempPath(), "ucli-infrastructure-storage-root");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            UcliStoragePathResolver.ResolveBuildRunOutputDirectory(storageRoot, "abc123", runId));
 
         Assert.Equal("runId", exception.ParamName);
     }

--- a/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
@@ -21,8 +21,8 @@ public sealed class BuildRunCliOutputContractTests
     private const string BuildRunGoldenDirectory = "build-run";
     private const string BuildArtifactFixtureRoot = "tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts";
     private const string ArtifactRoot = "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1";
-    private const string SuccessManifestDigest = "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1";
-    private const string FailedManifestDigest = "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444";
+    private const string SuccessManifestDigest = "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b";
+    private const string FailedManifestDigest = "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21";
 
     private static readonly string RepositoryRoot = FindRepositoryRoot();
     private static readonly string BuildDigest = new('a', 64);
@@ -238,6 +238,7 @@ public sealed class BuildRunCliOutputContractTests
         var manifestDigest = succeeded ? SuccessManifestDigest : FailedManifestDigest;
         var errorCount = succeeded ? 0 : 1;
         var warningCount = succeeded ? 1 : 0;
+        var entryCount = succeeded ? 1 : 0;
         var fileCount = succeeded ? 2 : 0;
         var totalBytes = succeeded ? 33 : 0;
         var build = new BuildOutput(
@@ -249,7 +250,7 @@ public sealed class BuildRunCliOutputContractTests
             Output: new BuildArtifactOutput(
                 ManifestRef: BuildReportRefs.BuildOutputManifest,
                 ManifestDigest: manifestDigest,
-                EntryCount: fileCount,
+                EntryCount: entryCount,
                 FileCount: fileCount,
                 TotalBytes: totalBytes),
             Generations: CreateGenerations(),
@@ -735,20 +736,37 @@ public sealed class BuildRunCliOutputContractTests
 
     private static BuildOutputManifestContentJsonContract ReadOutputManifestContent (JsonElement root)
     {
+        var targetElement = root.GetProperty("target");
+        var entryElements = root.GetProperty("entries");
+        var entries = new List<BuildOutputManifestEntryJsonContract>(entryElements.GetArrayLength());
+        foreach (var entry in entryElements.EnumerateArray())
+        {
+            entries.Add(new BuildOutputManifestEntryJsonContract(
+                entry.GetProperty("id").GetString()!,
+                entry.GetProperty("kind").GetString()!,
+                entry.GetProperty("sourcePath").GetString()!));
+        }
+
         var fileElements = root.GetProperty("files");
         var files = new List<BuildOutputManifestFileJsonContract>(fileElements.GetArrayLength());
         foreach (var file in fileElements.EnumerateArray())
         {
             files.Add(new BuildOutputManifestFileJsonContract(
-                file.GetProperty("path").GetString()!,
+                file.GetProperty("entryId").GetString()!,
+                file.GetProperty("logicalPath").GetString()!,
+                file.GetProperty("sourcePath").GetString()!,
+                file.GetProperty("artifactPath").GetString()!,
                 file.GetProperty("sizeBytes").GetInt64(),
                 file.GetProperty("sha256").GetString()!));
         }
 
         return new BuildOutputManifestContentJsonContract(
             root.GetProperty("schemaVersion").GetInt32(),
-            root.GetProperty("outputRoot").GetString()!,
-            root.GetProperty("buildTarget").GetString()!,
+            new BuildOutputManifestTargetJsonContract(
+                targetElement.GetProperty("stableName").GetString()!,
+                targetElement.GetProperty("unityBuildTarget").GetString()!),
+            entries,
+            root.GetProperty("entryCount").GetInt32(),
             root.GetProperty("fileCount").GetInt32(),
             root.GetProperty("totalBytes").GetInt64(),
             files);

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -187,8 +187,10 @@ public sealed class FileBuildRunArtifactStoreTests
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
         var directorySourcePath = Path.Combine(paths.RunnerOutputDirectory, "player");
         var fileSourcePath = Path.Combine(paths.RunnerOutputDirectory, "Game.x86_64");
-        var configSourcePath = Path.Combine(directorySourcePath, "Data", "config.json");
-        var configBytes = WriteUtf8(configSourcePath, "{\"quality\":\"high\"}\n");
+        var zConfigSourcePath = Path.Combine(directorySourcePath, "Data", "z-config.json");
+        var aConfigSourcePath = Path.Combine(directorySourcePath, "Data", "a-config.json");
+        var zConfigBytes = WriteUtf8(zConfigSourcePath, "{\"quality\":\"high\"}\n");
+        var aConfigBytes = WriteUtf8(aConfigSourcePath, "{\"quality\":\"low\"}\n");
         var playerBytes = WriteUtf8(fileSourcePath, "player binary\n");
         var buildReportBytes = WriteUtf8(paths.BuildReportJsonPath, "{\"result\":\"succeeded\"}\n");
         var buildLogBytes = WriteUtf8(paths.BuildLogPath, "build log\n");
@@ -250,33 +252,42 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal("file", entries[1].GetProperty("kind").GetString());
         Assert.Equal(Path.GetFullPath(fileSourcePath), entries[1].GetProperty("sourcePath").GetString());
         Assert.Equal(2, outputRoot.GetProperty("entryCount").GetInt32());
-        Assert.Equal(2, outputRoot.GetProperty("fileCount").GetInt32());
-        Assert.Equal(configBytes.Length + playerBytes.Length, outputRoot.GetProperty("totalBytes").GetInt64());
+        Assert.Equal(3, outputRoot.GetProperty("fileCount").GetInt32());
+        Assert.Equal(aConfigBytes.Length + zConfigBytes.Length + playerBytes.Length, outputRoot.GetProperty("totalBytes").GetInt64());
         Assert.Equal(result.OutputManifest.ManifestDigest, outputRoot.GetProperty("manifestDigest").GetString());
         Assert.Equal(2, result.OutputManifest.EntryCount);
-        Assert.Equal(2, result.OutputManifest.FileCount);
-        Assert.Equal(configBytes.Length + playerBytes.Length, result.OutputManifest.TotalBytes);
+        Assert.Equal(3, result.OutputManifest.FileCount);
+        Assert.Equal(aConfigBytes.Length + zConfigBytes.Length + playerBytes.Length, result.OutputManifest.TotalBytes);
         AssertLowerSha256(result.OutputManifest.ManifestDigest);
 
         var files = outputRoot.GetProperty("files");
         Assert.Equal("output-0001", files[0].GetProperty("entryId").GetString());
-        Assert.Equal("output-0001/Data/config.json", files[0].GetProperty("logicalPath").GetString());
-        Assert.Equal(Path.GetFullPath(configSourcePath), files[0].GetProperty("sourcePath").GetString());
-        Assert.Equal("output/output-0001/Data/config.json", files[0].GetProperty("artifactPath").GetString());
-        Assert.Equal(configBytes.Length, files[0].GetProperty("sizeBytes").GetInt64());
-        Assert.Equal(Sha256LowerHex.Compute(configBytes), files[0].GetProperty("sha256").GetString());
-        Assert.Equal("output-0002", files[1].GetProperty("entryId").GetString());
-        Assert.Equal("output-0002/Game.x86_64", files[1].GetProperty("logicalPath").GetString());
-        Assert.Equal(Path.GetFullPath(fileSourcePath), files[1].GetProperty("sourcePath").GetString());
-        Assert.Equal("output/output-0002/Game.x86_64", files[1].GetProperty("artifactPath").GetString());
-        Assert.Equal(playerBytes.Length, files[1].GetProperty("sizeBytes").GetInt64());
-        Assert.Equal(Sha256LowerHex.Compute(playerBytes), files[1].GetProperty("sha256").GetString());
+        Assert.Equal("output-0001/Data/a-config.json", files[0].GetProperty("logicalPath").GetString());
+        Assert.Equal(Path.GetFullPath(aConfigSourcePath), files[0].GetProperty("sourcePath").GetString());
+        Assert.Equal("output/output-0001/Data/a-config.json", files[0].GetProperty("artifactPath").GetString());
+        Assert.Equal(aConfigBytes.Length, files[0].GetProperty("sizeBytes").GetInt64());
+        Assert.Equal(Sha256LowerHex.Compute(aConfigBytes), files[0].GetProperty("sha256").GetString());
+        Assert.Equal("output-0001", files[1].GetProperty("entryId").GetString());
+        Assert.Equal("output-0001/Data/z-config.json", files[1].GetProperty("logicalPath").GetString());
+        Assert.Equal(Path.GetFullPath(zConfigSourcePath), files[1].GetProperty("sourcePath").GetString());
+        Assert.Equal("output/output-0001/Data/z-config.json", files[1].GetProperty("artifactPath").GetString());
+        Assert.Equal(zConfigBytes.Length, files[1].GetProperty("sizeBytes").GetInt64());
+        Assert.Equal(Sha256LowerHex.Compute(zConfigBytes), files[1].GetProperty("sha256").GetString());
+        Assert.Equal("output-0002", files[2].GetProperty("entryId").GetString());
+        Assert.Equal("output-0002/Game.x86_64", files[2].GetProperty("logicalPath").GetString());
+        Assert.Equal(Path.GetFullPath(fileSourcePath), files[2].GetProperty("sourcePath").GetString());
+        Assert.Equal("output/output-0002/Game.x86_64", files[2].GetProperty("artifactPath").GetString());
+        Assert.Equal(playerBytes.Length, files[2].GetProperty("sizeBytes").GetInt64());
+        Assert.Equal(Sha256LowerHex.Compute(playerBytes), files[2].GetProperty("sha256").GetString());
         await AssertFileSha256Async(
-            Path.Combine(paths.ArtifactOutputDirectory, "output-0001", "Data", "config.json"),
+            Path.Combine(paths.ArtifactOutputDirectory, "output-0001", "Data", "a-config.json"),
             files[0].GetProperty("sha256").GetString()!);
         await AssertFileSha256Async(
-            Path.Combine(paths.ArtifactOutputDirectory, "output-0002", "Game.x86_64"),
+            Path.Combine(paths.ArtifactOutputDirectory, "output-0001", "Data", "z-config.json"),
             files[1].GetProperty("sha256").GetString()!);
+        await AssertFileSha256Async(
+            Path.Combine(paths.ArtifactOutputDirectory, "output-0002", "Game.x86_64"),
+            files[2].GetProperty("sha256").GetString()!);
         var recalculatedManifestDigest = new BuildOutputManifestJsonContractWriter().CalculateManifestDigest(
             ReadOutputManifestContent(outputRoot));
         Assert.Equal(recalculatedManifestDigest, result.OutputManifest.ManifestDigest);
@@ -353,6 +364,37 @@ public sealed class FileBuildRunArtifactStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenOutputSourceContainsSymbolicLinkAncestor_ReturnsOutputManifestFailed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "output-symlink-ancestor");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        var outputSourceDirectory = Path.Combine(paths.RunnerOutputDirectory, "build");
+        Directory.CreateDirectory(outputSourceDirectory);
+        var targetDirectory = scope.CreateDirectory("outside-output");
+        var targetFilePath = Path.Combine(targetDirectory, "payload.txt");
+        WriteUtf8(targetFilePath, "external output");
+        var linkPath = Path.Combine(outputSourceDirectory, "linked");
+        if (!TryCreateDirectorySymbolicLink(linkPath, targetDirectory))
+        {
+            return;
+        }
+
+        var writeResult = await store.AccountArtifactsAsync(
+            CreateAccountingRequest(paths, Path.Combine(linkPath, "payload.txt")),
+            CancellationToken.None);
+
+        Assert.False(writeResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(writeResult.Error);
+        Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
+        Assert.Contains("reparse point", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public async Task AccountArtifactsAsync_WhenOutputContainsFifo_ReturnsOutputManifestFailed ()
     {
         if (OperatingSystem.IsWindows())
@@ -380,6 +422,87 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
         Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
         Assert.Contains("regular file", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenOutputFileIsUnreadable_ReturnsOutputManifestFailed ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "output-unreadable-file");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        var outputPath = Path.Combine(paths.RunnerOutputDirectory, "build");
+        WriteUtf8(outputPath, "secret");
+        var originalMode = File.GetUnixFileMode(outputPath);
+        try
+        {
+            File.SetUnixFileMode(outputPath, UnixFileMode.UserWrite);
+            if (CanOpenForRead(outputPath))
+            {
+                return;
+            }
+
+            var writeResult = await store.AccountArtifactsAsync(
+                CreateAccountingRequest(paths),
+                CancellationToken.None);
+
+            Assert.False(writeResult.IsSuccess);
+            var error = Assert.IsType<ExecutionError>(writeResult.Error);
+            Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+            Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
+        }
+        finally
+        {
+            File.SetUnixFileMode(outputPath, originalMode);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenOutputDirectoryIsNonTraversable_ReturnsOutputManifestFailed ()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "output-non-traversable-directory");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        var blockedDirectory = Path.Combine(paths.RunnerOutputDirectory, "build", "blocked");
+        var outputPath = Path.Combine(blockedDirectory, "payload.txt");
+        WriteUtf8(outputPath, "secret");
+        var originalMode = File.GetUnixFileMode(blockedDirectory);
+        try
+        {
+            File.SetUnixFileMode(blockedDirectory, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            if (CanEnumerateDirectory(blockedDirectory))
+            {
+                return;
+            }
+
+            var writeResult = await store.AccountArtifactsAsync(
+                CreateAccountingRequest(paths),
+                CancellationToken.None);
+
+            Assert.False(writeResult.IsSuccess);
+            var error = Assert.IsType<ExecutionError>(writeResult.Error);
+            Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
+            Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
+        }
+        finally
+        {
+            File.SetUnixFileMode(blockedDirectory, originalMode);
+        }
     }
 
     [Fact]
@@ -433,6 +556,31 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
         Assert.Equal(BuildErrorCodes.BuildOutputPathInvalid, error.Code);
         Assert.Contains("output path", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenOutputSourceResolvesOutsideRunnerOutputRoot_ReturnsOutputPathInvalid ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "source-outside-runner-output-root");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        WriteUnityGeneratedArtifacts(paths);
+        var outsideSourcePath = scope.WriteFile("external-output.bin", "external");
+        var request = CreateAccountingRequest(paths) with
+        {
+            OutputSources = [new BuildOutputSourceEntry(outsideSourcePath)],
+        };
+
+        var writeResult = await store.AccountArtifactsAsync(request, CancellationToken.None);
+
+        Assert.False(writeResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(writeResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildOutputPathInvalid, error.Code);
+        Assert.Contains("runner output root", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -759,6 +907,55 @@ public sealed class FileBuildRunArtifactStoreTests
             return false;
         }
         catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryCreateDirectorySymbolicLink (
+        string symbolicLinkPath,
+        string targetPath)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(symbolicLinkPath, targetPath);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool CanOpenForRead (string path)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool CanEnumerateDirectory (string path)
+    {
+        try
+        {
+            _ = Directory.EnumerateFileSystemEntries(path).Any();
+            return true;
+        }
+        catch (UnauthorizedAccessException)
         {
             return false;
         }

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -29,7 +29,8 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.True(result.IsSuccess);
         var paths = Assert.IsType<BuildRunArtifactPaths>(result.Paths);
         Assert.True(Directory.Exists(paths.ArtifactsDirectory));
-        Assert.True(Directory.Exists(paths.OutputDirectory));
+        Assert.True(Directory.Exists(paths.RunnerOutputDirectory));
+        Assert.False(Directory.Exists(paths.ArtifactOutputDirectory));
         Assert.Equal(
             Path.Combine(
                 scope.FullPath,
@@ -41,6 +42,18 @@ public sealed class FileBuildRunArtifactStoreTests
                 UcliStoragePathNames.BuildArtifactsDirectoryName,
                 "run-1"),
             paths.ArtifactsDirectory);
+        Assert.Equal(
+            Path.Combine(
+                scope.FullPath,
+                UcliStoragePathNames.UcliDirectoryName,
+                UcliStoragePathNames.LocalDirectoryName,
+                UcliStoragePathNames.FingerprintsDirectoryName,
+                "fingerprint",
+                UcliStoragePathNames.WorkDirectoryName,
+                UcliStoragePathNames.BuildWorkDirectoryName,
+                "run-1",
+                UcliStoragePathNames.BuildOutputDirectoryName),
+            paths.RunnerOutputDirectory);
     }
 
     [Fact]
@@ -92,7 +105,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.RunnerOutputDirectory, "standaloneLinux64", out var layout));
 
         var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout!);
 
@@ -111,7 +124,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.RunnerOutputDirectory, "standaloneLinux64", out var layout));
         WriteUtf8(layout!.LocationPathName, "existing player");
 
         var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout);
@@ -131,8 +144,8 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.OutputDirectory, "standaloneLinux64", out var layout));
-        WriteUtf8(Path.Combine(paths.OutputDirectory, "player"), "blocking file");
+        Assert.True(IpcBuildOutputLayoutResolver.TryResolve(paths.RunnerOutputDirectory, "standaloneLinux64", out var layout));
+        WriteUtf8(Path.Combine(paths.RunnerOutputDirectory, "player"), "blocking file");
 
         var result = store.PrepareBuildPipelineOutputLayout(paths, "standaloneLinux64", layout!);
 
@@ -153,7 +166,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
         var layout = new IpcBuildOutputLayout(
             Shape: ContractLiteralCodec.ToValue(IpcBuildOutputLayoutShape.File),
-            LocationPathName: Path.Combine(paths.OutputDirectory, "player", "Player"));
+            LocationPathName: Path.Combine(paths.RunnerOutputDirectory, "player", "Player"));
 
         var result = store.PrepareBuildPipelineOutputLayout(paths, "switch", layout);
 
@@ -172,13 +185,16 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        var configBytes = WriteUtf8(Path.Combine(paths.OutputDirectory, "Data", "config.json"), "{\"quality\":\"high\"}\n");
-        var playerBytes = WriteUtf8(Path.Combine(paths.OutputDirectory, "Game.x86_64"), "player binary\n");
+        var directorySourcePath = Path.Combine(paths.RunnerOutputDirectory, "player");
+        var fileSourcePath = Path.Combine(paths.RunnerOutputDirectory, "Game.x86_64");
+        var configSourcePath = Path.Combine(directorySourcePath, "Data", "config.json");
+        var configBytes = WriteUtf8(configSourcePath, "{\"quality\":\"high\"}\n");
+        var playerBytes = WriteUtf8(fileSourcePath, "player binary\n");
         var buildReportBytes = WriteUtf8(paths.BuildReportJsonPath, "{\"result\":\"succeeded\"}\n");
         var buildLogBytes = WriteUtf8(paths.BuildLogPath, "build log\n");
 
         var accountingOperation = await store.AccountArtifactsAsync(
-            CreateAccountingRequest(paths),
+            CreateAccountingRequest(paths, directorySourcePath, fileSourcePath),
             CancellationToken.None);
 
         Assert.True(accountingOperation.IsSuccess);
@@ -222,10 +238,18 @@ public sealed class FileBuildRunArtifactStoreTests
 
         using var outputManifest = JsonDocument.Parse(await File.ReadAllTextAsync(paths.OutputManifestJsonPath, CancellationToken.None));
         var outputRoot = outputManifest.RootElement;
-        Assert.Equal(
-            ToRepositoryRelativeSlashPath(scope.FullPath, paths.OutputDirectory),
-            outputRoot.GetProperty("outputRoot").GetString());
-        Assert.Equal("standaloneLinux64", outputRoot.GetProperty("buildTarget").GetString());
+        var target = outputRoot.GetProperty("target");
+        Assert.Equal("standaloneLinux64", target.GetProperty("stableName").GetString());
+        Assert.Equal("StandaloneLinux64", target.GetProperty("unityBuildTarget").GetString());
+        var entries = outputRoot.GetProperty("entries");
+        Assert.Equal(2, entries.GetArrayLength());
+        Assert.Equal("output-0001", entries[0].GetProperty("id").GetString());
+        Assert.Equal("directory", entries[0].GetProperty("kind").GetString());
+        Assert.Equal(Path.GetFullPath(directorySourcePath), entries[0].GetProperty("sourcePath").GetString());
+        Assert.Equal("output-0002", entries[1].GetProperty("id").GetString());
+        Assert.Equal("file", entries[1].GetProperty("kind").GetString());
+        Assert.Equal(Path.GetFullPath(fileSourcePath), entries[1].GetProperty("sourcePath").GetString());
+        Assert.Equal(2, outputRoot.GetProperty("entryCount").GetInt32());
         Assert.Equal(2, outputRoot.GetProperty("fileCount").GetInt32());
         Assert.Equal(configBytes.Length + playerBytes.Length, outputRoot.GetProperty("totalBytes").GetInt64());
         Assert.Equal(result.OutputManifest.ManifestDigest, outputRoot.GetProperty("manifestDigest").GetString());
@@ -235,12 +259,24 @@ public sealed class FileBuildRunArtifactStoreTests
         AssertLowerSha256(result.OutputManifest.ManifestDigest);
 
         var files = outputRoot.GetProperty("files");
-        Assert.Equal("Data/config.json", files[0].GetProperty("path").GetString());
+        Assert.Equal("output-0001", files[0].GetProperty("entryId").GetString());
+        Assert.Equal("output-0001/Data/config.json", files[0].GetProperty("logicalPath").GetString());
+        Assert.Equal(Path.GetFullPath(configSourcePath), files[0].GetProperty("sourcePath").GetString());
+        Assert.Equal("output/output-0001/Data/config.json", files[0].GetProperty("artifactPath").GetString());
         Assert.Equal(configBytes.Length, files[0].GetProperty("sizeBytes").GetInt64());
         Assert.Equal(Sha256LowerHex.Compute(configBytes), files[0].GetProperty("sha256").GetString());
-        Assert.Equal("Game.x86_64", files[1].GetProperty("path").GetString());
+        Assert.Equal("output-0002", files[1].GetProperty("entryId").GetString());
+        Assert.Equal("output-0002/Game.x86_64", files[1].GetProperty("logicalPath").GetString());
+        Assert.Equal(Path.GetFullPath(fileSourcePath), files[1].GetProperty("sourcePath").GetString());
+        Assert.Equal("output/output-0002/Game.x86_64", files[1].GetProperty("artifactPath").GetString());
         Assert.Equal(playerBytes.Length, files[1].GetProperty("sizeBytes").GetInt64());
         Assert.Equal(Sha256LowerHex.Compute(playerBytes), files[1].GetProperty("sha256").GetString());
+        await AssertFileSha256Async(
+            Path.Combine(paths.ArtifactOutputDirectory, "output-0001", "Data", "config.json"),
+            files[0].GetProperty("sha256").GetString()!);
+        await AssertFileSha256Async(
+            Path.Combine(paths.ArtifactOutputDirectory, "output-0002", "Game.x86_64"),
+            files[1].GetProperty("sha256").GetString()!);
         var recalculatedManifestDigest = new BuildOutputManifestJsonContractWriter().CalculateManifestDigest(
             ReadOutputManifestContent(outputRoot));
         Assert.Equal(recalculatedManifestDigest, result.OutputManifest.ManifestDigest);
@@ -258,7 +294,7 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.Equal("buildPipeline", buildRoot.GetProperty("runner").GetProperty("kind").GetString());
         Assert.Equal("file", buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("shape").GetString());
         Assert.Equal(
-            "/repo/.ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output/player/Player",
+            "/repo/.ucli/local/fingerprints/fingerprint/work/build/run-1/output/player/Player",
             buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal("standaloneLinux64", buildRoot.GetProperty("input").GetProperty("buildTarget").GetProperty("stableName").GetString());
 
@@ -298,7 +334,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
         var targetPath = scope.WriteFile("target.txt", "linked output");
-        var linkPath = Path.Combine(paths.OutputDirectory, "linked.txt");
+        var linkPath = Path.Combine(paths.RunnerOutputDirectory, "build");
         if (!TryCreateFileSymbolicLink(linkPath, targetPath))
         {
             return;
@@ -329,7 +365,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        var fifoPath = Path.Combine(paths.OutputDirectory, "pipe");
+        var fifoPath = Path.Combine(paths.RunnerOutputDirectory, "build");
         if (!TryCreateFifo(fifoPath))
         {
             return;
@@ -360,7 +396,9 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        File.WriteAllText(Path.Combine(paths.OutputDirectory, "foo\\..\\..\\outside"), "ambiguous");
+        var outputSourceDirectory = Path.Combine(paths.RunnerOutputDirectory, "build");
+        Directory.CreateDirectory(outputSourceDirectory);
+        File.WriteAllText(Path.Combine(outputSourceDirectory, "foo\\..\\..\\outside"), "ambiguous");
 
         var writeResult = await store.AccountArtifactsAsync(
             CreateAccountingRequest(paths),
@@ -375,9 +413,9 @@ public sealed class FileBuildRunArtifactStoreTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public async Task AccountArtifactsAsync_WhenReportedOutputPathEscapesOutputDirectory_ReturnsOutputManifestFailed ()
+    public async Task AccountArtifactsAsync_WhenOutputSourceResolvesInsideArtifactRoot_ReturnsOutputPathInvalid ()
     {
-        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "reported-output-escape");
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "source-inside-artifact-root");
         var store = CreateStore();
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
@@ -385,16 +423,72 @@ public sealed class FileBuildRunArtifactStoreTests
         WriteUnityGeneratedArtifacts(paths);
         var request = CreateAccountingRequest(paths) with
         {
-            ReportedOutputPath = Path.Combine(scope.FullPath, "outside", "build"),
+            OutputSources = [new BuildOutputSourceEntry(Path.Combine(paths.ArtifactsDirectory, "source"))],
         };
 
         var writeResult = await store.AccountArtifactsAsync(request, CancellationToken.None);
 
         Assert.False(writeResult.IsSuccess);
         var error = Assert.IsType<ExecutionError>(writeResult.Error);
+        Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
+        Assert.Equal(BuildErrorCodes.BuildOutputPathInvalid, error.Code);
+        Assert.Contains("output path", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenSuccessfulOutputSourceIsMissing_ReturnsOutputManifestFailed ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "missing-success-output");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        WriteUnityGeneratedArtifacts(paths);
+
+        var writeResult = await store.AccountArtifactsAsync(
+            CreateAccountingRequest(paths),
+            CancellationToken.None);
+
+        Assert.False(writeResult.IsSuccess);
+        var error = Assert.IsType<ExecutionError>(writeResult.Error);
         Assert.Equal(ExecutionErrorKind.InternalError, error.Kind);
         Assert.Equal(BuildErrorCodes.BuildOutputManifestFailed, error.Code);
-        Assert.Contains("output path", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public async Task AccountArtifactsAsync_WhenEmptyManifestIsAllowedAndSourceIsMissing_WritesEmptyManifest ()
+    {
+        using var scope = TestDirectories.CreateTempScope("build-artifact-store", "empty-output-manifest");
+        var store = CreateStore();
+        var project = CreateProject(scope);
+        var prepareResult = store.Prepare(project, "run-1");
+        var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
+        WriteUnityGeneratedArtifacts(paths);
+        var request = CreateAccountingRequest(paths) with
+        {
+            AllowEmptyOutputManifest = true,
+        };
+
+        var writeResult = await store.AccountArtifactsAsync(request, CancellationToken.None);
+
+        Assert.True(writeResult.IsSuccess);
+        var result = Assert.IsType<BuildRunArtifactAccountingResult>(writeResult.Result);
+        Assert.Equal(0, result.OutputManifest.EntryCount);
+        Assert.Equal(0, result.OutputManifest.FileCount);
+        Assert.Equal(0, result.OutputManifest.TotalBytes);
+        using var outputManifest = JsonDocument.Parse(await File.ReadAllTextAsync(paths.OutputManifestJsonPath, CancellationToken.None));
+        var outputRoot = outputManifest.RootElement;
+        Assert.Equal(0, outputRoot.GetProperty("entries").GetArrayLength());
+        Assert.Equal(0, outputRoot.GetProperty("files").GetArrayLength());
+        Assert.Equal(0, outputRoot.GetProperty("entryCount").GetInt32());
+        Assert.Equal(0, outputRoot.GetProperty("fileCount").GetInt32());
+        Assert.Equal(0, outputRoot.GetProperty("totalBytes").GetInt64());
+        var recalculatedManifestDigest = new BuildOutputManifestJsonContractWriter().CalculateManifestDigest(
+            ReadOutputManifestContent(outputRoot));
+        Assert.Equal(recalculatedManifestDigest, result.OutputManifest.ManifestDigest);
+        await AssertFileSha256Async(paths.OutputManifestJsonPath, result.BuildOutputManifest.Digest);
     }
 
     [Theory]
@@ -402,7 +496,8 @@ public sealed class FileBuildRunArtifactStoreTests
     [InlineData("buildReport")]
     [InlineData("buildLog")]
     [InlineData("outputManifest")]
-    [InlineData("output")]
+    [InlineData("artifactOutput")]
+    [InlineData("runnerOutput")]
     [Trait("Size", "Small")]
     public async Task AccountArtifactsAsync_WhenArtifactPathEscapesLayout_ReturnsInvalidArgumentWithoutWriting (string pathKind)
     {
@@ -411,7 +506,7 @@ public sealed class FileBuildRunArtifactStoreTests
         var project = CreateProject(scope);
         var prepareResult = store.Prepare(project, "run-1");
         var paths = Assert.IsType<BuildRunArtifactPaths>(prepareResult.Paths);
-        var escapedPath = pathKind == "output"
+        var escapedPath = pathKind is "artifactOutput" or "runnerOutput"
             ? scope.CreateDirectory("escaped-output")
             : Path.Combine(scope.FullPath, $"escaped-{pathKind}.json");
         var request = CreateAccountingRequest(EscapeArtifactPath(paths, pathKind, escapedPath));
@@ -421,7 +516,7 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.False(writeResult.IsSuccess);
         var error = Assert.IsType<ExecutionError>(writeResult.Error);
         Assert.Equal(ExecutionErrorKind.InvalidArgument, error.Kind);
-        if (pathKind != "output")
+        if (pathKind is not "artifactOutput" and not "runnerOutput")
         {
             Assert.False(File.Exists(escapedPath));
         }
@@ -449,7 +544,7 @@ public sealed class FileBuildRunArtifactStoreTests
             BuildReportJsonPath = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildReportFileName),
             BuildLogPath = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildLogFileName),
             OutputManifestJsonPath = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputManifestFileName),
-            OutputDirectory = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName),
+            ArtifactOutputDirectory = Path.Combine(artifactsDirectory, UcliStoragePathNames.BuildOutputDirectoryName),
         });
 
         var writeResult = await store.AccountArtifactsAsync(request, CancellationToken.None);
@@ -475,12 +570,19 @@ public sealed class FileBuildRunArtifactStoreTests
             PathSource: UnityProjectPathSource.CommandOption);
     }
 
-    private static BuildRunArtifactAccountingRequest CreateAccountingRequest (BuildRunArtifactPaths paths)
+    private static BuildRunArtifactAccountingRequest CreateAccountingRequest (
+        BuildRunArtifactPaths paths,
+        params string[] outputSourcePaths)
     {
+        var sourcePaths = outputSourcePaths.Length == 0
+            ? [Path.Combine(paths.RunnerOutputDirectory, "build")]
+            : outputSourcePaths;
         return new BuildRunArtifactAccountingRequest(
             paths,
-            Path.Combine(paths.OutputDirectory, "build"),
-            "standaloneLinux64");
+            "standaloneLinux64",
+            "StandaloneLinux64",
+            sourcePaths.Select(static path => new BuildOutputSourceEntry(path)).ToArray(),
+            AllowEmptyOutputManifest: false);
     }
 
     private static BuildRunArtifactPaths EscapeArtifactPath (
@@ -506,9 +608,13 @@ public sealed class FileBuildRunArtifactStoreTests
             {
                 OutputManifestJsonPath = escapedPath,
             },
-            "output" => paths with
+            "artifactOutput" => paths with
             {
-                OutputDirectory = escapedPath,
+                ArtifactOutputDirectory = escapedPath,
+            },
+            "runnerOutput" => paths with
+            {
+                RunnerOutputDirectory = escapedPath,
             },
             _ => throw new ArgumentOutOfRangeException(nameof(pathKind), pathKind, "Unknown artifact path kind."),
         };
@@ -527,7 +633,7 @@ public sealed class FileBuildRunArtifactStoreTests
             runId,
             ParseJsonElement("""{"projectPath":"/repo/UnityProject","projectFingerprint":"fingerprint","unityVersion":"6000.1.4f1"}"""),
             ParseJsonElement("""{"path":"/repo/.ucli/build/player.json","digest":"profile-digest"}"""),
-            ParseJsonElement("""{"kind":"buildPipeline","method":null,"invocation":{"arguments":{},"environment":[]},"outputLayout":{"shape":"file","locationPathName":"/repo/.ucli/local/fingerprints/fingerprint/artifacts/build/run-1/output/player/Player"}}"""),
+            ParseJsonElement("""{"kind":"buildPipeline","method":null,"invocation":{"arguments":{},"environment":[]},"outputLayout":{"shape":"file","locationPathName":"/repo/.ucli/local/fingerprints/fingerprint/work/build/run-1/output/player/Player"}}"""),
             ParseJsonElement("""{"buildTarget":{"stableName":"standaloneLinux64"}}"""),
             ParseJsonElement("""{"state":"completed"}"""),
             ParseJsonElement("""{"compile":"42","domainReload":"7"}"""),
@@ -546,21 +652,39 @@ public sealed class FileBuildRunArtifactStoreTests
 
     private static BuildOutputManifestContentJsonContract ReadOutputManifestContent (JsonElement root)
     {
+        var targetElement = root.GetProperty("target");
+        var entryElements = root.GetProperty("entries");
+        var entries = new List<BuildOutputManifestEntryJsonContract>(entryElements.GetArrayLength());
+        for (var i = 0; i < entryElements.GetArrayLength(); i++)
+        {
+            var entry = entryElements[i];
+            entries.Add(new BuildOutputManifestEntryJsonContract(
+                entry.GetProperty("id").GetString()!,
+                entry.GetProperty("kind").GetString()!,
+                entry.GetProperty("sourcePath").GetString()!));
+        }
+
         var fileElements = root.GetProperty("files");
         var files = new List<BuildOutputManifestFileJsonContract>(fileElements.GetArrayLength());
         for (var i = 0; i < fileElements.GetArrayLength(); i++)
         {
             var file = fileElements[i];
             files.Add(new BuildOutputManifestFileJsonContract(
-                file.GetProperty("path").GetString()!,
+                file.GetProperty("entryId").GetString()!,
+                file.GetProperty("logicalPath").GetString()!,
+                file.GetProperty("sourcePath").GetString()!,
+                file.GetProperty("artifactPath").GetString()!,
                 file.GetProperty("sizeBytes").GetInt64(),
                 file.GetProperty("sha256").GetString()!));
         }
 
         return new BuildOutputManifestContentJsonContract(
             root.GetProperty("schemaVersion").GetInt32(),
-            root.GetProperty("outputRoot").GetString()!,
-            root.GetProperty("buildTarget").GetString()!,
+            new BuildOutputManifestTargetJsonContract(
+                targetElement.GetProperty("stableName").GetString()!,
+                targetElement.GetProperty("unityBuildTarget").GetString()!),
+            entries,
+            root.GetProperty("entryCount").GetInt32(),
             root.GetProperty("fileCount").GetInt32(),
             root.GetProperty("totalBytes").GetInt64(),
             files);

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
@@ -74,7 +74,7 @@
   },
   "output": {
     "manifestRef": "buildOutputManifest",
-    "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
+    "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21",
     "entryCount": 0,
     "fileCount": 0,
     "totalBytes": 0

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/output-manifest.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/output-manifest.json
@@ -1,9 +1,13 @@
 {
   "schemaVersion": 1,
-  "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
-  "buildTarget": "standaloneLinux64",
+  "target": {
+    "stableName": "standaloneLinux64",
+    "unityBuildTarget": "StandaloneLinux64"
+  },
+  "entries": [],
+  "entryCount": 0,
   "fileCount": 0,
   "totalBytes": 0,
   "files": [],
-  "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444"
+  "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21"
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
@@ -74,8 +74,8 @@
   },
   "output": {
     "manifestRef": "buildOutputManifest",
-    "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
-    "entryCount": 2,
+    "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b",
+    "entryCount": 1,
     "fileCount": 2,
     "totalBytes": 33
   },

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/output-manifest.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/output-manifest.json
@@ -1,20 +1,36 @@
 {
   "schemaVersion": 1,
-  "outputRoot": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output",
-  "buildTarget": "standaloneLinux64",
+  "target": {
+    "stableName": "standaloneLinux64",
+    "unityBuildTarget": "StandaloneLinux64"
+  },
+  "entries": [
+    {
+      "id": "output-0001",
+      "kind": "directory",
+      "sourcePath": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/work/build/build-run-1/output/player"
+    }
+  ],
+  "entryCount": 1,
   "fileCount": 2,
   "totalBytes": 33,
   "files": [
     {
-      "path": "Data/config.json",
+      "entryId": "output-0001",
+      "logicalPath": "output-0001/Data/config.json",
+      "sourcePath": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/work/build/build-run-1/output/player/Data/config.json",
+      "artifactPath": "output/output-0001/Data/config.json",
       "sizeBytes": 19,
       "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
     },
     {
-      "path": "Game.x86_64",
+      "entryId": "output-0001",
+      "logicalPath": "output-0001/Game.x86_64",
+      "sourcePath": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/work/build/build-run-1/output/player/Game.x86_64",
+      "artifactPath": "output/output-0001/Game.x86_64",
       "sizeBytes": 14,
       "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
     }
   ],
-  "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1"
+  "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b"
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
@@ -29,7 +29,7 @@
       },
       "output": {
         "manifestRef": "buildOutputManifest",
-        "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
+        "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21",
         "entryCount": 0,
         "fileCount": 0,
         "totalBytes": 0
@@ -307,7 +307,7 @@
             "evidenceRef": "build",
             "data": {
               "manifestRef": "buildOutputManifest",
-              "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444",
+              "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21",
               "entryCount": 0,
               "fileCount": 0,
               "totalBytes": 0
@@ -324,7 +324,7 @@
         "verifierRef": "build",
         "statement": "Build output manifest digest was verified against the written artifact.",
         "subject": {
-          "manifestDigest": "8deb35edf72becffdfe16011c3975ba597d30d506dc484c1d3ccd43224a3a444"
+          "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21"
         },
         "evidence": [
           {

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
@@ -29,8 +29,8 @@
       },
       "output": {
         "manifestRef": "buildOutputManifest",
-        "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
-        "entryCount": 2,
+        "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b",
+        "entryCount": 1,
         "fileCount": 2,
         "totalBytes": 33
       },
@@ -298,7 +298,7 @@
         "statement": "Build output artifacts were counted in the output manifest.",
         "subject": {
           "manifestRef": "buildOutputManifest",
-          "entryCount": 2,
+          "entryCount": 1,
           "fileCount": 2
         },
         "evidence": [
@@ -307,8 +307,8 @@
             "evidenceRef": "build",
             "data": {
               "manifestRef": "buildOutputManifest",
-              "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1",
-              "entryCount": 2,
+              "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b",
+              "entryCount": 1,
               "fileCount": 2,
               "totalBytes": 33
             }
@@ -324,7 +324,7 @@
         "verifierRef": "build",
         "statement": "Build output manifest digest was verified against the written artifact.",
         "subject": {
-          "manifestDigest": "da24a52f15e07fd877e58e370b776bc7136b18409317bc73b300c1ff3acb52f1"
+          "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b"
         },
         "evidence": [
           {


### PR DESCRIPTION
## Summary
- Implements the final build output artifact accounting contract for Issue #402.
- Separates the runner working output directory from the artifact-store output directory.
- Ingests BuildPipeline output as manifest source entries and projects the new manifest summary into build output payloads.

## Scope
- Build manifest contracts now emit `target`, `entries`, `entryCount`, canonical file records, and `manifestDigest` from JSON that excludes the digest field.
- Build artifact storage now copies source files/directories into `<artifactRoot>/output/<entryId>/...`, rejects artifact-root sources and unsupported filesystem nodes, and digests copied artifact files.
- BuildService and Unity IPC handler now validate and pass the runner work output path while artifacts are stored under the build run artifact root.
- Error catalog entries and build output golden fixtures are updated for the new path and digest accounting model.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, `bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`, `bash scripts/verify.sh --include-unity --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`)
- Coverage: N/A

## Risks / Rollback
- Build artifact layout now distinguishes runner work output from final artifact output; callers that inspect internal work paths should use `output-manifest.json` and `<artifactRoot>/output/` instead.
- Rollback is reverting the two commits in this PR, which restores the previous flat output manifest and artifact output layout.

## Checklist
- [x] Manifest contract and digest calculation updated.
- [x] Artifact-store ingestion and path policy covered by tests.
- [x] BuildService and Unity handler path validation updated.
- [x] Golden fixtures and error catalog updated.

Closes #402