### PR TITLE
Add catalog IDs to official skills

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "mackysoft.agentskills.cli": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "commands": [
         "agent-skills"
       ],

--- a/schemas/v1/cli-output/payload/skills.list.schema.json
+++ b/schemas/v1/cli-output/payload/skills.list.schema.json
@@ -63,6 +63,9 @@
               "developer"
             ]
           },
+          "catalogId": {
+            "type": "string"
+          },
           "contentDigest": {
             "type": "string",
             "pattern": "^[0-9a-f]{64}$"
@@ -112,6 +115,7 @@
           "displayName",
           "description",
           "tier",
+          "catalogId",
           "contentDigest",
           "hostArtifacts"
         ]

--- a/skills/definitions/ucli-plan-apply/skill.json
+++ b/skills/definitions/ucli-plan-apply/skill.json
@@ -4,6 +4,7 @@
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "references": [
     "request-workflow.md"
   ]

--- a/skills/definitions/ucli-read-project/skill.json
+++ b/skills/definitions/ucli-read-project/skill.json
@@ -4,6 +4,7 @@
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "references": [
     "project-reading-workflow.md"
   ]

--- a/skills/definitions/ucli-troubleshoot/skill.json
+++ b/skills/definitions/ucli-troubleshoot/skill.json
@@ -4,6 +4,7 @@
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "references": [
     "troubleshooting-workflow.md"
   ]

--- a/skills/definitions/ucli-verify-changes/skill.json
+++ b/skills/definitions/ucli-verify-changes/skill.json
@@ -4,6 +4,7 @@
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "references": [
     "verification-workflow.md"
   ]

--- a/skills/generated/ucli-plan-apply/agent-skill.json
+++ b/skills/generated/ucli-plan-apply/agent-skill.json
@@ -4,8 +4,9 @@
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "contentDigest": "d3d9db28b8eee92bf52611edf83d4c8804b8af9d7a23a224f12ccf1435cf6551",
-  "manifestDigest": "d1e4fe621d3e1a5c970859cc82eb28159e478abd5397a3cc88499de92f278ea3",
+  "manifestDigest": "af9eae7d9cafdba1581b63da6cfe9497898f48d51223247d9ed1533fdcd08bae",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-read-project/agent-skill.json
+++ b/skills/generated/ucli-read-project/agent-skill.json
@@ -4,8 +4,9 @@
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "contentDigest": "83b22557264afc9cab9190764c503159731609fe662fed35000ea9dff5228474",
-  "manifestDigest": "2efdaa008a620ed0f8202a44450faccfb6516f9aced8dd258310f24ee6c2eca0",
+  "manifestDigest": "25441d09cce01afbfced187134cca48e03e88e5f6061c4bb14101ff8883fba53",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-troubleshoot/agent-skill.json
+++ b/skills/generated/ucli-troubleshoot/agent-skill.json
@@ -4,8 +4,9 @@
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "contentDigest": "59f0d5c66874c986a0f70e8cf01a802ec5eae35e7eb65bad218954b6d9be81b6",
-  "manifestDigest": "c1d44f9c541e5b8d2be103ea94584a9477c7de5845b90df648b3280ac8f74da8",
+  "manifestDigest": "7e5963a543c8e93ba23771ac6aa23c49cde1c4317811044ec3ff1beb093a0a0f",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-verify-changes/agent-skill.json
+++ b/skills/generated/ucli-verify-changes/agent-skill.json
@@ -4,8 +4,9 @@
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
   "tier": "basic",
+  "catalogId": "com.mackysoft.ucli",
   "contentDigest": "207c2c6d9ae29d3c66ddc1aa7f3ef73850adb6fbba4339304055ad040d2cff70",
-  "manifestDigest": "fbb64766cf1486740d7f0c6a01f639c59d57156cf0ba3e0c35a917e224ffb783",
+  "manifestDigest": "dc3d1fc9953da1aeb16c7287bd16d7548b629c4ead52d1051651d0769aea30d1",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -49,6 +49,7 @@ internal static class SkillsCommandResultFactory
                         package.Manifest.DisplayName,
                         package.Manifest.Description,
                         tier = package.Manifest.Tier.Value,
+                        catalogId = package.Manifest.CatalogId.Value,
                         package.Manifest.ContentDigest,
                         package.Manifest.HostArtifacts,
                     })

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.4.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>
 

--- a/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
+++ b/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.4.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -154,7 +154,7 @@ public sealed class PackageMetadataTests
             .GetProperty("tools")
             .GetProperty("mackysoft.agentskills.cli");
 
-        Assert.Equal("0.4.0", tool.GetProperty("version").GetString());
+        Assert.Equal("0.5.0", tool.GetProperty("version").GetString());
         Assert.Contains(
             "agent-skills",
             tool.GetProperty("commands").EnumerateArray().Select(static command => command.GetString()));

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -120,6 +120,7 @@ public sealed class SkillsCliOutputContractTests
                 .HasValueKind("displayName", JsonValueKind.String)
                 .HasValueKind("description", JsonValueKind.String)
                 .HasString("tier", "basic")
+                .HasString("catalogId", "com.mackysoft.ucli")
                 .HasValueKind("contentDigest", JsonValueKind.String)
                 .HasArrayLength("hostArtifacts", 3))
             .HasProperty("supportedHosts", 0, static host => host

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -1306,6 +1306,7 @@ internal static class Program
             Required("displayName", StringSchema()),
             Required("description", StringSchema()),
             Required("tier", SkillTierLiteralSchema()),
+            Required("catalogId", StringSchema()),
             Required("contentDigest", Sha256LowerHexSchema()),
             Required("hostArtifacts", ArraySchema(CreateSkillsListHostArtifactSchema())));
     }


### PR DESCRIPTION
## Summary

- Add `catalogId: com.mackysoft.ucli` to bundled official SKILL definitions and regenerated manifests.
- Update AgentSkills runtime and CLI tool pins to 0.5.0.
- Include `catalogId` in the `skills list` payload schema and command output.

## Verification

- `bash scripts/verify-skills.sh`
- `dotnet test tests/Ucli.Tests/Ucli.Tests.csproj --filter "FullyQualifiedName~Skills|FullyQualifiedName~PackageMetadata"`
- `dotnet test tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj --filter "FullyQualifiedName~OfficialSkill"`
- `bash scripts/code-quality.sh verify --include src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs tests/Ucli.Tests/SkillsCliOutputContractTests.cs tests/Ucli.Tests/Packaging/PackageMetadataTests.cs tools/Ucli.SchemaGenerator/Program.cs`
- `bash scripts/verify.sh`

## Risks / Rollback

- Risk is limited to official SKILL package metadata and skills list output. Roll back by reverting this PR and regenerating bundled skills with the previous AgentSkills tool pin.

Issue: none (ad-hoc task)