### PR TITLE
fix(runtime): propagate trace env through supervisor launchers

### DIFF
--- a/src/Ucli.Infrastructure/Xml/PropertyListXmlBuilder.cs
+++ b/src/Ucli.Infrastructure/Xml/PropertyListXmlBuilder.cs
@@ -107,6 +107,39 @@ internal sealed class PropertyListXmlBuilder
         writer.WriteEndElement();
     }
 
+    /// <summary> Writes one string dictionary value to the current dictionary. </summary>
+    /// <param name="key"> The plist dictionary key. </param>
+    /// <param name="values"> The ordered key-value entries. </param>
+    /// <exception cref="ArgumentException"> Thrown when <paramref name="key" /> or one entry key is empty or whitespace. </exception>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="values" /> or one entry value is <see langword="null" />. </exception>
+    public void WriteStringDictionary (
+        string key,
+        IReadOnlyList<KeyValuePair<string, string>> values)
+    {
+        ThrowIfInvalidKey(key);
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        writer.WriteElementString("key", key);
+        writer.WriteStartElement("dict");
+        for (var i = 0; i < values.Count; i++)
+        {
+            var entry = values[i];
+            ThrowIfInvalidKey(entry.Key);
+            if (entry.Value == null)
+            {
+                throw new ArgumentNullException(nameof(values), "Dictionary values must not contain null.");
+            }
+
+            writer.WriteElementString("key", entry.Key);
+            writer.WriteElementString("string", entry.Value);
+        }
+
+        writer.WriteEndElement();
+    }
+
     private static XmlWriterSettings CreateWriterSettings ()
     {
         return new XmlWriterSettings

--- a/src/Ucli/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactory.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactory.cs
@@ -19,10 +19,35 @@ internal static class LaunchAgentPlistDocumentFactory
         string storageRoot,
         string logPath)
     {
+        return Build(
+            label,
+            launchCommand,
+            storageRoot,
+            logPath,
+            Array.Empty<KeyValuePair<string, string>>());
+    }
+
+    /// <summary> Builds one LaunchAgent plist document. </summary>
+    /// <param name="label"> The LaunchAgent label. </param>
+    /// <param name="launchCommand"> The base command used to relaunch uCLI. </param>
+    /// <param name="storageRoot"> The supervisor storage root. </param>
+    /// <param name="logPath"> The shared stdout and stderr log path. </param>
+    /// <param name="environmentVariables"> The ordered environment variables to pass to the LaunchAgent. </param>
+    /// <returns> The complete plist XML document without a trailing newline. </returns>
+    /// <exception cref="ArgumentException"> Thrown when a required string value is empty or whitespace. </exception>
+    /// <exception cref="ArgumentNullException"> Thrown when <paramref name="launchCommand" /> or <paramref name="environmentVariables" /> is <see langword="null" />. </exception>
+    public static string Build (
+        string label,
+        SupervisorLaunchCommand launchCommand,
+        string storageRoot,
+        string logPath,
+        IReadOnlyList<KeyValuePair<string, string>> environmentVariables)
+    {
         ThrowIfNullOrWhiteSpace(label, nameof(label));
         ArgumentNullException.ThrowIfNull(launchCommand);
         ThrowIfNullOrWhiteSpace(storageRoot, nameof(storageRoot));
         ThrowIfNullOrWhiteSpace(logPath, nameof(logPath));
+        ArgumentNullException.ThrowIfNull(environmentVariables);
 
         var programArguments = BuildProgramArguments(launchCommand, storageRoot);
         return PropertyListXmlBuilder.BuildRootDictionary(builder =>
@@ -33,6 +58,10 @@ internal static class LaunchAgentPlistDocumentFactory
             builder.WriteBoolean("RunAtLoad", true);
             builder.WriteString("StandardOutPath", logPath);
             builder.WriteString("StandardErrorPath", logPath);
+            if (environmentVariables.Count != 0)
+            {
+                builder.WriteStringDictionary("EnvironmentVariables", environmentVariables);
+            }
         });
     }
 

--- a/src/Ucli/Features/Daemon/Supervisor/Launch/LaunchdSupervisorProcessLauncher.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Launch/LaunchdSupervisorProcessLauncher.cs
@@ -49,7 +49,12 @@ internal sealed class LaunchdSupervisorProcessLauncher
                 FileSystemAccessBoundary.EnsureSecureDirectory(plistDirectoryPath);
             }
 
-            var plistContents = LaunchAgentPlistDocumentFactory.Build(label, launchCommand, normalizedStorageRoot, logPath);
+            var plistContents = LaunchAgentPlistDocumentFactory.Build(
+                label,
+                launchCommand,
+                normalizedStorageRoot,
+                logPath,
+                SupervisorRuntimeTraceEnvironment.Capture());
             await FileUtilities.WriteAllTextAtomicallyAsync(plistPath, plistContents + Environment.NewLine, cancellationToken).ConfigureAwait(false);
 
             await processRunner.RunIgnoringExitCodeAsync(

--- a/src/Ucli/Features/Daemon/Supervisor/Launch/SupervisorRuntimeTraceEnvironment.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Launch/SupervisorRuntimeTraceEnvironment.cs
@@ -1,0 +1,35 @@
+namespace MackySoft.Ucli.Features.Daemon.Supervisor.Launch;
+
+/// <summary> Captures opt-in runtime trace environment variables for detached supervisor hosts. </summary>
+internal static class SupervisorRuntimeTraceEnvironment
+{
+    internal const string TraceDirectoryEnvironmentVariableName = "UCLI_RUNTIME_TRACE_DIR";
+
+    internal const string TraceSessionEnvironmentVariableName = "UCLI_RUNTIME_TRACE_SESSION";
+
+    /// <summary> Captures runtime trace variables from the current process environment. </summary>
+    /// <returns> Ordered environment entries to propagate to the supervisor process. </returns>
+    public static IReadOnlyList<KeyValuePair<string, string>> Capture ()
+    {
+        var traceDirectory = Environment.GetEnvironmentVariable(TraceDirectoryEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(traceDirectory))
+        {
+            return Array.Empty<KeyValuePair<string, string>>();
+        }
+
+        var traceSession = Environment.GetEnvironmentVariable(TraceSessionEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(traceSession))
+        {
+            return
+            [
+                new KeyValuePair<string,string>(TraceDirectoryEnvironmentVariableName, traceDirectory),
+            ];
+        }
+
+        return
+        [
+            new KeyValuePair<string,string>(TraceDirectoryEnvironmentVariableName, traceDirectory),
+            new KeyValuePair<string,string>(TraceSessionEnvironmentVariableName, traceSession),
+        ];
+    }
+}

--- a/src/Ucli/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncher.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncher.cs
@@ -34,7 +34,11 @@ internal sealed class SystemdRunSupervisorProcessLauncher
         {
             var normalizedStorageRoot = UcliStoragePathResolver.NormalizeStorageRootPath(storageRoot);
             var unitName = BuildSystemdUnitName(normalizedStorageRoot);
-            var arguments = BuildArguments(normalizedStorageRoot, unitName, launchCommand);
+            var arguments = BuildArguments(
+                normalizedStorageRoot,
+                unitName,
+                launchCommand,
+                SupervisorRuntimeTraceEnvironment.Capture());
 
             var launchResult = await processRunner.RunAsync(
                     "systemd-run",
@@ -69,7 +73,21 @@ internal sealed class SystemdRunSupervisorProcessLauncher
         string unitName,
         SupervisorLaunchCommand launchCommand)
     {
+        return BuildArguments(
+            normalizedStorageRoot,
+            unitName,
+            launchCommand,
+            Array.Empty<KeyValuePair<string, string>>());
+    }
+
+    internal static IReadOnlyList<string> BuildArguments (
+        string normalizedStorageRoot,
+        string unitName,
+        SupervisorLaunchCommand launchCommand,
+        IReadOnlyList<KeyValuePair<string, string>> environmentVariables)
+    {
         ArgumentNullException.ThrowIfNull(launchCommand);
+        ArgumentNullException.ThrowIfNull(environmentVariables);
 
         var arguments = new List<string>
         {
@@ -80,8 +98,25 @@ internal sealed class SystemdRunSupervisorProcessLauncher
             unitName,
             "--working-directory",
             normalizedStorageRoot,
-            launchCommand.FileName,
         };
+        for (var i = 0; i < environmentVariables.Count; i++)
+        {
+            var environmentVariable = environmentVariables[i];
+            if (string.IsNullOrWhiteSpace(environmentVariable.Key))
+            {
+                throw new ArgumentException("Environment variable name must not be empty.", nameof(environmentVariables));
+            }
+
+            if (environmentVariable.Value == null)
+            {
+                throw new ArgumentNullException(nameof(environmentVariables), "Environment variable values must not contain null.");
+            }
+
+            arguments.Add("--setenv");
+            arguments.Add($"{environmentVariable.Key}={environmentVariable.Value}");
+        }
+
+        arguments.Add(launchCommand.FileName);
         arguments.AddRange(launchCommand.Arguments);
         arguments.AddRange(SupervisorInvocationArguments.Build(normalizedStorageRoot));
         return arguments;

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactoryTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactoryTests.cs
@@ -57,6 +57,35 @@ public sealed class LaunchAgentPlistDocumentFactoryTests
             GetArrayStrings(document, "ProgramArguments"));
     }
 
+    [Fact]
+    [Trait("Size", "Small")]
+    public void Build_WhenEnvironmentVariablesAreSpecified_WritesLaunchAgentEnvironmentVariables ()
+    {
+        const string label = "dev.mackysoft.ucli.supervisor.test";
+        const string storageRoot = "/repo";
+        const string logPath = "/repo/supervisor.log";
+        var launchCommand = new SupervisorLaunchCommand("ucli", ["--base"]);
+
+        var plist = LaunchAgentPlistDocumentFactory.Build(
+            label,
+            launchCommand,
+            storageRoot,
+            logPath,
+            [
+                new KeyValuePair<string,string>("UCLI_RUNTIME_TRACE_DIR", "/tmp/ucli-trace"),
+                new KeyValuePair<string,string>("UCLI_RUNTIME_TRACE_SESSION", "before"),
+            ]);
+        var document = XDocument.Parse(plist);
+
+        Assert.Equal(
+            new Dictionary<string, string>
+            {
+                ["UCLI_RUNTIME_TRACE_DIR"] = "/tmp/ucli-trace",
+                ["UCLI_RUNTIME_TRACE_SESSION"] = "before",
+            },
+            GetDictionaryStrings(document, "EnvironmentVariables"));
+    }
+
     private static string GetString (
         XDocument document,
         string key)
@@ -72,6 +101,25 @@ public sealed class LaunchAgentPlistDocumentFactoryTests
             .Elements("string")
             .Select(static element => element.Value)
             .ToArray();
+    }
+
+    private static Dictionary<string, string> GetDictionaryStrings (
+        XDocument document,
+        string key)
+    {
+        var elements = GetValueElement(document, key).Elements().ToArray();
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (var i = 0; i < elements.Length - 1; i += 2)
+        {
+            if (!string.Equals(elements[i].Name.LocalName, "key", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            values[elements[i].Value] = elements[i + 1].Value;
+        }
+
+        return values;
     }
 
     private static XElement GetValueElement (

--- a/tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncherTests.cs
+++ b/tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncherTests.cs
@@ -30,4 +30,41 @@ public sealed class SystemdRunSupervisorProcessLauncherTests
             ],
             arguments);
     }
+
+    [Fact]
+    [Trait("Size", "Small")]
+    public void BuildArguments_WhenEnvironmentVariablesAreSpecified_AppendsSetEnvironmentOptionsBeforeCommand ()
+    {
+        const string repositoryRoot = "/repo";
+        const string unitName = "mackysoft-ucli-supervisor-test";
+        var launchCommand = new SupervisorLaunchCommand("ucli", ["--base"]);
+
+        var arguments = SystemdRunSupervisorProcessLauncher.BuildArguments(
+            repositoryRoot,
+            unitName,
+            launchCommand,
+            [
+                new KeyValuePair<string,string>("UCLI_RUNTIME_TRACE_DIR", "/tmp/ucli-trace"),
+                new KeyValuePair<string,string>("UCLI_RUNTIME_TRACE_SESSION", "before"),
+            ]);
+
+        Assert.Equal(
+            [
+                "--user",
+                "--quiet",
+                "--collect",
+                "--unit",
+                unitName,
+                "--working-directory",
+                repositoryRoot,
+                "--setenv",
+                "UCLI_RUNTIME_TRACE_DIR=/tmp/ucli-trace",
+                "--setenv",
+                "UCLI_RUNTIME_TRACE_SESSION=before",
+                "ucli",
+                "--base",
+                ..SupervisorInvocationArguments.Build(repositoryRoot),
+            ],
+            arguments);
+    }
 }


### PR DESCRIPTION
## Summary
- propagate opt-in runtime trace environment variables into launchd and systemd supervisor hosts
- add plist string-dictionary support for LaunchAgent EnvironmentVariables
- cover launchd plist and systemd-run argument generation with focused tests

## Verification
- bash scripts/code-quality.sh verify --include src/Ucli.Infrastructure/Xml/PropertyListXmlBuilder.cs src/Ucli/Features/Daemon/Supervisor/Launch/SupervisorRuntimeTraceEnvironment.cs src/Ucli/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactory.cs src/Ucli/Features/Daemon/Supervisor/Launch/LaunchdSupervisorProcessLauncher.cs src/Ucli/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncher.cs tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/LaunchAgentPlistDocumentFactoryTests.cs tests/Ucli.Tests/Features/Daemon/Supervisor/Launch/SystemdRunSupervisorProcessLauncherTests.cs
- dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter "FullyQualifiedName~LaunchAgentPlistDocumentFactoryTests|FullyQualifiedName~SystemdRunSupervisorProcessLauncherTests"
- bash scripts/verify.sh