### PR TITLE
feat(runtime): add runtime performance tracing

### DIFF
--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Dispatch/ExecuteRequestDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Dispatch/ExecuteRequestDispatcher.cs
@@ -128,7 +128,12 @@ namespace MackySoft.Ucli.Unity.Execution.Dispatch
                     SerializerOptions);
             }
 
-            var normalizationResult = requestNormalizer.Normalize(request, cancellationToken);
+            ExecuteRequestNormalizationResult normalizationResult;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Normalize))
+            {
+                normalizationResult = requestNormalizer.Normalize(request, cancellationToken);
+            }
+
             if (!normalizationResult.IsSuccess)
             {
                 var normalizationError = normalizationResult.Error!;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Pipeline/OperationPhaseExecutor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Pipeline/OperationPhaseExecutor.cs
@@ -7,6 +7,7 @@ using MackySoft.Ucli.Contracts.Configuration;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Ipc.ContractReading;
 using MackySoft.Ucli.Unity.Execution.Requests;
+using MackySoft.Ucli.Unity.Runtime;
 
 #nullable enable
 
@@ -78,7 +79,12 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
 
             using var executionContext = new OperationExecutionContext();
             var operationPreflight = CreateOperationPreflight(command, request.AllowDangerous);
-            var planPassResult = await planPassExecutor.ExecuteAsync(request, executionContext, operationPreflight, cancellationToken).ConfigureAwait(false);
+            PlanPassResult planPassResult;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.PhasePlan))
+            {
+                planPassResult = await planPassExecutor.ExecuteAsync(request, executionContext, operationPreflight, cancellationToken).ConfigureAwait(false);
+            }
+
             if (!planPassResult.IsSuccess)
             {
                 if (command == PhaseExecutionCommand.Call
@@ -168,10 +174,15 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
                     errors: new[]
                     {
                         dangerousCallFailure!,
-                    });
+                });
             }
 
-            var callPassResult = await callPassExecutor.ExecuteAsync(planPassResult.PreparedOperations, executionContext, cancellationToken).ConfigureAwait(false);
+            CallPassResult callPassResult;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.PhaseCall))
+            {
+                callPassResult = await callPassExecutor.ExecuteAsync(planPassResult.PreparedOperations, executionContext, cancellationToken).ConfigureAwait(false);
+            }
+
             return callPassResult.IsSuccess
                 ? PhaseExecutionTrace.Success(request.ProtocolVersion, request.RequestId, planPassResult.CompiledSteps, callPassResult.OperationTraces)
                 : PhaseExecutionTrace.Failure(request.ProtocolVersion, request.RequestId, planPassResult.CompiledSteps, callPassResult.OperationTraces, callPassResult.Errors);

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcMethodDispatcher.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcMethodDispatcher.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Infrastructure.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -66,13 +67,19 @@ namespace MackySoft.Ucli.Unity.Ipc
                 if (methodHandler is IRecoverableUnityIpcMethodHandler recoverableMethodHandler
                     && recoverableOperationStore != null)
                 {
-                    return await DispatchRecoverableAsync(
-                        recoverableMethodHandler,
-                        request,
-                        cancellationToken);
+                    using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Dispatch))
+                    {
+                        return await DispatchRecoverableAsync(
+                            recoverableMethodHandler,
+                            request,
+                            cancellationToken);
+                    }
                 }
 
-                return await methodHandler.HandleAsync(request, cancellationToken);
+                using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Dispatch))
+                {
+                    return await methodHandler.HandleAsync(request, cancellationToken);
+                }
             }
             catch (OperationCanceledException)
             {
@@ -126,7 +133,10 @@ namespace MackySoft.Ucli.Unity.Ipc
                         null);
                 }
 
-                return await streamingMethodHandler.HandleStreamingAsync(request, streamWriter, cancellationToken);
+                using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Dispatch))
+                {
+                    return await streamingMethodHandler.HandleStreamingAsync(request, streamWriter, cancellationToken);
+                }
             }
             catch (OperationCanceledException)
             {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcRequestHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcRequestHandler.cs
@@ -5,6 +5,7 @@ using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Infrastructure.Ipc;
 using MackySoft.Ucli.Contracts.Text;
+using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -38,7 +39,12 @@ namespace MackySoft.Ucli.Unity.Ipc
             IpcRequest request,
             CancellationToken cancellationToken = default)
         {
-            var validationErrorResponse = await ValidateCommonAsync(request, cancellationToken);
+            IpcResponse validationErrorResponse;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Validate))
+            {
+                validationErrorResponse = await ValidateCommonAsync(request, cancellationToken);
+            }
+
             if (validationErrorResponse != null)
             {
                 return validationErrorResponse;
@@ -64,7 +70,12 @@ namespace MackySoft.Ucli.Unity.Ipc
                 throw new ArgumentNullException(nameof(streamWriter));
             }
 
-            var validationErrorResponse = await ValidateCommonAsync(request, cancellationToken);
+            IpcResponse validationErrorResponse;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Validate))
+            {
+                validationErrorResponse = await ValidateCommonAsync(request, cancellationToken);
+            }
+
             if (validationErrorResponse != null)
             {
                 return validationErrorResponse;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcRequestProcessor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Dispatch/UnityIpcRequestProcessor.cs
@@ -31,7 +31,7 @@ namespace MackySoft.Ucli.Unity.Ipc
         /// <param name="cancellationToken"> The cancellation token propagated by host execution. </param>
         /// <returns> The processed IPC response envelope. </returns>
         /// <exception cref="ArgumentNullException"> Thrown when <paramref name="request" /> is <see langword="null" />. </exception>
-        public Task<IpcResponse> ProcessAsync (
+        public async Task<IpcResponse> ProcessAsync (
             IpcRequest request,
             CancellationToken cancellationToken = default)
         {
@@ -41,13 +41,16 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            return mainThreadRequestExecutor.ExecuteAsync(
-                () => requestHandler.HandleAsync(request, cancellationToken),
-                cancellationToken);
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.UnityMainThread))
+            {
+                return await mainThreadRequestExecutor.ExecuteAsync(
+                    () => requestHandler.HandleAsync(request, cancellationToken),
+                    cancellationToken);
+            }
         }
 
         /// <inheritdoc />
-        public Task<IpcResponse> ProcessStreamingAsync (
+        public async Task<IpcResponse> ProcessStreamingAsync (
             IpcRequest request,
             IIpcStreamFrameWriter streamWriter,
             CancellationToken cancellationToken = default)
@@ -63,9 +66,12 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            return mainThreadRequestExecutor.ExecuteAsync(
-                () => requestHandler.HandleStreamingAsync(request, streamWriter, cancellationToken),
-                cancellationToken);
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.UnityMainThread))
+            {
+                return await mainThreadRequestExecutor.ExecuteAsync(
+                    () => requestHandler.HandleStreamingAsync(request, streamWriter, cancellationToken),
+                    cancellationToken);
+            }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -16,6 +16,7 @@ using MackySoft.Ucli.Contracts.Text;
 using MackySoft.Ucli.Infrastructure.Paths;
 using MackySoft.Ucli.Infrastructure.Storage;
 using MackySoft.Ucli.Unity.Build;
+using MackySoft.Ucli.Unity.Runtime;
 using UnityEngine;
 
 #nullable enable
@@ -234,21 +235,29 @@ namespace MackySoft.Ucli.Unity.Ipc
 
                 if (normalizedReport != null)
                 {
-                    await WriteJsonAtomicallyAsync(
-                            buildRunRequest.BuildReportPath,
-                            normalizedReport,
+                    using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.ArtifactWrite))
+                    {
+                        await WriteJsonAtomicallyAsync(
+                                buildRunRequest.BuildReportPath,
+                                normalizedReport,
+                                executionCancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                }
+
+                EditorLogRangeExportResult logSummaryCounts;
+                using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
+                {
+                    logSummaryCounts = await ExportBuildLogAsync(
+                            logSourcePath,
+                            buildRunRequest.BuildLogPath,
+                            logStartOffset,
+                            logEndOffset,
+                            IsExecuteMethodRunner(buildRunRequest) ? buildRunRequest.RunnerEnvironmentSecretValues : null,
                             executionCancellationToken)
                         .ConfigureAwait(false);
                 }
 
-                var logSummaryCounts = await ExportBuildLogAsync(
-                        logSourcePath,
-                        buildRunRequest.BuildLogPath,
-                        logStartOffset,
-                        logEndOffset,
-                        IsExecuteMethodRunner(buildRunRequest) ? buildRunRequest.RunnerEnvironmentSecretValues : null,
-                        executionCancellationToken)
-                    .ConfigureAwait(false);
                 var completionReason = UnityBuildReportNormalizer.ToCompletionReason(
                     normalizedReport?.Result ?? runnerResult!.Status);
                 var logs = new IpcBuildLogSummary(

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/DaemonLogsRead/DaemonLogsReadUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/DaemonLogsRead/DaemonLogsReadUnityIpcMethodHandler.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -65,24 +66,35 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return new ValueTask<IpcResponse>(decodeErrorResponse);
             }
 
-            var snapshot = daemonLogStream.Snapshot();
-
-            if (!requestValidator.TryValidate(
-                    payload,
-                    snapshot.StreamId,
-                    out var filter,
-                    out var errorMessage))
+            DaemonLogSnapshot snapshot;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
             {
-                daemonLogger.Warning(
-                    DaemonLogCategories.Ipc,
-                    "Daemon logs read rejected due to invalid argument.",
-                    errorMessage);
-                return new ValueTask<IpcResponse>(CreateInvalidArgumentResponse(request, errorMessage));
+                snapshot = daemonLogStream.Snapshot();
             }
 
-            var filteredEvents = queryEngine.Filter(snapshot.Events, filter);
-            var responsePayload = responseFactory.Create(filteredEvents, snapshot.NextCursor);
-            return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateSuccessResponse(request, responsePayload));
+            DaemonLogsReadFilter filter;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Validate))
+            {
+                if (!requestValidator.TryValidate(
+                        payload,
+                        snapshot.StreamId,
+                        out filter,
+                        out var errorMessage))
+                {
+                    daemonLogger.Warning(
+                        DaemonLogCategories.Ipc,
+                        "Daemon logs read rejected due to invalid argument.",
+                        errorMessage);
+                    return new ValueTask<IpcResponse>(CreateInvalidArgumentResponse(request, errorMessage));
+                }
+            }
+
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
+            {
+                var filteredEvents = queryEngine.Filter(snapshot.Events, filter);
+                var responsePayload = responseFactory.Create(filteredEvents, snapshot.NextCursor);
+                return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateSuccessResponse(request, responsePayload));
+            }
         }
 
         /// <summary> Creates one invalid-argument response envelope. </summary>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/UnityLogsRead/UnityLogsReadUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/UnityLogsRead/UnityLogsReadUnityIpcMethodHandler.cs
@@ -3,6 +3,7 @@ using MackySoft.Ucli.Contracts;
 using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -60,23 +61,35 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return new ValueTask<IpcResponse>(decodeErrorResponse);
             }
 
-            var snapshot = unityLogStream.Snapshot();
-            if (!requestValidator.TryValidate(payload, snapshot.StreamId, out var filter, out var errorMessage))
+            UnityLogSnapshot snapshot;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
             {
-                daemonLogger.Warning(
-                    DaemonLogCategories.Ipc,
-                    "Unity logs read rejected due to invalid argument.",
-                    errorMessage);
-                return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateErrorResponse(
-                    request,
-                    UcliCoreErrorCodes.InvalidArgument,
-                    errorMessage,
-                    null));
+                snapshot = unityLogStream.Snapshot();
             }
 
-            var filteredEvents = queryEngine.Filter(snapshot.Events, filter);
-            var responsePayload = responseFactory.Create(filteredEvents, snapshot.NextCursor);
-            return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateSuccessResponse(request, responsePayload));
+            UnityLogsReadFilter filter;
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Validate))
+            {
+                if (!requestValidator.TryValidate(payload, snapshot.StreamId, out filter, out var errorMessage))
+                {
+                    daemonLogger.Warning(
+                        DaemonLogCategories.Ipc,
+                        "Unity logs read rejected due to invalid argument.",
+                        errorMessage);
+                    return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateErrorResponse(
+                        request,
+                        UcliCoreErrorCodes.InvalidArgument,
+                        errorMessage,
+                        null));
+                }
+            }
+
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
+            {
+                var filteredEvents = queryEngine.Filter(snapshot.Events, filter);
+                var responsePayload = responseFactory.Create(filteredEvents, snapshot.NextCursor);
+                return new ValueTask<IpcResponse>(UnityIpcResponseFactory.CreateSuccessResponse(request, responsePayload));
+            }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Protocol/UnityIpcRequestCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Protocol/UnityIpcRequestCodec.cs
@@ -1,6 +1,7 @@
 using System;
 using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
 
 namespace MackySoft.Ucli.Unity.Ipc
 {
@@ -220,26 +221,29 @@ namespace MackySoft.Ucli.Unity.Ipc
                 throw new ArgumentNullException(nameof(request));
             }
 
-            if (IpcPayloadCodec.TryDeserialize(
-                request.Payload,
-                out TPayload parsedPayload,
-                out var readError))
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.Validate))
             {
-                payload = parsedPayload;
-                errorResponse = null;
-                return true;
-            }
+                if (IpcPayloadCodec.TryDeserialize(
+                    request.Payload,
+                    out TPayload parsedPayload,
+                    out var readError))
+                {
+                    payload = parsedPayload;
+                    errorResponse = null;
+                    return true;
+                }
 
-            payload = default;
-            var message = readError.Kind == IpcPayloadReadErrorKind.NullPayload
-                ? $"{methodName} payload is null."
-                : readError.Message;
-            errorResponse = UnityIpcResponseFactory.CreateErrorResponse(
-                request,
-                UcliCoreErrorCodes.InvalidArgument,
-                $"{methodName} payload is invalid. {message}",
-                null);
-            return false;
+                payload = default;
+                var message = readError.Kind == IpcPayloadReadErrorKind.NullPayload
+                    ? $"{methodName} payload is null."
+                    : readError.Message;
+                errorResponse = UnityIpcResponseFactory.CreateErrorResponse(
+                    request,
+                    UcliCoreErrorCodes.InvalidArgument,
+                    $"{methodName} payload is invalid. {message}",
+                    null);
+                return false;
+            }
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Server/UnityIpcConnectionHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Server/UnityIpcConnectionHandler.cs
@@ -32,10 +32,12 @@ namespace MackySoft.Ucli.Unity.Ipc
             Stream stream,
             CancellationToken cancellationToken = default)
         {
+            var receiveMeasurement = RuntimePerformanceTracer.StartDetachedSection(RuntimePerformanceTracer.SectionNames.IpcReceive);
             var readResult = await IpcFrameCodec.TryReadModelAsync<IpcRequest>(
                 stream,
                 IpcJsonSerializerOptions.Default,
                 cancellationToken: cancellationToken);
+            var receiveSection = receiveMeasurement.Stop();
             if (!readResult.IsSuccess)
             {
                 var errorResponse = UnityIpcResponseFactory.CreateMalformedFrameResponse(
@@ -64,6 +66,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
 
             var request = readResult.Value;
+            using var requestTrace = RuntimePerformanceTracer.BeginRequest(request, receiveSection);
             if (IsStreamingResponse(request))
             {
                 using var requestCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -76,16 +79,25 @@ namespace MackySoft.Ucli.Unity.Ipc
                     streamWriter,
                     requestCancellationTokenSource,
                     cancellationToken);
-                await WriteTerminalSafelyAsync(streamWriter, streamingResponse, cancellationToken);
+                requestTrace.SetResponse(streamingResponse);
+                using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.IpcResponseWrite))
+                {
+                    await WriteTerminalSafelyAsync(streamWriter, streamingResponse, cancellationToken);
+                }
+
                 return new UnityIpcConnectionHandleResult(request, streamingResponse);
             }
 
             var response = await requestProcessor.ProcessAsync(request, cancellationToken);
-            await IpcFrameCodec.WriteModelAsync(
-                stream,
-                response,
-                IpcJsonSerializerOptions.Default,
-                cancellationToken: cancellationToken);
+            requestTrace.SetResponse(response);
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.IpcResponseWrite))
+            {
+                await IpcFrameCodec.WriteModelAsync(
+                    stream,
+                    response,
+                    IpcJsonSerializerOptions.Default,
+                    cancellationToken: cancellationToken);
+            }
 
             return new UnityIpcConnectionHandleResult(request, response);
         }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Testing/TestRun/UnityTestRunService.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Testing/TestRun/UnityTestRunService.cs
@@ -78,13 +78,20 @@ namespace MackySoft.Ucli.Unity.Ipc
             cancellationToken.ThrowIfCancellationRequested();
             var endOffset = GetFileLengthOrZero(requestContext.ConsoleLogPath);
 
-            testResultsXmlWriter.Write(testResult, requestContext.ResultsXmlPath);
-            await editorLogRangeExporter.ExportRangeAsync(
-                requestContext.ConsoleLogPath,
-                requestContext.EditorLogPath,
-                startOffset,
-                endOffset,
-                cancellationToken: cancellationToken);
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.ArtifactWrite))
+            {
+                testResultsXmlWriter.Write(testResult, requestContext.ResultsXmlPath);
+            }
+
+            using (RuntimePerformanceTracer.Measure(RuntimePerformanceTracer.SectionNames.LogExport))
+            {
+                await editorLogRangeExporter.ExportRangeAsync(
+                    requestContext.ConsoleLogPath,
+                    requestContext.EditorLogPath,
+                    startOffset,
+                    endOffset,
+                    cancellationToken: cancellationToken);
+            }
 
             var exitCode = testResult.FailCount > 0 ? 2 : 0;
             return UnityTestRunServiceResult.Success(new IpcTestRunResponse(exitCode));

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cc87ef830d72435daf39e9d22458c40
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance/RuntimePerformanceTracer.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance/RuntimePerformanceTracer.cs
@@ -1,0 +1,815 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using MackySoft.Ucli.Contracts.Ipc;
+
+namespace MackySoft.Ucli.Unity.Runtime
+{
+    /// <summary> Records opt-in runtime request performance traces with wall-time and allocation sections. </summary>
+    internal static class RuntimePerformanceTracer
+    {
+        internal const string TraceDirectoryEnvironmentVariableName = "UCLI_RUNTIME_TRACE_DIR";
+        internal const string TraceSessionEnvironmentVariableName = "UCLI_RUNTIME_TRACE_SESSION";
+
+        private const int SchemaVersion = 1;
+        private const string RuntimeName = "unity-editor";
+        private const string UnknownResponseStatus = "unknown";
+
+        private static readonly object SyncRoot = new object();
+        private static readonly AsyncLocal<RuntimePerformanceTraceContext?> CurrentContext = new AsyncLocal<RuntimePerformanceTraceContext?>();
+        private static readonly Dictionary<string, int> WorkloadIterations = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        private static RuntimePerformanceTraceSettings? cachedSettings;
+        private static RuntimePerformanceTraceSettings? testSettings;
+
+        /// <summary> Gets a value indicating whether runtime performance tracing is currently enabled. </summary>
+        public static bool IsEnabled => ResolveSettings().IsEnabled;
+
+        /// <summary> Creates one detached section measurement for work that happens before the request context exists. </summary>
+        /// <param name="name"> The section name written to the trace output. </param>
+        /// <returns> A measurement that can be completed after the section finishes. </returns>
+        public static RuntimePerformanceSectionMeasurement StartDetachedSection (string name)
+        {
+            if (!ResolveSettings().IsEnabled || string.IsNullOrWhiteSpace(name))
+            {
+                return default;
+            }
+
+            return RuntimePerformanceSectionMeasurement.Start(name);
+        }
+
+        /// <summary> Begins one request trace and installs it as the ambient runtime performance context. </summary>
+        /// <param name="request"> The decoded IPC request envelope. </param>
+        /// <param name="receiveSection"> The optional IPC receive section that completed before request tracing started. </param>
+        /// <returns> A request trace scope. Disposing the scope writes one JSON trace when tracing is enabled. </returns>
+        public static RuntimePerformanceRequestScope BeginRequest (
+            IpcRequest request,
+            RuntimePerformanceCompletedSection receiveSection = default)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var settings = ResolveSettings();
+            if (!settings.IsEnabled)
+            {
+                return default;
+            }
+
+            var command = ResolveCommand(request);
+            var workloadKey = CreateWorkloadKey(request.Method, command);
+            var iteration = IncrementWorkloadIteration(workloadKey);
+            var context = RuntimePerformanceTraceContext.Start(
+                settings,
+                request,
+                command,
+                iteration,
+                receiveSection);
+            var previousContext = CurrentContext.Value;
+            CurrentContext.Value = context;
+            return new RuntimePerformanceRequestScope(context, previousContext);
+        }
+
+        /// <summary> Begins one section in the active request trace. </summary>
+        /// <param name="name"> The section name written to the trace output. </param>
+        /// <returns> A section scope that records elapsed wall-time and allocations when disposed. </returns>
+        public static RuntimePerformanceSectionScope Measure (string name)
+        {
+            if (!ResolveSettings().IsEnabled || string.IsNullOrWhiteSpace(name))
+            {
+                return default;
+            }
+
+            var context = CurrentContext.Value;
+            if (context == null)
+            {
+                return default;
+            }
+
+            return new RuntimePerformanceSectionScope(context, RuntimePerformanceSectionMeasurement.Start(name));
+        }
+
+        /// <summary> Overrides trace settings for deterministic tests. </summary>
+        /// <param name="outputDirectory"> The directory that receives request trace JSON files.</param>
+        /// <param name="sessionId"> The session identifier written to the trace output.</param>
+        /// <returns> A disposable scope that restores the previous settings.</returns>
+        internal static IDisposable OverrideForTests (
+            string outputDirectory,
+            string sessionId)
+        {
+            if (string.IsNullOrWhiteSpace(outputDirectory))
+            {
+                throw new ArgumentException("Output directory must not be empty.", nameof(outputDirectory));
+            }
+
+            if (string.IsNullOrWhiteSpace(sessionId))
+            {
+                throw new ArgumentException("Session id must not be empty.", nameof(sessionId));
+            }
+
+            lock (SyncRoot)
+            {
+                var previousTestSettings = testSettings;
+                var previousCachedSettings = cachedSettings;
+                testSettings = RuntimePerformanceTraceSettings.Enabled(
+                    Path.GetFullPath(outputDirectory),
+                    sessionId);
+                cachedSettings = testSettings;
+                WorkloadIterations.Clear();
+                CurrentContext.Value = null;
+                return new TestSettingsScope(previousTestSettings, previousCachedSettings);
+            }
+        }
+
+        private static RuntimePerformanceTraceSettings ResolveSettings ()
+        {
+            var settings = Volatile.Read(ref cachedSettings);
+            if (settings != null)
+            {
+                return settings;
+            }
+
+            lock (SyncRoot)
+            {
+                if (cachedSettings != null)
+                {
+                    return cachedSettings;
+                }
+
+                cachedSettings = testSettings ?? ReadSettingsFromEnvironment();
+                return cachedSettings;
+            }
+        }
+
+        private static RuntimePerformanceTraceSettings ReadSettingsFromEnvironment ()
+        {
+            var outputDirectory = Environment.GetEnvironmentVariable(TraceDirectoryEnvironmentVariableName);
+            if (string.IsNullOrWhiteSpace(outputDirectory))
+            {
+                return RuntimePerformanceTraceSettings.Disabled;
+            }
+
+            var sessionId = Environment.GetEnvironmentVariable(TraceSessionEnvironmentVariableName);
+            if (string.IsNullOrWhiteSpace(sessionId))
+            {
+                sessionId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+            }
+
+            return RuntimePerformanceTraceSettings.Enabled(
+                Path.GetFullPath(outputDirectory),
+                sessionId);
+        }
+
+        private static int IncrementWorkloadIteration (string workloadKey)
+        {
+            lock (SyncRoot)
+            {
+                WorkloadIterations.TryGetValue(workloadKey, out var current);
+                var next = checked(current + 1);
+                WorkloadIterations[workloadKey] = next;
+                return next;
+            }
+        }
+
+        private static string CreateWorkloadKey (
+            string method,
+            string? command)
+        {
+            return string.IsNullOrWhiteSpace(command)
+                ? method
+                : method + ":" + command;
+        }
+
+        private static string? ResolveCommand (IpcRequest request)
+        {
+            if (!string.Equals(request.Method, IpcMethodNames.Execute, StringComparison.Ordinal)
+                || request.Payload.ValueKind != JsonValueKind.Object
+                || !request.Payload.TryGetProperty("command", out var commandElement)
+                || commandElement.ValueKind != JsonValueKind.String)
+            {
+                return null;
+            }
+
+            return commandElement.GetString();
+        }
+
+        private static void WriteTrace (RuntimePerformanceTraceDocument document)
+        {
+            try
+            {
+                Directory.CreateDirectory(document.OutputDirectory);
+                var fileName = CreateTraceFileName(document);
+                var tracePath = Path.Combine(document.OutputDirectory, fileName);
+                using var stream = new FileStream(tracePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+                using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+                {
+                    Indented = true,
+                });
+                WriteTraceJson(writer, document);
+            }
+            catch (Exception exception) when (exception is IOException
+                or UnauthorizedAccessException
+                or JsonException
+                or ArgumentException
+                or NotSupportedException)
+            {
+                UnityEngine.Debug.LogWarning($"uCLI runtime performance trace write failed. {exception.Message}");
+            }
+        }
+
+        private static string CreateTraceFileName (RuntimePerformanceTraceDocument document)
+        {
+            return string.Concat(
+                document.StartedAtUtc.UtcDateTime.ToString("yyyyMMddTHHmmss.fffffffZ", CultureInfo.InvariantCulture),
+                "_",
+                document.Iteration.ToString(CultureInfo.InvariantCulture),
+                "_",
+                SanitizeFileNameFragment(document.Method),
+                "_",
+                SanitizeFileNameFragment(document.Command ?? "method"),
+                "_",
+                document.Warmth,
+                "_",
+                document.TraceId,
+                ".json");
+        }
+
+        private static string SanitizeFileNameFragment (string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return "unknown";
+            }
+
+            var invalidCharacters = Path.GetInvalidFileNameChars();
+            var buffer = value.ToCharArray();
+            for (var i = 0; i < buffer.Length; i++)
+            {
+                var character = buffer[i];
+                if (char.IsWhiteSpace(character) || Array.IndexOf(invalidCharacters, character) >= 0)
+                {
+                    buffer[i] = '_';
+                }
+            }
+
+            return new string(buffer);
+        }
+
+        private static void WriteTraceJson (
+            Utf8JsonWriter writer,
+            RuntimePerformanceTraceDocument document)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("schemaVersion", SchemaVersion);
+            writer.WriteString("traceId", document.TraceId);
+            writer.WriteString("sessionId", document.SessionId);
+            writer.WriteString("runtime", RuntimeName);
+            writer.WriteString("requestId", document.RequestId);
+            writer.WriteString("method", document.Method);
+            WriteNullableString(writer, "command", document.Command);
+            writer.WriteString("status", document.ResponseStatus);
+            writer.WriteString("startedAtUtc", document.StartedAtUtc.ToString("O", CultureInfo.InvariantCulture));
+            writer.WriteString("warmth", document.Warmth);
+            writer.WriteNumber("iteration", document.Iteration);
+            writer.WritePropertyName("allocation");
+            writer.WriteStartObject();
+            writer.WriteString("provider", RuntimePerformanceAllocationCounter.ProviderName);
+            writer.WriteBoolean("supported", RuntimePerformanceAllocationCounter.IsSupported);
+            writer.WriteEndObject();
+            writer.WritePropertyName("total");
+            WriteSection(writer, document.Total);
+            writer.WritePropertyName("sections");
+            writer.WriteStartArray();
+            for (var i = 0; i < document.Sections.Count; i++)
+            {
+                WriteSection(writer, document.Sections[i]);
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteSection (
+            Utf8JsonWriter writer,
+            RuntimePerformanceCompletedSection section)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("name", section.Name);
+            writer.WriteNumber("wallTimeMs", section.WallTimeMilliseconds);
+            WriteNullableNumber(writer, "allocatedBytes", section.AllocatedBytes);
+            writer.WriteEndObject();
+        }
+
+        private static void WriteNullableString (
+            Utf8JsonWriter writer,
+            string propertyName,
+            string? value)
+        {
+            writer.WritePropertyName(propertyName);
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStringValue(value);
+        }
+
+        private static void WriteNullableNumber (
+            Utf8JsonWriter writer,
+            string propertyName,
+            long? value)
+        {
+            writer.WritePropertyName(propertyName);
+            if (!value.HasValue)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteNumberValue(value.Value);
+        }
+
+        internal static class SectionNames
+        {
+            public const string ArtifactWrite = "artifact.write";
+            public const string Dispatch = "dispatch";
+            public const string IpcReceive = "ipc.receive";
+            public const string IpcResponseWrite = "ipc.response_write";
+            public const string LogExport = "log.export";
+            public const string Normalize = "normalize";
+            public const string PhaseCall = "phase.call";
+            public const string PhasePlan = "phase.plan";
+            public const string UnityMainThread = "unity.main_thread";
+            public const string Validate = "validate";
+        }
+
+        internal readonly struct RuntimePerformanceSectionMeasurement
+        {
+            private readonly string? name;
+            private readonly RuntimePerformanceMeasurementPoint start;
+
+            private RuntimePerformanceSectionMeasurement (
+                string name,
+                RuntimePerformanceMeasurementPoint start)
+            {
+                this.name = name;
+                this.start = start;
+            }
+
+            public bool IsActive => name != null;
+
+            public static RuntimePerformanceSectionMeasurement Start (string name)
+            {
+                return new RuntimePerformanceSectionMeasurement(
+                    name,
+                    RuntimePerformanceMeasurementPoint.Capture());
+            }
+
+            public static RuntimePerformanceSectionMeasurement StartAt (
+                string name,
+                RuntimePerformanceCompletedSection section)
+            {
+                return new RuntimePerformanceSectionMeasurement(
+                    name,
+                    RuntimePerformanceMeasurementPoint.FromSectionStart(section));
+            }
+
+            public RuntimePerformanceCompletedSection Stop ()
+            {
+                if (name == null)
+                {
+                    return default;
+                }
+
+                return RuntimePerformanceCompletedSection.Create(
+                    name,
+                    start,
+                    RuntimePerformanceMeasurementPoint.Capture());
+            }
+        }
+
+        internal readonly struct RuntimePerformanceCompletedSection
+        {
+            private static readonly double StopwatchTickMilliseconds = 1000d / Stopwatch.Frequency;
+
+            private RuntimePerformanceCompletedSection (
+                string name,
+                long startTimestamp,
+                long endTimestamp,
+                long? startAllocatedBytes,
+                int startThreadId,
+                long? allocatedBytes)
+            {
+                Name = name;
+                StartTimestamp = startTimestamp;
+                EndTimestamp = endTimestamp;
+                StartAllocatedBytes = startAllocatedBytes;
+                StartThreadId = startThreadId;
+                AllocatedBytes = allocatedBytes;
+            }
+
+            public string Name { get; }
+
+            public long StartTimestamp { get; }
+
+            public long EndTimestamp { get; }
+
+            public long? StartAllocatedBytes { get; }
+
+            public int StartThreadId { get; }
+
+            public bool IsActive => Name != null;
+
+            public long? AllocatedBytes { get; }
+
+            public double WallTimeMilliseconds => Math.Max(0d, (EndTimestamp - StartTimestamp) * StopwatchTickMilliseconds);
+
+            public static RuntimePerformanceCompletedSection Create (
+                string name,
+                RuntimePerformanceMeasurementPoint start,
+                RuntimePerformanceMeasurementPoint end)
+            {
+                long? allocatedBytes = null;
+                if (start.ThreadId == end.ThreadId
+                    && start.AllocatedBytes.HasValue
+                    && end.AllocatedBytes.HasValue
+                    && end.AllocatedBytes.Value >= start.AllocatedBytes.Value)
+                {
+                    allocatedBytes = end.AllocatedBytes.Value - start.AllocatedBytes.Value;
+                }
+
+                return new RuntimePerformanceCompletedSection(
+                    name,
+                    start.Timestamp,
+                    end.Timestamp,
+                    start.AllocatedBytes,
+                    start.ThreadId,
+                    allocatedBytes);
+            }
+        }
+
+        internal struct RuntimePerformanceRequestScope : IDisposable
+        {
+            private readonly RuntimePerformanceTraceContext? context;
+            private readonly RuntimePerformanceTraceContext? previousContext;
+
+            internal RuntimePerformanceRequestScope (
+                RuntimePerformanceTraceContext context,
+                RuntimePerformanceTraceContext? previousContext)
+            {
+                this.context = context;
+                this.previousContext = previousContext;
+            }
+
+            public void SetResponse (IpcResponse response)
+            {
+                if (response == null)
+                {
+                    throw new ArgumentNullException(nameof(response));
+                }
+
+                context?.SetResponseStatus(response.Status);
+            }
+
+            public void Dispose ()
+            {
+                if (context == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    WriteTrace(context.Complete());
+                }
+                finally
+                {
+                    CurrentContext.Value = previousContext;
+                }
+            }
+        }
+
+        internal readonly struct RuntimePerformanceSectionScope : IDisposable
+        {
+            private readonly RuntimePerformanceTraceContext? context;
+            private readonly RuntimePerformanceSectionMeasurement measurement;
+
+            internal RuntimePerformanceSectionScope (
+                RuntimePerformanceTraceContext context,
+                RuntimePerformanceSectionMeasurement measurement)
+            {
+                this.context = context;
+                this.measurement = measurement;
+            }
+
+            public void Dispose ()
+            {
+                if (context == null || !measurement.IsActive)
+                {
+                    return;
+                }
+
+                context.AddSection(measurement.Stop());
+            }
+        }
+
+        internal readonly struct RuntimePerformanceMeasurementPoint
+        {
+            private RuntimePerformanceMeasurementPoint (
+                long timestamp,
+                long? allocatedBytes,
+                int threadId)
+            {
+                Timestamp = timestamp;
+                AllocatedBytes = allocatedBytes;
+                ThreadId = threadId;
+            }
+
+            public long Timestamp { get; }
+
+            public long? AllocatedBytes { get; }
+
+            public int ThreadId { get; }
+
+            public static RuntimePerformanceMeasurementPoint Capture ()
+            {
+                return new RuntimePerformanceMeasurementPoint(
+                    Stopwatch.GetTimestamp(),
+                    RuntimePerformanceAllocationCounter.CaptureAllocatedBytes(),
+                    Thread.CurrentThread.ManagedThreadId);
+            }
+
+            public static RuntimePerformanceMeasurementPoint FromSectionStart (RuntimePerformanceCompletedSection section)
+            {
+                return new RuntimePerformanceMeasurementPoint(
+                    section.StartTimestamp,
+                    section.StartAllocatedBytes,
+                    section.StartThreadId);
+            }
+        }
+
+        internal sealed class RuntimePerformanceTraceContext
+        {
+            private readonly object syncRoot = new object();
+            private readonly RuntimePerformanceTraceSettings settings;
+            private readonly RuntimePerformanceSectionMeasurement totalMeasurement;
+            private readonly List<RuntimePerformanceCompletedSection> sections;
+
+            private RuntimePerformanceTraceContext (
+                RuntimePerformanceTraceSettings settings,
+                IpcRequest request,
+                string? command,
+                int iteration,
+                RuntimePerformanceSectionMeasurement totalMeasurement,
+                IReadOnlyList<RuntimePerformanceCompletedSection> initialSections)
+            {
+                this.settings = settings;
+                this.totalMeasurement = totalMeasurement;
+                TraceId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
+                RequestId = request.RequestId;
+                Method = request.Method;
+                Command = command;
+                Iteration = iteration;
+                Warmth = iteration == 1 ? "cold" : "warm";
+                StartedAtUtc = DateTimeOffset.UtcNow;
+                ResponseStatus = UnknownResponseStatus;
+                sections = new List<RuntimePerformanceCompletedSection>(Math.Max(16, initialSections.Count + 8));
+                for (var i = 0; i < initialSections.Count; i++)
+                {
+                    sections.Add(initialSections[i]);
+                }
+            }
+
+            public string TraceId { get; }
+
+            public string RequestId { get; }
+
+            public string Method { get; }
+
+            public string? Command { get; }
+
+            public int Iteration { get; }
+
+            public string Warmth { get; }
+
+            public DateTimeOffset StartedAtUtc { get; }
+
+            public string ResponseStatus { get; private set; }
+
+            public static RuntimePerformanceTraceContext Start (
+                RuntimePerformanceTraceSettings settings,
+                IpcRequest request,
+                string? command,
+                int iteration,
+                RuntimePerformanceCompletedSection receiveSection)
+            {
+                var initialSections = receiveSection.IsActive
+                    ? new[] { receiveSection }
+                    : Array.Empty<RuntimePerformanceCompletedSection>();
+                var totalMeasurement = receiveSection.IsActive
+                    ? RuntimePerformanceSectionMeasurement.StartAt("total", receiveSection)
+                    : RuntimePerformanceSectionMeasurement.Start("total");
+                return new RuntimePerformanceTraceContext(
+                    settings,
+                    request,
+                    command,
+                    iteration,
+                    totalMeasurement,
+                    initialSections);
+            }
+
+            public void AddSection (RuntimePerformanceCompletedSection section)
+            {
+                if (!section.IsActive)
+                {
+                    return;
+                }
+
+                lock (syncRoot)
+                {
+                    sections.Add(section);
+                }
+            }
+
+            public void SetResponseStatus (string status)
+            {
+                ResponseStatus = string.IsNullOrWhiteSpace(status) ? UnknownResponseStatus : status;
+            }
+
+            public RuntimePerformanceTraceDocument Complete ()
+            {
+                RuntimePerformanceCompletedSection[] sectionSnapshot;
+                lock (syncRoot)
+                {
+                    sectionSnapshot = sections.ToArray();
+                }
+
+                return new RuntimePerformanceTraceDocument(
+                    settings.OutputDirectory!,
+                    settings.SessionId!,
+                    TraceId,
+                    RequestId,
+                    Method,
+                    Command,
+                    ResponseStatus,
+                    StartedAtUtc,
+                    Warmth,
+                    Iteration,
+                    totalMeasurement.Stop(),
+                    sectionSnapshot);
+            }
+        }
+
+        internal sealed class RuntimePerformanceTraceDocument
+        {
+            public RuntimePerformanceTraceDocument (
+                string outputDirectory,
+                string sessionId,
+                string traceId,
+                string requestId,
+                string method,
+                string? command,
+                string responseStatus,
+                DateTimeOffset startedAtUtc,
+                string warmth,
+                int iteration,
+                RuntimePerformanceCompletedSection total,
+                IReadOnlyList<RuntimePerformanceCompletedSection> sections)
+            {
+                OutputDirectory = outputDirectory;
+                SessionId = sessionId;
+                TraceId = traceId;
+                RequestId = requestId;
+                Method = method;
+                Command = command;
+                ResponseStatus = responseStatus;
+                StartedAtUtc = startedAtUtc;
+                Warmth = warmth;
+                Iteration = iteration;
+                Total = total;
+                Sections = sections;
+            }
+
+            public string OutputDirectory { get; }
+
+            public string SessionId { get; }
+
+            public string TraceId { get; }
+
+            public string RequestId { get; }
+
+            public string Method { get; }
+
+            public string? Command { get; }
+
+            public string ResponseStatus { get; }
+
+            public DateTimeOffset StartedAtUtc { get; }
+
+            public string Warmth { get; }
+
+            public int Iteration { get; }
+
+            public RuntimePerformanceCompletedSection Total { get; }
+
+            public IReadOnlyList<RuntimePerformanceCompletedSection> Sections { get; }
+        }
+
+        internal sealed class RuntimePerformanceTraceSettings
+        {
+            public static RuntimePerformanceTraceSettings Disabled { get; } = new RuntimePerformanceTraceSettings(false, null, null);
+
+            private RuntimePerformanceTraceSettings (
+                bool isEnabled,
+                string? outputDirectory,
+                string? sessionId)
+            {
+                IsEnabled = isEnabled;
+                OutputDirectory = outputDirectory;
+                SessionId = sessionId;
+            }
+
+            public bool IsEnabled { get; }
+
+            public string? OutputDirectory { get; }
+
+            public string? SessionId { get; }
+
+            public static RuntimePerformanceTraceSettings Enabled (
+                string outputDirectory,
+                string sessionId)
+            {
+                return new RuntimePerformanceTraceSettings(true, outputDirectory, sessionId);
+            }
+        }
+
+        private static class RuntimePerformanceAllocationCounter
+        {
+            public const string ProviderName = "GC.GetAllocatedBytesForCurrentThread";
+
+            private static readonly Func<long>? AllocatedBytesProvider = CreateAllocatedBytesProvider();
+
+            public static bool IsSupported => AllocatedBytesProvider != null;
+
+            public static long? CaptureAllocatedBytes ()
+            {
+                return AllocatedBytesProvider?.Invoke();
+            }
+
+            private static Func<long>? CreateAllocatedBytesProvider ()
+            {
+                var method = typeof(GC).GetMethod(
+                    "GetAllocatedBytesForCurrentThread",
+                    BindingFlags.Public | BindingFlags.Static,
+                    null,
+                    Type.EmptyTypes,
+                    null);
+                if (method == null || method.ReturnType != typeof(long))
+                {
+                    return null;
+                }
+
+                try
+                {
+                    return (Func<long>)Delegate.CreateDelegate(typeof(Func<long>), method);
+                }
+                catch (ArgumentException)
+                {
+                    return null;
+                }
+            }
+        }
+
+        private sealed class TestSettingsScope : IDisposable
+        {
+            private readonly RuntimePerformanceTraceSettings? previousTestSettings;
+            private readonly RuntimePerformanceTraceSettings? previousCachedSettings;
+
+            public TestSettingsScope (
+                RuntimePerformanceTraceSettings? previousTestSettings,
+                RuntimePerformanceTraceSettings? previousCachedSettings)
+            {
+                this.previousTestSettings = previousTestSettings;
+                this.previousCachedSettings = previousCachedSettings;
+            }
+
+            public void Dispose ()
+            {
+                lock (SyncRoot)
+                {
+                    testSettings = previousTestSettings;
+                    cachedSettings = previousCachedSettings;
+                    WorkloadIterations.Clear();
+                    CurrentContext.Value = null;
+                }
+            }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance/RuntimePerformanceTracer.cs.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime/Performance/RuntimePerformanceTracer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02756dc6631354c5ab26cb2d7370306c

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22c3b26ac770b4bc3bb08f5ace7582de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance/RuntimePerformanceTracerTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance/RuntimePerformanceTracerTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using MackySoft.Ucli.Contracts.Ipc;
+using MackySoft.Ucli.Infrastructure.Ipc;
+using MackySoft.Ucli.Unity.Ipc;
+using MackySoft.Ucli.Unity.Runtime;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace MackySoft.Ucli.Unity.Tests
+{
+    public sealed class RuntimePerformanceTracerTests
+    {
+        [UnityTest]
+        [Category("Size.Small")]
+        public IEnumerator RequestTrace_WhenSameWorkloadRunsTwice_WritesColdAndWarmJson () => UniTask.ToCoroutine(async () =>
+        {
+            var traceDirectory = Path.Combine(Path.GetTempPath(), "ucli-runtime-trace-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(traceDirectory);
+
+            try
+            {
+                using (RuntimePerformanceTracer.OverrideForTests(traceDirectory, "test-session"))
+                {
+                    var handler = new UnityIpcConnectionHandler(new TracingRequestProcessor());
+
+                    await HandleShutdownAsync(handler, "req-trace-1");
+                    await HandleShutdownAsync(handler, "req-trace-2");
+                }
+
+                var traces = Directory.GetFiles(traceDirectory, "*.json")
+                    .Select(ReadTrace)
+                    .OrderBy(static trace => trace.Iteration)
+                    .ToArray();
+
+                Assert.That(traces.Length, Is.EqualTo(2));
+                Assert.That(traces[0].SessionId, Is.EqualTo("test-session"));
+                Assert.That(traces[0].Runtime, Is.EqualTo("unity-editor"));
+                Assert.That(traces[0].RequestId, Is.EqualTo("req-trace-1"));
+                Assert.That(traces[0].Method, Is.EqualTo(IpcMethodNames.Shutdown));
+                Assert.That(traces[0].CommandIsNull, Is.True);
+                Assert.That(traces[0].Status, Is.EqualTo(IpcProtocol.StatusOk));
+                Assert.That(traces[0].Warmth, Is.EqualTo("cold"));
+                Assert.That(traces[0].Iteration, Is.EqualTo(1));
+                Assert.That(traces[0].AllocationProvider, Is.EqualTo("GC.GetAllocatedBytesForCurrentThread"));
+                Assert.That(traces[0].AllocationSupportedIsBoolean, Is.True);
+                Assert.That(traces[0].TotalWallTimeMilliseconds, Is.GreaterThanOrEqualTo(0d));
+                Assert.That(traces[0].AllSectionsExposeAllocatedBytes, Is.True);
+                Assert.That(traces[0].SectionNames, Does.Contain(RuntimePerformanceTracer.SectionNames.IpcReceive));
+                Assert.That(traces[0].SectionNames, Does.Contain("test.section"));
+                Assert.That(traces[0].SectionNames, Does.Contain(RuntimePerformanceTracer.SectionNames.IpcResponseWrite));
+
+                Assert.That(traces[1].RequestId, Is.EqualTo("req-trace-2"));
+                Assert.That(traces[1].Warmth, Is.EqualTo("warm"));
+                Assert.That(traces[1].Iteration, Is.EqualTo(2));
+            }
+            finally
+            {
+                if (Directory.Exists(traceDirectory))
+                {
+                    Directory.Delete(traceDirectory, recursive: true);
+                }
+            }
+        });
+
+        private static async Task HandleShutdownAsync (
+            UnityIpcConnectionHandler handler,
+            string requestId)
+        {
+            var request = new IpcRequest(
+                ProtocolVersion: IpcProtocol.CurrentVersion,
+                RequestId: requestId,
+                SessionToken: "token",
+                Method: IpcMethodNames.Shutdown,
+                Payload: IpcPayloadCodec.SerializeToElement(new IpcShutdownRequest("tests")),
+                responseMode: IpcResponseMode.Single);
+
+            using var stream = new MemoryStream();
+            await IpcFrameCodec.WriteModelAsync(
+                stream,
+                request,
+                IpcJsonSerializerOptions.Default,
+                cancellationToken: CancellationToken.None);
+            stream.Position = 0;
+
+            await handler.HandleAsync(stream, CancellationToken.None);
+        }
+
+        private static RuntimeTraceProjection ReadTrace (string path)
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            var allocation = root.GetProperty("allocation");
+            var sectionNames = new List<string>();
+            var allSectionsExposeAllocatedBytes = true;
+            foreach (var section in root.GetProperty("sections").EnumerateArray())
+            {
+                sectionNames.Add(section.GetProperty("name").GetString());
+                allSectionsExposeAllocatedBytes &= section.TryGetProperty("allocatedBytes", out _);
+            }
+
+            return new RuntimeTraceProjection(
+                sessionId: root.GetProperty("sessionId").GetString(),
+                runtime: root.GetProperty("runtime").GetString(),
+                requestId: root.GetProperty("requestId").GetString(),
+                method: root.GetProperty("method").GetString(),
+                commandIsNull: root.GetProperty("command").ValueKind == JsonValueKind.Null,
+                status: root.GetProperty("status").GetString(),
+                warmth: root.GetProperty("warmth").GetString(),
+                iteration: root.GetProperty("iteration").GetInt32(),
+                allocationProvider: allocation.GetProperty("provider").GetString(),
+                allocationSupportedIsBoolean: allocation.GetProperty("supported").ValueKind is JsonValueKind.True or JsonValueKind.False,
+                totalWallTimeMilliseconds: root.GetProperty("total").GetProperty("wallTimeMs").GetDouble(),
+                allSectionsExposeAllocatedBytes: allSectionsExposeAllocatedBytes,
+                sectionNames: sectionNames);
+        }
+
+        private sealed class TracingRequestProcessor : IUnityIpcRequestProcessor
+        {
+            public async Task<IpcResponse> ProcessAsync (
+                IpcRequest request,
+                CancellationToken cancellationToken = default)
+            {
+                using (RuntimePerformanceTracer.Measure("test.section"))
+                {
+                    await Task.Yield();
+                }
+
+                return new IpcResponse(
+                    ProtocolVersion: IpcProtocol.CurrentVersion,
+                    RequestId: request.RequestId,
+                    Status: IpcProtocol.StatusOk,
+                    Payload: IpcPayloadCodec.SerializeToElement(new IpcShutdownResponse(true, "ok")),
+                    Errors: Array.Empty<IpcError>());
+            }
+
+            public Task<IpcResponse> ProcessStreamingAsync (
+                IpcRequest request,
+                IIpcStreamFrameWriter streamWriter,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private sealed class RuntimeTraceProjection
+        {
+            public RuntimeTraceProjection (
+                string sessionId,
+                string runtime,
+                string requestId,
+                string method,
+                bool commandIsNull,
+                string status,
+                string warmth,
+                int iteration,
+                string allocationProvider,
+                bool allocationSupportedIsBoolean,
+                double totalWallTimeMilliseconds,
+                bool allSectionsExposeAllocatedBytes,
+                IReadOnlyList<string> sectionNames)
+            {
+                SessionId = sessionId;
+                Runtime = runtime;
+                RequestId = requestId;
+                Method = method;
+                CommandIsNull = commandIsNull;
+                Status = status;
+                Warmth = warmth;
+                Iteration = iteration;
+                AllocationProvider = allocationProvider;
+                AllocationSupportedIsBoolean = allocationSupportedIsBoolean;
+                TotalWallTimeMilliseconds = totalWallTimeMilliseconds;
+                AllSectionsExposeAllocatedBytes = allSectionsExposeAllocatedBytes;
+                SectionNames = sectionNames;
+            }
+
+            public string SessionId { get; }
+
+            public string Runtime { get; }
+
+            public string RequestId { get; }
+
+            public string Method { get; }
+
+            public bool CommandIsNull { get; }
+
+            public string Status { get; }
+
+            public string Warmth { get; }
+
+            public int Iteration { get; }
+
+            public string AllocationProvider { get; }
+
+            public bool AllocationSupportedIsBoolean { get; }
+
+            public double TotalWallTimeMilliseconds { get; }
+
+            public bool AllSectionsExposeAllocatedBytes { get; }
+
+            public IReadOnlyList<string> SectionNames { get; }
+        }
+    }
+}

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance/RuntimePerformanceTracerTests.cs.meta
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/Runtime/Performance/RuntimePerformanceTracerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 65fec45153139414cafe9ee67e540dc0


### PR DESCRIPTION
## Summary
- Adds opt-in Unity runtime tracing so runtime optimization can start from comparable before data.
- Emits per-request JSON with cold/warm iteration, wall time, and allocation metadata.
- Instruments IPC receive through response write across validate, normalize, dispatch, Unity main thread, artifact write, and log export sections.

## Scope
- `RuntimePerformanceTracer` records opt-in request traces when `UCLI_RUNTIME_TRACE_DIR` is set, with optional `UCLI_RUNTIME_TRACE_SESSION`.
- IPC, execute dispatch, build/test artifact output, and log read/export paths now mark runtime sections.
- Unity Editor tests lock the trace schema and cold/warm behavior.

## Verification
- Gate level: Standard
- Format: PASS (`bash scripts/code-quality.sh format --include ...`, `bash scripts/code-quality.sh verify --include ...`)
- Tests: PASS (`bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor"`)
- Coverage: N/A

## Risks / Rollback
- Tracing is disabled unless `UCLI_RUNTIME_TRACE_DIR` is set; normal execution overhead is limited to disabled guard checks.
- Trace files are diagnostic output only and can be rolled back by reverting this PR.
- Per the performance plan, this temporary measurement code should be removed after all targeted workload bottlenecks are resolved.

## Checklist
- [ ] Collect before traces for representative runtime workloads.
- [ ] Use measured bottlenecks to split follow-up optimization PRs by workload.
- [ ] Remove measurement code after the performance improvement goal is complete.

Issue: none (ad-hoc task)