### PR TITLE
chore(dotmet): update ucli architecture rules

### DIFF
--- a/.dotmet/.gitignore
+++ b/.dotmet/.gitignore
@@ -1,0 +1,2 @@
+# dotmet local state
+local/

--- a/.dotmet/rules.json
+++ b/.dotmet/rules.json
@@ -1,343 +1,1325 @@
 {
-  "layers": [
-    {
-      "name": "Application",
-      "projectExact": [
-        "src/Ucli.Application/Ucli.Application.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Application"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Application"
-      ],
-      "pathPrefix": [
-        "src/Ucli.Application"
-      ]
-    },
-    {
-      "name": "ApplicationTests",
-      "projectExact": [
-        "tests/Ucli.Application.Tests/Ucli.Application.Tests.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Application.Tests"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Application.Tests"
-      ],
-      "pathPrefix": [
-        "tests/Ucli.Application.Tests"
-      ]
-    },
-    {
-      "name": "ArchitectureTests",
-      "projectExact": [
-        "tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Architecture.Tests"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Architecture.Tests"
-      ],
-      "pathPrefix": [
-        "tests/Ucli.Architecture.Tests"
-      ]
-    },
-    {
-      "name": "CliHost",
-      "projectExact": [
-        "src/Ucli/Ucli.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli"
-      ],
-      "pathPrefix": [
-        "src/Ucli"
-      ]
-    },
-    {
-      "name": "CliHostTests",
-      "projectExact": [
-        "tests/Ucli.Tests/Ucli.Tests.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Tests"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Tests"
-      ],
-      "pathPrefix": [
-        "tests/Ucli.Tests"
-      ]
-    },
-    {
-      "name": "Contracts",
-      "projectExact": [
-        "src/Ucli.Contracts/Ucli.Contracts.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Contracts"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Contracts"
-      ],
-      "pathPrefix": [
-        "src/Ucli.Contracts"
-      ]
-    },
-    {
-      "name": "ContractsTests",
-      "projectExact": [
-        "tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Contracts.Tests"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Contracts.Tests"
-      ],
-      "pathPrefix": [
-        "tests/Ucli.Contracts.Tests"
-      ]
-    },
-    {
-      "name": "External",
-      "namespacePrefix": [
-        "ConsoleAppFramework",
-        "Cysharp.Threading.Tasks",
-        "MackySoft.AgentSkills",
-        "Microsoft",
-        "Newtonsoft.Json",
-        "NUnit",
-        "System",
-        "UnityEditor",
-        "UnityEditor.TestTools",
-        "UnityEngine",
-        "UnityEngine.TestTools",
-        "Xunit"
-      ]
-    },
-    {
-      "name": "Infrastructure",
-      "projectExact": [
-        "src/Ucli.Infrastructure/Ucli.Infrastructure.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Infrastructure"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Infrastructure"
-      ],
-      "pathPrefix": [
-        "src/Ucli.Infrastructure"
-      ]
-    },
-    {
-      "name": "InfrastructureTests",
-      "projectExact": [
-        "tests/Ucli.Infrastructure.Tests/Ucli.Infrastructure.Tests.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Infrastructure.Tests"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Infrastructure.Tests"
-      ],
-      "pathPrefix": [
-        "tests/Ucli.Infrastructure.Tests"
-      ]
-    },
-    {
-      "name": "TestsHelper",
-      "projectExact": [
-        "tests/Tests.Helper/Tests.Helper.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Tests.Helper"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Tests.Helper"
-      ],
-      "pathPrefix": [
-        "tests/Tests.Helper"
-      ]
-    },
-    {
-      "name": "Tools",
-      "projectExact": [
-        "tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.SchemaGenerator"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.SchemaGenerator"
-      ],
-      "pathPrefix": [
-        "tools/Ucli.SchemaGenerator"
-      ]
-    },
-    {
-      "name": "UnityPlugin",
-      "projectExact": [
-        "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Unity.Editor"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Unity"
-      ],
-      "pathPrefix": [
-        "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity"
-      ]
-    },
-    {
-      "name": "UnityTests",
-      "projectExact": [
-        "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Sandbox.Tests/Editor/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.asmdef",
-        "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/MackySoft.Ucli.Unity.Tests.Editor.asmdef",
-        "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Runtime/MackySoft.Ucli.Unity.Tests.Runtime.asmdef"
-      ],
-      "assemblyExact": [
-        "MackySoft.Ucli.Unity.Sandbox.Tests.Editor",
-        "MackySoft.Ucli.Unity.Tests.Editor",
-        "MackySoft.Ucli.Unity.Tests.Runtime"
-      ],
-      "namespacePrefix": [
-        "MackySoft.Ucli.Unity.Sandbox.Tests",
-        "MackySoft.Ucli.Unity.Tests"
-      ],
-      "pathPrefix": [
-        "src/Ucli.Unity/Assets/Tests"
-      ]
-    }
-  ],
-  "allowDependencies": [
-    {
-      "from": "Application",
-      "to": [
-        "Application",
-        "Contracts",
-        "External"
-      ]
-    },
-    {
-      "from": "ApplicationTests",
-      "to": [
-        "Application",
-        "ApplicationTests",
-        "Contracts",
-        "External",
-        "TestsHelper"
-      ]
-    },
-    {
-      "from": "ArchitectureTests",
-      "to": [
-        "ArchitectureTests",
-        "External"
-      ]
-    },
-    {
-      "from": "CliHost",
-      "to": [
-        "Application",
-        "CliHost",
-        "Contracts",
-        "External",
-        "Infrastructure"
-      ]
-    },
-    {
-      "from": "CliHostTests",
-      "to": [
-        "Application",
-        "CliHost",
-        "CliHostTests",
-        "Contracts",
-        "External",
-        "Infrastructure",
-        "TestsHelper"
-      ]
-    },
-    {
-      "from": "Contracts",
-      "to": [
-        "Contracts",
-        "External"
-      ]
-    },
-    {
-      "from": "ContractsTests",
-      "to": [
-        "Contracts",
-        "ContractsTests",
-        "External",
-        "TestsHelper"
-      ]
-    },
-    {
-      "from": "External",
-      "to": [
-        "External"
-      ]
-    },
-    {
-      "from": "Infrastructure",
-      "to": [
-        "Contracts",
-        "External",
-        "Infrastructure"
-      ]
-    },
-    {
-      "from": "InfrastructureTests",
-      "to": [
-        "Contracts",
-        "External",
-        "Infrastructure",
-        "InfrastructureTests",
-        "TestsHelper"
-      ]
-    },
-    {
-      "from": "TestsHelper",
-      "to": [
-        "External",
-        "TestsHelper"
-      ]
-    },
-    {
-      "from": "Tools",
-      "to": [
-        "Contracts",
-        "External",
-        "Tools"
-      ]
-    },
-    {
-      "from": "UnityPlugin",
-      "to": [
-        "Contracts",
-        "External",
-        "Infrastructure",
-        "UnityPlugin"
-      ]
-    },
-    {
-      "from": "UnityTests",
-      "to": [
-        "Contracts",
-        "External",
-        "Infrastructure",
-        "UnityPlugin",
-        "UnityTests"
-      ]
-    }
-  ],
+  "subjects": {
+    "owned": [
+      {
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli/",
+              "src/Ucli.Application",
+              "src/Ucli.Contracts",
+              "src/Ucli.Infrastructure",
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity",
+              "src/Ucli.Unity/Assets/Tests",
+              "tests",
+              "tools/Ucli.SchemaGenerator"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Runtime.csproj"
+            ]
+          },
+          {
+            "projectExact": [
+              "src/Ucli/Ucli.csproj"
+            ],
+            "pathPrefix": [
+              "ConsoleAppFramework"
+            ]
+          }
+        ]
+      }
+    ],
+    "external": [
+      {
+        "matches": [
+          {
+            "assemblyExact": [
+              "ConsoleAppFramework",
+              "MackySoft.AgentSkills",
+              "Microsoft.Bcl.AsyncInterfaces",
+              "Microsoft.CodeAnalysis",
+              "Microsoft.CodeAnalysis.CSharp",
+              "Microsoft.CodeCoverage",
+              "Microsoft.Extensions.DependencyInjection",
+              "Microsoft.Extensions.DependencyInjection.Abstractions",
+              "Microsoft.Extensions.Logging.Abstractions",
+              "Microsoft.NET.Test.Sdk",
+              "Microsoft.TestPlatform.ObjectModel",
+              "Microsoft.TestPlatform.TestHost",
+              "Newtonsoft.Json",
+              "System.Buffers",
+              "System.Collections",
+              "System.Collections.Concurrent",
+              "System.Collections.Immutable",
+              "System.ComponentModel.Primitives",
+              "System.Console",
+              "System.Diagnostics.Process",
+              "System.Diagnostics.TraceSource",
+              "System.IO",
+              "System.IO.FileSystem.AccessControl",
+              "System.Linq",
+              "System.Memory",
+              "System.Net.Sockets",
+              "System.Numerics.Vectors",
+              "System.Private.CoreLib",
+              "System.Reflection",
+              "System.Reflection.Metadata",
+              "System.Runtime",
+              "System.Runtime.CompilerServices.Unsafe",
+              "System.Runtime.Extensions",
+              "System.Runtime.InteropServices",
+              "System.Security.Cryptography",
+              "System.Security.Cryptography.Algorithms",
+              "System.Security.Cryptography.Primitives",
+              "System.Security.AccessControl",
+              "System.Security.Principal.Windows",
+              "System.Text.Encoding",
+              "System.Text.Encoding.CodePages",
+              "System.Text.Encodings.Web",
+              "System.Text.Json",
+              "System.Text.RegularExpressions",
+              "System.Threading",
+              "System.Threading.Tasks.Extensions",
+              "System.Xml.ReaderWriter",
+              "UniTask",
+              "Unity.Mathematics",
+              "UnityEditor",
+              "UnityEditor.CoreModule",
+              "UnityEditor.TestRunner",
+              "UnityEngine",
+              "UnityEngine.AnimationModule",
+              "UnityEngine.CoreModule",
+              "UnityEngine.SceneManagementModule",
+              "UnityEngine.TestRunner",
+              "UnityEngine.UI",
+              "netstandard",
+              "nunit.framework",
+              "xunit.abstractions",
+              "xunit.analyzers",
+              "xunit.assert",
+              "xunit.core",
+              "xunit.extensibility.core",
+              "xunit.extensibility.execution",
+              "xunit.runner.visualstudio"
+            ]
+          },
+          {
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/Packages",
+              "src/Ucli.Unity/Library/PackageCache"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "classifiers": {
+    "codeKind": [],
+    "domain": [
+      {
+        "label": "Application",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli.Application"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Cli",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli/"
+            ]
+          },
+          {
+            "projectExact": [
+              "src/Ucli/Ucli.csproj"
+            ],
+            "pathPrefix": [
+              "ConsoleAppFramework"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Contracts",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli.Contracts"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Infrastructure",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli.Infrastructure"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Tests",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/Tests",
+              "tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Runtime.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Tools",
+        "matches": [
+          {
+            "pathPrefix": [
+              "tools/Ucli.SchemaGenerator"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Unity",
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      }
+    ],
+    "layer": [
+      {
+        "label": "ApplicationBootstrap",
+        "matches": [
+          {
+            "pathExact": [
+              "src/Ucli.Application/AssemblyInfo.cs",
+              "src/Ucli.Application/GlobalUsings.cs",
+              "src/Ucli.Application/Ucli.Application.csproj",
+              "src/Ucli.Application/UcliApplicationServiceCollectionExtensions.cs"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ApplicationDiagnostics",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Diagnostics"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Application/Diagnostics"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Diagnostics"
+            ],
+            "pathExact": [
+              "src/Ucli.Application/Ucli.Application.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ApplicationFeatures",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Features"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Application/Features"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Features"
+            ],
+            "pathExact": [
+              "src/Ucli.Application/Ucli.Application.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ApplicationShared",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Shared"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Application/Shared"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Shared"
+            ],
+            "pathExact": [
+              "src/Ucli.Application/Ucli.Application.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ApplicationTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Application.Tests"
+            ],
+            "pathPrefix": [
+              "tests/Ucli.Application.Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Ucli.Application.Tests/Ucli.Application.Tests.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ArchitectureTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Architecture.Tests"
+            ],
+            "pathPrefix": [
+              "tests/Ucli.Architecture.Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliAdapters",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Features",
+              "MackySoft.Ucli.Shared",
+              "MackySoft.Ucli.UnityIntegration"
+            ],
+            "pathPrefix": [
+              "src/Ucli/Features",
+              "src/Ucli/Shared",
+              "src/Ucli/UnityIntegration"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Features",
+              "MackySoft.Ucli.Shared",
+              "MackySoft.Ucli.UnityIntegration"
+            ],
+            "pathExact": [
+              "src/Ucli/Ucli.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliCommandHost",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Cli"
+            ],
+            "pathPrefix": [
+              "src/Ucli/Hosting/Cli"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Cli"
+            ],
+            "pathExact": [
+              "src/Ucli/Ucli.csproj"
+            ]
+          },
+          {
+            "projectExact": [
+              "src/Ucli/Ucli.csproj"
+            ],
+            "pathPrefix": [
+              "ConsoleAppFramework"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliComposition",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Composition"
+            ],
+            "pathPrefix": [
+              "src/Ucli/Hosting/Composition"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Composition"
+            ],
+            "pathExact": [
+              "src/Ucli/Ucli.csproj"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli/Ucli.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliRoot",
+        "matches": [
+          {
+            "pathExact": [
+              "src/Ucli/GlobalUsings.cs",
+              "src/Ucli/Hosting/AssemblyInfo.cs",
+              "src/Ucli/Hosting/Program.cs"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliSupervisor",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Supervisor"
+            ],
+            "pathPrefix": [
+              "src/Ucli/Hosting/Supervisor"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Hosting.Supervisor"
+            ],
+            "pathExact": [
+              "src/Ucli/Ucli.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "CliHostTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Tests",
+              "MackySoft.Ucli.Tests"
+            ],
+            "pathPrefix": [
+              "tests/Ucli.Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Ucli.Tests/Ucli.Tests.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Contracts",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Contracts"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Contracts"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Contracts/Ucli.Contracts.csproj"
+            ]
+          },
+          {
+            "pathPrefix": [
+              "src/Ucli.Contracts/Compatibility"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "ContractsTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Contracts.Tests"
+            ],
+            "pathPrefix": [
+              "tests/Ucli.Contracts.Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Infrastructure",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Infrastructure"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Infrastructure"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Infrastructure/Ucli.Infrastructure.csproj"
+            ]
+          },
+          {
+            "pathPrefix": [
+              "src/Ucli.Infrastructure/Compatibility"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "InfrastructureTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Infrastructure.Tests"
+            ],
+            "pathPrefix": [
+              "tests/Ucli.Infrastructure.Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Ucli.Infrastructure.Tests/Ucli.Infrastructure.Tests.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "TestsHelper",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Tests",
+              "MackySoft.Ucli.Tests",
+              "MackySoft.Ucli.Tests.Helper"
+            ],
+            "pathPrefix": [
+              "tests/Tests.Helper"
+            ]
+          },
+          {
+            "pathExact": [
+              "tests/Tests.Helper/Tests.Helper.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Tools",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.SchemaGenerator"
+            ],
+            "pathPrefix": [
+              "tools/Ucli.SchemaGenerator"
+            ]
+          },
+          {
+            "pathExact": [
+              "tools/Ucli.SchemaGenerator/Ucli.SchemaGenerator.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityExecution",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Execution"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Execution"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Execution"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityIndex",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Index"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Index"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Index"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityIpc",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Ipc"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Ipc"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Ipc"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityProject",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Project"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Project"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Project"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityRuntime",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Runtime"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Runtime"
+            ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Runtime"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnitySupport",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Build",
+              "MackySoft.Ucli.Unity.Compatibility",
+              "MackySoft.Ucli.Unity.SceneInspection"
+            ],
+              "pathPrefix": [
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildAudit",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPipeline",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildProfiles",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildPreconditions",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility",
+                "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/SceneInspection"
+              ]
+          },
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Build",
+              "MackySoft.Ucli.Unity.Compatibility",
+              "MackySoft.Ucli.Unity.SceneInspection"
+            ],
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          },
+          {
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildProfiles",
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/BuildRunner"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/AssemblyInfo.cs",
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/Compatibility/IsExternalInit.cs",
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity/Editor/MackySoft.Ucli.Unity.Editor.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj"
+            ]
+          }
+        ]
+      },
+      {
+        "label": "UnityTests",
+        "matches": [
+          {
+            "namespacePrefix": [
+              "MackySoft.Ucli.Unity.Sandbox.Tests",
+              "MackySoft.Ucli.Unity.Tests"
+            ],
+            "pathPrefix": [
+              "src/Ucli.Unity/Assets/Tests"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Sandbox.Tests/Editor/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.asmdef",
+              "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Editor/MackySoft.Ucli.Unity.Tests.Editor.asmdef",
+              "src/Ucli.Unity/Assets/Tests/MackySoft.Ucli.Unity.Tests/Runtime/MackySoft.Ucli.Unity.Tests.Runtime.asmdef",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Runtime.csproj"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "policies": {
+    "dependencies": [
+      {
+        "from": {
+          "layer": [
+            "ApplicationBootstrap"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationBootstrap",
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ApplicationDiagnostics"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ApplicationFeatures"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ApplicationShared"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationDiagnostics",
+              "ApplicationShared",
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ApplicationTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationBootstrap",
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "ApplicationTests",
+              "Contracts",
+              "TestsHelper"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ArchitectureTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ArchitectureTests"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliAdapters"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "CliAdapters",
+              "Contracts",
+              "Infrastructure"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliCommandHost"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "CliAdapters",
+              "CliCommandHost",
+              "CliComposition",
+              "Contracts",
+              "Infrastructure"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliComposition"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationBootstrap",
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "CliAdapters",
+              "CliCommandHost",
+              "CliComposition",
+              "CliSupervisor",
+              "Contracts",
+              "Infrastructure"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliHostTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "ApplicationBootstrap",
+              "ApplicationDiagnostics",
+              "ApplicationFeatures",
+              "ApplicationShared",
+              "CliAdapters",
+              "CliCommandHost",
+              "CliComposition",
+              "CliHostTests",
+              "CliRoot",
+              "CliSupervisor",
+              "Contracts",
+              "Infrastructure",
+              "TestsHelper"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliRoot"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "CliAdapters",
+              "CliCommandHost",
+              "CliComposition",
+              "CliRoot",
+              "CliSupervisor",
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "CliSupervisor"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "CliAdapters",
+              "CliComposition",
+              "CliSupervisor"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "Contracts"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "ContractsTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "ContractsTests",
+              "TestsHelper"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "Infrastructure"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "InfrastructureTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "InfrastructureTests",
+              "TestsHelper"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "TestsHelper"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "TestsHelper"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "Tools"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Tools"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityExecution"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityExecution",
+              "UnityIndex",
+              "UnityProject",
+              "UnityRuntime",
+              "UnitySupport"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityIndex"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityIndex",
+              "UnitySupport"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityIpc"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityExecution",
+              "UnityIndex",
+              "UnityIpc",
+              "UnityProject",
+              "UnityRuntime",
+              "UnitySupport"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityProject"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityProject"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityRuntime"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "UnityRuntime"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnitySupport"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityIpc",
+              "UnityProject",
+              "UnityRuntime",
+              "UnitySupport"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      },
+      {
+        "from": {
+          "layer": [
+            "UnityTests"
+          ]
+        },
+        "allow": [
+          {
+            "layer": [
+              "Contracts",
+              "Infrastructure",
+              "UnityExecution",
+              "UnityIndex",
+              "UnityIpc",
+              "UnityProject",
+              "UnityRuntime",
+              "UnitySupport",
+              "UnityTests"
+            ]
+          },
+          {
+            "subject": "external"
+          }
+        ]
+      }
+    ]
+  },
+  "coverage": {
+    "ownedSubjectsMustClassify": [
+      "domain",
+      "layer"
+    ],
+    "localSubjectsMustBeOwned": [
+      {
+        "matches": [
+          {
+            "pathPrefix": [
+              "src/Ucli/",
+              "src/Ucli.Application",
+              "src/Ucli.Contracts",
+              "src/Ucli.Infrastructure",
+              "src/Ucli.Unity/Assets/MackySoft/MackySoft.Ucli.Unity",
+              "src/Ucli.Unity/Assets/Tests",
+              "tests",
+              "tools/Ucli.SchemaGenerator"
+            ]
+          },
+          {
+            "pathExact": [
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Sandbox.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Editor.csproj",
+              "src/Ucli.Unity/MackySoft.Ucli.Unity.Tests.Runtime.csproj"
+            ]
+          }
+        ]
+      }
+    ]
+  },
   "thresholds": {
     "cyclomaticComplexity": 10,
     "methodLoc": 20,

--- a/.dotmet/targets.json
+++ b/.dotmet/targets.json
@@ -1,0 +1,16 @@
+{
+  "contractVersion": "dotmet.targetSet@1",
+  "id": "ucli",
+  "targets": [
+    {
+      "id": "dotnet",
+      "adapter": "dotnet",
+      "solutionPath": "Ucli.slnx"
+    },
+    {
+      "id": "unity",
+      "adapter": "unity",
+      "projectPath": "src/Ucli.Unity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Update dotmet rules from the legacy layer-only shape to subject, classifier, dependency policy, threshold, and coverage rules.
- Add a target set so dotmet analyzes both the .NET solution and Unity project from the shared repository configuration.
- Track shared dotmet configuration while keeping dotmet local state ignored.

## Scope
- `.dotmet/rules.json`
- `.dotmet/targets.json`
- `.dotmet/.gitignore`

## Verification
- `jq -e . .dotmet/rules.json`
- `jq -e . .dotmet/targets.json`
- `dotnet run --project /Users/makihiro/.codex/worktrees/2a2b/dotmet/src/Dotmet.Cli -- analyze --repositoryRoot /Users/makihiro/Repositories/ucli --cacheMode off --outputPath <temp>/analyze.json --pretty`
  - status: `ok`
  - analysisCompleteness: `full`
  - rulesCoverage: `full`
  - referenceResolution: `full`
  - unresolved references: `0`
  - command exit code: `1` because the updated rules expose existing fail-impact findings

## Risks / Rollback
- Risk: the stricter rules expose existing architecture and metric findings that were not enforced by the old rules.
- Rollback: revert this dotmet configuration commit.

## Checklist
- [x] dotmet JSON configuration is valid
- [x] dotnet and Unity targets are both present in the target set
- [x] dotmet analysis reaches full completeness and full rules coverage

Issue: none (ad-hoc task)