### PR TITLE
refactor(core): compare contract literals through codec

### DIFF
--- a/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Execution/BuildService.cs
@@ -1168,7 +1168,7 @@ internal sealed class BuildService : IBuildService
         }
 
         if (inputKind == BuildProfileInputsKind.UnityBuildProfile
-            && string.Equals(buildTarget, ContractLiteralCodec.ToValue(BuildTargetStableName.Android), StringComparison.Ordinal)
+            && ContractLiteralCodec.Matches(buildTarget, BuildTargetStableName.Android)
             && IpcBuildOutputLayoutResolver.TryResolve(
                 expectedOutputDirectory,
                 buildTarget,
@@ -1186,18 +1186,22 @@ internal sealed class BuildService : IBuildService
         IpcBuildOutputLayout actual,
         IpcBuildOutputLayout expected)
     {
-        return string.Equals(actual.Shape, expected.Shape, StringComparison.Ordinal)
+        return ContractLiteralCodec.TryParse<IpcBuildOutputLayoutShape>(actual.Shape, out var actualShape)
+            && ContractLiteralCodec.TryParse<IpcBuildOutputLayoutShape>(expected.Shape, out var expectedShape)
+            && actualShape == expectedShape
             && string.Equals(actual.LocationPathName, expected.LocationPathName, StringComparison.Ordinal);
     }
 
     private static ApplicationFailure? ValidateResponseInputBuildTarget (IpcBuildInputProbe input)
     {
-        if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolve(input.BuildTarget, out var expectedUnityBuildTarget))
+        if (!ContractLiteralCodec.TryParse<BuildTargetStableName>(input.BuildTarget, out var expectedBuildTarget)
+            || !BuildTargetStableNameUnityBuildTargetResolver.TryResolve(expectedBuildTarget, out var expectedUnityBuildTarget))
         {
             return ApplicationFailure.InternalError($"Unity build response contains unsupported buildTarget: {input.BuildTarget}.");
         }
 
-        if (!string.Equals(input.UnityBuildTarget, expectedUnityBuildTarget, StringComparison.Ordinal))
+        if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(input.UnityBuildTarget, out var actualBuildTarget)
+            || actualBuildTarget != expectedBuildTarget)
         {
             return ApplicationFailure.InternalError(
                 $"Unity build response buildTarget and Unity BuildTarget mismatch. BuildTarget={input.BuildTarget}, ExpectedUnityBuildTarget={expectedUnityBuildTarget}, ActualUnityBuildTarget={input.UnityBuildTarget}.");
@@ -1215,13 +1219,14 @@ internal sealed class BuildService : IBuildService
             return ApplicationFailure.InternalError("Unity build response unityBuildProfile input must be omitted for explicit build inputs.");
         }
 
-        if (!string.Equals(response.Input.BuildTarget, expectedProfile.BuildTarget.StableName, StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(response.Input.BuildTarget, expectedProfile.BuildTarget.StableNameValue))
         {
             return ApplicationFailure.InternalError(
                 $"Unity build response buildTarget mismatch. Requested={expectedProfile.BuildTarget.StableName}, Actual={response.Input.BuildTarget}.");
         }
 
-        if (!string.Equals(response.Input.UnityBuildTarget, expectedProfile.BuildTarget.UnityBuildTargetLiteral, StringComparison.Ordinal))
+        if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(response.Input.UnityBuildTarget, out var actualBuildTarget)
+            || actualBuildTarget != expectedProfile.BuildTarget.StableNameValue)
         {
             return ApplicationFailure.InternalError(
                 $"Unity build response Unity BuildTarget mismatch. Requested={expectedProfile.BuildTarget.UnityBuildTargetLiteral}, Actual={response.Input.UnityBuildTarget}.");
@@ -2055,7 +2060,7 @@ internal sealed class BuildService : IBuildService
             effects.Insert(1, ContractLiteralCodec.ToValue(BuildEffect.UnityBuildReportRead));
         }
 
-        if (string.Equals(runnerKind, ContractLiteralCodec.ToValue(BuildProfileRunnerKind.ExecuteMethod), StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(runnerKind, BuildProfileRunnerKind.ExecuteMethod))
         {
             effects.Insert(1, ContractLiteralCodec.ToValue(BuildEffect.UnityExecuteMethod));
         }
@@ -2252,10 +2257,7 @@ internal sealed class BuildService : IBuildService
             : IpcBuildReportResult.Unknown;
         var succeeded = reportResult == IpcBuildReportResult.Succeeded;
         var knownTerminalResult = reportResult is IpcBuildReportResult.Succeeded or IpcBuildReportResult.Failed or IpcBuildReportResult.Canceled;
-        var isExecuteMethod = string.Equals(
-            build.Runner.Kind,
-            ContractLiteralCodec.ToValue(BuildProfileRunnerKind.ExecuteMethod),
-            StringComparison.Ordinal);
+        var isExecuteMethod = ContractLiteralCodec.Matches(build.Runner.Kind, BuildProfileRunnerKind.ExecuteMethod);
         var hasBuildReport = build.Summary.ReportRef != null;
         var terminalEvidenceKind = ContractLiteralCodec.ToValue(
             isExecuteMethod ? BuildEffect.UnityExecuteMethod : BuildEffect.UnityBuildPipeline);
@@ -2441,7 +2443,7 @@ internal sealed class BuildService : IBuildService
 
     private static BuildClaimStatus ResolveProjectMutationClaimStatus (IpcBuildProjectMutationAudit projectMutation)
     {
-        return IsFullProjectMutationCoverage(projectMutation)
+        return ContractLiteralCodec.Matches(projectMutation.Coverage, IpcBuildProjectMutationAuditCoverage.Full)
             ? BuildClaimStatus.Passed
             : BuildClaimStatus.Indeterminate;
     }
@@ -2452,7 +2454,7 @@ internal sealed class BuildService : IBuildService
     {
         var hasMutationRisk = mode == BuildProfileProjectMutationMode.Audit && projectMutation.Mutated;
         var hasCoverageRisk = (mode == BuildProfileProjectMutationMode.Audit || mode == BuildProfileProjectMutationMode.AllowWithAudit)
-            && !IsFullProjectMutationCoverage(projectMutation);
+            && !ContractLiteralCodec.Matches(projectMutation.Coverage, IpcBuildProjectMutationAuditCoverage.Full);
         if (hasMutationRisk || hasCoverageRisk)
         {
             return
@@ -2484,25 +2486,12 @@ internal sealed class BuildService : IBuildService
         IpcBuildProjectMutationAudit projectMutation)
     {
         return mode == BuildProfileProjectMutationMode.Forbid
-            && (projectMutation.Mutated || !IsFullProjectMutationCoverage(projectMutation));
-    }
-
-    private static bool IsFullProjectMutationCoverage (IpcBuildProjectMutationAudit projectMutation)
-    {
-        if (projectMutation == null)
-        {
-            return false;
-        }
-
-        return string.Equals(
-            projectMutation.Coverage,
-            ContractLiteralCodec.ToValue(IpcBuildProjectMutationAuditCoverage.Full),
-            StringComparison.Ordinal);
+            && (projectMutation.Mutated || !ContractLiteralCodec.Matches(projectMutation.Coverage, IpcBuildProjectMutationAuditCoverage.Full));
     }
 
     private static string ResolveRunnerEffect (string runnerKind)
     {
-        return string.Equals(runnerKind, ContractLiteralCodec.ToValue(BuildProfileRunnerKind.ExecuteMethod), StringComparison.Ordinal)
+        return ContractLiteralCodec.Matches(runnerKind, BuildProfileRunnerKind.ExecuteMethod)
             ? ContractLiteralCodec.ToValue(BuildEffect.UnityExecuteMethod)
             : ContractLiteralCodec.ToValue(BuildEffect.UnityBuildPipeline);
     }

--- a/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
+++ b/src/Ucli.Application/Features/Assurance/Build/Semantics/BuildAssuranceSemanticInvariantRule.cs
@@ -357,7 +357,8 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         }
 
         if (TryReadBuildResult(buildElement, out var result)
-            && !string.Equals(status, result, StringComparison.Ordinal))
+            && ContractLiteralCodec.TryParse<IpcBuildReportResult>(result, out var parsedResult)
+            && parsedStatus != parsedResult)
         {
             AddViolation(violations, "$.build.summary.result", "Build summary result must match runnerResult status.");
         }
@@ -594,8 +595,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
 
         if (HasCompleteGenerationSnapshots(buildElement))
         {
-            var passedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
-            if (!string.Equals(status, passedLiteral, StringComparison.Ordinal))
+            if (!ContractLiteralCodec.Matches(status, BuildClaimStatus.Passed))
             {
                 AddViolation(
                     violations,
@@ -606,8 +606,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        var indeterminateLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
-        if (!string.Equals(status, indeterminateLiteral, StringComparison.Ordinal)
+        if (!ContractLiteralCodec.Matches(status, BuildClaimStatus.Indeterminate)
             && !string.Equals(status, UnverifiedClaimStatus, StringComparison.Ordinal))
         {
             AddViolation(
@@ -843,12 +842,9 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        var succeededLiteral = ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded);
-        var passedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
-        var failedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Failed);
-        if (string.Equals(result, succeededLiteral, StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(result, IpcBuildReportResult.Succeeded))
         {
-            if (!string.Equals(status, passedLiteral, StringComparison.Ordinal))
+            if (!ContractLiteralCodec.Matches(status, BuildClaimStatus.Passed))
             {
                 AddViolation(violations, BuildPropertyPath(claimPath, "status"), "UNITY_BUILD_SUCCEEDED must pass when BuildReport result is succeeded.");
             }
@@ -856,7 +852,7 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        if (!string.Equals(status, failedLiteral, StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(status, BuildClaimStatus.Failed))
         {
             AddViolation(violations, BuildPropertyPath(claimPath, "status"), "UNITY_BUILD_SUCCEEDED must fail when BuildReport result is not succeeded.");
         }
@@ -875,12 +871,10 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             return;
         }
 
-        var passedLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Passed);
-        var indeterminateLiteral = ContractLiteralCodec.ToValue(BuildClaimStatus.Indeterminate);
         var expectedStatus = parsedResult is IpcBuildReportResult.Succeeded or IpcBuildReportResult.Failed or IpcBuildReportResult.Canceled
-            ? passedLiteral
-            : indeterminateLiteral;
-        if (!string.Equals(status, expectedStatus, StringComparison.Ordinal))
+            ? BuildClaimStatus.Passed
+            : BuildClaimStatus.Indeterminate;
+        if (!ContractLiteralCodec.Matches(status, expectedStatus))
         {
             AddViolation(
                 violations,
@@ -1047,7 +1041,13 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
         if (BuildClaimCodes.UnityBuildCompleted.EqualsValue(claimId)
             || BuildClaimCodes.UnityBuildSucceeded.EqualsValue(claimId))
         {
-            return IsExecuteMethodRunner(buildElement) ? BuildReportRefs.Build : BuildReportRefs.BuildReport;
+            if (TryReadRunnerKind(buildElement, out var runnerKind)
+                && runnerKind == BuildProfileRunnerKind.ExecuteMethod)
+            {
+                return BuildReportRefs.Build;
+            }
+
+            return BuildReportRefs.BuildReport;
         }
 
         if (BuildClaimCodes.UnityBuildReportAccounted.EqualsValue(claimId))
@@ -1072,7 +1072,8 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
     {
         var hasBuildReport = HasBuildReport(payload);
         var isExecuteMethod = payload.TryGetProperty("build", out var buildElement)
-            && IsExecuteMethodRunner(buildElement);
+            && TryReadRunnerKind(buildElement, out var runnerKind)
+            && runnerKind == BuildProfileRunnerKind.ExecuteMethod;
         var claims = new List<string>
         {
             BuildClaimCodes.UnityBuildProfileResolved.Value,
@@ -1119,12 +1120,6 @@ internal sealed class BuildAssuranceSemanticInvariantRule : IAssuranceSemanticIn
             && summaryElement.ValueKind == JsonValueKind.Object
             && TryReadString(summaryElement, "reportRef", out var reportRef)
             && string.Equals(reportRef, BuildReportRefs.BuildReport, StringComparison.Ordinal);
-    }
-
-    private static bool IsExecuteMethodRunner (JsonElement buildElement)
-    {
-        return TryReadRunnerKind(buildElement, out var runnerKind)
-            && runnerKind == BuildProfileRunnerKind.ExecuteMethod;
     }
 
     private static bool TryReadRunnerKind (

--- a/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
+++ b/src/Ucli.Application/Features/Daemon/Common/Projection/StartupFailureDetailFactory.cs
@@ -53,7 +53,7 @@ internal static class StartupFailureDetailFactory
             startup,
             diagnosis,
             classification.RetryDisposition,
-            string.Equals(classification.RetryDisposition, ContractLiteralCodec.ToValue(DaemonStartupRetryDisposition.RetryImmediately), StringComparison.Ordinal));
+            ContractLiteralCodec.Matches(classification.RetryDisposition, DaemonStartupRetryDisposition.RetryImmediately));
     }
 
     /// <summary> Creates a detail for an endpoint that never became reachable before the command timeout. </summary>

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/ExistingSession/DaemonExistingSessionGateService.cs
@@ -101,7 +101,7 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
             if (editorMode.HasValue)
             {
                 var requestedEditorMode = ContractLiteralCodec.ToValue(editorMode.Value);
-                if (!string.Equals(session.EditorMode, requestedEditorMode, StringComparison.Ordinal))
+                if (!ContractLiteralCodec.Matches(session.EditorMode, editorMode.Value))
                 {
                     return DaemonStartResult.Failure(ExecutionError.InvalidArgument(
                         $"Requested daemon editorMode '{requestedEditorMode}' does not match running daemon editorMode '{session.EditorMode}'.",
@@ -231,7 +231,7 @@ internal sealed class DaemonExistingSessionGateService : IDaemonExistingSessionG
                 if (editorMode.HasValue)
                 {
                     var requestedEditorMode = ContractLiteralCodec.ToValue(editorMode.Value);
-                    if (!string.Equals(session.EditorMode, requestedEditorMode, StringComparison.Ordinal))
+                    if (!ContractLiteralCodec.Matches(session.EditorMode, editorMode.Value))
                     {
                         return DaemonStartResult.Failure(ExecutionError.InvalidArgument(
                             $"Requested daemon editorMode '{requestedEditorMode}' does not match running daemon editorMode '{session.EditorMode}'.",

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationAwaiter.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/GuiEndpoint/DaemonGuiSessionRegistrationAwaiter.cs
@@ -119,7 +119,7 @@ internal sealed class DaemonGuiSessionRegistrationAwaiter : IDaemonGuiSessionReg
             }
 
             return string.Equals(pingResponse.ProjectFingerprint, unityProject.ProjectFingerprint, StringComparison.Ordinal)
-                   && string.Equals(pingResponse.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal)
+                   && ContractLiteralCodec.Matches(pingResponse.EditorMode, DaemonEditorMode.Gui)
                 ? DaemonGuiSessionRegistrationWaitResult.Success(session, lifecycleSnapshot)
                 : null;
         }
@@ -179,7 +179,7 @@ internal sealed class DaemonGuiSessionRegistrationAwaiter : IDaemonGuiSessionReg
             return false;
         }
 
-        if (!string.Equals(candidate.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(candidate.EditorMode, DaemonEditorMode.Gui))
         {
             return false;
         }

--- a/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolver.cs
+++ b/src/Ucli.Application/Features/Daemon/Lifecycle/Start/Startup/DaemonStartupBlockedProcessPolicyResolver.cs
@@ -29,22 +29,22 @@ internal static class DaemonStartupBlockedProcessPolicyResolver
                 ProcessActionWhenNotTerminated: ContractLiteralCodec.ToValue(DaemonStartupProcessAction.None));
         }
 
-        if (!canShutdownProcess || string.Equals(ownerKind, ContractLiteralCodec.ToValue(DaemonSessionOwnerKind.User), StringComparison.Ordinal))
+        if (!canShutdownProcess || ContractLiteralCodec.Matches(ownerKind, DaemonSessionOwnerKind.User))
         {
             return Keep();
         }
 
-        if (!string.Equals(ownerKind, ContractLiteralCodec.ToValue(DaemonSessionOwnerKind.Cli), StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(ownerKind, DaemonSessionOwnerKind.Cli))
         {
             return Keep();
         }
 
-        if (string.Equals(editorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Batchmode), StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(editorMode, DaemonEditorMode.Batchmode))
         {
             return ResolveCliOwnedBatchmode(policy);
         }
 
-        if (string.Equals(editorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(editorMode, DaemonEditorMode.Gui))
         {
             return ResolveCliOwnedGui(policy);
         }

--- a/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
+++ b/src/Ucli.Application/Features/Daemon/UseCases/Start/DaemonStartFailureExecutionOutput.cs
@@ -33,7 +33,7 @@ internal sealed record DaemonStartFailureExecutionOutput (
             ToOutput(startup, retryDisposition),
             diagnosis,
             retryDisposition,
-            string.Equals(retryDisposition, ContractLiteralCodec.ToValue(DaemonStartupRetryDisposition.RetryImmediately), StringComparison.Ordinal));
+            ContractLiteralCodec.Matches(retryDisposition, DaemonStartupRetryDisposition.RetryImmediately));
     }
 
     private static string ResolveFinalRetryDisposition (DaemonStartupObservation? startup)
@@ -43,7 +43,7 @@ internal sealed record DaemonStartFailureExecutionOutput (
             return ContractLiteralCodec.ToValue(DaemonStartupRetryDisposition.Unknown);
         }
 
-        return string.Equals(startup.RetryDisposition, ContractLiteralCodec.ToValue(DaemonStartupRetryDisposition.WaitThenRetry), StringComparison.Ordinal)
+        return ContractLiteralCodec.Matches(startup.RetryDisposition, DaemonStartupRetryDisposition.WaitThenRetry)
             ? ContractLiteralCodec.ToValue(DaemonStartupRetryDisposition.Unknown)
             : startup.RetryDisposition;
     }

--- a/src/Ucli.Application/Features/Play/UseCases/Enter/PlayEnterService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Enter/PlayEnterService.cs
@@ -173,7 +173,7 @@ internal sealed class PlayEnterService : IPlayEnterService
         }
 
         var lifecycle = LifecycleProjectionFactory.Create(currentSnapshot);
-        if (!string.Equals(lifecycle.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(lifecycle.EditorMode, DaemonEditorMode.Gui))
         {
             return PlayEnterOutputCreationResult.Failure(ApplicationFailure.InternalError(
                 RequiresGuiEditorMessage,

--- a/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Exit/PlayExitService.cs
@@ -173,7 +173,7 @@ internal sealed class PlayExitService : IPlayExitService
         }
 
         var lifecycle = LifecycleProjectionFactory.Create(currentSnapshot);
-        if (!string.Equals(lifecycle.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(lifecycle.EditorMode, DaemonEditorMode.Gui))
         {
             return PlayExitOutputCreationResult.Failure(ApplicationFailure.InternalError(
                 RequiresGuiEditorMessage,

--- a/src/Ucli.Application/Features/Play/UseCases/Status/PlayStatusService.cs
+++ b/src/Ucli.Application/Features/Play/UseCases/Status/PlayStatusService.cs
@@ -125,8 +125,7 @@ internal sealed class PlayStatusService : IPlayStatusService
         }
 
         var lifecycle = LifecycleProjectionFactory.Create(snapshot);
-        var guiEditorMode = ContractLiteralCodec.ToValue(DaemonEditorMode.Gui);
-        if (!string.Equals(lifecycle.EditorMode, guiEditorMode, StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(lifecycle.EditorMode, DaemonEditorMode.Gui))
         {
             return PlayStatusExecutionResult.Failure(CreateRequiresGuiEditorError());
         }
@@ -140,7 +139,7 @@ internal sealed class PlayStatusService : IPlayStatusService
             Project: playContext.Project,
             DaemonStatus: DaemonStatusKind.Running,
             ServerVersion: lifecycle.ServerVersion,
-            EditorMode: guiEditorMode,
+            EditorMode: ContractLiteralCodec.ToValue(DaemonEditorMode.Gui),
             LifecycleState: lifecycle.LifecycleState,
             BlockingReason: lifecycle.BlockingReason,
             CompileState: lifecycle.CompileState,
@@ -177,8 +176,7 @@ internal sealed class PlayStatusService : IPlayStatusService
             return null;
         }
 
-        var guiEditorMode = ContractLiteralCodec.ToValue(DaemonEditorMode.Gui);
-        if (!string.Equals(observation.EditorMode, guiEditorMode, StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(observation.EditorMode, DaemonEditorMode.Gui))
         {
             return null;
         }
@@ -193,7 +191,7 @@ internal sealed class PlayStatusService : IPlayStatusService
             Project: playContext.Project,
             DaemonStatus: DaemonStatusKind.Running,
             ServerVersion: observation.ServerVersion,
-            EditorMode: guiEditorMode,
+            EditorMode: ContractLiteralCodec.ToValue(DaemonEditorMode.Gui),
             LifecycleState: observation.LifecycleState,
             BlockingReason: observation.BlockingReason,
             CompileState: observation.CompileState,

--- a/src/Ucli.Contracts/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolver.cs
+++ b/src/Ucli.Contracts/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolver.cs
@@ -88,4 +88,23 @@ internal static class BuildTargetStableNameUnityBuildTargetResolver
                 return false;
         }
     }
+
+    /// <summary> Tries to resolve one Unity BuildTarget literal to its stable buildTarget name. </summary>
+    public static bool TryResolveStableName (
+        string unityBuildTargetLiteral,
+        out BuildTargetStableName stableName)
+    {
+        foreach (BuildTargetStableName candidate in Enum.GetValues(typeof(BuildTargetStableName)))
+        {
+            if (TryResolve(candidate, out var candidateUnityBuildTargetLiteral)
+                && string.Equals(candidateUnityBuildTargetLiteral, unityBuildTargetLiteral, StringComparison.Ordinal))
+            {
+                stableName = candidate;
+                return true;
+            }
+        }
+
+        stableName = default;
+        return false;
+    }
 }

--- a/src/Ucli.Contracts/Ipc/Operations/Metadata/Policy/UcliOperationPolicyDeriver.cs
+++ b/src/Ucli.Contracts/Ipc/Operations/Metadata/Policy/UcliOperationPolicyDeriver.cs
@@ -79,7 +79,7 @@ internal static class UcliOperationPolicyDeriver
             policy = Max(policy, OperationPolicy.Advanced);
         }
 
-        if (string.Equals(assurance.PlanMode, ContractLiteralCodec.ToValue(UcliOperationPlanMode.MayCreatePreviewState), StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(assurance.PlanMode, UcliOperationPlanMode.MayCreatePreviewState))
         {
             policy = Max(policy, OperationPolicy.Advanced);
         }

--- a/src/Ucli.Contracts/Ipc/Operations/Metadata/Validation/UcliOperationAssuranceContractValidator.cs
+++ b/src/Ucli.Contracts/Ipc/Operations/Metadata/Validation/UcliOperationAssuranceContractValidator.cs
@@ -77,7 +77,7 @@ internal static class UcliOperationAssuranceContractValidator
         out string errorMessage)
     {
         if (!allowMayCreatePreviewState
-            && string.Equals(assurance.PlanMode, ContractLiteralCodec.ToValue(UcliOperationPlanMode.MayCreatePreviewState), StringComparison.Ordinal))
+            && ContractLiteralCodec.Matches(assurance.PlanMode, UcliOperationPlanMode.MayCreatePreviewState))
         {
             errorMessage = $"{ownerName} public raw assurance metadata must not use planMode '{ContractLiteralCodec.ToValue(UcliOperationPlanMode.MayCreatePreviewState)}'.";
             return false;

--- a/src/Ucli.Contracts/Ipc/Operations/Metadata/Validation/UcliOperationInputConstraintValidator.cs
+++ b/src/Ucli.Contracts/Ipc/Operations/Metadata/Validation/UcliOperationInputConstraintValidator.cs
@@ -153,7 +153,7 @@ internal static class UcliOperationInputConstraintValidator
         UcliOperationInputConstraintContract constraint,
         out string errorMessage)
     {
-        if (!string.Equals(constraint.TypeKind, ContractLiteralCodec.ToValue(UcliOperationTypeKind.Component), StringComparison.Ordinal)
+        if (!ContractLiteralCodec.Matches(constraint.TypeKind, UcliOperationTypeKind.Component)
             || constraint.AssetKind != null
             || constraint.TargetKind != null
             || constraint.Access != null
@@ -172,7 +172,7 @@ internal static class UcliOperationInputConstraintValidator
         UcliOperationInputConstraintContract constraint,
         out string errorMessage)
     {
-        if (!string.Equals(constraint.Access, ContractLiteralCodec.ToValue(UcliOperationSerializedPropertyAccess.Write), StringComparison.Ordinal)
+        if (!ContractLiteralCodec.Matches(constraint.Access, UcliOperationSerializedPropertyAccess.Write)
             || constraint.AssetKind != null
             || constraint.TargetKind != null
             || constraint.TypeKind != null

--- a/src/Ucli.Contracts/Text/ContractLiteralCodec.cs
+++ b/src/Ucli.Contracts/Text/ContractLiteralCodec.cs
@@ -69,6 +69,20 @@ public static class ContractLiteralCodec
         return Cache<TEnum>.Table.IsDefined(value);
     }
 
+    /// <summary> Determines whether one canonical contract literal maps to the specified enum value. </summary>
+    /// <typeparam name="TEnum"> The enum type. </typeparam>
+    /// <param name="literal"> The canonical contract literal. </param>
+    /// <param name="value"> The expected enum value. </param>
+    /// <returns> <see langword="true" /> when <paramref name="literal" /> maps to <paramref name="value" />; otherwise <see langword="false" />. </returns>
+    public static bool Matches<TEnum> (
+        string? literal,
+        TEnum value)
+        where TEnum : struct, Enum
+    {
+        return Cache<TEnum>.Table.TryParse(literal, out var parsedValue)
+            && EqualityComparer<TEnum>.Default.Equals(parsedValue, value);
+    }
+
     /// <summary> Gets the canonical contract literals for one enum type in declaration order. </summary>
     /// <typeparam name="TEnum"> The enum type. </typeparam>
     /// <returns> The canonical contract literal list. </returns>

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildAudit/UnityProjectMutationAuditProbe.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildAudit/UnityProjectMutationAuditProbe.cs
@@ -44,7 +44,7 @@ namespace MackySoft.Ucli.Unity.Build
             var coverage = ResolveCoverage(baseline.Coverage, after.Coverage);
             return new IpcBuildProjectMutationAudit(
                 Mode: mode,
-                Coverage: coverage,
+                Coverage: ContractLiteralCodec.ToValue(coverage),
                 Mutated: items.Count != 0,
                 BeforeDigest: baseline.Digest,
                 AfterDigest: after.Digest,
@@ -107,7 +107,7 @@ namespace MackySoft.Ucli.Unity.Build
             }
 
             return new ProjectMutationSnapshot(
-                ContractLiteralCodec.ToValue(coverage),
+                coverage,
                 CalculateAggregateDigest(files),
                 filesByPath);
         }
@@ -209,25 +209,23 @@ namespace MackySoft.Ucli.Unity.Build
             return items;
         }
 
-        private static string ResolveCoverage (
-            string baselineCoverage,
-            string afterCoverage)
+        private static IpcBuildProjectMutationAuditCoverage ResolveCoverage (
+            IpcBuildProjectMutationAuditCoverage baselineCoverage,
+            IpcBuildProjectMutationAuditCoverage afterCoverage)
         {
-            var indeterminate = ContractLiteralCodec.ToValue(IpcBuildProjectMutationAuditCoverage.Indeterminate);
-            if (string.Equals(baselineCoverage, indeterminate, StringComparison.Ordinal)
-                || string.Equals(afterCoverage, indeterminate, StringComparison.Ordinal))
+            if (baselineCoverage == IpcBuildProjectMutationAuditCoverage.Indeterminate
+                || afterCoverage == IpcBuildProjectMutationAuditCoverage.Indeterminate)
             {
-                return indeterminate;
+                return IpcBuildProjectMutationAuditCoverage.Indeterminate;
             }
 
-            var partial = ContractLiteralCodec.ToValue(IpcBuildProjectMutationAuditCoverage.Partial);
-            if (string.Equals(baselineCoverage, partial, StringComparison.Ordinal)
-                || string.Equals(afterCoverage, partial, StringComparison.Ordinal))
+            if (baselineCoverage == IpcBuildProjectMutationAuditCoverage.Partial
+                || afterCoverage == IpcBuildProjectMutationAuditCoverage.Partial)
             {
-                return partial;
+                return IpcBuildProjectMutationAuditCoverage.Partial;
             }
 
-            return ContractLiteralCodec.ToValue(IpcBuildProjectMutationAuditCoverage.Full);
+            return IpcBuildProjectMutationAuditCoverage.Full;
         }
 
         private static string NormalizeProjectRelativePath (
@@ -287,7 +285,7 @@ namespace MackySoft.Ucli.Unity.Build
         }
 
         internal sealed record ProjectMutationSnapshot (
-            string Coverage,
+            IpcBuildProjectMutationAuditCoverage Coverage,
             string Digest,
             IReadOnlyDictionary<string, ProjectMutationFileEntry> FilesByPath);
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Assurance;
+using MackySoft.Ucli.Contracts.Daemon;
 using MackySoft.Ucli.Contracts.Ipc;
 using MackySoft.Ucli.Contracts.Text;
 using MackySoft.Ucli.Infrastructure.Paths;
@@ -140,7 +141,7 @@ namespace MackySoft.Ucli.Unity.Build
                         null));
             }
 
-            if (IsPartialCoverage(dirtyState))
+            if (ContractLiteralCodec.Matches(dirtyState.Coverage, IpcBuildDirtyStateCoverage.Partial))
             {
                 return UnityBuildPreconditionProbeResult.Failure(
                     projectIdentity,
@@ -344,23 +345,20 @@ namespace MackySoft.Ucli.Unity.Build
                 return false;
             }
 
+            if (!ContractLiteralCodec.TryParse<DaemonEditorMode>(editorMode, out var resolvedEditorMode))
+            {
+                return false;
+            }
+
             for (var i = 0; i < allowedEditorModes.Count; i++)
             {
-                if (string.Equals(editorMode, allowedEditorModes[i], StringComparison.Ordinal))
+                if (ContractLiteralCodec.Matches(allowedEditorModes[i], resolvedEditorMode))
                 {
                     return true;
                 }
             }
 
             return false;
-        }
-
-        private static bool IsPartialCoverage (IpcBuildDirtyState dirtyState)
-        {
-            return string.Equals(
-                dirtyState.Coverage,
-                ContractLiteralCodec.ToValue(IpcBuildDirtyStateCoverage.Partial),
-                StringComparison.Ordinal);
         }
 
         private static bool TryResolveScenePaths (

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildProfiles/Unity6000BuildProfileInputResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildProfiles/Unity6000BuildProfileInputResolver.cs
@@ -163,20 +163,14 @@ namespace MackySoft.Ucli.Unity.Build
             out string unityBuildTargetLiteral)
         {
             unityBuildTargetLiteral = target.ToString();
-            foreach (BuildTargetStableName stableName in Enum.GetValues(typeof(BuildTargetStableName)))
+            if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(unityBuildTargetLiteral, out var stableName))
             {
-                if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var candidateUnityBuildTargetLiteral)
-                    || !string.Equals(candidateUnityBuildTargetLiteral, unityBuildTargetLiteral, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                stableBuildTarget = ContractLiteralCodec.ToValue(stableName);
-                return true;
+                stableBuildTarget = string.Empty;
+                return false;
             }
 
-            stableBuildTarget = string.Empty;
-            return false;
+            stableBuildTarget = ContractLiteralCodec.ToValue(stableName);
+            return true;
         }
 
         private static bool TryResolveScenePaths (
@@ -246,7 +240,7 @@ namespace MackySoft.Ucli.Unity.Build
             string stableBuildTarget,
             out IpcBuildOutputLayout? outputLayout)
         {
-            var androidAppBundle = string.Equals(stableBuildTarget, ContractLiteralCodec.ToValue(BuildTargetStableName.Android), StringComparison.Ordinal)
+            var androidAppBundle = ContractLiteralCodec.Matches(stableBuildTarget, BuildTargetStableName.Android)
                 && EditorUserBuildSettings.buildAppBundle;
             return IpcBuildOutputLayoutResolver.TryResolve(
                 outputPath,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner/Execution/BuildExecuteMethodRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner/Execution/BuildExecuteMethodRunner.cs
@@ -160,8 +160,8 @@ namespace MackySoft.Ucli.Unity.Build
             out UcliCode? errorCode,
             out string? errorMessage)
         {
-            if (!ContractLiteralCodec.IsDefined<IpcBuildReportResult>(result.Status)
-                || string.Equals(result.Status, ContractLiteralCodec.ToValue(IpcBuildReportResult.Unknown), StringComparison.Ordinal))
+            if (!ContractLiteralCodec.TryParse<IpcBuildReportResult>(result.Status, out var status)
+                || status == IpcBuildReportResult.Unknown)
             {
                 errorCode = BuildErrorCodes.BuildRunnerResultInvalid;
                 errorMessage = "Build executeMethod runner result status is invalid.";
@@ -184,8 +184,7 @@ namespace MackySoft.Ucli.Unity.Build
                 return false;
             }
 
-            if (string.Equals(result.Status, ContractLiteralCodec.ToValue(IpcBuildReportResult.Succeeded), StringComparison.Ordinal)
-                && result.Outputs.Count == 0)
+            if (status == IpcBuildReportResult.Succeeded && result.Outputs.Count == 0)
             {
                 errorCode = BuildErrorCodes.BuildRunnerResultInvalid;
                 errorMessage = "Build executeMethod runner result requires at least one output when status is succeeded.";

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityGuiSessionPersistence.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Bootstrap/UnityGuiSessionPersistence.cs
@@ -230,13 +230,10 @@ namespace MackySoft.Ucli.Unity.Ipc
         {
             return sessionContract.SchemaVersion == DaemonSessionStorageContract.CurrentSchemaVersion
                 && string.Equals(sessionContract.ProjectFingerprint, projectFingerprint, StringComparison.Ordinal)
-                && string.Equals(sessionContract.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal)
+                && ContractLiteralCodec.Matches(sessionContract.EditorMode, DaemonEditorMode.Gui)
                 && string.Equals(sessionContract.OwnerKind, sessionOptions.OwnerKind, StringComparison.Ordinal)
                 && sessionContract.CanShutdownProcess == sessionOptions.CanShutdownProcess
-                && string.Equals(
-                    sessionContract.EndpointTransportKind,
-                    ContractLiteralCodec.ToValue(expectedEndpoint.TransportKind),
-                    StringComparison.Ordinal)
+                && ContractLiteralCodec.Matches(sessionContract.EndpointTransportKind, expectedEndpoint.TransportKind)
                 && string.Equals(sessionContract.EndpointAddress, expectedEndpoint.Address, StringComparison.Ordinal)
                 && sessionContract.ProcessId == currentProcessId
                 && MatchesCurrentProcessIdentity(sessionContract, currentProcessStartedAtUtc, currentEditorInstanceId)
@@ -262,10 +259,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             IpcEndpoint expectedEndpoint)
         {
             if (expectedEndpoint.TransportKind != IpcTransportKind.UnixDomainSocket
-                || !string.Equals(
-                    sessionContract.EndpointTransportKind,
-                    ContractLiteralCodec.ToValue(expectedEndpoint.TransportKind),
-                    StringComparison.Ordinal)
+                || !ContractLiteralCodec.Matches(sessionContract.EndpointTransportKind, expectedEndpoint.TransportKind)
                 || !string.Equals(sessionContract.EndpointAddress, expectedEndpoint.Address, StringComparison.Ordinal))
             {
                 return;
@@ -286,11 +280,8 @@ namespace MackySoft.Ucli.Unity.Ipc
                 && sessionContract.IssuedAtUtc == registration.IssuedAtUtc
                 && sessionContract.CanShutdownProcess == registration.CanShutdownProcess
                 && sessionContract.ProcessId == currentProcess.Id
-                && string.Equals(sessionContract.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal)
-                && string.Equals(
-                    sessionContract.EndpointTransportKind,
-                    ContractLiteralCodec.ToValue(registration.Endpoint.TransportKind),
-                    StringComparison.Ordinal)
+                && ContractLiteralCodec.Matches(sessionContract.EditorMode, DaemonEditorMode.Gui)
+                && ContractLiteralCodec.Matches(sessionContract.EndpointTransportKind, registration.Endpoint.TransportKind)
                 && string.Equals(sessionContract.EndpointAddress, registration.Endpoint.Address, StringComparison.Ordinal);
         }
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/BuildRun/BuildRunUnityIpcMethodHandler.cs
@@ -30,8 +30,6 @@ namespace MackySoft.Ucli.Unity.Ipc
         private const string ProgressLogEntryTruncatedSuffix = "... [truncated for build progress stream]";
 
         private static readonly UTF8Encoding Utf8NoBomEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        private static readonly string RunnerKindBuildPipeline = ContractLiteralCodec.ToValue(IpcBuildRunnerKind.BuildPipeline);
-        private static readonly string RunnerKindExecuteMethod = ContractLiteralCodec.ToValue(IpcBuildRunnerKind.ExecuteMethod);
 
         private readonly UnityBuildPreconditionProbe preconditionProbe;
 
@@ -162,6 +160,16 @@ namespace MackySoft.Ucli.Unity.Ipc
                     null);
             }
 
+            if (!ContractLiteralCodec.TryParse<BuildProfileInputsKind>(buildRunRequest.InputKind, out var inputKind)
+                || !ContractLiteralCodec.TryParse<IpcBuildRunnerKind>(buildRunRequest.RunnerKind, out var runnerKind))
+            {
+                return UnityIpcResponseFactory.CreateErrorResponse(
+                    request,
+                    UcliCoreErrorCodes.InternalError,
+                    "Validated build.run request contained unsupported contract literals.",
+                    null);
+            }
+
             IIpcRequestTimeoutScope? requestTimeoutScope = null;
             UnityBuildPreconditionProbeResult? precondition = null;
             IpcUnityBuildProfileInput? unityBuildProfile = null;
@@ -175,7 +183,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 progressSink = progressSinkFactory?.Invoke(executionCancellationToken);
                 UnityBuildPreconditionInput preconditionInput;
                 IpcBuildOutputLayout? outputLayout;
-                if (IsUnityBuildProfileRequest(buildRunRequest))
+                if (inputKind == BuildProfileInputsKind.UnityBuildProfile)
                 {
                     var profileResolution = await buildProfileInputResolver.ResolveAsync(
                             buildRunRequest,
@@ -221,16 +229,16 @@ namespace MackySoft.Ucli.Unity.Ipc
                     errorCode: null);
 
                 FileSystemAccessBoundary.EnsureSecureDirectory(buildRunRequest.OutputPath);
-                if (IsUnityBuildProfileRequest(buildRunRequest))
+                if (inputKind == BuildProfileInputsKind.UnityBuildProfile)
                 {
                     EnsureBuildPipelineOutputLayoutReady(outputLayout!);
                 }
-                else if (IsBuildPipelineRunner(buildRunRequest))
+                else if (runnerKind == IpcBuildRunnerKind.BuildPipeline)
                 {
                     EnsureBuildPipelineOutputLayoutReady(buildRunRequest.OutputLayout!);
                 }
 
-                if (IsBuildPipelineRunner(buildRunRequest))
+                if (runnerKind == IpcBuildRunnerKind.BuildPipeline)
                 {
                     PublishProgress(
                         progressSink,
@@ -245,7 +253,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 var logSourcePath = Application.consoleLogPath;
                 var logStartOffset = GetLogLength(logSourcePath);
                 var logStartSnapshot = unityLogStream.Snapshot();
-                using var unityLogRedactionScope = IsExecuteMethodRunner(buildRunRequest)
+                using var unityLogRedactionScope = runnerKind == IpcBuildRunnerKind.ExecuteMethod
                     ? unityLogRedactionScopeProvider.BeginScope(buildRunRequest.RunnerEnvironmentSecretValues.Values)
                     : null;
                 var startedAtUtc = DateTimeOffset.UtcNow;
@@ -253,7 +261,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 executionCancellationToken.ThrowIfCancellationRequested();
                 IpcBuildRunnerResultArtifact? runnerResult = null;
                 IpcBuildReportArtifact? normalizedReport = null;
-                if (IsExecuteMethodRunner(buildRunRequest))
+                if (runnerKind == IpcBuildRunnerKind.ExecuteMethod)
                 {
                     var invocationResult = executeMethodRunner.Run(
                         buildRunRequest,
@@ -283,7 +291,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                         buildRunRequest.RunnerKind,
                         runnerStatus: null,
                         errorCode: null);
-                    normalizedReport = IsUnityBuildProfileRequest(buildRunRequest)
+                    normalizedReport = inputKind == BuildProfileInputsKind.UnityBuildProfile
                         ? buildProfileBuildRunner.Run(unityBuildProfile!, precondition.ResolvedInput!, outputLayout!)
                         : buildPipelineRunner.Run(UnityBuildPlayerOptionsFactory.Create(buildRunRequest, precondition.ResolvedInput!));
                     if (normalizedReport != null)
@@ -326,7 +334,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                     logStartOffset = 0;
                 }
 
-                if (normalizedReport == null && IsBuildPipelineRunner(buildRunRequest))
+                if (normalizedReport == null && runnerKind == IpcBuildRunnerKind.BuildPipeline)
                 {
                     return CreateErrorResponse(
                         request,
@@ -350,7 +358,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                         buildRunRequest.BuildLogPath,
                         logStartOffset,
                         logEndOffset,
-                        IsExecuteMethodRunner(buildRunRequest) ? buildRunRequest.RunnerEnvironmentSecretValues : null,
+                        runnerKind == IpcBuildRunnerKind.ExecuteMethod ? buildRunRequest.RunnerEnvironmentSecretValues : null,
                         executionCancellationToken)
                     .ConfigureAwait(false);
                 var completionReason = UnityBuildReportNormalizer.ToCompletionReason(
@@ -678,12 +686,6 @@ namespace MackySoft.Ucli.Unity.Ipc
                     .ConfigureAwait(false);
         }
 
-        private static bool IsUnityBuildProfileRequest (IpcBuildRunRequest request)
-        {
-            return ContractLiteralCodec.TryParse<BuildProfileInputsKind>(request.InputKind, out var inputKind)
-                && inputKind == BuildProfileInputsKind.UnityBuildProfile;
-        }
-
         private static bool HasRedactableSensitiveValues (IReadOnlyDictionary<string, string>? sensitiveValues)
         {
             if (sensitiveValues == null || sensitiveValues.Count == 0)
@@ -778,14 +780,20 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
-            if (!HasValidRunnerContract(request, out errorMessage))
+            if (!ContractLiteralCodec.TryParse<IpcBuildRunnerKind>(request.RunnerKind, out var runnerKind))
+            {
+                errorMessage = $"Build runnerKind is invalid: {request.RunnerKind}.";
+                return false;
+            }
+
+            if (!HasValidRunnerContract(request, runnerKind, out errorMessage))
             {
                 return false;
             }
 
             if (inputKind == BuildProfileInputsKind.UnityBuildProfile)
             {
-                return TryValidateUnityBuildProfileRequest(request, out errorMessage);
+                return TryValidateUnityBuildProfileRequest(request, runnerKind, out errorMessage);
             }
 
             if (inputKind != BuildProfileInputsKind.Explicit)
@@ -794,12 +802,13 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
-            return TryValidateExplicitRequest(request, expectedOutputPath!, out errorMessage);
+            return TryValidateExplicitRequest(request, expectedOutputPath!, runnerKind, out errorMessage);
         }
 
         private static bool TryValidateExplicitRequest (
             IpcBuildRunRequest request,
             string expectedOutputPath,
+            IpcBuildRunnerKind runnerKind,
             out string? errorMessage)
         {
             if (request.UnityBuildProfile != null)
@@ -828,21 +837,21 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
-            if (IsBuildPipelineRunner(request) && request.OutputLayout == null)
+            if (runnerKind == IpcBuildRunnerKind.BuildPipeline && request.OutputLayout == null)
             {
                 errorMessage = "Build outputLayout must match the expected uCLI build artifact layout.";
                 return false;
             }
 
             IpcBuildOutputLayout? expectedOutputLayout = null;
-            if (IsBuildPipelineRunner(request)
+            if (runnerKind == IpcBuildRunnerKind.BuildPipeline
                 && !IpcBuildOutputLayoutResolver.TryResolve(expectedOutputPath, request.BuildTarget, out expectedOutputLayout))
             {
                 errorMessage = $"Build outputLayout could not be resolved for build target: {request.BuildTarget}.";
                 return false;
             }
 
-            if (IsBuildPipelineRunner(request)
+            if (runnerKind == IpcBuildRunnerKind.BuildPipeline
                 && (!string.Equals(request.OutputLayout!.Shape, expectedOutputLayout!.Shape, StringComparison.Ordinal)
                     || !PathEquals(request.OutputLayout.LocationPathName, expectedOutputLayout.LocationPathName)))
             {
@@ -856,6 +865,7 @@ namespace MackySoft.Ucli.Unity.Ipc
 
         private static bool TryValidateUnityBuildProfileRequest (
             IpcBuildRunRequest request,
+            IpcBuildRunnerKind runnerKind,
             out string? errorMessage)
         {
             if (request.BuildTarget != null
@@ -870,7 +880,7 @@ namespace MackySoft.Ucli.Unity.Ipc
                 return false;
             }
 
-            if (!IsBuildPipelineRunner(request))
+            if (runnerKind != IpcBuildRunnerKind.BuildPipeline)
             {
                 errorMessage = "unityBuildProfile input requires buildPipeline runner.";
                 return false;
@@ -896,15 +906,10 @@ namespace MackySoft.Ucli.Unity.Ipc
 
         private static bool HasValidRunnerContract (
             IpcBuildRunRequest request,
+            IpcBuildRunnerKind runnerKind,
             out string? errorMessage)
         {
-            if (!IsBuildPipelineRunner(request) && !IsExecuteMethodRunner(request))
-            {
-                errorMessage = $"Build runnerKind is invalid: {request.RunnerKind}.";
-                return false;
-            }
-
-            if (IsBuildPipelineRunner(request))
+            if (runnerKind == IpcBuildRunnerKind.BuildPipeline)
             {
                 if (!string.IsNullOrWhiteSpace(request.RunnerMethod)
                     || request.RunnerArguments.Count != 0
@@ -919,6 +924,12 @@ namespace MackySoft.Ucli.Unity.Ipc
 
                 errorMessage = null;
                 return true;
+            }
+
+            if (runnerKind != IpcBuildRunnerKind.ExecuteMethod)
+            {
+                errorMessage = $"Build runnerKind is invalid: {request.RunnerKind}.";
+                return false;
             }
 
             if (string.IsNullOrWhiteSpace(request.ProfilePath)
@@ -968,16 +979,6 @@ namespace MackySoft.Ucli.Unity.Ipc
             }
 
             return true;
-        }
-
-        private static bool IsBuildPipelineRunner (IpcBuildRunRequest request)
-        {
-            return string.Equals(request.RunnerKind, RunnerKindBuildPipeline, StringComparison.Ordinal);
-        }
-
-        private static bool IsExecuteMethodRunner (IpcBuildRunRequest request)
-        {
-            return string.Equals(request.RunnerKind, RunnerKindExecuteMethod, StringComparison.Ordinal);
         }
 
         private static bool HasValidAllowedEditorModes (IReadOnlyList<string> allowedEditorModes)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayEnter/PlayEnterTransitionRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayEnter/PlayEnterTransitionRunner.cs
@@ -271,7 +271,7 @@ namespace MackySoft.Ucli.Unity.Ipc
 
         private PlayEnterTransitionExecutionResult ValidatePreconditions (IpcPlayLifecycleSnapshot before)
         {
-            if (!string.Equals(before.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+            if (!ContractLiteralCodec.Matches(before.EditorMode, DaemonEditorMode.Gui))
             {
                 return CreateFailure(
                     PlayModeErrorCodes.PlayModeRequiresGuiEditor,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Methods/PlayExit/PlayExitTransitionRunner.cs
@@ -273,7 +273,7 @@ namespace MackySoft.Ucli.Unity.Ipc
 
         private PlayExitTransitionExecutionResult ValidatePreconditions (IpcPlayLifecycleSnapshot before)
         {
-            if (!string.Equals(before.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+            if (!ContractLiteralCodec.Matches(before.EditorMode, DaemonEditorMode.Gui))
             {
                 return CreateFailure(
                     PlayModeErrorCodes.PlayModeRequiresGuiEditor,

--- a/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildProfiles/Unity6000BuildProfileInputResolverTests.cs
+++ b/src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/BuildProfiles/Unity6000BuildProfileInputResolverTests.cs
@@ -78,7 +78,7 @@ namespace MackySoft.Ucli.Unity.Tests
                 Assert.That(IpcBuildOutputLayoutResolver.TryResolve(
                     outputScope.OutputPath,
                     stableBuildTarget,
-                    string.Equals(stableBuildTarget, ContractLiteralCodec.ToValue(BuildTargetStableName.Android), StringComparison.Ordinal)
+                    ContractLiteralCodec.Matches(stableBuildTarget, BuildTargetStableName.Android)
                         && EditorUserBuildSettings.buildAppBundle,
                     out var expectedOutputLayout), Is.True);
                 Assert.That(result.OutputLayout!.Shape, Is.EqualTo(expectedOutputLayout!.Shape));
@@ -334,20 +334,14 @@ namespace MackySoft.Ucli.Unity.Tests
             out string unityBuildTargetLiteral)
         {
             unityBuildTargetLiteral = target.ToString();
-            foreach (BuildTargetStableName stableName in Enum.GetValues(typeof(BuildTargetStableName)))
+            if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(unityBuildTargetLiteral, out var stableName))
             {
-                if (!BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var candidateUnityBuildTargetLiteral)
-                    || !string.Equals(candidateUnityBuildTargetLiteral, unityBuildTargetLiteral, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                stableBuildTarget = ContractLiteralCodec.ToValue(stableName);
-                return true;
+                stableBuildTarget = string.Empty;
+                return false;
             }
 
-            stableBuildTarget = string.Empty;
-            return false;
+            stableBuildTarget = ContractLiteralCodec.ToValue(stableName);
+            return true;
         }
 
         private static string CreateSavedScene (

--- a/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
+++ b/src/Ucli/Features/Assurance/Build/FileBuildRunArtifactStore.cs
@@ -1006,7 +1006,7 @@ internal sealed class FileBuildRunArtifactStore : IBuildRunArtifactStore
         var entryOutputDirectory = Path.Combine(paths.ArtifactOutputDirectory, entryId);
         FileSystemAccessBoundary.EnsureSecureDirectory(entryOutputDirectory);
 
-        if (string.Equals(sourceEntry.Kind, OutputEntryKindFile, StringComparison.Ordinal))
+        if (ContractLiteralCodec.Matches(sourceEntry.Kind, BuildOutputManifestEntryKind.File))
         {
             var fileName = Path.GetFileName(sourceEntry.SourcePath);
             EnsureSafeOutputRelativePath(fileName, sourceEntry.SourcePath);

--- a/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
+++ b/src/Ucli/Features/Daemon/Lifecycle/Start/Launch/DaemonLaunchService.cs
@@ -1249,7 +1249,7 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (IsProcessExitBlocker(blocker))
+        if (ContractLiteralCodec.Matches(blocker.StartupBlockingReason, DaemonStartupBlockingReason.ProcessExit))
         {
             var cleanupResult = await daemonLaunchCompensationService.CleanupFailedLaunchAsync(
                     unityProject,
@@ -1290,19 +1290,10 @@ internal sealed class DaemonLaunchService : IDaemonLaunchService
                 : ContractLiteralCodec.ToValue(DaemonStartupProcessAction.Unknown));
     }
 
-    private static bool IsProcessExitBlocker (DaemonGuiStartupBlocker blocker)
-    {
-        ArgumentNullException.ThrowIfNull(blocker);
-        return string.Equals(
-            blocker.StartupBlockingReason,
-            ContractLiteralCodec.ToValue(DaemonStartupBlockingReason.ProcessExit),
-            StringComparison.Ordinal);
-    }
-
     private static UcliCode ResolveGuiStartupBlockedErrorCode (DaemonGuiStartupBlocker blocker)
     {
         ArgumentNullException.ThrowIfNull(blocker);
-        return IsProcessExitBlocker(blocker)
+        return ContractLiteralCodec.Matches(blocker.StartupBlockingReason, DaemonStartupBlockingReason.ProcessExit)
             ? DaemonErrorCodes.DaemonStartProcessExited
             : DaemonErrorCodes.DaemonStartupBlocked;
     }

--- a/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorClient.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorClient.cs
@@ -131,8 +131,8 @@ internal sealed class SupervisorClient
                     progressSink,
                     ensureRunningPayload.ProjectFingerprint,
                     ensureRunningPayload.TimeoutMilliseconds,
-                    ensureRunningPayload.EditorMode,
-                    ensureRunningPayload.OnStartupBlocked);
+                    editorMode,
+                    onStartupBlocked);
             var response = progressFrameForwarder is null
                 ? await SendWithUnboundedResponseWaitAsync(manifest, request, timeout, cancellationToken).ConfigureAwait(false)
                 : await SendStreamingWithUnboundedResponseWaitAsync(
@@ -161,17 +161,17 @@ internal sealed class SupervisorClient
                     $"Supervisor ensureRunning response payload is invalid. {payloadError.Message}"));
             }
 
-            if (string.Equals(payload.StartStatus, ContractLiteralCodec.ToValue(DaemonStartStatus.Started), StringComparison.Ordinal))
+            if (ContractLiteralCodec.Matches(payload.StartStatus, DaemonStartStatus.Started))
             {
                 return DaemonStartResult.Started(payload.Session, payload.LifecycleSnapshot);
             }
 
-            if (string.Equals(payload.StartStatus, ContractLiteralCodec.ToValue(DaemonStartStatus.AlreadyRunning), StringComparison.Ordinal))
+            if (ContractLiteralCodec.Matches(payload.StartStatus, DaemonStartStatus.AlreadyRunning))
             {
                 return DaemonStartResult.AlreadyRunning(payload.Session, payload.LifecycleSnapshot);
             }
 
-            if (string.Equals(payload.StartStatus, ContractLiteralCodec.ToValue(DaemonStartStatus.Attached), StringComparison.Ordinal))
+            if (ContractLiteralCodec.Matches(payload.StartStatus, DaemonStartStatus.Attached))
             {
                 return DaemonStartResult.Attached(payload.Session, payload.LifecycleSnapshot);
             }
@@ -236,12 +236,12 @@ internal sealed class SupervisorClient
                     $"Supervisor stopProject response payload is invalid. {payloadError.Message}"));
             }
 
-            if (string.Equals(payload.StopStatus, ContractLiteralCodec.ToValue(DaemonStopStatus.Stopped), StringComparison.Ordinal))
+            if (ContractLiteralCodec.Matches(payload.StopStatus, DaemonStopStatus.Stopped))
             {
                 return DaemonStopResult.Stopped();
             }
 
-            if (string.Equals(payload.StopStatus, ContractLiteralCodec.ToValue(DaemonStopStatus.NotRunning), StringComparison.Ordinal))
+            if (ContractLiteralCodec.Matches(payload.StopStatus, DaemonStopStatus.NotRunning))
             {
                 return DaemonStopResult.NotRunning();
             }
@@ -368,7 +368,7 @@ internal sealed class SupervisorClient
 
     private static DaemonStatusKind ResolveDaemonStatus (string? daemonStatus)
     {
-        return string.Equals(daemonStatus, ContractLiteralCodec.ToValue(DaemonStatusKind.Stale), StringComparison.Ordinal)
+        return ContractLiteralCodec.Matches(daemonStatus, DaemonStatusKind.Stale)
             ? DaemonStatusKind.Stale
             : DaemonStatusKind.NotRunning;
     }

--- a/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorDaemonStartProgressFrameForwarder.cs
+++ b/src/Ucli/Features/Daemon/Supervisor/Client/SupervisorDaemonStartProgressFrameForwarder.cs
@@ -12,21 +12,20 @@ internal sealed class SupervisorDaemonStartProgressFrameForwarder
     private readonly ICommandProgressSink progressSink;
     private readonly string projectFingerprint;
     private readonly int timeoutMilliseconds;
-    private readonly string? editorMode;
-    private readonly string onStartupBlocked;
+    private readonly DaemonEditorMode? editorMode;
+    private readonly DaemonStartupBlockedProcessPolicy onStartupBlocked;
 
     /// <summary> Initializes a new instance of the <see cref="SupervisorDaemonStartProgressFrameForwarder" /> class. </summary>
     public SupervisorDaemonStartProgressFrameForwarder (
         ICommandProgressSink progressSink,
         string projectFingerprint,
         int timeoutMilliseconds,
-        string? editorMode,
-        string onStartupBlocked)
+        DaemonEditorMode? editorMode,
+        DaemonStartupBlockedProcessPolicy onStartupBlocked)
     {
         this.progressSink = progressSink ?? throw new ArgumentNullException(nameof(progressSink));
         ArgumentException.ThrowIfNullOrWhiteSpace(projectFingerprint);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(timeoutMilliseconds);
-        ArgumentException.ThrowIfNullOrWhiteSpace(onStartupBlocked);
 
         this.projectFingerprint = projectFingerprint;
         this.timeoutMilliseconds = timeoutMilliseconds;
@@ -137,12 +136,12 @@ internal sealed class SupervisorDaemonStartProgressFrameForwarder
         string? entryEditorMode,
         string entryOnStartupBlocked)
     {
-        return string.Equals(payloadKind, ContractLiteralCodec.ToValue(expectedPayloadKind), StringComparison.Ordinal)
+        return ContractLiteralCodec.Matches(payloadKind, expectedPayloadKind)
             && string.Equals(entryProjectFingerprint, projectFingerprint, StringComparison.Ordinal)
             && entryTimeoutMilliseconds == timeoutMilliseconds
-            && string.Equals(entryOnStartupBlocked, onStartupBlocked, StringComparison.Ordinal)
+            && ContractLiteralCodec.Matches(entryOnStartupBlocked, onStartupBlocked)
             && IsOptionalContractLiteral<DaemonEditorMode>(entryEditorMode)
-            && (editorMode is null || string.Equals(entryEditorMode, editorMode, StringComparison.Ordinal));
+            && (!editorMode.HasValue || ContractLiteralCodec.Matches(entryEditorMode, editorMode.Value));
     }
 
     private static bool IsOptionalContractLiteral<TEnum> (string? value)

--- a/src/Ucli/Hosting/Cli/Assurance/BuildRunCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Assurance/BuildRunCommandResultFactory.cs
@@ -57,7 +57,7 @@ internal static class BuildRunCommandResultFactory
             ProtocolVersion: IpcProtocol.CurrentVersion,
             Command: UcliCommandNames.BuildRun,
             Status: IpcProtocol.StatusOk,
-            ExitCode: string.Equals(output.Verdict, ContractLiteralCodec.ToValue(BuildVerdict.Pass), StringComparison.Ordinal)
+            ExitCode: ContractLiteralCodec.Matches(output.Verdict, BuildVerdict.Pass)
                 ? (int)CliExitCode.Success
                 : 1,
             Message: executionResult.Message,

--- a/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Execution/UnityIpcRequestBuilder.cs
@@ -173,10 +173,7 @@ internal sealed class UnityIpcRequestBuilder
 
     private static string? ResolveOneshotActiveBuildProfilePath (UnityRequestPayload.BuildRun buildRun)
     {
-        if (!string.Equals(
-                buildRun.InputKind,
-                ContractLiteralCodec.ToValue(BuildProfileInputsKind.UnityBuildProfile),
-                StringComparison.Ordinal)
+        if (!ContractLiteralCodec.Matches(buildRun.InputKind, BuildProfileInputsKind.UnityBuildProfile)
             || buildRun.UnityBuildProfile?.Path == null
             || !UnityAssetPathContract.IsNormalizedBuildProfileAssetPath(buildRun.UnityBuildProfile.Path))
         {

--- a/src/Ucli/UnityIntegration/Ipc/Recovery/UnityDaemonRecoveryWaiter.cs
+++ b/src/Ucli/UnityIntegration/Ipc/Recovery/UnityDaemonRecoveryWaiter.cs
@@ -79,7 +79,7 @@ internal sealed class UnityDaemonRecoveryWaiter
         }
 
         var session = sessionReadResult.Session!;
-        if (!string.Equals(session.EditorMode, ContractLiteralCodec.ToValue(DaemonEditorMode.Gui), StringComparison.Ordinal))
+        if (!ContractLiteralCodec.Matches(session.EditorMode, DaemonEditorMode.Gui))
         {
             return false;
         }

--- a/tests/Ucli.Contracts.Tests/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolverTests.cs
+++ b/tests/Ucli.Contracts.Tests/Assurance/Build/BuildTargetStableNameUnityBuildTargetResolverTests.cs
@@ -15,11 +15,14 @@ public sealed class BuildTargetStableNameUnityBuildTargetResolverTests
     {
         var stringResolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableName, out var stringLiteral);
         var enumResolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolve(stableNameValue, out var enumLiteral);
+        var stableNameResolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(expectedUnityBuildTargetLiteral, out var resolvedStableName);
 
         Assert.True(stringResolved);
         Assert.Equal(expectedUnityBuildTargetLiteral, stringLiteral);
         Assert.True(enumResolved);
         Assert.Equal(expectedUnityBuildTargetLiteral, enumLiteral);
+        Assert.True(stableNameResolved);
+        Assert.Equal(stableNameValue, resolvedStableName);
     }
 
     [Fact]
@@ -47,6 +50,18 @@ public sealed class BuildTargetStableNameUnityBuildTargetResolverTests
 
         Assert.False(resolved);
         Assert.Null(unityBuildTargetLiteral);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("UnknownTarget")]
+    [Trait("Size", "Small")]
+    public void TryResolveStableName_WithUnsupportedUnityBuildTargetLiteral_ReturnsFalse (string unityBuildTargetLiteral)
+    {
+        var resolved = BuildTargetStableNameUnityBuildTargetResolver.TryResolveStableName(unityBuildTargetLiteral, out var stableName);
+
+        Assert.False(resolved);
+        Assert.Equal(default, stableName);
     }
 
     public static TheoryData<string, BuildTargetStableName, string> SupportedTargetCases ()

--- a/tests/Ucli.Contracts.Tests/Text/ContractLiteralCodecTests.cs
+++ b/tests/Ucli.Contracts.Tests/Text/ContractLiteralCodecTests.cs
@@ -55,6 +55,20 @@ public sealed class ContractLiteralCodecTests
 
     [Theory]
     [Trait("Size", "Small")]
+    [InlineData("dangerous", OperationPolicy.Dangerous, true)]
+    [InlineData("dangerous", OperationPolicy.Safe, false)]
+    [InlineData("DANGEROUS", OperationPolicy.Dangerous, false)]
+    [InlineData(null, OperationPolicy.Dangerous, false)]
+    public void Matches_ReturnsWhetherLiteralMapsToExpectedValue (
+        string? literal,
+        OperationPolicy expectedValue,
+        bool expectedResult)
+    {
+        Assert.Equal(expectedResult, ContractLiteralCodec.Matches(literal, expectedValue));
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("safe ")]


### PR DESCRIPTION
## Summary
- Centralizes contract literal comparisons through ContractLiteralCodec instead of scattered raw string equality.
- Removes thin delegation helpers that only wrapped one expression without adding domain meaning.
- Keeps typed comparisons inside build, daemon, play, supervisor, and Unity IPC flows, with literal conversion at boundaries.

## Scope
- Contracts: add ContractLiteralCodec.Matches and build target stable-name reverse lookup.
- Application/CLI/Unity: replace direct literal equality and redundant helpers with codec-backed or typed comparisons.
- Tests: cover the new codec match helper and build target reverse lookup behavior.

## Verification
- Gate level: Standard
- Format: PASS (bash scripts/code-quality.sh format --include changed .cs files; bash scripts/code-quality.sh verify --include changed .cs files)
- Tests: PASS (bash scripts/test-dotnet.sh; bash scripts/test-unity.sh --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor")
- Coverage: N/A

## Risks / Rollback
- Risk is limited to literal comparison paths; rollback is reverting the single refactor commit.

## Checklist
- [x] Review comments about raw string literal comparisons and thin helper methods addressed.

Issue: none (ad-hoc task)