### PR TITLE
feat(skills): add tier option

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "mackysoft.agentskills.cli": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "commands": [
         "agent-skills"
       ],

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Supported host keys are `openai`, `claude`, and `copilot`. Project scope install
 
 Run the command from the target repository. Use `--repoRoot <path>` only when the current working directory is outside the repository or when automation needs to select a repository explicitly.
 
-The `--tier` option is required on every `ucli skills` subcommand. uCLI defines `basic`, `advanced`, and `developer`; the bundled official skills currently belong to `basic`. Selecting `advanced` or `developer` is valid and succeeds with an empty skill set until uCLI ships skills in those tiers. To select multiple tiers in one command, pass a comma-separated value such as `--tier basic,advanced`.
+uCLI defines `basic`, `advanced`, and `developer`; the bundled official skills currently belong to `basic`. `skills export`, `install`, `update`, `uninstall`, and `doctor` require `--tier`. `skills list` may omit `--tier` to show all defined tiers and their bundled skill counts. Selecting `advanced` or `developer` is valid and succeeds with an empty skill set until uCLI ships skills in those tiers. To select multiple tiers in one command, pass a comma-separated value such as `--tier basic,advanced`.
 
-Use `skills list` when you want to inspect the bundled skills, selected tiers, supported hosts, target directories, and reload guidance:
+Use `skills list` when you want to inspect the bundled skills, selected tiers, available tiers, supported hosts, target directories, and reload guidance:
 
 ```bash
-ucli skills list --tier basic
+ucli skills list
 ```
 
 Use user scope only for local, non-repository defaults:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ uCLI ships official agent skills with the CLI package. Install them when an agen
 Install the skills into a repository for the agent host you use:
 
 ```bash
-ucli skills install --host openai --scope project
+ucli skills install --host openai --tier basic --scope project
 ```
 
 Supported host keys are `openai`, `claude`, and `copilot`. Project scope installs host-native skill files under the repository root:
@@ -92,29 +92,31 @@ Supported host keys are `openai`, `claude`, and `copilot`. Project scope install
 
 Run the command from the target repository. Use `--repoRoot <path>` only when the current working directory is outside the repository or when automation needs to select a repository explicitly.
 
-Use `skills list` when you want to inspect the bundled skills, supported hosts, target directories, and reload guidance:
+The `--tier` option is required on every `ucli skills` subcommand. uCLI defines `basic`, `advanced`, and `developer`; the bundled official skills currently belong to `basic`. Selecting `advanced` or `developer` is valid and succeeds with an empty skill set until uCLI ships skills in those tiers. To select multiple tiers in one command, pass a comma-separated value such as `--tier basic,advanced`.
+
+Use `skills list` when you want to inspect the bundled skills, selected tiers, supported hosts, target directories, and reload guidance:
 
 ```bash
-ucli skills list
+ucli skills list --tier basic
 ```
 
 Use user scope only for local, non-repository defaults:
 
 ```bash
-ucli skills install --host openai --scope user
+ucli skills install --host openai --tier basic --scope user
 ```
 
 Preview file changes before writing:
 
 ```bash
-ucli skills install --host openai --scope project --dryRun --printDiff
+ucli skills install --host openai --tier basic --scope project --dryRun --printDiff
 ```
 
 Keep installed skills aligned with the current CLI version and diagnose drift:
 
 ```bash
-ucli skills update --host openai --scope project
-ucli skills doctor --host openai --scope project
+ucli skills update --host openai --tier basic --scope project
+ucli skills doctor --host openai --tier basic --scope project
 ```
 
 After installing or updating, reload the agent host. The command result includes `payload.reloadGuidance`; for Codex, start a new session or restart the app so newly installed skills are loaded.

--- a/schemas/v1/cli-output/payload/skills.list.schema.json
+++ b/schemas/v1/cli-output/payload/skills.list.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/skills.list.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "tiers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "basic",
+          "advanced",
+          "developer"
+        ]
+      }
+    },
+    "availableTiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tier": {
+            "type": "string",
+            "enum": [
+              "basic",
+              "advanced",
+              "developer"
+            ]
+          },
+          "skillCount": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "tier",
+          "skillCount"
+        ]
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "skillName": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "basic",
+              "advanced",
+              "developer"
+            ]
+          },
+          "contentDigest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "hostArtifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "digest": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{64}$"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "materializedFrontmatterDigest": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{64}$"
+                }
+              },
+              "required": [
+                "host",
+                "path",
+                "digest",
+                "materializedFrontmatterDigest"
+              ]
+            }
+          }
+        },
+        "required": [
+          "skillName",
+          "displayName",
+          "description",
+          "tier",
+          "contentDigest",
+          "hostArtifacts"
+        ]
+      }
+    },
+    "supportedHosts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "host": {
+            "type": "string"
+          },
+          "projectTargetDirectory": {
+            "type": "string"
+          },
+          "userTargetDirectory": {
+            "type": "string"
+          },
+          "reloadGuidance": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "host",
+          "projectTargetDirectory",
+          "userTargetDirectory",
+          "reloadGuidance"
+        ]
+      }
+    }
+  },
+  "required": [
+    "tiers",
+    "availableTiers",
+    "skills",
+    "supportedHosts"
+  ]
+}

--- a/schemas/v1/schema-manifest.json
+++ b/schemas/v1/schema-manifest.json
@@ -202,6 +202,12 @@
       "command": "codes.describe"
     },
     {
+      "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/skills.list.schema.json",
+      "path": "cli-output/payload/skills.list.schema.json",
+      "kind": "cli-output-payload",
+      "command": "skills.list"
+    },
+    {
       "$id": "https://schemas.mackysoft.dev/ucli/v1/cli-output/payload/play.status.schema.json",
       "path": "cli-output/payload/play.status.schema.json",
       "kind": "cli-output-payload",

--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -114,8 +114,33 @@ if ! grep -F '"skillName": "ucli-plan-apply"' <<< "${skills_list}" >/dev/null; t
   exit 1
 fi
 
+require_python3
+SKILLS_LIST_JSON="${skills_list}" python3 - <<'PY'
+import json
+import os
+import sys
+
+root = json.loads(os.environ["SKILLS_LIST_JSON"])
+payload = root.get("payload") or {}
+actual = [
+    (tier.get("tier"), tier.get("skillCount"))
+    for tier in payload.get("availableTiers", [])
+]
+expected = [
+    ("basic", 4),
+    ("advanced", 0),
+    ("developer", 0),
+]
+if actual != expected:
+    print(
+        f"ucli skills list did not report expected availableTiers. Expected: {expected}. Actual: {actual}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
 export_path="${tool_path}/exported-skills"
-"${tool_path}/ucli" skills export --host openai --output "${export_path}" >/dev/null
+"${tool_path}/ucli" skills export --host openai --tier basic --output "${export_path}" >/dev/null
 while IFS= read -r relative_path; do
   exported_file="${export_path}/${relative_path}"
   if [[ ! -f "${exported_file}" ]]; then
@@ -125,9 +150,9 @@ while IFS= read -r relative_path; do
 done < <(list_host_independent_skill_files)
 
 install_repo="$(mktemp -d "${temp_root%/}/ucli-skills-install.XXXXXX")"
-"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
-"${tool_path}/ucli" skills install --host openai --scope project --repoRoot "${install_repo}" >/dev/null
-"${tool_path}/ucli" skills doctor --host openai --scope project --repoRoot "${install_repo}" >/dev/null
+"${tool_path}/ucli" skills install --host openai --tier basic --scope project --repoRoot "${install_repo}" >/dev/null
+"${tool_path}/ucli" skills install --host openai --tier basic --scope project --repoRoot "${install_repo}" >/dev/null
+"${tool_path}/ucli" skills doctor --host openai --tier basic --scope project --repoRoot "${install_repo}" >/dev/null
 installed_path="${install_repo}/.agents/skills"
 if [[ ! -d "${installed_path}" ]]; then
   echo "ucli skills install did not create the project skills directory: ${installed_path}" >&2

--- a/skills/definitions/ucli-plan-apply/skill.json
+++ b/skills/definitions/ucli-plan-apply/skill.json
@@ -3,6 +3,7 @@
   "skillName": "ucli-plan-apply",
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
+  "tier": "basic",
   "references": [
     "request-workflow.md"
   ]

--- a/skills/definitions/ucli-read-project/skill.json
+++ b/skills/definitions/ucli-read-project/skill.json
@@ -3,6 +3,7 @@
   "skillName": "ucli-read-project",
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
+  "tier": "basic",
   "references": [
     "project-reading-workflow.md"
   ]

--- a/skills/definitions/ucli-troubleshoot/skill.json
+++ b/skills/definitions/ucli-troubleshoot/skill.json
@@ -3,6 +3,7 @@
   "skillName": "ucli-troubleshoot",
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
+  "tier": "basic",
   "references": [
     "troubleshooting-workflow.md"
   ]

--- a/skills/definitions/ucli-verify-changes/skill.json
+++ b/skills/definitions/ucli-verify-changes/skill.json
@@ -3,6 +3,7 @@
   "skillName": "ucli-verify-changes",
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
+  "tier": "basic",
   "references": [
     "verification-workflow.md"
   ]

--- a/skills/generated/ucli-plan-apply/agent-skill.json
+++ b/skills/generated/ucli-plan-apply/agent-skill.json
@@ -3,8 +3,9 @@
   "skillName": "ucli-plan-apply",
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
+  "tier": "basic",
   "contentDigest": "d3d9db28b8eee92bf52611edf83d4c8804b8af9d7a23a224f12ccf1435cf6551",
-  "manifestDigest": "ddf6f9b953bcc0a7f86de75db3ec5b0c750e6bcf57f89991ae1b398de0732709",
+  "manifestDigest": "d1e4fe621d3e1a5c970859cc82eb28159e478abd5397a3cc88499de92f278ea3",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-read-project/agent-skill.json
+++ b/skills/generated/ucli-read-project/agent-skill.json
@@ -3,8 +3,9 @@
   "skillName": "ucli-read-project",
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
+  "tier": "basic",
   "contentDigest": "83b22557264afc9cab9190764c503159731609fe662fed35000ea9dff5228474",
-  "manifestDigest": "8cd1cad63edf03d6c2cc47cdb8c7076d1dddb3c026fb70cabb77c625f496bd65",
+  "manifestDigest": "2efdaa008a620ed0f8202a44450faccfb6516f9aced8dd258310f24ee6c2eca0",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-troubleshoot/agent-skill.json
+++ b/skills/generated/ucli-troubleshoot/agent-skill.json
@@ -3,8 +3,9 @@
   "skillName": "ucli-troubleshoot",
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
+  "tier": "basic",
   "contentDigest": "59f0d5c66874c986a0f70e8cf01a802ec5eae35e7eb65bad218954b6d9be81b6",
-  "manifestDigest": "40aff6408d0fbcf7e97c7c199afac90afd0ea159c8c8a30f409a2c355a8e59fe",
+  "manifestDigest": "c1d44f9c541e5b8d2be103ea94584a9477c7de5845b90df648b3280ac8f74da8",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-verify-changes/agent-skill.json
+++ b/skills/generated/ucli-verify-changes/agent-skill.json
@@ -3,8 +3,9 @@
   "skillName": "ucli-verify-changes",
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
+  "tier": "basic",
   "contentDigest": "207c2c6d9ae29d3c66ddc1aa7f3ef73850adb6fbba4339304055ad040d2cff70",
-  "manifestDigest": "259464141b649dda96b1843ec1808520727f2448feafb110e3daa85a4460a58c",
+  "manifestDigest": "fbb64766cf1486740d7f0c6a01f639c59d57156cf0ba3e0c35a917e224ffb783",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/src/Ucli/Hosting/Cli/Common/Parsing/SubcommandValidationHelper.cs
+++ b/src/Ucli/Hosting/Cli/Common/Parsing/SubcommandValidationHelper.cs
@@ -101,8 +101,9 @@ internal static class SubcommandValidationHelper
             return null;
         }
 
-        var unexpectedArgument = args[expectedArgumentCount];
-        if (CommandTokenClassifier.IsHelpOptionToken(unexpectedArgument)
+        var unexpectedArgument = FindUnexpectedPositionalArgument(args, expectedArgumentCount);
+        if (unexpectedArgument == null
+            || CommandTokenClassifier.IsHelpOptionToken(unexpectedArgument)
             || CommandTokenClassifier.IsVersionOptionToken(unexpectedArgument))
         {
             return null;
@@ -111,5 +112,31 @@ internal static class SubcommandValidationHelper
         return CommandResult.InvalidArgument(
             command: resultCommandName,
             message: $"Argument '{unexpectedArgument}' is not recognized.");
+    }
+
+    private static string? FindUnexpectedPositionalArgument (
+        string[] args,
+        int startIndex)
+    {
+        var mayBeOptionValue = false;
+        for (var i = startIndex; i < args.Length; i++)
+        {
+            var argument = args[i];
+            if (CommandTokenClassifier.IsOptionToken(argument))
+            {
+                mayBeOptionValue = true;
+                continue;
+            }
+
+            if (mayBeOptionValue)
+            {
+                mayBeOptionValue = false;
+                continue;
+            }
+
+            return argument;
+        }
+
+        return null;
     }
 }

--- a/src/Ucli/Hosting/Cli/Common/Tokens/CommandTokenClassifier.cs
+++ b/src/Ucli/Hosting/Cli/Common/Tokens/CommandTokenClassifier.cs
@@ -20,6 +20,15 @@ internal static class CommandTokenClassifier
             || token.StartsWith("-", StringComparison.Ordinal);
     }
 
+    /// <summary> Determines whether a token is an option token. </summary>
+    /// <param name="token"> The command-line token. </param>
+    /// <returns> <see langword="true" /> when token starts with <c>-</c>; otherwise <see langword="false" />. </returns>
+    public static bool IsOptionToken (string? token)
+    {
+        return !string.IsNullOrWhiteSpace(token)
+            && token.StartsWith("-", StringComparison.Ordinal);
+    }
+
     /// <summary> Determines whether a token is a help option token. </summary>
     /// <param name="token"> The command-line token. </param>
     /// <returns> <see langword="true" /> when token is <c>-h</c> or <c>--help</c>; otherwise <see langword="false" />. </returns>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -34,7 +34,7 @@ internal static class SkillsCommandOptionNormalizer
             return null;
         }
 
-        var result = MackySoft.AgentSkills.Tiers.SkillTierSelection.Parse(UcliSkillTiers.All, tiers);
+        var result = MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseSelectedTiers(UcliSkillTierLiterals.Defined, tiers);
         if (!result.IsSuccess)
         {
             errorResult = CommandResult.InvalidArgument(

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -15,6 +15,37 @@ internal static class SkillsCommandOptionNormalizer
     private const string DirectoryExportFormatLiteral = "directory";
     private const string ZipExportFormatLiteral = "zip";
 
+    /// <summary> Normalizes the required tier option. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="tiers"> The raw tier options. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The normalized tier selection, or <see langword="null" /> when normalization fails. </returns>
+    public static IReadOnlyList<MackySoft.AgentSkills.Tiers.SkillTier>? NormalizeTiers (
+        string command,
+        string[]? tiers,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        errorResult = null;
+        if (tiers == null || tiers.Length == 0)
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--tier' is required.");
+            return null;
+        }
+
+        var result = MackySoft.AgentSkills.Tiers.SkillTierSelection.Parse(UcliSkillTiers.All, tiers);
+        if (!result.IsSuccess)
+        {
+            errorResult = CommandResult.InvalidArgument(
+                command,
+                result.Failure!.Message);
+            return null;
+        }
+
+        return result.Value!;
+    }
+
     /// <summary> Normalizes a required host option to its canonical host key. </summary>
     /// <param name="command"> The command name used for error results. </param>
     /// <param name="host"> The raw host option. </param>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -46,6 +46,33 @@ internal static class SkillsCommandOptionNormalizer
         return result.Value!;
     }
 
+    /// <summary> Normalizes the optional tier option used by list discovery. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="tiers"> The raw tier options. When omitted, all defined product-owned tiers are selected. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The normalized tier selection, or <see langword="null" /> when normalization fails. </returns>
+    public static IReadOnlyList<MackySoft.AgentSkills.Tiers.SkillTier>? NormalizeOptionalTiers (
+        string command,
+        string[]? tiers,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        errorResult = null;
+        var result = tiers == null || tiers.Length == 0
+            ? MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseDefinedTiers(UcliSkillTierLiterals.Defined)
+            : MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseSelectedTiers(UcliSkillTierLiterals.Defined, tiers);
+        if (!result.IsSuccess)
+        {
+            errorResult = CommandResult.InvalidArgument(
+                command,
+                result.Failure!.Message);
+            return null;
+        }
+
+        return result.Value!;
+    }
+
     /// <summary> Normalizes a required host option to its canonical host key. </summary>
     /// <param name="command"> The command name used for error results. </param>
     /// <param name="host"> The raw host option. </param>

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -23,16 +23,19 @@ internal static class SkillsCommandResultFactory
     /// <returns> The command result serialized to stdout. </returns>
     public static CommandResult CreateList (
         IReadOnlyList<CanonicalSkillPackage> packages,
-        SkillHostAdapterSet hostAdapters)
+        SkillHostAdapterSet hostAdapters,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(packages);
         ArgumentNullException.ThrowIfNull(hostAdapters);
+        ArgumentNullException.ThrowIfNull(tiers);
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsList,
             message: "uCLI official SKILL package list retrieval completed.",
             payload: new
             {
+                tiers,
                 skills = packages
                     .OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal)
                     .Select(static package => new
@@ -40,6 +43,7 @@ internal static class SkillsCommandResultFactory
                         package.Manifest.SkillName,
                         package.Manifest.DisplayName,
                         package.Manifest.Description,
+                        tier = package.Manifest.Tier.Value,
                         package.Manifest.ContentDigest,
                         package.Manifest.HostArtifacts,
                     })
@@ -66,10 +70,12 @@ internal static class SkillsCommandResultFactory
         IReadOnlyList<CanonicalSkillPackage> packages,
         string host,
         SkillExportFormat format,
-        string reloadGuidance)
+        string reloadGuidance,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(packages);
+        ArgumentNullException.ThrowIfNull(tiers);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -84,6 +90,7 @@ internal static class SkillsCommandResultFactory
             payload: new
             {
                 host,
+                tiers,
                 format = ToExportFormatLiteral(format),
                 outputRoot = result.Value!,
                 skills = CreateSkillNameList(packages),
@@ -102,9 +109,11 @@ internal static class SkillsCommandResultFactory
         string host,
         SkillScopeKind scope,
         string? repositoryRoot,
-        string reloadGuidance)
+        string reloadGuidance,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(tiers);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -127,6 +136,7 @@ internal static class SkillsCommandResultFactory
             payload: new
             {
                 host,
+                tiers,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 installResult.TargetRoot,
@@ -152,9 +162,11 @@ internal static class SkillsCommandResultFactory
         string host,
         SkillScopeKind scope,
         string? repositoryRoot,
-        string reloadGuidance)
+        string reloadGuidance,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(tiers);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -177,6 +189,7 @@ internal static class SkillsCommandResultFactory
             payload: new
             {
                 host,
+                tiers,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 updateResult.TargetRoot,
@@ -202,9 +215,11 @@ internal static class SkillsCommandResultFactory
         string host,
         SkillScopeKind scope,
         string? repositoryRoot,
-        string reloadGuidance)
+        string reloadGuidance,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(tiers);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -227,6 +242,7 @@ internal static class SkillsCommandResultFactory
             payload: new
             {
                 host,
+                tiers,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 uninstallResult.TargetRoot,
@@ -249,14 +265,17 @@ internal static class SkillsCommandResultFactory
         SkillDoctorResult result,
         SkillScopeKind scope,
         string? repositoryRoot,
-        string reloadGuidance)
+        string reloadGuidance,
+        IReadOnlyList<string> tiers)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ArgumentNullException.ThrowIfNull(tiers);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
         var payload = new
         {
             host = result.Host,
+            tiers,
             scope = ToScopeLiteral(scope),
             repositoryRoot,
             result.TargetRoot,

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -18,25 +18,30 @@ internal static class SkillsCommandResultFactory
     private const string UserScopeLiteral = "user";
 
     /// <summary> Creates a successful command result for <c>skills list</c>. </summary>
-    /// <param name="packages"> The official SKILL packages. </param>
+    /// <param name="catalog"> The official SKILL package catalog. </param>
     /// <param name="hostAdapters"> The supported host adapter set. </param>
     /// <returns> The command result serialized to stdout. </returns>
     public static CommandResult CreateList (
-        IReadOnlyList<CanonicalSkillPackage> packages,
-        SkillHostAdapterSet hostAdapters,
-        IReadOnlyList<string> tiers)
+        SkillPackageCatalog catalog,
+        SkillHostAdapterSet hostAdapters)
     {
-        ArgumentNullException.ThrowIfNull(packages);
+        ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(hostAdapters);
-        ArgumentNullException.ThrowIfNull(tiers);
 
         return CommandResult.Success(
             command: UcliCommandNames.SkillsList,
             message: "uCLI official SKILL package list retrieval completed.",
             payload: new
             {
-                tiers,
-                skills = packages
+                tiers = catalog.SelectedTiers.Select(static tier => tier.Value).ToArray(),
+                availableTiers = catalog.AvailableTiers
+                    .Select(static tier => new
+                    {
+                        tier = tier.Tier.Value,
+                        skillCount = tier.PackageCount,
+                    })
+                    .ToArray(),
+                skills = catalog.Packages
                     .OrderBy(static package => package.Manifest.SkillName, StringComparer.Ordinal)
                     .Select(static package => new
                     {

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -107,7 +107,7 @@ internal sealed class SkillsDoctorCommand
             return targetErrorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsDoctor, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -42,6 +42,7 @@ internal sealed class SkillsDoctorCommand
     /// <param name="scope"> Required install scope (project|user). </param>
     /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.DoctorSubcommand)]
@@ -50,6 +51,7 @@ internal sealed class SkillsDoctorCommand
         string? scope = null,
         string? repoRoot = null,
         string? targetDir = null,
+        string[]? tier = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -87,6 +89,16 @@ internal sealed class SkillsDoctorCommand
             return errorResult.ExitCode;
         }
 
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsDoctor,
+            tier,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
         var targetResult = targetResolver.ResolveTarget(new SkillInstallRequest(normalizedHost!, normalizedScope!.Value, repositoryRoot, targetDir));
         if (!targetResult.IsSuccess)
         {
@@ -95,12 +107,21 @@ internal sealed class SkillsDoctorCommand
             return targetErrorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsDoctor, packagesResult.Failure!);
             commandResultWriter.WriteToStandardOutput(packageErrorResult);
             return packageErrorResult.ExitCode;
+        }
+
+        var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
+        if (packagesResult.Value!.Count == 0)
+        {
+            var emptyDoctorResult = new SkillDoctorResult(normalizedHost!, targetResult.Value!.TargetRoot, Array.Empty<SkillDoctorDiagnostic>());
+            var emptyCommandResult = SkillsCommandResultFactory.CreateDoctor(emptyDoctorResult, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+            commandResultWriter.WriteToStandardOutput(emptyCommandResult);
+            return emptyCommandResult.ExitCode;
         }
 
         var doctorResult = await doctorService.DiagnoseAsync(
@@ -109,8 +130,7 @@ internal sealed class SkillsDoctorCommand
                 targetResult.Value!.TargetRoot,
                 cancellationToken)
             .ConfigureAwait(false);
-        var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateDoctor(doctorResult, normalizedScope.Value, repositoryRoot, reloadGuidance);
+        var commandResult = SkillsCommandResultFactory.CreateDoctor(doctorResult, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
@@ -35,6 +35,7 @@ internal sealed class SkillsExportCommand
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="output"> Required output directory. </param>
     /// <param name="format"> Optional output format (directory|zip). </param>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ExportSubcommand)]
@@ -42,6 +43,7 @@ internal sealed class SkillsExportCommand
         string? host = null,
         string? output = null,
         string? format = null,
+        string[]? tier = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -79,7 +81,17 @@ internal sealed class SkillsExportCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsExport,
+            tier,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsExport, packagesResult.Failure!);
@@ -95,7 +107,7 @@ internal sealed class SkillsExportCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateExport(exportResult, packagesResult.Value!, normalizedHost!, normalizedFormat.Value, reloadGuidance);
+        var commandResult = SkillsCommandResultFactory.CreateExport(exportResult, packagesResult.Value!, normalizedHost!, normalizedFormat.Value, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
@@ -91,7 +91,7 @@ internal sealed class SkillsExportCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsExport, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -102,7 +102,7 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsInstall, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -42,6 +42,7 @@ internal sealed class SkillsInstallCommand
     /// <param name="dryRun"> --dryRun, Whether to return the install plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>
     /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.InstallSubcommand)]
@@ -53,6 +54,7 @@ internal sealed class SkillsInstallCommand
         bool dryRun = false,
         bool force = false,
         bool printDiff = false,
+        string[]? tier = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -90,7 +92,17 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsInstall,
+            tier,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsInstall, packagesResult.Failure!);
@@ -108,7 +120,7 @@ internal sealed class SkillsInstallCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateInstall(installResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance);
+        var commandResult = SkillsCommandResultFactory.CreateInstall(installResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
@@ -28,17 +28,30 @@ internal sealed class SkillsListCommand
     }
 
     /// <summary> Executes the skills list command and emits the JSON result contract. </summary>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ListSubcommand)]
-    public async Task<int> ListAsync (CancellationToken cancellationToken = default)
+    public async Task<int> ListAsync (
+        string[]? tier = null,
+        CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         CommandExecutionState.MarkStarted();
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsList,
+            tier,
+            out var errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         var commandResult = packagesResult.IsSuccess
-            ? SkillsCommandResultFactory.CreateList(packagesResult.Value!, hostAdapters)
+            ? SkillsCommandResultFactory.CreateList(packagesResult.Value!, hostAdapters, normalizedTiers!.Select(static tier => tier.Value).ToArray())
             : SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsList, packagesResult.Failure!);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;

--- a/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
@@ -28,7 +28,7 @@ internal sealed class SkillsListCommand
     }
 
     /// <summary> Executes the skills list command and emits the JSON result contract. </summary>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Omit to list all defined tiers. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ListSubcommand)]
@@ -39,7 +39,7 @@ internal sealed class SkillsListCommand
         cancellationToken.ThrowIfCancellationRequested();
         CommandExecutionState.MarkStarted();
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeOptionalTiers(
             UcliCommandNames.SkillsList,
             tier,
             out var errorResult);
@@ -49,10 +49,12 @@ internal sealed class SkillsListCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
-        var commandResult = packagesResult.IsSuccess
-            ? SkillsCommandResultFactory.CreateList(packagesResult.Value!, hostAdapters, normalizedTiers!.Select(static tier => tier.Value).ToArray())
-            : SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsList, packagesResult.Failure!);
+        var catalogResult = await packageProvider.GetPackageCatalogAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var commandResult = catalogResult.IsSuccess
+            ? SkillsCommandResultFactory.CreateList(
+                catalogResult.Value!,
+                hostAdapters)
+            : SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsList, catalogResult.Failure!);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
@@ -49,7 +49,7 @@ internal sealed class SkillsListCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         var commandResult = packagesResult.IsSuccess
             ? SkillsCommandResultFactory.CreateList(packagesResult.Value!, hostAdapters, normalizedTiers!.Select(static tier => tier.Value).ToArray())
             : SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsList, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -41,6 +41,7 @@ internal sealed class SkillsUninstallCommand
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="dryRun"> --dryRun, Whether to return the uninstall plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be deleted. </param>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UninstallSubcommand)]
@@ -51,6 +52,7 @@ internal sealed class SkillsUninstallCommand
         string? targetDir = null,
         bool dryRun = false,
         bool force = false,
+        string[]? tier = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -88,7 +90,17 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsUninstall,
+            tier,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUninstall, packagesResult.Failure!);
@@ -105,7 +117,7 @@ internal sealed class SkillsUninstallCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateUninstall(uninstallResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance);
+        var commandResult = SkillsCommandResultFactory.CreateUninstall(uninstallResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -100,7 +100,7 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUninstall, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -42,6 +42,7 @@ internal sealed class SkillsUpdateCommand
     /// <param name="dryRun"> --dryRun, Whether to return the update plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>
     /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
+    /// <param name="tier"> Required SKILL tier literals. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UpdateSubcommand)]
@@ -53,6 +54,7 @@ internal sealed class SkillsUpdateCommand
         bool dryRun = false,
         bool force = false,
         bool printDiff = false,
+        string[]? tier = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -90,7 +92,17 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(cancellationToken).ConfigureAwait(false);
+        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+            UcliCommandNames.SkillsUpdate,
+            tier,
+            out errorResult);
+        if (errorResult is not null)
+        {
+            commandResultWriter.WriteToStandardOutput(errorResult);
+            return errorResult.ExitCode;
+        }
+
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUpdate, packagesResult.Failure!);
@@ -108,7 +120,7 @@ internal sealed class SkillsUpdateCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateUpdate(updateResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance);
+        var commandResult = SkillsCommandResultFactory.CreateUpdate(updateResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -102,7 +102,7 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTiers.All, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUpdate, packagesResult.Failure!);

--- a/src/Ucli/Hosting/Cli/Skills/UcliSkillTierLiterals.cs
+++ b/src/Ucli/Hosting/Cli/Skills/UcliSkillTierLiterals.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Defines product-owned uCLI SKILL tier literals. </summary>
+internal static class UcliSkillTierLiterals
+{
+    /// <summary> Gets the complete set of uCLI-defined SKILL tier literals. </summary>
+    public static IReadOnlyList<string> Defined { get; } = ["basic", "advanced", "developer"];
+}

--- a/src/Ucli/Hosting/Cli/Skills/UcliSkillTiers.cs
+++ b/src/Ucli/Hosting/Cli/Skills/UcliSkillTiers.cs
@@ -1,8 +1,0 @@
-namespace MackySoft.Ucli.Hosting.Cli.Skills;
-
-/// <summary> Defines product-owned uCLI SKILL tier literals. </summary>
-internal static class UcliSkillTiers
-{
-    /// <summary> Gets all supported uCLI SKILL tier literals. </summary>
-    public static IReadOnlyList<string> All { get; } = ["basic", "advanced", "developer"];
-}

--- a/src/Ucli/Hosting/Cli/Skills/UcliSkillTiers.cs
+++ b/src/Ucli/Hosting/Cli/Skills/UcliSkillTiers.cs
@@ -1,0 +1,8 @@
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Defines product-owned uCLI SKILL tier literals. </summary>
+internal static class UcliSkillTiers
+{
+    /// <summary> Gets all supported uCLI SKILL tier literals. </summary>
+    public static IReadOnlyList<string> All { get; } = ["basic", "advanced", "developer"];
+}

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.3.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>
 

--- a/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
+++ b/tests/Tests.Helper/Helpers/JsonAssertions/JsonSchemaArtifactSet.cs
@@ -21,6 +21,7 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
         "enum",
         "const",
         "pattern",
+        "minimum",
         "oneOf",
     };
 
@@ -206,6 +207,13 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
             && !MatchesPattern(element, patternElement))
         {
             errors.Add($"path '{path}' did not match schema pattern.");
+            return;
+        }
+
+        if (schema.TryGetProperty("minimum", out var minimumElement)
+            && !MatchesMinimum(element, minimumElement))
+        {
+            errors.Add($"path '{path}' was less than schema minimum.");
             return;
         }
 
@@ -580,6 +588,12 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
             ValidatePatternDefinition(patternElement, schemaPath, path, errors);
         }
 
+        if (schema.TryGetProperty("minimum", out var minimumElement)
+            && (minimumElement.ValueKind != JsonValueKind.Number || !minimumElement.TryGetDecimal(out _)))
+        {
+            errors.Add($"schema '{schemaPath}' for path '{path}' has a non-number minimum.");
+        }
+
         if (schema.TryGetProperty("oneOf", out var oneOfElement))
         {
             if (oneOfElement.ValueKind != JsonValueKind.Array)
@@ -699,6 +713,23 @@ internal sealed class JsonSchemaArtifactSet : IDisposable
         {
             return false;
         }
+    }
+
+    private static bool MatchesMinimum (
+        JsonElement element,
+        JsonElement minimumElement)
+    {
+        if (element.ValueKind != JsonValueKind.Number)
+        {
+            return true;
+        }
+
+        if (!element.TryGetDecimal(out var value) || !minimumElement.TryGetDecimal(out var minimum))
+        {
+            return false;
+        }
+
+        return value >= minimum;
     }
 
     private static void ValidatePatternDefinition (

--- a/tests/Ucli.Architecture.Tests/Architecture/OfficialSkillDistributionPolicyTests.cs
+++ b/tests/Ucli.Architecture.Tests/Architecture/OfficialSkillDistributionPolicyTests.cs
@@ -1,4 +1,13 @@
 using System.Text.RegularExpressions;
+using MackySoft.AgentSkills.Digests;
+using MackySoft.AgentSkills.Generation;
+using MackySoft.AgentSkills.Hosts.Claude;
+using MackySoft.AgentSkills.Hosts.Copilot;
+using MackySoft.AgentSkills.Hosts.OpenAi;
+using MackySoft.AgentSkills.Hosts.Registration;
+using MackySoft.AgentSkills.Manifests;
+using MackySoft.AgentSkills.Packaging.Canonical;
+using MackySoft.AgentSkills.Sources;
 
 namespace MackySoft.Ucli.Architecture.Tests.Architecture;
 
@@ -138,6 +147,36 @@ public sealed class OfficialSkillDistributionPolicyTests
     }
 
     [Fact]
+    [Trait("Size", "Medium")]
+    public async Task Generated_official_skills_are_in_sync_with_source_definitions ()
+    {
+        var temporaryRoot = Path.Combine(Path.GetTempPath(), $"ucli-skills-generated-drift-{Guid.NewGuid():N}");
+        try
+        {
+            var generatedRoot = Path.Combine(temporaryRoot, "generated");
+            var generationService = CreateGenerationService();
+            var writer = new CanonicalSkillPackageWriter();
+
+            var packagesResult = await generationService.GenerateAllAsync(
+                ArchitectureTestRepository.ToRegularDirectoryFullPath("skills/definitions"),
+                CancellationToken.None);
+            Assert.True(packagesResult.IsSuccess, packagesResult.Failure?.Message);
+
+            var writeResult = await writer.WriteAllAsync(packagesResult.Value!, generatedRoot, cleanOutputRoot: true, CancellationToken.None);
+            Assert.True(writeResult.IsSuccess, writeResult.Failure?.Message);
+
+            AssertGeneratedTreesEqual(ArchitectureTestRepository.ToRegularDirectoryFullPath("skills/generated"), generatedRoot);
+        }
+        finally
+        {
+            if (Directory.Exists(temporaryRoot))
+            {
+                Directory.Delete(temporaryRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     [Trait("Size", "Small")]
     public void Verify_skill_documents_profile_side_effects_and_probe_only_limit ()
     {
@@ -223,6 +262,47 @@ public sealed class OfficialSkillDistributionPolicyTests
                     || fileName.Equals("SKILL.md.template", StringComparison.Ordinal);
             })
             .Select(ArchitectureTestRepository.NormalizeRepositoryRelativePath);
+    }
+
+    private static SkillPackageGenerationService CreateGenerationService ()
+    {
+        var manifestSerializer = new SkillManifestJsonSerializer();
+        return new SkillPackageGenerationService(
+            new SkillSourceDefinitionReader(),
+            new SkillHostAdapterSet(
+            [
+                new ClaudeSkillHostAdapter(),
+                new CopilotSkillHostAdapter(),
+                new OpenAiSkillHostAdapter(),
+            ]),
+            new SkillDigestCalculator(),
+            manifestSerializer,
+            new SkillManifestDigestCalculator(manifestSerializer));
+    }
+
+    private static void AssertGeneratedTreesEqual (
+        string expectedRoot,
+        string actualRoot)
+    {
+        var expectedFiles = EnumerateRelativeFiles(expectedRoot);
+        var actualFiles = EnumerateRelativeFiles(actualRoot);
+        Assert.Equal(expectedFiles, actualFiles);
+
+        foreach (var relativePath in expectedFiles)
+        {
+            var expected = File.ReadAllText(Path.Combine(expectedRoot, relativePath));
+            var actual = File.ReadAllText(Path.Combine(actualRoot, relativePath));
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    private static string[] EnumerateRelativeFiles (string root)
+    {
+        return Directory
+            .EnumerateFiles(root, "*", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static IEnumerable<string> FindRegexMatches (string file, Regex pattern)

--- a/tests/Ucli.Architecture.Tests/Architecture/PackageReferenceBoundaryTests.cs
+++ b/tests/Ucli.Architecture.Tests/Architecture/PackageReferenceBoundaryTests.cs
@@ -35,6 +35,14 @@ public sealed class PackageReferenceBoundaryTests
     [Trait("Size", "Small")]
     public void TestProjects_use_only_allowed_packages ()
     {
+        string[] expectedArchitectureTestPackages =
+        [
+            "coverlet.collector",
+            "MackySoft.AgentSkills",
+            "Microsoft.NET.Test.Sdk",
+            "xunit",
+            "xunit.runner.visualstudio",
+        ];
         string[] expectedTestPackages =
         [
             "coverlet.collector",
@@ -44,7 +52,7 @@ public sealed class PackageReferenceBoundaryTests
         ];
         var expectedPackagesByProject = new Dictionary<string, string[]>(StringComparer.Ordinal)
         {
-            ["tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj"] = expectedTestPackages,
+            ["tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj"] = expectedArchitectureTestPackages,
             ["tests/Tests.Helper/Tests.Helper.csproj"] = expectedTestPackages,
             ["tests/Ucli.Application.Tests/Ucli.Application.Tests.csproj"] = expectedTestPackages,
             ["tests/Ucli.Contracts.Tests/Ucli.Contracts.Tests.csproj"] = expectedTestPackages,

--- a/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
+++ b/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
+++ b/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.3.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -154,7 +154,7 @@ public sealed class PackageMetadataTests
             .GetProperty("tools")
             .GetProperty("mackysoft.agentskills.cli");
 
-        Assert.Equal("0.3.0", tool.GetProperty("version").GetString());
+        Assert.Equal("0.4.0", tool.GetProperty("version").GetString());
         Assert.Contains(
             "agent-skills",
             tool.GetProperty("commands").EnumerateArray().Select(static command => command.GetString()));

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -87,7 +87,7 @@ public sealed class SkillsCliOutputContractTests
     [Trait("Size", "Medium")]
     public async Task SkillsList_ReturnsOfficialSkillsAndSupportedHosts ()
     {
-        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand);
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand, "--tier", "basic");
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.Success, result.ExitCode);
@@ -100,12 +100,14 @@ public sealed class SkillsCliOutputContractTests
 
         var payload = outputJson.RootElement.GetProperty("payload");
         JsonAssert.For(payload)
+            .HasArrayLength("tiers", 1)
             .HasArrayLength("skills", ExpectedSkillNames.Length)
             .HasArrayLength("supportedHosts", 3)
             .HasProperty("skills", 0, static skill => skill
                 .HasString("skillName", ExpectedSkillNames[0])
                 .HasValueKind("displayName", JsonValueKind.String)
                 .HasValueKind("description", JsonValueKind.String)
+                .HasString("tier", "basic")
                 .HasValueKind("contentDigest", JsonValueKind.String)
                 .HasArrayLength("hostArtifacts", 3))
             .HasProperty("supportedHosts", 0, static host => host
@@ -124,11 +126,111 @@ public sealed class SkillsCliOutputContractTests
                 .HasString("userTargetDirectory", "${CODEX_HOME}/skills or ~/.codex/skills")
                 .HasValueKind("reloadGuidance", JsonValueKind.String));
 
+        Assert.Equal(["basic"], payload
+            .GetProperty("tiers")
+            .EnumerateArray()
+            .Select(static tier => tier.GetString() ?? string.Empty)
+            .ToArray());
         Assert.Equal(ExpectedSkillNames, payload
             .GetProperty("skills")
             .EnumerateArray()
             .Select(static skill => skill.GetProperty("skillName").GetString())
             .ToArray());
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData("advanced")]
+    [InlineData("developer")]
+    public async Task SkillsList_WithEmptyTier_ReturnsEmptySkillList (string tier)
+    {
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand, "--tier", tier);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasArrayLength("tiers", 1)
+                .HasArrayLength("skills", 0));
+        Assert.Equal(tier, outputJson.RootElement.GetProperty("payload").GetProperty("tiers")[0].GetString());
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsList_WithMultipleTiers_ReturnsMatchingSkills ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand, "--tier", "basic,advanced");
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        Assert.Equal(["basic", "advanced"], payload
+            .GetProperty("tiers")
+            .EnumerateArray()
+            .Select(static tier => tier.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.Equal(ExpectedSkillNames, payload
+            .GetProperty("skills")
+            .EnumerateArray()
+            .Select(static skill => skill.GetProperty("skillName").GetString())
+            .ToArray());
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsList_WithoutTier_ReturnsInvalidArgument ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsSubcommand_WithEmptyTier_ReturnsSuccessfulEmptyResult (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"empty-tier-{subcommand}");
+        var repoRoot = scope.CreateDirectory("repo");
+        var args = CreateEmptyTierScenarioArgs(subcommand, repoRoot, scope.GetPath("exported"));
+
+        var result = await CliProcessRunner.RunCommandAsync(args);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasArrayLength("tiers", 1));
+        Assert.Equal("advanced", outputJson.RootElement.GetProperty("payload").GetProperty("tiers")[0].GetString());
     }
 
     [Fact]
@@ -143,6 +245,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.ExportSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--output",
             outputRoot);
 
@@ -157,6 +261,7 @@ public sealed class SkillsCliOutputContractTests
         JsonAssert.For(outputJson.RootElement)
             .HasProperty("payload", payload => payload
                 .HasString("host", "openai")
+                .HasArrayLength("tiers", 1)
                 .HasString("format", "directory")
                 .HasString("outputRoot", outputRoot)
                 .HasArrayLength("skills", ExpectedSkillNames.Length)
@@ -185,6 +290,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.ExportSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--format",
             "zip",
             "--output",
@@ -195,6 +302,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.ExportSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--format",
             "zip",
             "--output",
@@ -252,7 +361,9 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.Skills,
             UcliCommandNames.ExportSubcommand,
             "--host",
-            "openai");
+            "openai",
+            "--tier",
+            "basic");
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
         Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
@@ -484,6 +595,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.InstallSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "user");
 
@@ -512,6 +625,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.InstallSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "user",
             "--targetDir",
@@ -521,6 +636,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.UpdateSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "user",
             "--targetDir",
@@ -530,6 +647,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.DoctorSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "user",
             "--targetDir",
@@ -539,6 +658,8 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.UninstallSubcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "user",
             "--targetDir",
@@ -1250,6 +1371,8 @@ public sealed class SkillsCliOutputContractTests
             subcommand,
             "--host",
             "openai",
+            "--tier",
+            "basic",
             "--scope",
             "project",
         };
@@ -1287,6 +1410,9 @@ public sealed class SkillsCliOutputContractTests
             args.Add("--scope");
             args.Add(scope);
         }
+
+        args.Add("--tier");
+        args.Add("basic");
 
         args.AddRange([
             "--repoRoot",
@@ -1334,11 +1460,27 @@ public sealed class SkillsCliOutputContractTests
     {
         return subcommand switch
         {
-            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--output", outputRoot],
-            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
-            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
-            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
-            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--tier", "basic", "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot],
+            _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
+        };
+    }
+
+    private static string[] CreateEmptyTierScenarioArgs (
+        string subcommand,
+        string repoRoot,
+        string outputRoot)
+    {
+        return subcommand switch
+        {
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--tier", "advanced", "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--tier", "advanced", "--scope", "project", "--repoRoot", repoRoot, "--dryRun"],
+            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--tier", "advanced", "--scope", "project", "--repoRoot", repoRoot, "--dryRun"],
+            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--tier", "advanced", "--scope", "project", "--repoRoot", repoRoot, "--dryRun"],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--tier", "advanced", "--scope", "project", "--repoRoot", repoRoot],
             _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
         };
     }
@@ -1351,11 +1493,11 @@ public sealed class SkillsCliOutputContractTests
     {
         return subcommand switch
         {
-            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--output", outputRoot],
-            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
-            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
-            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
-            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
             _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
         };
     }

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -205,6 +205,26 @@ public sealed class SkillsCliOutputContractTests
 
     [Theory]
     [Trait("Size", "Medium")]
+    [InlineData("unknown")]
+    [InlineData("Basic")]
+    [InlineData("advanced ")]
+    public async Task SkillsList_WithInvalidTier_ReturnsInvalidArgument (string tier)
+    {
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand, "--tier", tier);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+        Assert.Contains("Unsupported SKILL tier:", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
     [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
     [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
     [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -26,6 +26,8 @@ public sealed class SkillsCliOutputContractTests
         "ucli-verify-changes",
     ];
 
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
     [Fact]
     [Trait("Size", "Medium")]
     public async Task Skills_WithoutSubcommand_ReturnsJsonEnvelopeError ()
@@ -101,8 +103,18 @@ public sealed class SkillsCliOutputContractTests
         var payload = outputJson.RootElement.GetProperty("payload");
         JsonAssert.For(payload)
             .HasArrayLength("tiers", 1)
+            .HasArrayLength("availableTiers", 3)
             .HasArrayLength("skills", ExpectedSkillNames.Length)
             .HasArrayLength("supportedHosts", 3)
+            .HasProperty("availableTiers", 0, static tier => tier
+                .HasString("tier", "basic")
+                .HasInt32("skillCount", ExpectedSkillNames.Length))
+            .HasProperty("availableTiers", 1, static tier => tier
+                .HasString("tier", "advanced")
+                .HasInt32("skillCount", 0))
+            .HasProperty("availableTiers", 2, static tier => tier
+                .HasString("tier", "developer")
+                .HasInt32("skillCount", 0))
             .HasProperty("skills", 0, static skill => skill
                 .HasString("skillName", ExpectedSkillNames[0])
                 .HasValueKind("displayName", JsonValueKind.String)
@@ -136,6 +148,7 @@ public sealed class SkillsCliOutputContractTests
             .EnumerateArray()
             .Select(static skill => skill.GetProperty("skillName").GetString())
             .ToArray());
+        AssertPayloadMatchesSchema(outputJson.RootElement);
     }
 
     [Theory]
@@ -156,8 +169,24 @@ public sealed class SkillsCliOutputContractTests
         JsonAssert.For(outputJson.RootElement)
             .HasProperty("payload", payload => payload
                 .HasArrayLength("tiers", 1)
+                .HasArrayLength("availableTiers", 3)
                 .HasArrayLength("skills", 0));
         Assert.Equal(tier, outputJson.RootElement.GetProperty("payload").GetProperty("tiers")[0].GetString());
+        Assert.Equal(["basic", "advanced", "developer"], ReadPayloadStringArray(outputJson.RootElement, "availableTiers", "tier"));
+    }
+
+    [Theory]
+    [Trait("Size", "Small")]
+    [InlineData("""{"tiers":["internal"],"availableTiers":[{"tier":"basic","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
+    [InlineData("""{"tiers":["basic"],"availableTiers":[{"tier":"internal","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
+    [InlineData("""{"tiers":["basic"],"availableTiers":[{"tier":"basic","skillCount":-1}],"skills":[],"supportedHosts":[]}""")]
+    public void SkillsListPayloadSchema_RejectsInvalidTierInventory (string payloadJson)
+    {
+        using var payload = JsonDocument.Parse(payloadJson);
+
+        var errors = ValidateSkillsListPayload(payload.RootElement);
+
+        Assert.NotEmpty(errors);
     }
 
     [Fact]
@@ -180,6 +209,7 @@ public sealed class SkillsCliOutputContractTests
             .EnumerateArray()
             .Select(static tier => tier.GetString() ?? string.Empty)
             .ToArray());
+        Assert.Equal(["basic", "advanced", "developer"], ReadPayloadStringArray(outputJson.RootElement, "availableTiers", "tier"));
         Assert.Equal(ExpectedSkillNames, payload
             .GetProperty("skills")
             .EnumerateArray()
@@ -189,18 +219,30 @@ public sealed class SkillsCliOutputContractTests
 
     [Fact]
     [Trait("Size", "Medium")]
-    public async Task SkillsList_WithoutTier_ReturnsInvalidArgument ()
+    public async Task SkillsList_WithoutTier_ReturnsAllDefinedTiersAndMatchingSkills ()
     {
         var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand);
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
-        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
         CommandResultAssert.HasStandardEnvelope(
             outputJson.RootElement,
             command: UcliCommandNames.SkillsList,
-            status: "error",
-            exitCode: (int)CliExitCode.InvalidArgument);
-        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        Assert.Equal(["basic", "advanced", "developer"], payload
+            .GetProperty("tiers")
+            .EnumerateArray()
+            .Select(static tier => tier.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.Equal(["basic", "advanced", "developer"], ReadPayloadStringArray(outputJson.RootElement, "availableTiers", "tier"));
+        Assert.Equal(ExpectedSkillNames, payload
+            .GetProperty("skills")
+            .EnumerateArray()
+            .Select(static skill => skill.GetProperty("skillName").GetString())
+            .ToArray());
     }
 
     [Theory]
@@ -221,6 +263,31 @@ public sealed class SkillsCliOutputContractTests
             exitCode: (int)CliExitCode.InvalidArgument);
         CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
         Assert.Contains("Unsupported SKILL tier:", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [Trait("Size", "Medium")]
+    [InlineData(UcliCommandNames.ExportSubcommand, UcliCommandNames.SkillsExport)]
+    [InlineData(UcliCommandNames.InstallSubcommand, UcliCommandNames.SkillsInstall)]
+    [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
+    [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
+    [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
+    public async Task SkillsOperationSubcommand_WithoutTier_ReturnsInvalidArgument (
+        string subcommand,
+        string expectedCommand)
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"missing-tier-{subcommand}");
+        var result = await CliProcessRunner.RunCommandAsync(CreateMissingTierScenarioArgs(subcommand, scope.CreateDirectory("repo"), scope.GetPath("exported")));
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: expectedCommand,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
+        Assert.Contains("Option '--tier' is required.", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
     }
 
     [Theory]
@@ -1473,6 +1540,42 @@ public sealed class SkillsCliOutputContractTests
         return text.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
     }
 
+    private static void AssertPayloadMatchesSchema (JsonElement root)
+    {
+        var errors = ValidateSkillsListPayload(root.GetProperty("payload"), out var payloadSchemaPath);
+        Assert.True(errors.Count == 0, JsonSchemaValidationMessageBuilder.Build(errors, payloadSchemaPath));
+    }
+
+    private static IReadOnlyList<string> ValidateSkillsListPayload (JsonElement payload)
+    {
+        return ValidateSkillsListPayload(payload, out _);
+    }
+
+    private static IReadOnlyList<string> ValidateSkillsListPayload (
+        JsonElement payload,
+        out string payloadSchemaPath)
+    {
+        using var schemaSet = JsonSchemaArtifactSet.Load(Path.Combine(RepositoryRoot, "schemas", "v1"));
+        payloadSchemaPath = schemaSet.FindPayloadSchemaPath(UcliCommandNames.SkillsList)
+            ?? throw new InvalidOperationException("skills.list payload schema was not found.");
+        Assert.Equal("cli-output/payload/skills.list.schema.json", payloadSchemaPath);
+
+        return schemaSet.Validate(payloadSchemaPath, payload, "$.payload");
+    }
+
+    private static string[] ReadPayloadStringArray (
+        JsonElement root,
+        string arrayName,
+        string propertyName)
+    {
+        return root
+            .GetProperty("payload")
+            .GetProperty(arrayName)
+            .EnumerateArray()
+            .Select(value => value.GetProperty(propertyName).GetString() ?? string.Empty)
+            .ToArray();
+    }
+
     private static string[] CreateRequiredHostScenarioArgs (
         string subcommand,
         string repoRoot,
@@ -1505,6 +1608,22 @@ public sealed class SkillsCliOutputContractTests
         };
     }
 
+    private static string[] CreateMissingTierScenarioArgs (
+        string subcommand,
+        string repoRoot,
+        string outputRoot)
+    {
+        return subcommand switch
+        {
+            UcliCommandNames.ExportSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--output", outputRoot],
+            UcliCommandNames.InstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.UpdateSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.UninstallSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--scope", "project", "--repoRoot", repoRoot],
+            UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "openai", "--scope", "project", "--repoRoot", repoRoot],
+            _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
+        };
+    }
+
     private static string[] CreateUnsupportedHostScenarioArgs (
         string subcommand,
         string repoRoot,
@@ -1520,5 +1639,21 @@ public sealed class SkillsCliOutputContractTests
             UcliCommandNames.DoctorSubcommand => [UcliCommandNames.Skills, subcommand, "--host", "generic", "--tier", "basic", "--scope", "project", "--repoRoot", repoRoot, "--targetDir", targetDir],
             _ => throw new ArgumentOutOfRangeException(nameof(subcommand), subcommand, "Unsupported skills subcommand."),
         };
+    }
+
+    private static string FindRepositoryRoot ()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Ucli.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved from test base directory.");
     }
 }

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -114,6 +114,7 @@ internal static class Program
             CreatePayloadSchema(UcliCommandIds.OpsDescribe.Name, CreateOpsDescribePayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.CodesList.Name, CreateCodesListPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.CodesDescribe.Name, CreateCodesDescribePayloadSchema()),
+            CreatePayloadSchema(UcliCommandIds.SkillsList.Name, CreateSkillsListPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.PlayStatus.Name, CreatePlayStatusPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.PlayEnter.Name, CreatePlayEnterPayloadSchema()),
             CreatePayloadSchema(UcliCommandIds.PlayExit.Name, CreatePlayExitPayloadSchema()),
@@ -1279,6 +1280,61 @@ internal static class Program
             Required("description", StringSchema()));
     }
 
+    private static Dictionary<string, object?> CreateSkillsListPayloadSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("tiers", ArraySchema(SkillTierLiteralSchema())),
+            Required("availableTiers", ArraySchema(CreateSkillsListTierSchema())),
+            Required("skills", ArraySchema(CreateSkillsListSkillSchema())),
+            Required("supportedHosts", ArraySchema(CreateSkillsListSupportedHostSchema())));
+    }
+
+    private static Dictionary<string, object?> CreateSkillsListTierSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("tier", SkillTierLiteralSchema()),
+            Required("skillCount", NonNegativeIntegerSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateSkillsListSkillSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("skillName", StringSchema()),
+            Required("displayName", StringSchema()),
+            Required("description", StringSchema()),
+            Required("tier", SkillTierLiteralSchema()),
+            Required("contentDigest", Sha256LowerHexSchema()),
+            Required("hostArtifacts", ArraySchema(CreateSkillsListHostArtifactSchema())));
+    }
+
+    private static Dictionary<string, object?> CreateSkillsListHostArtifactSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("host", StringSchema()),
+            Required("path", NullableStringSchema()),
+            Required("digest", NullableSha256LowerHexSchema()),
+            Required("materializedFrontmatterDigest", Sha256LowerHexSchema()));
+    }
+
+    private static Dictionary<string, object?> CreateSkillsListSupportedHostSchema ()
+    {
+        return ObjectSchema(
+            additionalProperties: false,
+            Required("host", StringSchema()),
+            Required("projectTargetDirectory", StringSchema()),
+            Required("userTargetDirectory", StringSchema()),
+            Required("reloadGuidance", StringSchema()));
+    }
+
+    private static Dictionary<string, object?> SkillTierLiteralSchema ()
+    {
+        return EnumSchema("basic", "advanced", "developer");
+    }
+
     private static Dictionary<string, object?> CreateCodesListPayloadSchema ()
     {
         return ObjectSchema(
@@ -1843,6 +1899,11 @@ internal static class Program
         return PatternStringSchema("^[0-9a-f]{64}$");
     }
 
+    private static Dictionary<string, object?> NullableSha256LowerHexSchema ()
+    {
+        return OneOfSchema(Sha256LowerHexSchema(), NullSchema());
+    }
+
     private static Dictionary<string, object?> InputArgsPathSchema ()
     {
         var aliasPropertyName = Regex.Escape(UcliOperationContractPropertyNames.Alias);
@@ -1877,6 +1938,15 @@ internal static class Program
         return new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["type"] = "integer",
+        };
+    }
+
+    private static Dictionary<string, object?> NonNegativeIntegerSchema ()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "integer",
+            ["minimum"] = 0,
         };
     }
 


### PR DESCRIPTION
## Summary
- Add tier support to UCLI skill commands using product-defined tier literals: `basic`, `advanced`, and `developer`.
- Keep `skills export/install/update/uninstall/doctor` explicit by requiring `--tier`.
- Update `skills list` as a discovery command: omitted `--tier` lists all defined tiers and reports bundled skill counts.
- Update AgentSkills runtime and generator references to `0.4.0`.

## Scope
- `skills list/export/install/update/uninstall/doctor` resolve selected tiers before calling the shared AgentSkills provider.
- `skills list` now emits `tiers`, `availableTiers`, `skills`, and `supportedHosts`.
- The generated schema set includes `skills.list` payload validation with tier enum literals and non-negative tier counts.
- Package smoke tests verify `availableTiers` for the packaged CLI.

## Verification
- PASS: `NUGET_PACKAGES=/tmp/ucli-nuget-0.4.0 DOTNET_CLI_HOME=/tmp/ucli-dotnet-home-0.4.0 dotnet restore Ucli.slnx --configfile /tmp/agent-skills-release-0.4.0-nuget.config`
- PASS: `NUGET_PACKAGES=/tmp/ucli-nuget-0.4.0 DOTNET_CLI_HOME=/tmp/ucli-dotnet-home-0.4.0 dotnet tool restore --configfile /tmp/agent-skills-release-0.4.0-nuget.config --no-http-cache`
- PASS: `NUGET_PACKAGES=/tmp/ucli-nuget-0.4.0 DOTNET_CLI_HOME=/tmp/ucli-dotnet-home-0.4.0 bash scripts/generate-skills.sh`
- PASS: `NUGET_PACKAGES=/tmp/ucli-nuget-0.4.0 DOTNET_CLI_HOME=/tmp/ucli-dotnet-home-0.4.0 bash scripts/verify-skills.sh`
- PASS: `NUGET_PACKAGES=/tmp/ucli-nuget-0.4.0 DOTNET_CLI_HOME=/tmp/ucli-dotnet-home-0.4.0 bash scripts/verify.sh --no-restore`
- PASS: public NuGet restore/tool restore with isolated caches for AgentSkills `0.4.0`.

## Risks / Rollback
- Risk: consumers that expected `skills list` to require `--tier` now get discovery output when it is omitted.
- Rollback: revert this PR and restore AgentSkills references to the previous released version.

## Checklist
- [x] Existing four official skills return with `--tier basic`.
- [x] `--tier advanced` and `--tier developer` succeed with zero skills.
- [x] `skills list` without `--tier` returns all defined tiers and matching `basic` skills.
- [x] Runtime package and dotnet tool manifest use AgentSkills `0.4.0`.

Issue: none (ad-hoc task)
