### PR TITLE
feat(build): project build run output to runnerResult contract

### DIFF
--- a/schemas/v1/cli-output/payload/build.run.schema.json
+++ b/schemas/v1/cli-output/payload/build.run.schema.json
@@ -41,42 +41,71 @@
                 "digest"
               ]
             },
-            "buildTarget": {
-              "type": "string"
-            },
-            "scenes": {
+            "inputs": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "source": {
+                "inputKind": {
                   "type": "string",
-                  "enum": [
-                    "editorBuildSettings",
-                    "explicit"
+                  "const": "explicit"
+                },
+                "target": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "stableName": {
+                      "type": "string"
+                    },
+                    "unityBuildTarget": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "stableName",
+                    "unityBuildTarget"
                   ]
                 },
-                "paths": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                "scenes": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "editorBuildSettings",
+                        "explicit"
+                      ]
+                    },
+                    "paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "source",
+                    "paths"
+                  ]
+                },
+                "options": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "development": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "development"
+                  ]
                 }
               },
               "required": [
-                "source",
-                "paths"
-              ]
-            },
-            "options": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "development": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "development"
+                "inputKind",
+                "target",
+                "scenes",
+                "options"
               ]
             },
             "runner": {
@@ -157,7 +186,8 @@
                   "enum": [
                     "succeeded",
                     "failed",
-                    "canceled"
+                    "canceled",
+                    "unknown"
                   ]
                 }
               },
@@ -306,9 +336,7 @@
           "required": [
             "runId",
             "profile",
-            "buildTarget",
-            "scenes",
-            "options",
+            "inputs",
             "runner",
             "runnerResult",
             "output",

--- a/schemas/v1/cli-output/payload/build.run.schema.json
+++ b/schemas/v1/cli-output/payload/build.run.schema.json
@@ -186,8 +186,7 @@
                   "enum": [
                     "succeeded",
                     "failed",
-                    "canceled",
-                    "unknown"
+                    "canceled"
                   ]
                 }
               },
@@ -255,8 +254,7 @@
                   "enum": [
                     "succeeded",
                     "failed",
-                    "canceled",
-                    "unknown"
+                    "canceled"
                   ]
                 },
                 "durationMilliseconds": {

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildArtifactRef.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildArtifactRef.cs
@@ -2,7 +2,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 
 /// <summary> Represents one persisted build-run artifact reference. </summary>
 /// <param name="Kind"> The semantic artifact kind. </param>
-/// <param name="Path"> The repository-relative slash-separated artifact path. </param>
+/// <param name="Path"> The artifact-root relative slash-separated artifact path. </param>
 /// <param name="Digest"> The lowercase SHA-256 digest for the artifact identity. </param>
 internal sealed record BuildArtifactRef (
     BuildArtifactKind Kind,

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunArtifactPaths.cs
@@ -1,7 +1,7 @@
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 
 /// <summary> Represents the resolved filesystem layout for one build run. </summary>
-/// <param name="RepositoryRoot"> The repository root used to derive repository-relative artifact references. </param>
+/// <param name="RepositoryRoot"> The repository root used to resolve storage layout identity for this build run. </param>
 /// <param name="RunId"> The build run identifier. </param>
 /// <param name="ArtifactsDirectory"> The absolute build-run artifact directory path. </param>
 /// <param name="BuildJsonPath"> The absolute <c>build.json</c> path. </param>

--- a/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunMetadataDocument.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Artifacts/BuildRunMetadataDocument.cs
@@ -5,30 +5,24 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Artifacts;
 /// <summary> Represents the non-artifact-reference fields persisted into <c>build.json</c>. </summary>
 /// <param name="SchemaVersion"> The build metadata schema version. </param>
 /// <param name="RunId"> The build run identifier. </param>
-/// <param name="Project"> The project identity section. </param>
 /// <param name="Profile"> The profile metadata section. </param>
+/// <param name="Inputs"> The resolved build inputs section. </param>
 /// <param name="Runner"> The resolved runner metadata section. </param>
 /// <param name="RunnerResult"> The normalized runner terminal result section. </param>
-/// <param name="Input"> The resolved build inputs section. </param>
 /// <param name="Lifecycle"> The lifecycle evidence section. </param>
 /// <param name="Generations"> The Unity generation evidence section. </param>
 /// <param name="Summary"> The build summary section. </param>
 /// <param name="Logs"> The log reference metadata section. </param>
-/// <param name="Output"> The build output artifact accounting section. </param>
 /// <param name="ProjectMutation"> The project mutation audit section. </param>
-/// <param name="DirtyState"> The build dirty-state evidence section. </param>
 internal sealed record BuildRunMetadataDocument (
     int SchemaVersion,
     string RunId,
-    JsonElement Project,
     JsonElement Profile,
+    JsonElement Inputs,
     JsonElement Runner,
     JsonElement RunnerResult,
-    JsonElement Input,
     JsonElement Lifecycle,
     JsonElement Generations,
     JsonElement Summary,
     JsonElement Logs,
-    JsonElement Output,
-    JsonElement ProjectMutation,
-    JsonElement DirtyState);
+    JsonElement ProjectMutation);

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -281,10 +281,8 @@ internal sealed class BuildService : IBuildService
                 profile,
                 buildResponse,
                 accounting,
-                paths,
                 runnerInvocation);
             var metadata = CreateMetadataDocument(
-                project,
                 output,
                 buildResponse,
                 profile,
@@ -313,7 +311,6 @@ internal sealed class BuildService : IBuildService
             var completedOutput = output with
             {
                 Reports = CreateReports(
-                    paths,
                     accounting,
                     metadataWriteResult.Artifact!),
             };
@@ -1057,7 +1054,6 @@ internal sealed class BuildService : IBuildService
         ResolvedBuildProfile profile,
         IpcBuildRunResponse response,
         BuildRunArtifactAccountingResult accounting,
-        BuildRunArtifactPaths paths,
         ResolvedRunnerInvocationInput runnerInvocation)
     {
         var generations = CreateGenerations(response.LifecycleBefore, response.LifecycleAfter);
@@ -1124,7 +1120,7 @@ internal sealed class BuildService : IBuildService
                     ReportRef: BuildReportRefs.Build),
             ],
             Claims: claims,
-            Reports: CreateReports(paths, accounting, buildArtifact: null),
+            Reports: CreateReports(accounting, buildArtifact: null),
             ResidualRisks: residualRisks);
     }
 
@@ -1173,7 +1169,6 @@ internal sealed class BuildService : IBuildService
     }
 
     private static IReadOnlyDictionary<string, BuildReportOutput> CreateReports (
-        BuildRunArtifactPaths paths,
         BuildRunArtifactAccountingResult accounting,
         BuildArtifactRef? buildArtifact)
     {
@@ -1187,7 +1182,6 @@ internal sealed class BuildService : IBuildService
     }
 
     private static BuildRunMetadataDocument CreateMetadataDocument (
-        ProjectIdentityInfo project,
         BuildExecutionOutput output,
         IpcBuildRunResponse response,
         ResolvedBuildProfile profile,
@@ -1198,11 +1192,7 @@ internal sealed class BuildService : IBuildService
             SchemaVersion: BuildMetadataSchemaVersion,
             RunId: output.Build.RunId,
             Profile: SerializeMetadataElement(output.Build.Profile),
-            Inputs: SerializeMetadataElement(new BuildRunInputMetadata(
-                InputKind: output.Build.Inputs.InputKind,
-                Target: output.Build.Inputs.Target,
-                Scenes: output.Build.Inputs.Scenes,
-                Options: output.Build.Inputs.Options)),
+            Inputs: SerializeMetadataElement(CreateInputMetadata(output.Build.Inputs)),
             Runner: SerializeMetadataElement(new BuildRunRunnerMetadata(
                 Kind: ContractLiteralCodec.ToValue(profile.Runner.Kind),
                 Method: profile.Runner.Method,
@@ -1220,6 +1210,19 @@ internal sealed class BuildService : IBuildService
             Summary: SerializeMetadataElement(output.Build.Summary),
             Logs: SerializeMetadataElement(output.Build.Logs),
             ProjectMutation: SerializeMetadataElement(response.ProjectMutation));
+    }
+
+    private static BuildRunInputMetadata CreateInputMetadata (BuildInputsOutput inputs)
+    {
+        return new BuildRunInputMetadata(
+            InputKind: inputs.InputKind,
+            Target: new BuildRunTargetMetadata(
+                StableName: inputs.Target.StableName,
+                UnityBuildTarget: inputs.Target.UnityBuildTarget),
+            Scenes: new BuildRunScenesMetadata(
+                Source: inputs.Scenes.Source,
+                Paths: inputs.Scenes.Paths),
+            Options: new BuildRunOptionsMetadata(inputs.Options.Development));
     }
 
     private static object CreateRunnerResultMetadata (

--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -1079,11 +1079,15 @@ internal sealed class BuildService : IBuildService
         var build = new BuildOutput(
             RunId: runId,
             Profile: new BuildProfileOutput(profilePath, profile.Digest),
-            BuildTarget: profile.BuildTarget.StableName,
-            Scenes: new BuildScenesOutput(
-                Source: response.Input.SceneSource,
-                Paths: response.Input.Scenes),
-            Options: new BuildOptionsOutput(profile.Options.Development),
+            Inputs: new BuildInputsOutput(
+                InputKind: ContractLiteralCodec.ToValue(profile.Inputs.Kind),
+                Target: new BuildTargetOutput(
+                    StableName: profile.BuildTarget.StableName,
+                    UnityBuildTarget: response.Input.UnityBuildTarget),
+                Scenes: new BuildScenesOutput(
+                    Source: response.Input.SceneSource,
+                    Paths: response.Input.Scenes),
+                Options: new BuildOptionsOutput(profile.Options.Development)),
             Runner: new BuildRunnerOutput(
                 Kind: ContractLiteralCodec.ToValue(profile.Runner.Kind),
                 Method: profile.Runner.Method,
@@ -1175,10 +1179,10 @@ internal sealed class BuildService : IBuildService
     {
         return new Dictionary<string, BuildReportOutput>(StringComparer.Ordinal)
         {
-            [BuildReportRefs.Build] = new BuildReportOutput(paths.BuildJsonPath, buildArtifact?.Digest),
-            [BuildReportRefs.BuildReport] = new BuildReportOutput(paths.BuildReportJsonPath, accounting.BuildReport.Digest),
-            [BuildReportRefs.BuildOutputManifest] = new BuildReportOutput(paths.OutputManifestJsonPath, accounting.BuildOutputManifest.Digest),
-            [BuildReportRefs.BuildLog] = new BuildReportOutput(paths.BuildLogPath, accounting.BuildLog.Digest),
+            [BuildReportRefs.Build] = new BuildReportOutput(buildArtifact?.Path ?? "build.json", buildArtifact?.Digest),
+            [BuildReportRefs.BuildReport] = new BuildReportOutput(accounting.BuildReport.Path, accounting.BuildReport.Digest),
+            [BuildReportRefs.BuildOutputManifest] = new BuildReportOutput(accounting.BuildOutputManifest.Path, accounting.BuildOutputManifest.Digest),
+            [BuildReportRefs.BuildLog] = new BuildReportOutput(accounting.BuildLog.Path, accounting.BuildLog.Digest),
         };
     }
 
@@ -1193,8 +1197,12 @@ internal sealed class BuildService : IBuildService
         return new BuildRunMetadataDocument(
             SchemaVersion: BuildMetadataSchemaVersion,
             RunId: output.Build.RunId,
-            Project: SerializeMetadataElement(project),
             Profile: SerializeMetadataElement(output.Build.Profile),
+            Inputs: SerializeMetadataElement(new BuildRunInputMetadata(
+                InputKind: output.Build.Inputs.InputKind,
+                Target: output.Build.Inputs.Target,
+                Scenes: output.Build.Inputs.Scenes,
+                Options: output.Build.Inputs.Options)),
             Runner: SerializeMetadataElement(new BuildRunRunnerMetadata(
                 Kind: ContractLiteralCodec.ToValue(profile.Runner.Kind),
                 Method: profile.Runner.Method,
@@ -1205,20 +1213,13 @@ internal sealed class BuildService : IBuildService
                         Secrets: invocationEnv.Secrets)),
                 OutputLayout: outputLayout)),
             RunnerResult: SerializeMetadataElement(CreateRunnerResultMetadata(output, response)),
-            Input: SerializeMetadataElement(new BuildRunInputMetadata(
-                BuildTarget: output.Build.BuildTarget,
-                UnityBuildTarget: response.Input.UnityBuildTarget,
-                Scenes: output.Build.Scenes,
-                Options: output.Build.Options)),
             Lifecycle: SerializeMetadataElement(new BuildRunLifecycleMetadata(
                 Before: response.LifecycleBefore,
                 After: response.LifecycleAfter)),
             Generations: SerializeMetadataElement(output.Build.Generations),
             Summary: SerializeMetadataElement(output.Build.Summary),
             Logs: SerializeMetadataElement(output.Build.Logs),
-            Output: SerializeMetadataElement(output.Build.Output),
-            ProjectMutation: SerializeMetadataElement(response.ProjectMutation),
-            DirtyState: SerializeMetadataElement(response.DirtyState));
+            ProjectMutation: SerializeMetadataElement(response.ProjectMutation));
     }
 
     private static object CreateRunnerResultMetadata (
@@ -1325,8 +1326,8 @@ internal sealed class BuildService : IBuildService
                 "Unity resolved BuildPipeline BuildTarget and scenes.",
                 new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
-                    ["buildTarget"] = build.BuildTarget,
-                    ["sceneCount"] = build.Scenes.Paths.Count,
+                    ["buildTarget"] = build.Inputs.Target.StableName,
+                    ["sceneCount"] = build.Inputs.Scenes.Paths.Count,
                 },
                 [new BuildEvidenceOutput(Kind: ContractLiteralCodec.ToValue(BuildEvidenceKind.BuildInput), EvidenceRef: BuildReportRefs.Build, Data: response.Input)]),
             CreateClaim(
@@ -1363,9 +1364,10 @@ internal sealed class BuildService : IBuildService
                 "Build runner terminal result was persisted in build metadata.",
                 new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
-                    ["result"] = build.Summary.Result,
+                    ["source"] = build.RunnerResult.Source,
+                    ["status"] = build.RunnerResult.Status,
                 },
-                [new BuildEvidenceOutput(Kind: ContractLiteralCodec.ToValue(BuildEffect.UnityBuildReportRead), EvidenceRef: BuildReportRefs.Build, Data: build.Summary)]),
+                [new BuildEvidenceOutput(Kind: ContractLiteralCodec.ToValue(BuildEffect.UnityBuildReportRead), EvidenceRef: BuildReportRefs.Build, Data: build.RunnerResult)]),
             CreateClaim(
                 BuildClaimCodes.UnityBuildReportAccounted,
                 BuildClaimStatus.Passed,

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
@@ -1,10 +1,8 @@
-using MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
-
 namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
 
 /// <summary> Represents the resolved BuildPipeline input persisted in <c>build.json</c>. </summary>
 internal sealed record BuildRunInputMetadata (
     string InputKind,
-    BuildTargetOutput Target,
-    BuildScenesOutput Scenes,
-    BuildOptionsOutput Options);
+    BuildRunTargetMetadata Target,
+    BuildRunScenesMetadata Scenes,
+    BuildRunOptionsMetadata Options);

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunInputMetadata.cs
@@ -4,7 +4,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
 
 /// <summary> Represents the resolved BuildPipeline input persisted in <c>build.json</c>. </summary>
 internal sealed record BuildRunInputMetadata (
-    string BuildTarget,
-    string UnityBuildTarget,
+    string InputKind,
+    BuildTargetOutput Target,
     BuildScenesOutput Scenes,
     BuildOptionsOutput Options);

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunOptionsMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunOptionsMetadata.cs
@@ -1,0 +1,5 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
+
+/// <summary> Represents resolved build options persisted in <c>build.json</c>. </summary>
+internal sealed record BuildRunOptionsMetadata (
+    bool Development);

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunScenesMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunScenesMetadata.cs
@@ -1,0 +1,6 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
+
+/// <summary> Represents resolved build scene input persisted in <c>build.json</c>. </summary>
+internal sealed record BuildRunScenesMetadata (
+    string Source,
+    IReadOnlyList<string> Paths);

--- a/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunTargetMetadata.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Metadata/BuildRunTargetMetadata.cs
@@ -1,0 +1,6 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Metadata;
+
+/// <summary> Represents the resolved build target identity persisted in <c>build.json</c>. </summary>
+internal sealed record BuildRunTargetMetadata (
+    string StableName,
+    string UnityBuildTarget);

--- a/src/Ucli.Application/Features/Assurance/Build/Payload/BuildInputsOutput.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Payload/BuildInputsOutput.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
+
+/// <summary> Represents the resolved build inputs emitted in public output. </summary>
+internal sealed record BuildInputsOutput (
+    string InputKind,
+    BuildTargetOutput Target,
+    BuildScenesOutput Scenes,
+    BuildOptionsOutput Options);

--- a/src/Ucli.Application/Features/Assurance/Build/Payload/BuildOutput.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Payload/BuildOutput.cs
@@ -4,9 +4,7 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
 internal sealed record BuildOutput (
     string RunId,
     BuildProfileOutput Profile,
-    string BuildTarget,
-    BuildScenesOutput Scenes,
-    BuildOptionsOutput Options,
+    BuildInputsOutput Inputs,
     BuildRunnerOutput Runner,
     BuildRunnerResultOutput RunnerResult,
     BuildArtifactOutput Output,

--- a/src/Ucli.Application/Features/Assurance/Build/Payload/BuildTargetOutput.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Payload/BuildTargetOutput.cs
@@ -1,0 +1,6 @@
+namespace MackySoft.Ucli.Application.Features.Assurance.Build.Payload;
+
+/// <summary> Represents the resolved build target identity. </summary>
+internal sealed record BuildTargetOutput (
+    string StableName,
+    string UnityBuildTarget);

--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -27,16 +27,13 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         new HashSet<string>(ContractLiteralCodec.GetLiterals<BuildEffect>(), StringComparer.Ordinal);
 
     /// <inheritdoc />
-    public void ValidateClaim (
+    public void ValidatePayload (
         JsonElement payload,
-        JsonElement claimElement,
-        string claimPath,
-        string claimId,
         List<AssuranceSemanticInvariantViolation> violations)
     {
         ArgumentNullException.ThrowIfNull(violations);
 
-        if (!IsBuildClaim(claimId) || !payload.TryGetProperty("build", out var buildElement))
+        if (!payload.TryGetProperty("build", out var buildElement) || buildElement.ValueKind != JsonValueKind.Object)
         {
             return;
         }
@@ -52,6 +49,23 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         ValidateBuildGenerations(buildElement, violations);
         ValidateBuildLogCompletionReason(buildElement, violations);
         ValidateVerifier(payload, violations);
+    }
+
+    /// <inheritdoc />
+    public void ValidateClaim (
+        JsonElement payload,
+        JsonElement claimElement,
+        string claimPath,
+        string claimId,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        ArgumentNullException.ThrowIfNull(violations);
+
+        if (!IsBuildClaim(claimId) || !payload.TryGetProperty("build", out var buildElement))
+        {
+            return;
+        }
+
         ValidateClaimEvidence(buildElement, claimElement, claimPath, claimId, violations);
         if (BuildClaimCodes.UnityBuildCompleted.EqualsValue(claimId))
         {
@@ -125,7 +139,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         {
             AddViolation(violations, BuildPropertyPath(reportPath, "path"), $"Build report {reportKey} must declare path.");
         }
-        else if (IsAbsoluteLikePath(path))
+        else if (!IsArtifactRootRelativePath(path))
         {
             AddViolation(violations, BuildPropertyPath(reportPath, "path"), $"Build report {reportKey} path must be artifact-root relative.");
         }
@@ -936,14 +950,47 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         return true;
     }
 
-    private static bool IsAbsoluteLikePath (string value)
+    private static bool IsArtifactRootRelativePath (string value)
     {
-        return value.StartsWith("/", StringComparison.Ordinal)
+        if (string.IsNullOrWhiteSpace(value)
+            || value.Contains('\\', StringComparison.Ordinal)
+            || value.Contains("//", StringComparison.Ordinal)
+            || value.StartsWith("/", StringComparison.Ordinal)
             || value.StartsWith("\\", StringComparison.Ordinal)
-            || (value.Length >= 3
-                && char.IsAsciiLetter(value[0])
-                && value[1] == ':'
-                && (value[2] == '/' || value[2] == '\\'));
+            || value.EndsWith("/", StringComparison.Ordinal)
+            || IsWindowsDriveQualifiedPath(value))
+        {
+            return false;
+        }
+
+        var remaining = value.AsSpan();
+        while (!remaining.IsEmpty)
+        {
+            var separatorIndex = remaining.IndexOf('/');
+            var segment = separatorIndex < 0 ? remaining : remaining[..separatorIndex];
+            if (segment.IsEmpty
+                || segment.SequenceEqual(".")
+                || segment.SequenceEqual(".."))
+            {
+                return false;
+            }
+
+            if (separatorIndex < 0)
+            {
+                return true;
+            }
+
+            remaining = remaining[(separatorIndex + 1)..];
+        }
+
+        return true;
+    }
+
+    private static bool IsWindowsDriveQualifiedPath (string value)
+    {
+        return value.Length >= 2
+            && char.IsAsciiLetter(value[0])
+            && value[1] == ':';
     }
 
     private static string BuildPropertyPath (

--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -20,6 +20,9 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         BuildReportRefs.BuildLog,
     ];
 
+    private static readonly IReadOnlySet<string> RequiredReportKeySet =
+        new HashSet<string>(RequiredReportKeys, StringComparer.Ordinal);
+
     private static readonly IReadOnlySet<string> AllowedBuildEffects =
         new HashSet<string>(ContractLiteralCodec.GetLiterals<BuildEffect>(), StringComparer.Ordinal);
 
@@ -41,6 +44,8 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         ValidateReports(payload, violations);
         ValidateBuildInput(buildElement, violations);
         ValidateBuildProfile(buildElement, violations);
+        ValidateBuildRunner(buildElement, violations);
+        ValidateBuildRunnerResult(buildElement, violations);
         ValidateBuildOutput(payload, violations);
         ValidateBuildSummary(buildElement, violations);
         ValidateBuildLogs(buildElement, violations);
@@ -73,6 +78,15 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
+        foreach (var reportProperty in reportsElement.EnumerateObject())
+        {
+            if (!RequiredReportKeySet.Contains(reportProperty.Name))
+            {
+                AddViolation(violations, "$.reports", $"Build payload must not contain reports.{reportProperty.Name}.");
+                continue;
+            }
+        }
+
         for (var i = 0; i < RequiredReportKeys.Count; i++)
         {
             var reportKey = RequiredReportKeys[i];
@@ -97,9 +111,23 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        if (!TryReadString(reportElement, "path", out _))
+        if (reportElement.TryGetProperty("kind", out _))
+        {
+            AddViolation(violations, BuildPropertyPath(reportPath, "kind"), $"Build report {reportKey} must not expose kind.");
+        }
+
+        if (reportElement.TryGetProperty("category", out _))
+        {
+            AddViolation(violations, BuildPropertyPath(reportPath, "category"), $"Build report {reportKey} must not expose category.");
+        }
+
+        if (!TryReadString(reportElement, "path", out var path))
         {
             AddViolation(violations, BuildPropertyPath(reportPath, "path"), $"Build report {reportKey} must declare path.");
+        }
+        else if (IsAbsoluteLikePath(path))
+        {
+            AddViolation(violations, BuildPropertyPath(reportPath, "path"), $"Build report {reportKey} path must be artifact-root relative.");
         }
 
         if (!TryReadString(reportElement, "digest", out var digest))
@@ -116,9 +144,136 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         JsonElement buildElement,
         List<AssuranceSemanticInvariantViolation> violations)
     {
-        if (!TryReadString(buildElement, "buildTarget", out _))
+        if (!buildElement.TryGetProperty("inputs", out var inputsElement) || inputsElement.ValueKind != JsonValueKind.Object)
         {
-            AddViolation(violations, "$.build.buildTarget", "Build payload must declare buildTarget.");
+            AddViolation(violations, "$.build.inputs", "Build payload must declare inputs.");
+            return;
+        }
+
+        if (!TryReadString(inputsElement, "inputKind", out _))
+        {
+            AddViolation(violations, "$.build.inputs.inputKind", "Build inputs must declare inputKind.");
+        }
+
+        if (!inputsElement.TryGetProperty("target", out var targetElement) || targetElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.inputs.target", "Build inputs must declare target.");
+        }
+        else
+        {
+            if (!TryReadString(targetElement, "stableName", out _))
+            {
+                AddViolation(violations, "$.build.inputs.target.stableName", "Build inputs target must declare stableName.");
+            }
+
+            if (!TryReadString(targetElement, "unityBuildTarget", out _))
+            {
+                AddViolation(violations, "$.build.inputs.target.unityBuildTarget", "Build inputs target must declare unityBuildTarget.");
+            }
+        }
+
+        if (!inputsElement.TryGetProperty("scenes", out var scenesElement) || scenesElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.inputs.scenes", "Build inputs must declare scenes.");
+        }
+        else
+        {
+            if (!TryReadString(scenesElement, "source", out _))
+            {
+                AddViolation(violations, "$.build.inputs.scenes.source", "Build inputs scenes must declare source.");
+            }
+
+            if (!scenesElement.TryGetProperty("paths", out var pathsElement) || pathsElement.ValueKind != JsonValueKind.Array)
+            {
+                AddViolation(violations, "$.build.inputs.scenes.paths", "Build inputs scenes must declare paths.");
+            }
+        }
+
+        if (!inputsElement.TryGetProperty("options", out var optionsElement) || optionsElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.inputs.options", "Build inputs must declare options.");
+        }
+        else if (!optionsElement.TryGetProperty("development", out var developmentElement)
+            || developmentElement.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            AddViolation(violations, "$.build.inputs.options.development", "Build inputs options must declare development.");
+        }
+    }
+
+    private static void ValidateBuildRunner (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!buildElement.TryGetProperty("runner", out var runnerElement) || runnerElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.runner", "Build payload must declare runner.");
+            return;
+        }
+
+        if (!TryReadString(runnerElement, "kind", out _))
+        {
+            AddViolation(violations, "$.build.runner.kind", "Build runner must declare kind.");
+        }
+
+        if (!runnerElement.TryGetProperty("method", out var methodElement)
+            || methodElement.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+        {
+            AddViolation(violations, "$.build.runner.method", "Build runner must declare method.");
+        }
+
+        if (!runnerElement.TryGetProperty("invocation", out var invocationElement) || invocationElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.runner.invocation", "Build runner must declare invocation.");
+            return;
+        }
+
+        if (!invocationElement.TryGetProperty("arguments", out var argumentsElement) || argumentsElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.runner.invocation.arguments", "Build runner invocation must declare arguments.");
+        }
+
+        if (!invocationElement.TryGetProperty("environment", out var environmentElement) || environmentElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.runner.invocation.environment", "Build runner invocation must declare environment.");
+            return;
+        }
+
+        if (!environmentElement.TryGetProperty("variables", out var variablesElement) || variablesElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, "$.build.runner.invocation.environment.variables", "Build runner invocation environment must declare variables.");
+        }
+
+        if (!environmentElement.TryGetProperty("secrets", out var secretsElement) || secretsElement.ValueKind != JsonValueKind.Array)
+        {
+            AddViolation(violations, "$.build.runner.invocation.environment.secrets", "Build runner invocation environment must declare secrets.");
+        }
+    }
+
+    private static void ValidateBuildRunnerResult (
+        JsonElement buildElement,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        if (!buildElement.TryGetProperty("runnerResult", out var runnerResultElement) || runnerResultElement.ValueKind != JsonValueKind.Object)
+        {
+            AddViolation(violations, "$.build.runnerResult", "Build payload must declare runnerResult.");
+            return;
+        }
+
+        if (!TryReadString(runnerResultElement, "source", out _))
+        {
+            AddViolation(violations, "$.build.runnerResult.source", "Build runnerResult must declare source.");
+        }
+
+        if (!TryReadString(runnerResultElement, "status", out var status))
+        {
+            AddViolation(violations, "$.build.runnerResult.status", "Build runnerResult must declare status.");
+            return;
+        }
+
+        if (TryReadBuildResult(buildElement, out var result)
+            && !string.Equals(status, result, StringComparison.Ordinal))
+        {
+            AddViolation(violations, "$.build.summary.result", "Build summary result must match runnerResult status.");
         }
     }
 
@@ -581,20 +736,55 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
+        var expectedRefFound = false;
         foreach (var evidence in evidenceElement.EnumerateArray())
         {
             if (evidence.ValueKind == JsonValueKind.Object
                 && TryReadString(evidence, "evidenceRef", out var evidenceRef)
                 && string.Equals(evidenceRef, expectedEvidenceRef, StringComparison.Ordinal))
             {
-                return;
+                expectedRefFound = true;
+                if (!BuildClaimCodes.UnityBuildResultAccounted.EqualsValue(claimId)
+                    || EvidenceDataMatchesBuildRunnerResult(buildElement, evidence))
+                {
+                    return;
+                }
             }
+        }
+
+        if (expectedRefFound && BuildClaimCodes.UnityBuildResultAccounted.EqualsValue(claimId))
+        {
+            AddViolation(
+                violations,
+                BuildPropertyPath(claimPath, "evidence"),
+                "UNITY_BUILD_RESULT_ACCOUNTED evidence data must match payload.build.runnerResult.");
+            return;
         }
 
         AddViolation(
             violations,
             BuildPropertyPath(claimPath, "evidence"),
             $"Build claim {claimId} evidence must reference reports.{expectedEvidenceRef}.");
+    }
+
+    private static bool EvidenceDataMatchesBuildRunnerResult (
+        JsonElement buildElement,
+        JsonElement evidenceElement)
+    {
+        if (!buildElement.TryGetProperty("runnerResult", out var runnerResultElement)
+            || runnerResultElement.ValueKind != JsonValueKind.Object
+            || !evidenceElement.TryGetProperty("data", out var dataElement)
+            || dataElement.ValueKind != JsonValueKind.Object
+            || !TryReadString(runnerResultElement, "source", out var expectedSource)
+            || !TryReadString(runnerResultElement, "status", out var expectedStatus)
+            || !TryReadString(dataElement, "source", out var actualSource)
+            || !TryReadString(dataElement, "status", out var actualStatus))
+        {
+            return false;
+        }
+
+        return string.Equals(actualSource, expectedSource, StringComparison.Ordinal)
+            && string.Equals(actualStatus, expectedStatus, StringComparison.Ordinal);
     }
 
     private static void ValidateGenerationClaimEvidence (
@@ -744,6 +934,16 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
 
         return true;
+    }
+
+    private static bool IsAbsoluteLikePath (string value)
+    {
+        return value.StartsWith("/", StringComparison.Ordinal)
+            || value.StartsWith("\\", StringComparison.Ordinal)
+            || (value.Length >= 3
+                && char.IsAsciiLetter(value[0])
+                && value[1] == ':'
+                && (value[2] == '/' || value[2] == '\\'));
     }
 
     private static string BuildPropertyPath (

--- a/src/Ucli.Application/Features/Assurance/Compile/Semantics/CompileAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Compile/Semantics/CompileAssuranceSemanticInvariantRule.cs
@@ -8,6 +8,14 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Compile.Semantics;
 internal sealed class CompileAssuranceSemanticInvariantRule : IAssuranceSemanticInvariantRule
 {
     /// <inheritdoc />
+    public void ValidatePayload (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        ArgumentNullException.ThrowIfNull(violations);
+    }
+
+    /// <inheritdoc />
     public void ValidateClaim (
         JsonElement payload,
         JsonElement claimElement,

--- a/src/Ucli.Application/Features/Assurance/Ready/ReadyAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Ready/ReadyAssuranceSemanticInvariantRule.cs
@@ -7,6 +7,14 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Ready;
 internal sealed class ReadyAssuranceSemanticInvariantRule : IAssuranceSemanticInvariantRule
 {
     /// <inheritdoc />
+    public void ValidatePayload (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        ArgumentNullException.ThrowIfNull(violations);
+    }
+
+    /// <inheritdoc />
     public void ValidateClaim (
         JsonElement payload,
         JsonElement claimElement,

--- a/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/AssuranceSemanticInvariantValidator.cs
@@ -39,6 +39,7 @@ internal sealed class AssuranceSemanticInvariantValidator
         var claims = ReadClaims(payload, reports, violations);
         var payloadResidualRisks = ReadResidualRisks(payload, "$.residualRisks", violations);
 
+        ValidateCommandSpecificPayload(payload, violations);
         ValidateClaimVerifierReferences(claims, verifiers, violations);
         ValidatePrimaryClaims(verifiers, claims, violations);
         ValidateVerdict(payload, claims, payloadResidualRisks, violations);
@@ -399,6 +400,16 @@ internal sealed class AssuranceSemanticInvariantValidator
             }
 
             index++;
+        }
+    }
+
+    private void ValidateCommandSpecificPayload (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        for (var i = 0; i < rules.Count; i++)
+        {
+            rules[i].ValidatePayload(payload, violations);
         }
     }
 

--- a/src/Ucli.Application/Features/Assurance/Semantics/IAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Semantics/IAssuranceSemanticInvariantRule.cs
@@ -5,6 +5,13 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Semantics;
 /// <summary> Validates command-specific semantic invariants inside a common assurance payload. </summary>
 internal interface IAssuranceSemanticInvariantRule
 {
+    /// <summary> Validates command-specific payload-level invariants. </summary>
+    /// <param name="payload"> The assurance payload root. </param>
+    /// <param name="violations"> The violation sink shared with the common validator. </param>
+    void ValidatePayload (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations);
+
     /// <summary> Validates one claim while the common validator reads the payload. </summary>
     /// <param name="payload"> The assurance payload root. </param>
     /// <param name="claimElement"> The claim JSON element. </param>

--- a/src/Ucli.Application/Features/Assurance/Verify/Semantics/VerifyAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Verify/Semantics/VerifyAssuranceSemanticInvariantRule.cs
@@ -9,6 +9,14 @@ namespace MackySoft.Ucli.Application.Features.Assurance.Verify.Semantics;
 internal sealed class VerifyAssuranceSemanticInvariantRule : IAssuranceSemanticInvariantRule
 {
     /// <inheritdoc />
+    public void ValidatePayload (
+        JsonElement payload,
+        List<AssuranceSemanticInvariantViolation> violations)
+    {
+        ArgumentNullException.ThrowIfNull(violations);
+    }
+
+    /// <inheritdoc />
     public void ValidateClaim (
         JsonElement payload,
         JsonElement claimElement,

--- a/src/Ucli/Features/Assurance/Build/BuildRunMetadataDocumentWriter.cs
+++ b/src/Ucli/Features/Assurance/Build/BuildRunMetadataDocumentWriter.cs
@@ -30,19 +30,16 @@ internal sealed class BuildRunMetadataDocumentWriter
             writer.WriteStartObject();
             writer.WriteNumber("schemaVersion", document.SchemaVersion);
             writer.WriteString("runId", document.RunId);
-            WriteElement(writer, "project", document.Project);
             WriteElement(writer, "profile", document.Profile);
+            WriteElement(writer, "inputs", document.Inputs);
             WriteElement(writer, "runner", document.Runner);
             WriteElement(writer, "runnerResult", document.RunnerResult);
-            WriteElement(writer, "input", document.Input);
             WriteElement(writer, "lifecycle", document.Lifecycle);
             WriteElement(writer, "generations", document.Generations);
             WriteElement(writer, "summary", document.Summary);
             WriteElement(writer, "logs", document.Logs);
-            WriteElement(writer, "output", document.Output);
             WriteElement(writer, "projectMutation", document.ProjectMutation);
             WriteArtifacts(writer, artifacts);
-            WriteElement(writer, "dirtyState", document.DirtyState);
             writer.WriteEndObject();
         }
 

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -219,7 +219,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
         var buildReportAccountingResult = await AccountExistingArtifactAsync(
                 BuildArtifactKind.BuildReport,
-                request.Paths.RepositoryRoot,
+                request.Paths.ArtifactsDirectory,
                 request.Paths.BuildReportJsonPath,
                 "BuildReport artifact",
                 BuildErrorCodes.BuildReportMissing,
@@ -232,7 +232,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
         var buildLogAccountingResult = await AccountExistingArtifactAsync(
                 BuildArtifactKind.BuildLog,
-                request.Paths.RepositoryRoot,
+                request.Paths.ArtifactsDirectory,
                 request.Paths.BuildLogPath,
                 "Build log artifact",
                 BuildErrorCodes.BuildArtifactWriteFailed,
@@ -268,7 +268,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
             outputManifestRef = CreateArtifactRef(
                 BuildArtifactKind.BuildOutputManifest,
-                request.Paths.RepositoryRoot,
+                request.Paths.ArtifactsDirectory,
                 request.Paths.OutputManifestJsonPath,
                 persistedOutputManifestDigest);
         }
@@ -346,7 +346,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
                 .ConfigureAwait(false);
             buildRef = CreateArtifactRef(
                 BuildArtifactKind.Build,
-                request.Paths.RepositoryRoot,
+                request.Paths.ArtifactsDirectory,
                 request.Paths.BuildJsonPath,
                 buildDigest);
         }
@@ -1187,7 +1187,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
     private static async ValueTask<BuildArtifactAccountingResult> AccountExistingArtifactAsync (
         BuildArtifactKind kind,
-        string repositoryRoot,
+        string artifactRoot,
         string path,
         string description,
         UcliCode missingCode,
@@ -1196,7 +1196,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         try
         {
             var digest = await ComputeExistingArtifactSha256Async(path, cancellationToken).ConfigureAwait(false);
-            return BuildArtifactAccountingResult.Success(CreateArtifactRef(kind, repositoryRoot, path, digest));
+            return BuildArtifactAccountingResult.Success(CreateArtifactRef(kind, artifactRoot, path, digest));
         }
         catch (Exception exception) when (PathFormatExceptionClassifier.IsPathFormatException(exception))
         {
@@ -1359,14 +1359,41 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
 
     private static BuildArtifactRef CreateArtifactRef (
         BuildArtifactKind kind,
-        string repositoryRoot,
+        string artifactRoot,
         string path,
         string sha256)
     {
         return new BuildArtifactRef(
             kind,
-            NormalizeRepositoryRelativePath(repositoryRoot, path),
+            NormalizeArtifactRelativePath(artifactRoot, path),
             sha256);
+    }
+
+    private static string NormalizeArtifactRelativePath (
+        string artifactRoot,
+        string path)
+    {
+        var normalizedArtifactRoot = Path.GetFullPath(artifactRoot);
+        var normalizedPath = Path.GetFullPath(path);
+        if (!PathsAreSameOrNested(normalizedArtifactRoot, normalizedPath))
+        {
+            throw new InvalidOperationException(
+                $"Build artifact path must resolve inside the artifact root. ArtifactRoot={normalizedArtifactRoot}, Path={normalizedPath}.");
+        }
+
+        var relativePath = Path.GetRelativePath(normalizedArtifactRoot, normalizedPath)
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+        if (string.IsNullOrWhiteSpace(relativePath)
+            || relativePath.StartsWith("../", StringComparison.Ordinal)
+            || string.Equals(relativePath, "..", StringComparison.Ordinal)
+            || Path.IsPathRooted(relativePath))
+        {
+            throw new InvalidOperationException(
+                $"Build artifact path could not be normalized relative to the artifact root: {path}.");
+        }
+
+        return relativePath;
     }
 
     private static string NormalizeRepositoryRelativePath (

--- a/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Build/BuildServiceTests.cs
@@ -95,6 +95,8 @@ public sealed class BuildServiceTests
         Assert.Equal(ContractLiteralCodec.ToValue(BuildVerdict.Pass), output.Verdict);
         Assert.Equal(RunId, output.Build.RunId);
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded), output.Build.Summary.Result);
+        Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildRunnerResultSource.BuildPipelineBuildReport), output.Build.RunnerResult.Source);
+        Assert.Equal(output.Build.RunnerResult.Status, output.Build.Summary.Result);
         Assert.Equal(BuildReportRefs.BuildReport, output.Build.Summary.ReportRef);
         Assert.Equal(BuildReportRefs.BuildLog, output.Build.Logs.ReportRef);
         Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildLogCompletionReason.Completed), output.Build.Logs.CompletionReason);
@@ -103,6 +105,12 @@ public sealed class BuildServiceTests
         Assert.Equal("asset-after", output.Build.Generations.ValidFor.AssetRefreshGeneration);
         var expectedProfileDigest = BuildProfileResolver.ResolveJson(ProfileJson).Profile!.Digest;
         Assert.Equal(expectedProfileDigest, output.Build.Profile.Digest);
+        Assert.Equal("explicit", output.Build.Inputs.InputKind);
+        Assert.Equal("standaloneLinux64", output.Build.Inputs.Target.StableName);
+        Assert.Equal("StandaloneLinux64", output.Build.Inputs.Target.UnityBuildTarget);
+        Assert.Equal("explicit", output.Build.Inputs.Scenes.Source);
+        Assert.Equal(["Assets/Scenes/Main.unity"], output.Build.Inputs.Scenes.Paths);
+        Assert.True(output.Build.Inputs.Options.Development);
         Assert.Equal(BuildReportRefs.BuildOutputManifest, output.Build.Output.ManifestRef);
         Assert.Equal(OutputManifestDigest, output.Build.Output.ManifestDigest);
         Assert.Equal(1, output.Build.Output.EntryCount);
@@ -114,6 +122,10 @@ public sealed class BuildServiceTests
         Assert.Equal(BuildReportArtifactDigest, output.Reports[BuildReportRefs.BuildReport].Digest);
         Assert.Equal(BuildOutputManifestArtifactDigest, output.Reports[BuildReportRefs.BuildOutputManifest].Digest);
         Assert.Equal(BuildLogArtifactDigest, output.Reports[BuildReportRefs.BuildLog].Digest);
+        Assert.Equal("build.json", output.Reports[BuildReportRefs.Build].Path);
+        Assert.Equal("build-report.json", output.Reports[BuildReportRefs.BuildReport].Path);
+        Assert.Equal("output-manifest.json", output.Reports[BuildReportRefs.BuildOutputManifest].Path);
+        Assert.Equal("build.log", output.Reports[BuildReportRefs.BuildLog].Path);
         Assert.True(output.Reports.ContainsKey(output.Build.Output.ManifestRef));
         AssertEvidenceRefsResolveToReports(output);
         Assert.Equal(BuildClaimCodes.All.Count, output.Claims.Count);
@@ -128,8 +140,27 @@ public sealed class BuildServiceTests
         Assert.Equal(
             ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded),
             artifactStore.WrittenMetadata!.Summary.GetProperty("result").GetString());
+        Assert.Equal(
+            output.Build.RunnerResult.Source,
+            artifactStore.WrittenMetadata.RunnerResult.GetProperty("source").GetString());
+        Assert.Equal(
+            output.Build.RunnerResult.Status,
+            artifactStore.WrittenMetadata.RunnerResult.GetProperty("status").GetString());
         Assert.Equal(output.Build.Profile.Path, artifactStore.WrittenMetadata.Profile.GetProperty("path").GetString());
         Assert.Equal(expectedProfileDigest, artifactStore.WrittenMetadata.Profile.GetProperty("digest").GetString());
+        Assert.Equal(output.Build.Inputs.InputKind, artifactStore.WrittenMetadata.Inputs.GetProperty("inputKind").GetString());
+        Assert.Equal(
+            output.Build.Inputs.Target.StableName,
+            artifactStore.WrittenMetadata.Inputs.GetProperty("target").GetProperty("stableName").GetString());
+        Assert.Equal(
+            output.Build.Inputs.Target.UnityBuildTarget,
+            artifactStore.WrittenMetadata.Inputs.GetProperty("target").GetProperty("unityBuildTarget").GetString());
+        Assert.Equal(
+            output.Build.Inputs.Scenes.Source,
+            artifactStore.WrittenMetadata.Inputs.GetProperty("scenes").GetProperty("source").GetString());
+        Assert.Equal(
+            output.Build.Inputs.Options.Development,
+            artifactStore.WrittenMetadata.Inputs.GetProperty("options").GetProperty("development").GetBoolean());
         Assert.Equal("buildPipeline", artifactStore.WrittenMetadata.Runner.GetProperty("kind").GetString());
         Assert.Equal(JsonValueKind.Null, artifactStore.WrittenMetadata.Runner.GetProperty("method").ValueKind);
         Assert.Equal("{}", artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("arguments").GetRawText());
@@ -142,7 +173,6 @@ public sealed class BuildServiceTests
             artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").GetProperty("locationPathName").GetString());
         Assert.Equal(output.Build.Summary.ReportRef, artifactStore.WrittenMetadata.Summary.GetProperty("reportRef").GetString());
         Assert.Equal(output.Build.Logs.ReportRef, artifactStore.WrittenMetadata.Logs.GetProperty("reportRef").GetString());
-        Assert.Equal(output.Build.Output.ManifestRef, artifactStore.WrittenMetadata.Output.GetProperty("manifestRef").GetString());
         Assert.False(artifactStore.WrittenMetadata.ProjectMutation.GetProperty("mutated").GetBoolean());
         Assert.Equal("full", artifactStore.WrittenMetadata.ProjectMutation.GetProperty("coverage").GetString());
         Assert.Equal(output.Build.Generations.Before.CompileGeneration, artifactStore.WrittenMetadata.Generations.GetProperty("before").GetProperty("compileGeneration").GetString());
@@ -288,13 +318,21 @@ public sealed class BuildServiceTests
         var output = result.Output!;
         Assert.Equal("executeMethod", output.Build.Runner.Kind);
         Assert.Equal("Build.Entry.Run", output.Build.Runner.Method);
+        Assert.Equal(ContractLiteralCodec.ToValue(IpcBuildRunnerResultSource.UcliBuildRunnerResult), output.Build.RunnerResult.Source);
+        Assert.Equal(output.Build.RunnerResult.Status, output.Build.Summary.Result);
         Assert.Equal(["UCLI_MODE"], output.Build.Runner.Invocation.Environment.Variables);
         Assert.Equal(["UCLI_SECRET"], output.Build.Runner.Invocation.Environment.Secrets);
+        Assert.DoesNotContain(EnvironmentValue, JsonSerializer.Serialize(output, PayloadSerializerOptions));
         Assert.DoesNotContain(SecretValue, JsonSerializer.Serialize(output, PayloadSerializerOptions));
         Assert.NotNull(artifactStore.WrittenMetadata);
+        Assert.DoesNotContain(EnvironmentValue, JsonSerializer.Serialize(artifactStore.WrittenMetadata!, PayloadSerializerOptions));
         Assert.DoesNotContain(SecretValue, JsonSerializer.Serialize(artifactStore.WrittenMetadata!, PayloadSerializerOptions));
+        Assert.DoesNotContain(EnvironmentValue, JsonSerializer.Serialize(progressSink.Entries, PayloadSerializerOptions));
         Assert.DoesNotContain(SecretValue, JsonSerializer.Serialize(progressSink.Entries, PayloadSerializerOptions));
         Assert.Equal("executeMethod", artifactStore.WrittenMetadata!.Runner.GetProperty("kind").GetString());
+        Assert.Equal(JsonValueKind.Null, artifactStore.WrittenMetadata.Runner.GetProperty("outputLayout").ValueKind);
+        Assert.Equal(output.Build.RunnerResult.Source, artifactStore.WrittenMetadata.RunnerResult.GetProperty("source").GetString());
+        Assert.Equal(output.Build.RunnerResult.Status, artifactStore.WrittenMetadata.RunnerResult.GetProperty("status").GetString());
         Assert.Equal(
             ["UCLI_MODE"],
             artifactStore.WrittenMetadata.Runner.GetProperty("invocation").GetProperty("environment").GetProperty("variables").EnumerateArray().Select(static item => item.GetString()!).ToArray());
@@ -623,9 +661,9 @@ public sealed class BuildServiceTests
         var result = await service.ExecuteAsync(CreateInput());
 
         Assert.True(result.IsSuccess, string.Join(Environment.NewLine, result.Errors.Select(static error => $"{error.Code}: {error.Message}")));
-        Assert.Equal("editorBuildSettings", result.Output!.Build.Scenes.Source);
-        Assert.Equal(["Assets/Scenes/FromSettings.unity"], result.Output.Build.Scenes.Paths);
-        var metadataScenePaths = artifactStore.WrittenMetadata!.Input
+        Assert.Equal("editorBuildSettings", result.Output!.Build.Inputs.Scenes.Source);
+        Assert.Equal(["Assets/Scenes/FromSettings.unity"], result.Output.Build.Inputs.Scenes.Paths);
+        var metadataScenePaths = artifactStore.WrittenMetadata!.Inputs
             .GetProperty("scenes")
             .GetProperty("paths")
             .EnumerateArray()

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -72,6 +72,24 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     [Fact]
     [Trait("Size", "Small")]
+    public void Validate_WithBuildPayloadReportAbsolutePath_ReturnsReportPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(buildLogPath: "/workspace/.ucli/build.log"));
+
+        AssertViolationPath(result, "$.reports.buildLog.path");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildPayloadReportKind_ReturnsReportKindPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(includeBuildLogKind: true));
+
+        AssertViolationPath(result, "$.reports.buildLog.kind");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
     public void Validate_WithBuildPayloadMissingProfile_ReturnsProfilePath ()
     {
         var result = ValidateBuildPayload(CreateBuildPayload(includeBuildProfile: false));
@@ -1042,38 +1060,46 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         bool includeBuildGenerations = true,
         string validForAssetRefreshGeneration = "asset-after",
         bool includeBuildLogPath = true,
+        string? buildLogPath = null,
+        bool includeBuildLogKind = false,
         string buildLogDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
     {
         var reports = new Dictionary<string, object>(StringComparer.Ordinal)
         {
             ["build"] = new
             {
-                path = "artifacts/build.json",
+                path = "build.json",
                 digest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             },
             ["buildReport"] = new
             {
-                path = "artifacts/build-report.json",
+                path = "build-report.json",
                 digest = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             },
             ["buildOutputManifest"] = new
             {
-                path = "artifacts/output-manifest.json",
+                path = "output-manifest.json",
                 digest = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
             },
         };
         if (includeBuildLogReport)
         {
-            reports["buildLog"] = includeBuildLogDigest
-                ? (object)new
+            var buildLogReport = includeBuildLogDigest
+                ? new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
-                    path = includeBuildLogPath ? "artifacts/build.log" : null,
-                    digest = buildLogDigest,
+                    ["path"] = includeBuildLogPath ? buildLogPath ?? "build.log" : null,
+                    ["digest"] = buildLogDigest,
                 }
-                : new
+                : new Dictionary<string, object?>(StringComparer.Ordinal)
                 {
-                    path = "artifacts/build.log",
+                    ["path"] = buildLogPath ?? "build.log",
                 };
+            if (includeBuildLogKind)
+            {
+                buildLogReport["kind"] = "buildLog";
+            }
+
+            reports["buildLog"] = buildLogReport;
         }
 
         object? profile = includeBuildProfile
@@ -1106,6 +1132,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                     verifierRef = "build",
                     evidence = CreateBuildEvidence(
                         code.Value,
+                        buildResult,
                         buildSucceededEvidenceRef,
                         buildGenerationEvidenceDataOnly,
                         generationEvidenceData),
@@ -1118,8 +1145,47 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             verdict,
             build = new
             {
-                buildTarget = "standaloneLinux64",
                 profile,
+                inputs = new
+                {
+                    inputKind = "explicit",
+                    target = new
+                    {
+                        stableName = "standaloneLinux64",
+                        unityBuildTarget = "StandaloneLinux64",
+                    },
+                    scenes = new
+                    {
+                        source = "explicit",
+                        paths = new[]
+                        {
+                            "Assets/Scenes/Main.unity",
+                        },
+                    },
+                    options = new
+                    {
+                        development = true,
+                    },
+                },
+                runner = new
+                {
+                    kind = "buildPipeline",
+                    method = (string?)null,
+                    invocation = new
+                    {
+                        arguments = new Dictionary<string, string>(StringComparer.Ordinal),
+                        environment = new
+                        {
+                            variables = Array.Empty<string>(),
+                            secrets = Array.Empty<string>(),
+                        },
+                    },
+                },
+                runnerResult = new
+                {
+                    source = "buildPipelineBuildReport",
+                    status = buildResult,
+                },
                 output = new
                 {
                     manifestRef = buildManifestRef,
@@ -1257,6 +1323,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
 
     private static object[] CreateBuildEvidence (
         string claimId,
+        string buildResult,
         string? buildSucceededEvidenceRef,
         bool buildGenerationEvidenceDataOnly,
         object? buildGenerationEvidenceData)
@@ -1277,6 +1344,23 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         if (BuildClaimCodes.UnityBuildSucceeded.EqualsValue(claimId) && buildSucceededEvidenceRef != null)
         {
             evidenceRef = buildSucceededEvidenceRef;
+        }
+
+        if (BuildClaimCodes.UnityBuildResultAccounted.EqualsValue(claimId))
+        {
+            return
+            [
+                new
+                {
+                    kind = "evidence",
+                    evidenceRef,
+                    data = new
+                    {
+                        source = "buildPipelineBuildReport",
+                        status = buildResult,
+                    },
+                },
+            ];
         }
 
         return

--- a/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
+++ b/tests/Ucli.Application.Tests/Features/Assurance/Semantics/AssuranceSemanticInvariantValidatorTests.cs
@@ -70,11 +70,20 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         AssertViolationPath(result, "$.reports.buildLog.digest");
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Small")]
-    public void Validate_WithBuildPayloadReportAbsolutePath_ReturnsReportPath ()
+    [InlineData("/workspace/.ucli/build.log")]
+    [InlineData("C:/workspace/.ucli/build.log")]
+    [InlineData("C:workspace/.ucli/build.log")]
+    [InlineData("../build.log")]
+    [InlineData("artifacts/../build.log")]
+    [InlineData("artifacts//build.log")]
+    [InlineData("artifacts\\build.log")]
+    [InlineData(".")]
+    [InlineData("")]
+    public void Validate_WithBuildPayloadReportNonArtifactRootRelativePath_ReturnsReportPath (string buildLogPath)
     {
-        var result = ValidateBuildPayload(CreateBuildPayload(buildLogPath: "/workspace/.ucli/build.log"));
+        var result = ValidateBuildPayload(CreateBuildPayload(buildLogPath: buildLogPath));
 
         AssertViolationPath(result, "$.reports.buildLog.path");
     }
@@ -86,6 +95,17 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         var result = ValidateBuildPayload(CreateBuildPayload(includeBuildLogKind: true));
 
         AssertViolationPath(result, "$.reports.buildLog.kind");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildPayloadReportNonArtifactRootRelativePathAndNoClaims_ReturnsReportPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            includeBuildClaims: false,
+            buildLogPath: "../build.log"));
+
+        AssertViolationPath(result, "$.reports.buildLog.path");
     }
 
     [Fact]
@@ -315,6 +335,17 @@ public sealed class AssuranceSemanticInvariantValidatorTests
             buildSucceededClaimStatus: "failed"));
 
         AssertViolationPath(result, "$.build.logs.completionReason");
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Validate_WithBuildSummaryResultMismatch_ReturnsSummaryResultPath ()
+    {
+        var result = ValidateBuildPayload(CreateBuildPayload(
+            buildResult: "succeeded",
+            summaryResult: "failed"));
+
+        AssertViolationPath(result, "$.build.summary.result");
     }
 
     [Fact]
@@ -1055,11 +1086,13 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         bool includeBuildProfile = true,
         string buildManifestRef = "buildOutputManifest",
         string summaryReportRef = "buildReport",
+        string? summaryResult = null,
         string logsReportRef = "buildLog",
         IReadOnlyList<object>? verifierEffects = null,
         bool includeBuildGenerations = true,
         string validForAssetRefreshGeneration = "asset-after",
         bool includeBuildLogPath = true,
+        bool includeBuildClaims = true,
         string? buildLogPath = null,
         bool includeBuildLogKind = false,
         string buildLogDigest = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
@@ -1115,31 +1148,33 @@ public sealed class AssuranceSemanticInvariantValidatorTests
         var generationEvidenceData = buildGenerationEvidenceDataValidForAssetRefreshGeneration == null
             ? generations
             : CreateBuildGenerations(buildGenerationEvidenceDataValidForAssetRefreshGeneration);
-        var claims = BuildClaimCodes.All
-            .Select(code =>
-            {
-                var status = ResolveBuildClaimStatus(
-                    code,
-                    buildCompletedClaimStatus,
-                    buildSucceededClaimStatus,
-                    buildGenerationClaimStatus);
-                return new
+        var claims = includeBuildClaims
+            ? BuildClaimCodes.All
+                .Select(code =>
                 {
-                    id = code.Value,
-                    status,
-                    coverage = ResolveBuildClaimCoverage(status),
-                    required = true,
-                    verifierRef = "build",
-                    evidence = CreateBuildEvidence(
-                        code.Value,
-                        buildResult,
-                        buildSucceededEvidenceRef,
-                        buildGenerationEvidenceDataOnly,
-                        generationEvidenceData),
-                    residualRisks = Array.Empty<object>(),
-                };
-            })
-            .ToArray();
+                    var status = ResolveBuildClaimStatus(
+                        code,
+                        buildCompletedClaimStatus,
+                        buildSucceededClaimStatus,
+                        buildGenerationClaimStatus);
+                    return (object)new
+                    {
+                        id = code.Value,
+                        status,
+                        coverage = ResolveBuildClaimCoverage(status),
+                        required = true,
+                        verifierRef = "build",
+                        evidence = CreateBuildEvidence(
+                            code.Value,
+                            buildResult,
+                            buildSucceededEvidenceRef,
+                            buildGenerationEvidenceDataOnly,
+                            generationEvidenceData),
+                        residualRisks = Array.Empty<object>(),
+                    };
+                })
+                .ToArray()
+            : Array.Empty<object>();
         return JsonSerializer.Serialize(new
         {
             verdict,
@@ -1194,7 +1229,7 @@ public sealed class AssuranceSemanticInvariantValidatorTests
                 generations,
                 summary = new
                 {
-                    result = buildResult,
+                    result = summaryResult ?? buildResult,
                     reportRef = summaryReportRef,
                 },
                 logs = new

--- a/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/BuildRunCliOutputContractTests.cs
@@ -20,7 +20,6 @@ public sealed class BuildRunCliOutputContractTests
 {
     private const string BuildRunGoldenDirectory = "build-run";
     private const string BuildArtifactFixtureRoot = "tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts";
-    private const string ArtifactRoot = "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1";
     private const string SuccessManifestDigest = "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b";
     private const string FailedManifestDigest = "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21";
 
@@ -111,9 +110,77 @@ public sealed class BuildRunCliOutputContractTests
         var buildRoot = fixture.RootElement;
 
         AssertEquivalentJson(buildRoot.GetProperty("profile"), payloadBuild.GetProperty("profile"));
+        AssertEquivalentJson(buildRoot.GetProperty("inputs"), payloadBuild.GetProperty("inputs"));
         AssertEquivalentJson(buildRoot.GetProperty("summary"), payloadBuild.GetProperty("summary"));
         AssertEquivalentJson(buildRoot.GetProperty("logs"), payloadBuild.GetProperty("logs"));
         AssertEquivalentJson(buildRoot.GetProperty("generations"), payloadBuild.GetProperty("generations"));
+        Assert.Equal(
+            buildRoot.GetProperty("runner").GetProperty("kind").GetString(),
+            payloadBuild.GetProperty("runner").GetProperty("kind").GetString());
+        Assert.Equal(
+            buildRoot.GetProperty("runner").GetProperty("method").ValueKind,
+            payloadBuild.GetProperty("runner").GetProperty("method").ValueKind);
+        Assert.Equal(
+            buildRoot.GetProperty("runnerResult").GetProperty("source").GetString(),
+            payloadBuild.GetProperty("runnerResult").GetProperty("source").GetString());
+        Assert.Equal(
+            buildRoot.GetProperty("runnerResult").GetProperty("status").GetString(),
+            payloadBuild.GetProperty("runnerResult").GetProperty("status").GetString());
+        Assert.False(payloadBuild.TryGetProperty("buildTarget", out _));
+        Assert.False(payloadBuild.TryGetProperty("scenes", out _));
+        Assert.False(payloadBuild.TryGetProperty("options", out _));
+    }
+
+    [Theory]
+    [InlineData("success.json")]
+    [InlineData("build-report-failed.json")]
+    [Trait("Size", "Small")]
+    public void BuildRunPayloadGoldens_UseArtifactRelativeReportsWithoutLegacyKeys (string fileName)
+    {
+        var payload = ReadGoldenPayload(fileName);
+        var reports = payload.GetProperty("reports");
+
+        Assert.False(reports.TryGetProperty("buildResult", out _));
+        foreach (var report in reports.EnumerateObject())
+        {
+            Assert.False(report.Value.TryGetProperty("kind", out _));
+            Assert.False(report.Value.TryGetProperty("category", out _));
+            var path = report.Value.GetProperty("path").GetString()!;
+            Assert.False(IsAbsoluteLikePath(path), path);
+        }
+    }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void BuildRunPayloadSchema_UsesInputsAndReportRefs ()
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "schemas",
+            "v1",
+            "cli-output",
+            "payload",
+            "build.run.schema.json")));
+        var successSchema = document.RootElement.GetProperty("oneOf")[0];
+        var buildProperties = successSchema.GetProperty("properties").GetProperty("build").GetProperty("properties");
+        var reportProperties = successSchema.GetProperty("properties").GetProperty("reports").GetProperty("properties");
+
+        Assert.True(buildProperties.TryGetProperty("inputs", out _));
+        Assert.False(buildProperties.TryGetProperty("buildTarget", out _));
+        Assert.False(buildProperties.TryGetProperty("scenes", out _));
+        Assert.False(buildProperties.TryGetProperty("options", out _));
+        Assert.Equal(
+            [BuildReportRefs.Build, BuildReportRefs.BuildReport, BuildReportRefs.BuildOutputManifest, BuildReportRefs.BuildLog],
+            reportProperties.EnumerateObject().Select(static property => property.Name).ToArray());
+        foreach (var reportSchema in reportProperties.EnumerateObject())
+        {
+            var properties = reportSchema.Value.GetProperty("properties");
+            Assert.True(properties.TryGetProperty("path", out _));
+            Assert.True(properties.TryGetProperty("digest", out _));
+            Assert.False(properties.TryGetProperty("kind", out _));
+            Assert.False(properties.TryGetProperty("category", out _));
+            Assert.False(properties.TryGetProperty("buildResult", out _));
+        }
     }
 
     [Theory]
@@ -244,9 +311,11 @@ public sealed class BuildRunCliOutputContractTests
         var build = new BuildOutput(
             RunId: "build-run-1",
             Profile: new BuildProfileOutput("/workspace/UnityProject/.ucli/build/player.json", ProfileDigest),
-            BuildTarget: "standaloneLinux64",
-            Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
-            Options: new BuildOptionsOutput(Development: true),
+            Inputs: new BuildInputsOutput(
+                InputKind: "explicit",
+                Target: new BuildTargetOutput("standaloneLinux64", "StandaloneLinux64"),
+                Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
+                Options: new BuildOptionsOutput(Development: true)),
             Runner: new BuildRunnerOutput(
                 Kind: "buildPipeline",
                 Method: null,
@@ -432,8 +501,8 @@ public sealed class BuildRunCliOutputContractTests
         {
             return new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["buildTarget"] = build.BuildTarget,
-                ["sceneCount"] = build.Scenes.Paths.Count,
+                ["buildTarget"] = build.Inputs.Target.StableName,
+                ["sceneCount"] = build.Inputs.Scenes.Paths.Count,
             };
         }
 
@@ -466,7 +535,8 @@ public sealed class BuildRunCliOutputContractTests
         {
             return new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["result"] = build.Summary.Result,
+                ["source"] = build.RunnerResult.Source,
+                ["status"] = build.RunnerResult.Status,
             };
         }
 
@@ -562,10 +632,10 @@ public sealed class BuildRunCliOutputContractTests
                     BuildReportRefs.Build,
                     new Dictionary<string, object?>(StringComparer.Ordinal)
                     {
-                        ["buildTarget"] = build.BuildTarget,
-                        ["unityBuildTarget"] = "StandaloneLinux64",
-                        ["sceneSource"] = build.Scenes.Source,
-                        ["scenes"] = build.Scenes.Paths,
+                        ["buildTarget"] = build.Inputs.Target.StableName,
+                        ["unityBuildTarget"] = build.Inputs.Target.UnityBuildTarget,
+                        ["sceneSource"] = build.Inputs.Scenes.Source,
+                        ["scenes"] = build.Inputs.Scenes.Paths,
                         ["buildOptions"] = "Development",
                     }),
             ];
@@ -588,7 +658,7 @@ public sealed class BuildRunCliOutputContractTests
 
         if (BuildClaimCodes.UnityBuildResultAccounted == code)
         {
-            return [new BuildEvidenceOutput(ContractLiteralCodec.ToValue(BuildEffect.UnityBuildReportRead), BuildReportRefs.Build, build.Summary)];
+            return [new BuildEvidenceOutput(ContractLiteralCodec.ToValue(BuildEffect.UnityBuildReportRead), BuildReportRefs.Build, build.RunnerResult)];
         }
 
         if (BuildClaimCodes.UnityBuildReportAccounted == code)
@@ -637,10 +707,10 @@ public sealed class BuildRunCliOutputContractTests
     {
         return new Dictionary<string, BuildReportOutput>(StringComparer.Ordinal)
         {
-            [BuildReportRefs.Build] = new(ArtifactRoot + "/build.json", BuildDigest),
-            [BuildReportRefs.BuildReport] = new(ArtifactRoot + "/build-report.json", BuildReportDigest),
-            [BuildReportRefs.BuildOutputManifest] = new(ArtifactRoot + "/output-manifest.json", BuildOutputManifestArtifactDigest),
-            [BuildReportRefs.BuildLog] = new(ArtifactRoot + "/build.log", BuildLogDigest),
+            [BuildReportRefs.Build] = new("build.json", BuildDigest),
+            [BuildReportRefs.BuildReport] = new("build-report.json", BuildReportDigest),
+            [BuildReportRefs.BuildOutputManifest] = new("output-manifest.json", BuildOutputManifestArtifactDigest),
+            [BuildReportRefs.BuildLog] = new("build.log", BuildLogDigest),
         };
     }
 
@@ -788,6 +858,20 @@ public sealed class BuildRunCliOutputContractTests
         JsonElement actual)
     {
         Assert.Equal(JsonSerializer.Serialize(expected), JsonSerializer.Serialize(actual));
+    }
+
+    private static bool IsAbsoluteLikePath (string path)
+    {
+        return Path.IsPathRooted(path)
+            || path.StartsWith("/", StringComparison.Ordinal)
+            || path.StartsWith("\\", StringComparison.Ordinal)
+            || (path.Length >= 3 && IsAsciiLetter(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/'));
+    }
+
+    private static bool IsAsciiLetter (char value)
+    {
+        return value is (>= 'A' and <= 'Z')
+            or (>= 'a' and <= 'z');
     }
 
     private static void AssertNoRemovedPathSegment (

--- a/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
+++ b/tests/Ucli.Tests/Features/Assurance/Build/FileBuildRunArtifactStoreTests.cs
@@ -298,16 +298,20 @@ public sealed class FileBuildRunArtifactStoreTests
         var buildRoot = buildMetadata.RootElement;
         Assert.Equal(1, buildRoot.GetProperty("schemaVersion").GetInt32());
         Assert.Equal("run-1", buildRoot.GetProperty("runId").GetString());
+        Assert.False(buildRoot.TryGetProperty("project", out _));
+        Assert.False(buildRoot.TryGetProperty("input", out _));
+        Assert.False(buildRoot.TryGetProperty("output", out _));
+        Assert.False(buildRoot.TryGetProperty("dirtyState", out _));
         Assert.False(buildRoot.GetProperty("profile").TryGetProperty("output", out _));
-        Assert.False(buildRoot.GetProperty("output").TryGetProperty("kind", out _));
-        Assert.False(buildRoot.GetProperty("output").TryGetProperty("artifactRoot", out _));
-        Assert.False(buildRoot.GetProperty("output").TryGetProperty("outputRoot", out _));
         Assert.Equal("buildPipeline", buildRoot.GetProperty("runner").GetProperty("kind").GetString());
         Assert.Equal("file", buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("shape").GetString());
         Assert.Equal(
             "/repo/.ucli/local/fingerprints/fingerprint/work/build/run-1/output/player/Player",
             buildRoot.GetProperty("runner").GetProperty("outputLayout").GetProperty("locationPathName").GetString());
-        Assert.Equal("standaloneLinux64", buildRoot.GetProperty("input").GetProperty("buildTarget").GetProperty("stableName").GetString());
+        var inputs = buildRoot.GetProperty("inputs");
+        Assert.Equal("explicit", inputs.GetProperty("inputKind").GetString());
+        Assert.Equal("standaloneLinux64", inputs.GetProperty("target").GetProperty("stableName").GetString());
+        Assert.Equal("StandaloneLinux64", inputs.GetProperty("target").GetProperty("unityBuildTarget").GetString());
 
         var artifacts = buildRoot.GetProperty("artifacts");
         Assert.Equal(
@@ -320,15 +324,15 @@ public sealed class FileBuildRunArtifactStoreTests
         Assert.False(artifacts.TryGetProperty(GetArtifactKey(BuildArtifactKind.Build), out _));
         AssertArtifactRef(
             artifacts.GetProperty(GetArtifactKey(BuildArtifactKind.BuildReport)),
-            ToRepositoryRelativeSlashPath(scope.FullPath, paths.BuildReportJsonPath),
+            UcliStoragePathNames.BuildReportFileName,
             result.BuildReport.Digest);
         AssertArtifactRef(
             artifacts.GetProperty(GetArtifactKey(BuildArtifactKind.BuildOutputManifest)),
-            ToRepositoryRelativeSlashPath(scope.FullPath, paths.OutputManifestJsonPath),
+            UcliStoragePathNames.BuildOutputManifestFileName,
             result.BuildOutputManifest.Digest);
         AssertArtifactRef(
             artifacts.GetProperty(GetArtifactKey(BuildArtifactKind.BuildLog)),
-            ToRepositoryRelativeSlashPath(scope.FullPath, paths.BuildLogPath),
+            UcliStoragePathNames.BuildLogFileName,
             result.BuildLog.Digest);
         await AssertFileSha256Async(paths.BuildJsonPath, buildRef.Digest);
         await AssertFileSha256Async(paths.BuildReportJsonPath, result.BuildReport.Digest);
@@ -779,18 +783,15 @@ public sealed class FileBuildRunArtifactStoreTests
         return new BuildRunMetadataDocument(
             1,
             runId,
-            ParseJsonElement("""{"projectPath":"/repo/UnityProject","projectFingerprint":"fingerprint","unityVersion":"6000.1.4f1"}"""),
             ParseJsonElement("""{"path":"/repo/.ucli/build/player.json","digest":"profile-digest"}"""),
+            ParseJsonElement("""{"inputKind":"explicit","target":{"stableName":"standaloneLinux64","unityBuildTarget":"StandaloneLinux64"},"scenes":{"source":"explicit","paths":["Assets/Scenes/Main.unity"]},"options":{"development":true}}"""),
             ParseJsonElement("""{"kind":"buildPipeline","method":null,"invocation":{"arguments":{},"environment":{"variables":[],"secrets":[]}},"outputLayout":{"shape":"file","locationPathName":"/repo/.ucli/local/fingerprints/fingerprint/work/build/run-1/output/player/Player"}}"""),
             ParseJsonElement("""{"source":"buildPipelineBuildReport","status":"succeeded","summary":{"durationMilliseconds":1,"errorCount":0,"warningCount":0},"diagnostics":[],"buildReportRef":"buildReport"}"""),
-            ParseJsonElement("""{"buildTarget":{"stableName":"standaloneLinux64"}}"""),
             ParseJsonElement("""{"state":"completed"}"""),
             ParseJsonElement("""{"compile":"42","domainReload":"7"}"""),
             ParseJsonElement("""{"result":"succeeded"}"""),
             ParseJsonElement("""{"buildLog":{"stream":"file"}}"""),
-            ParseJsonElement("""{"manifestDigest":"manifest-digest"}"""),
-            ParseJsonElement("""{"mode":"forbid","coverage":"full","mutated":false,"beforeDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","afterDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","items":[]}"""),
-            ParseJsonElement("""{"checked":true,"dirty":false,"coverage":"full","items":[]}"""));
+            ParseJsonElement("""{"mode":"forbid","coverage":"full","mutated":false,"beforeDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","afterDigest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","items":[]}"""));
     }
 
     private static JsonElement ParseJsonElement (string json)

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/failed/build.json
@@ -1,18 +1,16 @@
 {
   "schemaVersion": 1,
   "runId": "build-run-1",
-  "project": {
-    "projectPath": "/workspace/UnityProject",
-    "projectFingerprint": "project-fingerprint",
-    "unityVersion": "6000.1.4f1"
-  },
   "profile": {
     "path": "/workspace/UnityProject/.ucli/build/player.json",
     "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   },
-  "input": {
-    "buildTarget": "standaloneLinux64",
-    "unityBuildTarget": "StandaloneLinux64",
+  "inputs": {
+    "inputKind": "explicit",
+    "target": {
+      "stableName": "standaloneLinux64",
+      "unityBuildTarget": "StandaloneLinux64"
+    },
     "scenes": {
       "source": "explicit",
       "paths": [
@@ -22,6 +20,32 @@
     "options": {
       "development": true
     }
+  },
+  "runner": {
+    "kind": "buildPipeline",
+    "method": null,
+    "invocation": {
+      "arguments": {},
+      "environment": {
+        "variables": [],
+        "secrets": []
+      }
+    },
+    "outputLayout": {
+      "shape": "file",
+      "locationPathName": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/work/build/build-run-1/output/player/Player"
+    }
+  },
+  "runnerResult": {
+    "source": "buildPipelineBuildReport",
+    "status": "failed",
+    "summary": {
+      "durationMilliseconds": 2400,
+      "errorCount": 1,
+      "warningCount": 0
+    },
+    "diagnostics": [],
+    "buildReportRef": "buildReport"
   },
   "lifecycle": {
     "before": {
@@ -72,13 +96,6 @@
       "completedAtUtc": "2026-06-01T00:00:02.5+00:00"
     }
   },
-  "output": {
-    "manifestRef": "buildOutputManifest",
-    "manifestDigest": "04d7d7e1eb32bc4521986964ba5e86b772fe46a3b50a73e4dd3783d4c4577d21",
-    "entryCount": 0,
-    "fileCount": 0,
-    "totalBytes": 0
-  },
   "projectMutation": {
     "mode": "forbid",
     "coverage": "full",
@@ -89,22 +106,16 @@
   },
   "artifacts": {
     "buildReport": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+      "path": "build-report.json",
       "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     },
     "buildOutputManifest": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+      "path": "output-manifest.json",
       "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     },
     "buildLog": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+      "path": "build.log",
       "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     }
-  },
-  "dirtyState": {
-    "checked": true,
-    "dirty": false,
-    "coverage": "full",
-    "items": []
   }
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/BuildRunArtifacts/success/build.json
@@ -1,18 +1,16 @@
 {
   "schemaVersion": 1,
   "runId": "build-run-1",
-  "project": {
-    "projectPath": "/workspace/UnityProject",
-    "projectFingerprint": "project-fingerprint",
-    "unityVersion": "6000.1.4f1"
-  },
   "profile": {
     "path": "/workspace/UnityProject/.ucli/build/player.json",
     "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   },
-  "input": {
-    "buildTarget": "standaloneLinux64",
-    "unityBuildTarget": "StandaloneLinux64",
+  "inputs": {
+    "inputKind": "explicit",
+    "target": {
+      "stableName": "standaloneLinux64",
+      "unityBuildTarget": "StandaloneLinux64"
+    },
     "scenes": {
       "source": "explicit",
       "paths": [
@@ -22,6 +20,32 @@
     "options": {
       "development": true
     }
+  },
+  "runner": {
+    "kind": "buildPipeline",
+    "method": null,
+    "invocation": {
+      "arguments": {},
+      "environment": {
+        "variables": [],
+        "secrets": []
+      }
+    },
+    "outputLayout": {
+      "shape": "file",
+      "locationPathName": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/work/build/build-run-1/output/player/Player"
+    }
+  },
+  "runnerResult": {
+    "source": "buildPipelineBuildReport",
+    "status": "succeeded",
+    "summary": {
+      "durationMilliseconds": 2500,
+      "errorCount": 0,
+      "warningCount": 1
+    },
+    "diagnostics": [],
+    "buildReportRef": "buildReport"
   },
   "lifecycle": {
     "before": {
@@ -72,13 +96,6 @@
       "completedAtUtc": "2026-06-01T00:00:02.5+00:00"
     }
   },
-  "output": {
-    "manifestRef": "buildOutputManifest",
-    "manifestDigest": "59a71d71a244ad7a978be0bbfe8f87328c036091bb4b5aefef9e89b855d82b9b",
-    "entryCount": 1,
-    "fileCount": 2,
-    "totalBytes": 33
-  },
   "projectMutation": {
     "mode": "forbid",
     "coverage": "full",
@@ -89,22 +106,16 @@
   },
   "artifacts": {
     "buildReport": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+      "path": "build-report.json",
       "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     },
     "buildOutputManifest": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+      "path": "output-manifest.json",
       "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
     },
     "buildLog": {
-      "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+      "path": "build.log",
       "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
     }
-  },
-  "dirtyState": {
-    "checked": true,
-    "dirty": false,
-    "coverage": "full",
-    "items": []
   }
 }

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/build-report-failed.json
@@ -17,15 +17,21 @@
         "path": "/workspace/UnityProject/.ucli/build/player.json",
         "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       },
-      "buildTarget": "standaloneLinux64",
-      "scenes": {
-        "source": "explicit",
-        "paths": [
-          "Assets/Scenes/Main.unity"
-        ]
-      },
-      "options": {
-        "development": true
+      "inputs": {
+        "inputKind": "explicit",
+        "target": {
+          "stableName": "standaloneLinux64",
+          "unityBuildTarget": "StandaloneLinux64"
+        },
+        "scenes": {
+          "source": "explicit",
+          "paths": [
+            "Assets/Scenes/Main.unity"
+          ]
+        },
+        "options": {
+          "development": true
+        }
       },
       "runner": {
         "kind": "buildPipeline",
@@ -269,18 +275,16 @@
         "verifierRef": "build",
         "statement": "Build runner terminal result was persisted in build metadata.",
         "subject": {
-          "result": "failed"
+          "source": "buildPipelineBuildReport",
+          "status": "failed"
         },
         "evidence": [
           {
             "kind": "unityBuildReportRead",
             "evidenceRef": "build",
             "data": {
-              "result": "failed",
-              "durationMilliseconds": 2400,
-              "errorCount": 1,
-              "warningCount": 0,
-              "reportRef": "buildReport"
+              "source": "buildPipelineBuildReport",
+              "status": "failed"
             }
           }
         ],
@@ -448,19 +452,19 @@
     ],
     "reports": {
       "build": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json",
+        "path": "build.json",
         "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       },
       "buildReport": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+        "path": "build-report.json",
         "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       },
       "buildOutputManifest": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+        "path": "output-manifest.json",
         "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
       },
       "buildLog": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+        "path": "build.log",
         "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       }
     },

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build-run/success.json
@@ -17,15 +17,21 @@
         "path": "/workspace/UnityProject/.ucli/build/player.json",
         "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       },
-      "buildTarget": "standaloneLinux64",
-      "scenes": {
-        "source": "explicit",
-        "paths": [
-          "Assets/Scenes/Main.unity"
-        ]
-      },
-      "options": {
-        "development": true
+      "inputs": {
+        "inputKind": "explicit",
+        "target": {
+          "stableName": "standaloneLinux64",
+          "unityBuildTarget": "StandaloneLinux64"
+        },
+        "scenes": {
+          "source": "explicit",
+          "paths": [
+            "Assets/Scenes/Main.unity"
+          ]
+        },
+        "options": {
+          "development": true
+        }
       },
       "runner": {
         "kind": "buildPipeline",
@@ -269,18 +275,16 @@
         "verifierRef": "build",
         "statement": "Build runner terminal result was persisted in build metadata.",
         "subject": {
-          "result": "succeeded"
+          "source": "buildPipelineBuildReport",
+          "status": "succeeded"
         },
         "evidence": [
           {
             "kind": "unityBuildReportRead",
             "evidenceRef": "build",
             "data": {
-              "result": "succeeded",
-              "durationMilliseconds": 2500,
-              "errorCount": 0,
-              "warningCount": 1,
-              "reportRef": "buildReport"
+              "source": "buildPipelineBuildReport",
+              "status": "succeeded"
             }
           }
         ],
@@ -448,19 +452,19 @@
     ],
     "reports": {
       "build": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json",
+        "path": "build.json",
         "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       },
       "buildReport": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+        "path": "build-report.json",
         "digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       },
       "buildOutputManifest": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+        "path": "output-manifest.json",
         "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
       },
       "buildLog": {
-        "path": "/workspace/UnityProject/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+        "path": "build.log",
         "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       }
     },

--- a/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
+++ b/tests/Ucli.Tests/GoldenFiles/Json/CliOutput/build/pass-success.json
@@ -17,15 +17,21 @@
         "path": "/workspace/.ucli/build/player.json",
         "digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       },
-      "buildTarget": "standaloneLinux64",
-      "scenes": {
-        "source": "explicit",
-        "paths": [
-          "Assets/Scenes/Main.unity"
-        ]
-      },
-      "options": {
-        "development": true
+      "inputs": {
+        "inputKind": "explicit",
+        "target": {
+          "stableName": "standaloneLinux64",
+          "unityBuildTarget": "StandaloneLinux64"
+        },
+        "scenes": {
+          "source": "explicit",
+          "paths": [
+            "Assets/Scenes/Main.unity"
+          ]
+        },
+        "options": {
+          "development": true
+        }
       },
       "runner": {
         "kind": "buildPipeline",
@@ -244,13 +250,17 @@
         "verifierRef": "build",
         "statement": "Build result accounted.",
         "subject": {
-          "kind": "build",
-          "runId": "build-run-1"
+          "source": "buildPipelineBuildReport",
+          "status": "succeeded"
         },
         "evidence": [
           {
             "kind": "artifact",
-            "evidenceRef": "build"
+            "evidenceRef": "build",
+            "data": {
+              "source": "buildPipelineBuildReport",
+              "status": "succeeded"
+            }
           }
         ],
         "residualRisks": []
@@ -372,19 +382,19 @@
     ],
     "reports": {
       "build": {
-        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json",
+        "path": "build.json",
         "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
       },
       "buildReport": {
-        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json",
+        "path": "build-report.json",
         "digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       },
       "buildOutputManifest": {
-        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json",
+        "path": "output-manifest.json",
         "digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
       },
       "buildLog": {
-        "path": "/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log",
+        "path": "build.log",
         "digest": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
       }
     },

--- a/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
+++ b/tests/Ucli.Tests/Hosting/Cli/BuildRunTestData.cs
@@ -87,9 +87,11 @@ internal static class BuildRunTestData
         return new BuildOutput(
             RunId: RunId,
             Profile: new BuildProfileOutput("/workspace/.ucli/build/player.json", Repeat('a')),
-            BuildTarget: "standaloneLinux64",
-            Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
-            Options: new BuildOptionsOutput(Development: true),
+            Inputs: new BuildInputsOutput(
+                InputKind: "explicit",
+                Target: new BuildTargetOutput("standaloneLinux64", "StandaloneLinux64"),
+                Scenes: new BuildScenesOutput("explicit", ["Assets/Scenes/Main.unity"]),
+                Options: new BuildOptionsOutput(Development: true)),
             Runner: new BuildRunnerOutput(
                 Kind: "buildPipeline",
                 Method: null,
@@ -143,7 +145,7 @@ internal static class BuildRunTestData
             CreateClaim(BuildClaimCodes.UnityBuildRunnerResolved, passed, "Build runner resolved.", BuildReportRefs.Build),
             CreateClaim(BuildClaimCodes.UnityBuildCompleted, passed, "BuildPipeline completed.", BuildReportRefs.BuildReport),
             CreateClaim(BuildClaimCodes.UnityBuildSucceeded, succeededStatus, "BuildPipeline succeeded.", BuildReportRefs.BuildReport),
-            CreateClaim(BuildClaimCodes.UnityBuildResultAccounted, passed, "Build result accounted.", BuildReportRefs.Build),
+            CreateClaim(BuildClaimCodes.UnityBuildResultAccounted, passed, "Build result accounted.", BuildReportRefs.Build, reportResult),
             CreateClaim(BuildClaimCodes.UnityBuildReportAccounted, passed, "BuildReport artifact accounted.", BuildReportRefs.BuildReport),
             CreateClaim(BuildClaimCodes.UnityBuildArtifactsAccounted, passed, "Build artifacts accounted.", BuildReportRefs.Build),
             CreateClaim(BuildClaimCodes.UnityBuildOutputDigested, passed, "Build output digested.", BuildReportRefs.BuildOutputManifest),
@@ -157,8 +159,33 @@ internal static class BuildRunTestData
         UcliCode code,
         string status,
         string statement,
-        string? evidenceRef)
+        string? evidenceRef,
+        string? reportResult = null)
     {
+        var subject = BuildClaimCodes.UnityBuildResultAccounted.Equals(code) && reportResult != null
+            ? new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["source"] = ContractLiteralCodec.ToValue(IpcBuildRunnerResultSource.BuildPipelineBuildReport),
+                ["status"] = reportResult,
+            }
+            : new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["kind"] = BuildReportRefs.Build,
+                ["runId"] = RunId,
+            };
+        var evidence = BuildClaimCodes.UnityBuildResultAccounted.Equals(code) && evidenceRef != null && reportResult != null
+            ? new BuildEvidenceOutput(
+                "artifact",
+                evidenceRef,
+                new
+                {
+                    source = ContractLiteralCodec.ToValue(IpcBuildRunnerResultSource.BuildPipelineBuildReport),
+                    status = reportResult,
+                })
+            : evidenceRef == null
+                ? new BuildEvidenceOutput("lifecycleSnapshot", Data: new { state = "ready" })
+                : new BuildEvidenceOutput("artifact", evidenceRef);
+
         return new BuildClaimOutput(
             Id: code.Value,
             Status: status,
@@ -166,17 +193,8 @@ internal static class BuildRunTestData
             Required: true,
             VerifierRef: BuildReportRefs.Build,
             Statement: statement,
-            Subject: new Dictionary<string, object?>(StringComparer.Ordinal)
-            {
-                ["kind"] = BuildReportRefs.Build,
-                ["runId"] = RunId,
-            },
-            Evidence:
-            [
-                evidenceRef == null
-                    ? new BuildEvidenceOutput("lifecycleSnapshot", Data: new { state = "ready" })
-                    : new BuildEvidenceOutput("artifact", evidenceRef),
-            ],
+            Subject: subject,
+            Evidence: [evidence],
             ResidualRisks: []);
     }
 
@@ -184,10 +202,10 @@ internal static class BuildRunTestData
     {
         return new Dictionary<string, BuildReportOutput>(StringComparer.Ordinal)
         {
-            [BuildReportRefs.Build] = new("/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.json", Repeat('c')),
-            [BuildReportRefs.BuildReport] = new("/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build-report.json", Repeat('d')),
-            [BuildReportRefs.BuildOutputManifest] = new("/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/output-manifest.json", Repeat('e')),
-            [BuildReportRefs.BuildLog] = new("/workspace/.ucli/local/fingerprints/project-fingerprint/artifacts/build/build-run-1/build.log", Repeat('f')),
+            [BuildReportRefs.Build] = new("build.json", Repeat('c')),
+            [BuildReportRefs.BuildReport] = new("build-report.json", Repeat('d')),
+            [BuildReportRefs.BuildOutputManifest] = new("output-manifest.json", Repeat('e')),
+            [BuildReportRefs.BuildLog] = new("build.log", Repeat('f')),
         };
     }
 

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -139,9 +139,13 @@ public sealed class CliOutputSchemaArtifactTests
         Assert.NotEmpty(errors);
     }
 
-    [Fact]
+    [Theory]
     [Trait("Size", "Small")]
-    public void BuildRunPayloadSchema_AcceptsUnknownRunnerResultStatus ()
+    [InlineData("runnerResult", "status")]
+    [InlineData("summary", "result")]
+    public void BuildRunPayloadSchema_RejectsUnknownBuildResult (
+        string ownerName,
+        string propertyName)
     {
         using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
         var goldenPath = Path.Combine(
@@ -154,15 +158,14 @@ public sealed class CliOutputSchemaArtifactTests
             "build-run",
             "success.json");
         var root = JsonNode.Parse(File.ReadAllText(goldenPath))!.AsObject();
-        root["payload"]!["build"]!["runnerResult"]!["status"] = "unknown";
-        root["payload"]!["build"]!["summary"]!["result"] = "unknown";
+        root["payload"]!["build"]![ownerName]![propertyName] = "unknown";
         using var document = JsonDocument.Parse(root.ToJsonString());
 
         var errors = schemaSet.Validate(
             "cli-output/payload/build.run.schema.json",
             document.RootElement.GetProperty("payload"));
 
-        Assert.Empty(errors);
+        Assert.NotEmpty(errors);
     }
 
     [Fact]

--- a/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
+++ b/tests/Ucli.Tests/Schemas/CliOutputSchemaArtifactTests.cs
@@ -141,7 +141,7 @@ public sealed class CliOutputSchemaArtifactTests
 
     [Fact]
     [Trait("Size", "Small")]
-    public void BuildRunPayloadSchema_RejectsUnknownRunnerResultStatus ()
+    public void BuildRunPayloadSchema_AcceptsUnknownRunnerResultStatus ()
     {
         using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
         var goldenPath = Path.Combine(
@@ -155,13 +155,14 @@ public sealed class CliOutputSchemaArtifactTests
             "success.json");
         var root = JsonNode.Parse(File.ReadAllText(goldenPath))!.AsObject();
         root["payload"]!["build"]!["runnerResult"]!["status"] = "unknown";
+        root["payload"]!["build"]!["summary"]!["result"] = "unknown";
         using var document = JsonDocument.Parse(root.ToJsonString());
 
         var errors = schemaSet.Validate(
             "cli-output/payload/build.run.schema.json",
             document.RootElement.GetProperty("payload"));
 
-        Assert.NotEmpty(errors);
+        Assert.Empty(errors);
     }
 
     [Fact]

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -683,11 +683,7 @@ internal static class Program
                 additionalProperties: false,
                 Required(
                     "result",
-                    EnumSchema(
-                        Literal(IpcBuildReportResult.Succeeded),
-                        Literal(IpcBuildReportResult.Failed),
-                        Literal(IpcBuildReportResult.Canceled),
-                        Literal(IpcBuildReportResult.Unknown))),
+                    BuildRunTerminalResultSchema()),
                 Required("durationMilliseconds", IntegerSchema()),
                 Required("errorCount", IntegerSchema()),
                 Required("warningCount", IntegerSchema()),
@@ -762,11 +758,15 @@ internal static class Program
                     Literal(IpcBuildRunnerResultSource.UcliBuildRunnerResult))),
             Required(
                 "status",
-                EnumSchema(
-                    Literal(IpcBuildReportResult.Succeeded),
-                    Literal(IpcBuildReportResult.Failed),
-                    Literal(IpcBuildReportResult.Canceled),
-                    Literal(IpcBuildReportResult.Unknown))));
+                BuildRunTerminalResultSchema()));
+    }
+
+    private static Dictionary<string, object?> BuildRunTerminalResultSchema ()
+    {
+        return EnumSchema(
+            Literal(IpcBuildReportResult.Succeeded),
+            Literal(IpcBuildReportResult.Failed),
+            Literal(IpcBuildReportResult.Canceled));
     }
 
     private static Dictionary<string, object?> CreateBuildRunClaimSchema ()

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -664,18 +664,7 @@ internal static class Program
                 additionalProperties: false,
                 Required("path", StringSchema()),
                 Required("digest", Sha256LowerHexSchema()))),
-            Required("buildTarget", StringSchema()),
-            Required("scenes", ObjectSchema(
-                additionalProperties: false,
-                Required(
-                    "source",
-                    EnumSchema(
-                        Literal(BuildProfileSceneSource.EditorBuildSettings),
-                        Literal(BuildProfileSceneSource.Explicit))),
-                Required("paths", ArraySchema(StringSchema())))),
-            Required("options", ObjectSchema(
-                additionalProperties: false,
-                Required("development", BooleanSchema()))),
+            Required("inputs", CreateBuildRunInputsSchema()),
             Required("runner", CreateBuildRunRunnerSchema()),
             Required("runnerResult", CreateBuildRunRunnerResultSchema()),
             Required("output", ObjectSchema(
@@ -714,11 +703,33 @@ internal static class Program
                     EnumSchema(
                         Literal(IpcBuildLogCompletionReason.Completed),
                         Literal(IpcBuildLogCompletionReason.Failed),
-                        Literal(IpcBuildLogCompletionReason.Canceled))),
+                    Literal(IpcBuildLogCompletionReason.Canceled))),
                 Required("window", ObjectSchema(
                     additionalProperties: false,
                     Required("startedAtUtc", StringSchema()),
                     Required("completedAtUtc", StringSchema()))))));
+    }
+
+    private static Dictionary<string, object?> CreateBuildRunInputsSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("inputKind", ConstString("explicit")),
+            Required("target", ObjectSchema(
+                additionalProperties: false,
+                Required("stableName", StringSchema()),
+                Required("unityBuildTarget", StringSchema()))),
+            Required("scenes", ObjectSchema(
+                additionalProperties: false,
+                Required(
+                    "source",
+                    EnumSchema(
+                        Literal(BuildProfileSceneSource.EditorBuildSettings),
+                        Literal(BuildProfileSceneSource.Explicit))),
+                Required("paths", ArraySchema(StringSchema())))),
+            Required("options", ObjectSchema(
+                additionalProperties: false,
+                Required("development", BooleanSchema()))));
     }
 
     private static Dictionary<string, object?> CreateBuildRunRunnerSchema ()
@@ -754,7 +765,8 @@ internal static class Program
                 EnumSchema(
                     Literal(IpcBuildReportResult.Succeeded),
                     Literal(IpcBuildReportResult.Failed),
-                    Literal(IpcBuildReportResult.Canceled))));
+                    Literal(IpcBuildReportResult.Canceled),
+                    Literal(IpcBuildReportResult.Unknown))));
     }
 
     private static Dictionary<string, object?> CreateBuildRunClaimSchema ()


### PR DESCRIPTION
## Summary
- Projected build metadata and CLI payloads to the final #403 runnerResult contract.
- Moved resolved explicit build inputs under `build.inputs` and removed the legacy direct `buildTarget` / `scenes` / `options` payload shape.
- Normalized build reports and metadata artifact references so local artifact paths are artifact-root relative and report entries expose only `path` / `digest`.

## Scope
- Build application payload and metadata projection: `BuildService`, build payload records, metadata document model, and metadata writer.
- Artifact storage: `FileBuildRunArtifactStore` now records artifact-root relative artifact refs and omits `build.json` self-reference from `build.json.artifacts`.
- Contract validation: build semantic invariants now validate `inputs`, `runner`, `runnerResult`, final report keys, relative report paths, and runnerResult evidence.
- Schema and fixtures: regenerated `build.run` payload schema and updated build-run / build command golden JSON fixtures.
- Tests: updated service, artifact store, schema, golden, and semantic invariant tests for the final contract.

## Verification
- Gate level: Full
- Format: PASS (`bash scripts/code-quality.sh format`, `bash scripts/code-quality.sh verify`)
- Tests: PASS (`bash scripts/test-dotnet.sh`, 1743 tests; `bash scripts/verify.sh`, 1743 tests)
- Coverage: N/A

## Risks / Rollback
- Risk: downstream consumers reading `payload.build.buildTarget`, `payload.build.scenes`, or `payload.build.options` must switch to `payload.build.inputs`.
- Risk: consumers expecting absolute report paths must resolve artifact-root relative paths from the run artifact root.
- Rollback: revert `be4f7e484` to restore the previous payload and metadata projection.

## Checklist
- [x] `build.json` top-level shape matches the final metadata contract.
- [x] `payload.build.runnerResult.status` matches `payload.build.summary.result`.
- [x] `payload.reports` and `build.json.artifacts` use final stable keys and omit `kind` / `category` / `buildResult`.
- [x] Schema and golden JSON are updated.

Closes #403
