### PR TITLE
fix(unity): prevent package nullable warnings

### DIFF
--- a/scripts/verify-unity-plugin-package.sh
+++ b/scripts/verify-unity-plugin-package.sh
@@ -44,6 +44,8 @@ required_entries=(
   "${nuspec_entry}"
   "ucli-plugin.json"
   "Editor/MackySoft.Ucli.Unity.Editor.asmdef"
+  "Editor/csc.rsp"
+  "Editor/csc.rsp.meta"
   "Editor/AssemblyInfo.cs"
   "Editor/Ipc/Bootstrap/UnityDaemonBootstrap.cs"
   "Editor/Execution/UnityExecutionServiceCollectionExtensions.cs"

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions/UnityBuildPreconditionProbe.cs
@@ -337,10 +337,15 @@ namespace MackySoft.Ucli.Unity.Build
         }
 
         private static bool IsEditorModeAllowed (
-            string editorMode,
+            string? editorMode,
             IReadOnlyList<string> allowedEditorModes)
         {
             if (allowedEditorModes == null || allowedEditorModes.Count == 0)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(editorMode))
             {
                 return false;
             }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner/Execution/BuildExecuteMethodRunner.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner/Execution/BuildExecuteMethodRunner.cs
@@ -59,7 +59,7 @@ namespace MackySoft.Ucli.Unity.Build
                     "Build executeMethod runner context requires profile path and profile digest.");
             }
 
-            var resolution = resolver.Resolve(request.RunnerMethod);
+            var resolution = resolver.Resolve(request.RunnerMethod!);
             if (!resolution.IsSuccess)
             {
                 return Failure(resolution.ErrorCode!.Value, resolution.ErrorMessage!);
@@ -135,7 +135,7 @@ namespace MackySoft.Ucli.Unity.Build
                 request.OutputPath,
                 request.ProfilePath!,
                 request.ProfileDigest!,
-                new UcliResolvedBuildTarget(request.BuildTarget, resolvedInput.UnityBuildTarget),
+                new UcliResolvedBuildTarget(request.BuildTarget!, resolvedInput.UnityBuildTarget),
                 resolvedInput.ScenePaths,
                 new UcliBuildOptions((resolvedInput.Options & BuildOptions.Development) == BuildOptions.Development),
                 request.RunnerArguments,

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationArgumentValueReader.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using MackySoft.Ucli.Contracts.Text;
 
@@ -15,7 +16,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when the property is valid; otherwise <see langword="false" />. </returns>
         public static bool TryReadRequiredString (
             JsonProperty property,
-            out string? value,
+            [NotNullWhen(true)] out string? value,
             out string errorMessage)
         {
             return TryReadRequiredString(
@@ -37,7 +38,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             JsonElement valueElement,
             string propertyPath,
             string expectedTypeDescription,
-            out string? value,
+            [NotNullWhen(true)] out string? value,
             out string errorMessage)
         {
             value = null;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationRuntimeTypeResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/OperationRuntimeTypeResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using MackySoft.Ucli.Contracts.Text;
 
 #nullable enable
@@ -15,7 +16,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when a runtime type is resolved; otherwise <see langword="false" />. </returns>
         public static bool TryResolveRuntimeType (
             string typeId,
-            out Type? runtimeType,
+            [NotNullWhen(true)] out Type? runtimeType,
             out string errorMessage)
         {
             runtimeType = null;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/asset/AssetOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/asset/AssetOperationUtilities.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using MackySoft.Ucli.Contracts;
 using MackySoft.Ucli.Contracts.Text;
@@ -89,8 +90,8 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
             UnityObjectReference reference,
             OperationExecutionContext executionContext,
             bool allowTemporaryState,
-            out UnityEngine.Object? unityObject,
-            out string assetPath,
+            [NotNullWhen(true)] out UnityEngine.Object? unityObject,
+            [NotNullWhen(true)] out string? assetPath,
             out string? sourceGlobalObjectId,
             out string errorMessage)
         {

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/asset/AssetTypeResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/asset/AssetTypeResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 #nullable enable
@@ -15,7 +16,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when a concrete scriptable-object type is resolved; otherwise <see langword="false" />. </returns>
         public static bool TryResolveCreateAssetType (
             string typeId,
-            out Type? assetType,
+            [NotNullWhen(true)] out Type? assetType,
             out string errorMessage)
         {
             assetType = null;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ComponentTypeResolver.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/comp/ComponentTypeResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using UnityEngine;
 
 #nullable enable
@@ -15,7 +16,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when a concrete <see cref="Component" /> type is resolved; otherwise <see langword="false" />. </returns>
         public static bool TryResolveComponentType (
             string typeId,
-            out Type? componentType,
+            [NotNullWhen(true)] out Type? componentType,
             out string errorMessage)
         {
             componentType = null;

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/Phases/Ops/prefab/PrefabOperationUtilities.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using MackySoft.Ucli.Contracts;
 using UnityEditor;
@@ -82,7 +83,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when the target prefab stage is opened; otherwise <see langword="false" />. </returns>
         public static bool TryGetOpenedPrefabStage (
             string prefabPath,
-            out PrefabStage? prefabStage,
+            [NotNullWhen(true)] out PrefabStage? prefabStage,
             out string errorMessage)
         {
             prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
@@ -110,7 +111,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         /// <returns> <see langword="true" /> when the prefab stage was opened successfully; otherwise <see langword="false" />. </returns>
         public static bool TryOpenPrefabStage (
             string prefabPath,
-            out PrefabStage? prefabStage,
+            [NotNullWhen(true)] out PrefabStage? prefabStage,
             out string errorMessage)
         {
             if (TryGetOpenedPrefabStage(prefabPath, out prefabStage, out errorMessage))
@@ -191,7 +192,7 @@ namespace MackySoft.Ucli.Unity.Execution.Phases
         public static bool TryGetOrLoadTemporaryPrefabContentsRoot (
             string prefabPath,
             OperationExecutionContext executionContext,
-            out GameObject? prefabContentsRoot,
+            [NotNullWhen(true)] out GameObject? prefabContentsRoot,
             out string errorMessage)
         {
             if (executionContext == null)

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Codec/PlanTokenCompactCodec.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution/PlanToken/Codec/PlanTokenCompactCodec.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
@@ -45,9 +46,9 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
         /// <returns> <see langword="true" /> when decode succeeds; otherwise <see langword="false" />. </returns>
         public static bool TryDecodeToken (
             string token,
-            out PlanTokenDecodedToken decodedToken)
+            [NotNullWhen(true)] out PlanTokenDecodedToken? decodedToken)
         {
-            decodedToken = default;
+            decodedToken = null;
             if (string.IsNullOrWhiteSpace(token))
             {
                 return false;
@@ -233,9 +234,9 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
         /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryReadHeader (
             ReadOnlyMemory<byte> headerBytes,
-            out PlanTokenHeader header)
+            [NotNullWhen(true)] out PlanTokenHeader? header)
         {
-            header = default;
+            header = null;
             try
             {
                 using var document = JsonDocument.Parse(headerBytes);
@@ -255,7 +256,7 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
                     return false;
                 }
 
-                header = new PlanTokenHeader(alg, kid, typ);
+                header = new PlanTokenHeader(alg!, kid!, typ!);
                 return true;
             }
             catch
@@ -270,9 +271,9 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
         /// <returns> <see langword="true" /> when parse succeeds; otherwise <see langword="false" />. </returns>
         private static bool TryReadPayload (
             ReadOnlyMemory<byte> payloadBytes,
-            out PlanTokenPayload payload)
+            [NotNullWhen(true)] out PlanTokenPayload? payload)
         {
-            payload = default;
+            payload = null;
             try
             {
                 using var document = JsonDocument.Parse(payloadBytes);
@@ -330,14 +331,14 @@ namespace MackySoft.Ucli.Unity.Execution.PlanToken
 
                 payload = new PlanTokenPayload(
                     Version: version,
-                    KeyId: kid,
-                    ProjectFingerprint: projectFingerprint,
-                    RequestDigest: requestDigest,
+                    KeyId: kid!,
+                    ProjectFingerprint: projectFingerprint!,
+                    RequestDigest: requestDigest!,
                     CompiledExecutionDigest: string.IsNullOrWhiteSpace(compiledExecutionDigest) ? null : compiledExecutionDigest,
-                    StateFingerprint: stateFingerprint,
+                    StateFingerprint: stateFingerprint!,
                     IssuedAtUtc: issuedAtUtc,
                     ExpiresAtUtc: expiresAtUtc,
-                    Nonce: nonce);
+                    Nonce: nonce!);
                 return true;
             }
             catch

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/AssetSchemaExtractor.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index/Schemas/AssetSchemaExtractor.cs
@@ -125,14 +125,18 @@ namespace MackySoft.Ucli.Unity.Index
             Type assetType,
             HashSet<string> editorAssemblyNames)
         {
-            var assemblyName = assetType?.Assembly.GetName().Name;
-            return assetType != null
-                && typeof(ScriptableObject).IsAssignableFrom(assetType)
+            if (assetType == null)
+            {
+                return false;
+            }
+
+            var assemblyName = assetType.Assembly.GetName().Name;
+            return typeof(ScriptableObject).IsAssignableFrom(assetType)
                 && !assetType.IsAbstract
                 && !assetType.IsGenericTypeDefinition
                 && !assetType.ContainsGenericParameters
                 && !string.IsNullOrWhiteSpace(assemblyName)
-                && !editorAssemblyNames.Contains(assemblyName);
+                && !editorAssemblyNames.Contains(assemblyName!);
         }
     }
 }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Diagnostics/LogReadFilterUtilities.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Diagnostics/LogReadFilterUtilities.cs
@@ -49,10 +49,12 @@ namespace MackySoft.Ucli.Unity.Ipc
             bool searchSecondaryText)
         {
             var primaryHit = searchPrimaryText
-                && !string.IsNullOrEmpty(primaryText)
+                && primaryText != null
+                && primaryText.Length > 0
                 && primaryText.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
             var secondaryHit = searchSecondaryText
-                && !string.IsNullOrEmpty(secondaryText)
+                && secondaryText != null
+                && secondaryText.Length > 0
                 && secondaryText.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
             return primaryHit || secondaryHit;
         }

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Protocol/UnityIpcResponseFactory.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc/Protocol/UnityIpcResponseFactory.cs
@@ -35,7 +35,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             IpcRequest request,
             UcliCode code,
             string message,
-            string opId)
+            string? opId)
         {
             return new IpcResponse(
                 ProtocolVersion: request.ProtocolVersion,
@@ -60,7 +60,7 @@ namespace MackySoft.Ucli.Unity.Ipc
             IpcRequest request,
             UcliCode code,
             string message,
-            string opId,
+            string? opId,
             TPayload payload)
         {
             return new IpcResponse(

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/SceneInspection/SceneTreeNodeSnapshotBuilder.cs
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/SceneInspection/SceneTreeNodeSnapshotBuilder.cs
@@ -82,7 +82,7 @@ namespace MackySoft.Ucli.Unity.SceneInspection
                 var resolvedGlobalObjectId = globalObjectIdResolver(gameObject);
                 if (!string.IsNullOrWhiteSpace(resolvedGlobalObjectId))
                 {
-                    return resolvedGlobalObjectId;
+                    return resolvedGlobalObjectId!;
                 }
             }
 

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/csc.rsp
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/csc.rsp
@@ -1,0 +1,1 @@
+-nullable:annotations

--- a/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/csc.rsp.meta
+++ b/src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16901095c74484a9fa9fe3f3d63d627d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add a package-scoped csc.rsp so the uCLI Unity editor assembly accepts nullable annotations without requiring consumer project settings.
- Tighten nullable contracts in existing #nullable enable package code instead of suppressing warnings or changing runtime behavior.
- Extend Unity package verification so the compiler response file is required in packaged artifacts.

## Scope
- Unity package compiler configuration: Editor/csc.rsp and generated .meta.
- Nullable contract fixes for Try-pattern helpers, IPC error opId, and local null-flow checks.
- Package verification script now asserts the csc.rsp entries are included.

## Verification
- Gate level: Full
- Format: PASS (scripts/code-quality.sh format/verify targeted files)
- Tests: PASS (bash scripts/verify.sh --include-unity --project-path "src/Ucli.Unity" --assembly-name "MackySoft.Ucli.Unity.Tests.Editor")
- Coverage: N/A
- Additional: PASS (Unity editor.log warning scan returned 0 warning entries)
- Additional: PASS (Unity package pack/verify confirmed Editor/csc.rsp and Editor/csc.rsp.meta are included)

## Risks / Rollback
- Risk is limited to Unity package compilation options and nullable contract annotations.
- Rollback by reverting this PR; runtime behavior is not intentionally changed.

## Checklist
- [x] Unity package warning scan is clean
- [x] Full .NET and Unity verification passed

Issue: none (ad-hoc task)