### PR TITLE
chore(config): allow dangerous ucli operations

### DIFF
--- a/.ucli/config.json
+++ b/.ucli/config.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "operationPolicy": "safe",
+  "operationPolicy": "dangerous",
   "planTokenMode": "optional",
   "readIndexDefaultMode": "requireFresh",
   "operationAllowlist": [


### PR DESCRIPTION
## Summary
- Set the repository-local uCLI operation policy to dangerous.
- Keep the existing operation allowlist unchanged.

## Scope
- .ucli/config.json only

## Verification
- `python3 -m json.tool .ucli/config.json >/dev/null`: PASS
- `git diff --check -- .ucli/config.json`: PASS
- Test execution: skipped because this changes only a repository-local JSON config value; acceptance is covered by JSON parsing and diff inspection.

## Risks / Rollback
- Risk: local uCLI authorization can allow dangerous-policy operations when the existing allowlist and explicit dangerous guards also permit them.
- Rollback: revert this PR to restore `operationPolicy` to `safe`.

## Checklist
- [x] Config policy changed to dangerous
- [x] Existing allowlist left unchanged

Issue: none (ad-hoc task)