### PR TITLE
ci(release): extend NuGet publication wait

### DIFF
--- a/.github/workflows/package-publish.yaml
+++ b/.github/workflows/package-publish.yaml
@@ -222,7 +222,7 @@ jobs:
             MackySoft.Ucli.Contracts
             MackySoft.Ucli.Infrastructure
             MackySoft.Ucli.Unity
-          max-attempts: 30
+          max-attempts: 90
           interval-seconds: 10
 
       - name: Mirror packages to GitHub Release


### PR DESCRIPTION
## Summary
- Extend the NuGet publication visibility wait in the package publish workflow.
- Keep the polling interval at 10 seconds and increase the maximum wait from 5 minutes to 15 minutes.

## Scope
- `.github/workflows/package-publish.yaml`: updates the `Wait for published NuGet packages` timeout budget.

## Verification
- Gate level: Standard
- Format: N/A; workflow-only numeric change
- Tests: PASS; `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/package-publish.yaml')"` and `git diff --check`
- Coverage: N/A

## Risks / Rollback
- Risk is limited to release workflow duration. Failed publications will take longer to time out.
- Rollback is restoring `max-attempts` to `30`.

## Checklist
- [x] NuGet wait budget reflects the observed 0.4.0 indexing delay
- [x] Workflow YAML parses locally

Issue: none (ad-hoc task)
