### PR TITLE
Support exact skill selection

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "mackysoft.agentskills.cli": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "commands": [
         "agent-skills"
       ],

--- a/README.md
+++ b/README.md
@@ -92,12 +92,18 @@ Supported host keys are `openai`, `claude`, and `copilot`. Project scope install
 
 Run the command from the target repository. Use `--repoRoot <path>` only when the current working directory is outside the repository or when automation needs to select a repository explicitly.
 
-uCLI defines `basic`, `advanced`, and `developer`; the bundled official skills currently belong to `basic`. `skills export`, `install`, `update`, `uninstall`, and `doctor` require `--tier`. `skills list` may omit `--tier` to show all defined tiers and their bundled skill counts. Selecting `advanced` or `developer` is valid and succeeds with an empty skill set until uCLI ships skills in those tiers. To select multiple tiers in one command, pass a comma-separated value such as `--tier basic,advanced`.
+uCLI defines `basic`, `advanced`, and `developer`; the bundled official skills currently belong to `basic`. `skills export`, `install`, `update`, `uninstall`, and `doctor` require at least one package selector: `--tier` or `--skill`. `--skill` selects exact `skillName` values, and combining it with `--tier` requires the named skills to belong to the selected tiers. `skills list` may omit both selectors to show all defined tiers and their bundled skill counts. Selecting `advanced` or `developer` is valid and succeeds with an empty skill set until uCLI ships skills in those tiers. To select multiple tiers or skills in one command, pass comma-separated values such as `--tier basic,advanced` or `--skill ucli-read-project,ucli-verify-changes`.
 
 Use `skills list` when you want to inspect the bundled skills, selected tiers, available tiers, supported hosts, target directories, and reload guidance:
 
 ```bash
 ucli skills list
+```
+
+Export a single named skill when you do not want the whole tier:
+
+```bash
+ucli skills export --host openai --skill ucli-read-project --output ./exported-skills
 ```
 
 Use user scope only for local, non-repository defaults:

--- a/schemas/v1/cli-output/payload/skills.list.schema.json
+++ b/schemas/v1/cli-output/payload/skills.list.schema.json
@@ -15,6 +15,12 @@
         ]
       }
     },
+    "skillNames": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "availableTiers": {
       "type": "array",
       "items": {
@@ -151,6 +157,7 @@
   },
   "required": [
     "tiers",
+    "skillNames",
     "availableTiers",
     "skills",
     "supportedHosts"

--- a/scripts/verify-cli-package.sh
+++ b/scripts/verify-cli-package.sh
@@ -122,6 +122,13 @@ import sys
 
 root = json.loads(os.environ["SKILLS_LIST_JSON"])
 payload = root.get("payload") or {}
+skill_names = payload.get("skillNames")
+if skill_names != []:
+    print(
+        f"ucli skills list did not report an empty skillNames selection. Actual: {skill_names}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 actual = [
     (tier.get("tier"), tier.get("skillCount"))
     for tier in payload.get("availableTiers", [])
@@ -139,6 +146,27 @@ if actual != expected:
     sys.exit(1)
 PY
 
+single_skill_list="$("${tool_path}/ucli" skills list --skill ucli-read-project)"
+SINGLE_SKILL_LIST_JSON="${single_skill_list}" python3 - <<'PY'
+import json
+import os
+import sys
+
+root = json.loads(os.environ["SINGLE_SKILL_LIST_JSON"])
+payload = root.get("payload") or {}
+skill_names = payload.get("skillNames")
+skills = [
+    skill.get("skillName")
+    for skill in payload.get("skills", [])
+]
+if skill_names != ["ucli-read-project"] or skills != ["ucli-read-project"]:
+    print(
+        f"ucli skills list --skill did not select only ucli-read-project. skillNames={skill_names}; skills={skills}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+
 export_path="${tool_path}/exported-skills"
 "${tool_path}/ucli" skills export --host openai --tier basic --output "${export_path}" >/dev/null
 while IFS= read -r relative_path; do
@@ -148,6 +176,17 @@ while IFS= read -r relative_path; do
     exit 1
   fi
 done < <(list_host_independent_skill_files)
+
+single_export_path="${tool_path}/exported-single-skill"
+"${tool_path}/ucli" skills export --host openai --skill ucli-read-project --output "${single_export_path}" >/dev/null
+if [[ ! -f "${single_export_path}/ucli-read-project/SKILL.md" ]]; then
+  echo "ucli skills export --skill did not materialize the selected SKILL." >&2
+  exit 1
+fi
+if [[ -e "${single_export_path}/ucli-plan-apply" ]]; then
+  echo "ucli skills export --skill materialized an unselected SKILL." >&2
+  exit 1
+fi
 
 install_repo="$(mktemp -d "${temp_root%/}/ucli-skills-install.XXXXXX")"
 "${tool_path}/ucli" skills install --host openai --tier basic --scope project --repoRoot "${install_repo}" >/dev/null

--- a/skills/definitions/ucli-plan-apply/skill.json
+++ b/skills/definitions/ucli-plan-apply/skill.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
   "skillName": "ucli-plan-apply",
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
   "references": [
     "request-workflow.md"
   ]

--- a/skills/definitions/ucli-read-project/skill.json
+++ b/skills/definitions/ucli-read-project/skill.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
   "skillName": "ucli-read-project",
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
   "references": [
     "project-reading-workflow.md"
   ]

--- a/skills/definitions/ucli-troubleshoot/skill.json
+++ b/skills/definitions/ucli-troubleshoot/skill.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
   "skillName": "ucli-troubleshoot",
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
   "references": [
     "troubleshooting-workflow.md"
   ]

--- a/skills/definitions/ucli-verify-changes/skill.json
+++ b/skills/definitions/ucli-verify-changes/skill.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
   "skillName": "ucli-verify-changes",
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
   "references": [
     "verification-workflow.md"
   ]

--- a/skills/generated/ucli-plan-apply/agent-skill.json
+++ b/skills/generated/ucli-plan-apply/agent-skill.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
+  "contentDigest": "d3d9db28b8eee92bf52611edf83d4c8804b8af9d7a23a224f12ccf1435cf6551",
+  "manifestDigest": "699cc95018cf9d8e2964c8814be8a5ed7c3fe1a478dc12a3a2d75b6584d0940f",
   "skillName": "ucli-plan-apply",
   "displayName": "uCLI Plan Apply",
   "description": "Use when building, validating, planning, and applying a uCLI JSON request for Unity changes. Enforces read -> ready -> describe -> build request -> validate -> plan -> call --withPlan -> verify.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
-  "contentDigest": "d3d9db28b8eee92bf52611edf83d4c8804b8af9d7a23a224f12ccf1435cf6551",
-  "manifestDigest": "af9eae7d9cafdba1581b63da6cfe9497898f48d51223247d9ed1533fdcd08bae",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-read-project/agent-skill.json
+++ b/skills/generated/ucli-read-project/agent-skill.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
+  "contentDigest": "83b22557264afc9cab9190764c503159731609fe662fed35000ea9dff5228474",
+  "manifestDigest": "56e631e290e519dfbcb8ed88e3f2c23e7aab85d818f7eac71a89d07828ba4c89",
   "skillName": "ucli-read-project",
   "displayName": "uCLI Read Project",
   "description": "Use when inspecting a Unity project with uCLI before choosing selectors, operation metadata, schemas, or readIndex freshness. Guides read-first discovery without hard-coding operation contracts.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
-  "contentDigest": "83b22557264afc9cab9190764c503159731609fe662fed35000ea9dff5228474",
-  "manifestDigest": "25441d09cce01afbfced187134cca48e03e88e5f6061c4bb14101ff8883fba53",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-troubleshoot/agent-skill.json
+++ b/skills/generated/ucli-troubleshoot/agent-skill.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
+  "contentDigest": "59f0d5c66874c986a0f70e8cf01a802ec5eae35e7eb65bad218954b6d9be81b6",
+  "manifestDigest": "b08a39f38c809a7c6e972cfbf60acb16f13902a933aa557fe78f53a112b743fd",
   "skillName": "ucli-troubleshoot",
   "displayName": "uCLI Troubleshoot",
   "description": "Use when diagnosing uCLI daemon, lifecycle, readIndex freshness, timeout, compile or domain reload, logs, IPC, and Unity execution failures.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
-  "contentDigest": "59f0d5c66874c986a0f70e8cf01a802ec5eae35e7eb65bad218954b6d9be81b6",
-  "manifestDigest": "7e5963a543c8e93ba23771ac6aa23c49cde1c4317811044ec3ff1beb093a0a0f",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/skills/generated/ucli-verify-changes/agent-skill.json
+++ b/skills/generated/ucli-verify-changes/agent-skill.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
+  "catalogId": "com.mackysoft.ucli",
+  "tier": "basic",
+  "contentDigest": "207c2c6d9ae29d3c66ddc1aa7f3ef73850adb6fbba4339304055ad040d2cff70",
+  "manifestDigest": "84911780e9f87d54a59c675c9d4d7f32953a0fd9542375a02a614b5ad189cf98",
   "skillName": "ucli-verify-changes",
   "displayName": "uCLI Verify Changes",
   "description": "Use when verifying uCLI-driven Unity changes with ucli verify profiles, claim packets, follow-up reads, ucli test, logs, artifacts, and opResults evidence after validation, plan, or call execution.",
-  "tier": "basic",
-  "catalogId": "com.mackysoft.ucli",
-  "contentDigest": "207c2c6d9ae29d3c66ddc1aa7f3ef73850adb6fbba4339304055ad040d2cff70",
-  "manifestDigest": "dc3d1fc9953da1aeb16c7287bd16d7548b629c4ead52d1051651d0769aea30d1",
   "hostArtifacts": [
     {
       "host": "claude",

--- a/src/Ucli/Hosting/Cli/Skills/SkillFailureApplicationFailureMapper.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillFailureApplicationFailureMapper.cs
@@ -19,6 +19,8 @@ internal static class SkillFailureApplicationFailureMapper
 
     private static bool IsInvalidArgumentFailureCode (SkillFailureCode code)
     {
-        return code == SkillFailureCodes.HostUnsupported || code == SkillFailureCodes.PathUnsafe;
+        return code == SkillFailureCodes.HostUnsupported
+            || code == SkillFailureCodes.InputInvalid
+            || code == SkillFailureCodes.PathUnsafe;
     }
 }

--- a/src/Ucli/Hosting/Cli/Skills/SkillPackageSelection.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillPackageSelection.cs
@@ -1,0 +1,10 @@
+using MackySoft.AgentSkills.Tiers;
+
+namespace MackySoft.Ucli.Hosting.Cli.Skills;
+
+/// <summary> Represents the normalized SKILL package selection supplied by CLI options. </summary>
+/// <param name="Tiers"> The selected SKILL tiers. </param>
+/// <param name="SkillNames"> The selected exact SKILL names. Empty means no name filter. </param>
+internal sealed record SkillPackageSelection (
+    IReadOnlyList<SkillTier> Tiers,
+    IReadOnlyList<string> SkillNames);

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandOptionNormalizer.cs
@@ -1,6 +1,8 @@
 using MackySoft.AgentSkills.Distribution;
 using MackySoft.AgentSkills.Hosts.Registration;
 using MackySoft.AgentSkills.Installation.Targeting;
+using MackySoft.AgentSkills.Selection;
+using MackySoft.AgentSkills.Tiers;
 using MackySoft.Ucli.Hosting.Cli.Common.Contracts;
 using MackySoft.Ucli.Infrastructure.Paths;
 using MackySoft.Ucli.Infrastructure.Storage;
@@ -15,62 +17,62 @@ internal static class SkillsCommandOptionNormalizer
     private const string DirectoryExportFormatLiteral = "directory";
     private const string ZipExportFormatLiteral = "zip";
 
-    /// <summary> Normalizes the required tier option. </summary>
-    /// <param name="command"> The command name used for error results. </param>
-    /// <param name="tiers"> The raw tier options. </param>
-    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
-    /// <returns> The normalized tier selection, or <see langword="null" /> when normalization fails. </returns>
-    public static IReadOnlyList<MackySoft.AgentSkills.Tiers.SkillTier>? NormalizeTiers (
-        string command,
-        string[]? tiers,
-        out CommandResult? errorResult)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(command);
-
-        errorResult = null;
-        if (tiers == null || tiers.Length == 0)
-        {
-            errorResult = CommandResult.InvalidArgument(command, "Option '--tier' is required.");
-            return null;
-        }
-
-        var result = MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseSelectedTiers(UcliSkillTierLiterals.Defined, tiers);
-        if (!result.IsSuccess)
-        {
-            errorResult = CommandResult.InvalidArgument(
-                command,
-                result.Failure!.Message);
-            return null;
-        }
-
-        return result.Value!;
-    }
-
-    /// <summary> Normalizes the optional tier option used by list discovery. </summary>
+    /// <summary> Normalizes an optional package selection used by list discovery. </summary>
     /// <param name="command"> The command name used for error results. </param>
     /// <param name="tiers"> The raw tier options. When omitted, all defined product-owned tiers are selected. </param>
+    /// <param name="skillNames"> The raw exact SKILL name options. When omitted, no name filter is applied. </param>
     /// <param name="errorResult"> The emitted error result when normalization fails. </param>
-    /// <returns> The normalized tier selection, or <see langword="null" /> when normalization fails. </returns>
-    public static IReadOnlyList<MackySoft.AgentSkills.Tiers.SkillTier>? NormalizeOptionalTiers (
+    /// <returns> The normalized package selection, or <see langword="null" /> when normalization fails. </returns>
+    public static SkillPackageSelection? NormalizeOptionalPackageSelection (
         string command,
         string[]? tiers,
+        string[]? skillNames,
         out CommandResult? errorResult)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(command);
 
-        errorResult = null;
-        var result = tiers == null || tiers.Length == 0
-            ? MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseDefinedTiers(UcliSkillTierLiterals.Defined)
-            : MackySoft.AgentSkills.Tiers.SkillTierLiteralParser.ParseSelectedTiers(UcliSkillTierLiterals.Defined, tiers);
-        if (!result.IsSuccess)
+        var normalizedTiers = NormalizeTierSelection(command, tiers, out errorResult);
+        if (errorResult is not null)
         {
-            errorResult = CommandResult.InvalidArgument(
-                command,
-                result.Failure!.Message);
             return null;
         }
 
-        return result.Value!;
+        var normalizedSkillNames = NormalizeSkillNameSelection(command, skillNames, out errorResult);
+        return errorResult is null
+            ? new SkillPackageSelection(normalizedTiers!, normalizedSkillNames!)
+            : null;
+    }
+
+    /// <summary> Normalizes a required package selection used by commands that act on packages. </summary>
+    /// <param name="command"> The command name used for error results. </param>
+    /// <param name="tiers"> The raw tier options. When omitted with SKILL names, all defined product-owned tiers are selected. </param>
+    /// <param name="skillNames"> The raw exact SKILL name options. </param>
+    /// <param name="errorResult"> The emitted error result when normalization fails. </param>
+    /// <returns> The normalized package selection, or <see langword="null" /> when normalization fails. </returns>
+    public static SkillPackageSelection? NormalizeRequiredPackageSelection (
+        string command,
+        string[]? tiers,
+        string[]? skillNames,
+        out CommandResult? errorResult)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        if (!HasOptionValues(tiers) && !HasOptionValues(skillNames))
+        {
+            errorResult = CommandResult.InvalidArgument(command, "Option '--tier' or '--skill' is required.");
+            return null;
+        }
+
+        var normalizedTiers = NormalizeTierSelection(command, tiers, out errorResult);
+        if (errorResult is not null)
+        {
+            return null;
+        }
+
+        var normalizedSkillNames = NormalizeSkillNameSelection(command, skillNames, out errorResult);
+        return errorResult is null
+            ? new SkillPackageSelection(normalizedTiers!, normalizedSkillNames!)
+            : null;
     }
 
     /// <summary> Normalizes a required host option to its canonical host key. </summary>
@@ -248,5 +250,49 @@ internal static class SkillsCommandOptionNormalizer
                 $"Current working directory path is invalid: {Environment.CurrentDirectory}. {ex.Message}");
             return null;
         }
+    }
+
+    private static IReadOnlyList<SkillTier>? NormalizeTierSelection (
+        string command,
+        string[]? tiers,
+        out CommandResult? errorResult)
+    {
+        errorResult = null;
+        var result = HasOptionValues(tiers)
+            ? SkillTierLiteralParser.ParseSelectedTiers(UcliSkillTierLiterals.Defined, tiers!)
+            : SkillTierLiteralParser.ParseDefinedTiers(UcliSkillTierLiterals.Defined);
+        if (!result.IsSuccess)
+        {
+            errorResult = CommandResult.InvalidArgument(command, result.Failure!.Message);
+            return null;
+        }
+
+        return result.Value!;
+    }
+
+    private static IReadOnlyList<string>? NormalizeSkillNameSelection (
+        string command,
+        string[]? skillNames,
+        out CommandResult? errorResult)
+    {
+        errorResult = null;
+        if (!HasOptionValues(skillNames))
+        {
+            return Array.Empty<string>();
+        }
+
+        var result = SkillNameLiteralParser.ParseSelectedSkillNames(skillNames!);
+        if (!result.IsSuccess)
+        {
+            errorResult = CommandResult.InvalidArgument(command, result.Failure!.Message);
+            return null;
+        }
+
+        return result.Value!;
+    }
+
+    private static bool HasOptionValues (string[]? values)
+    {
+        return values is { Length: > 0 };
     }
 }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsCommandResultFactory.cs
@@ -34,6 +34,7 @@ internal static class SkillsCommandResultFactory
             payload: new
             {
                 tiers = catalog.SelectedTiers.Select(static tier => tier.Value).ToArray(),
+                skillNames = catalog.SelectedSkillNames.ToArray(),
                 availableTiers = catalog.AvailableTiers
                     .Select(static tier => new
                     {
@@ -77,11 +78,13 @@ internal static class SkillsCommandResultFactory
         string host,
         SkillExportFormat format,
         string reloadGuidance,
-        IReadOnlyList<string> tiers)
+        IReadOnlyList<string> tiers,
+        IReadOnlyList<string> skillNames)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(packages);
         ArgumentNullException.ThrowIfNull(tiers);
+        ArgumentNullException.ThrowIfNull(skillNames);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -97,6 +100,7 @@ internal static class SkillsCommandResultFactory
             {
                 host,
                 tiers,
+                skillNames,
                 format = ToExportFormatLiteral(format),
                 outputRoot = result.Value!,
                 skills = CreateSkillNameList(packages),
@@ -116,10 +120,12 @@ internal static class SkillsCommandResultFactory
         SkillScopeKind scope,
         string? repositoryRoot,
         string reloadGuidance,
-        IReadOnlyList<string> tiers)
+        IReadOnlyList<string> tiers,
+        IReadOnlyList<string> skillNames)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(tiers);
+        ArgumentNullException.ThrowIfNull(skillNames);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -143,6 +149,7 @@ internal static class SkillsCommandResultFactory
             {
                 host,
                 tiers,
+                skillNames,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 installResult.TargetRoot,
@@ -169,10 +176,12 @@ internal static class SkillsCommandResultFactory
         SkillScopeKind scope,
         string? repositoryRoot,
         string reloadGuidance,
-        IReadOnlyList<string> tiers)
+        IReadOnlyList<string> tiers,
+        IReadOnlyList<string> skillNames)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(tiers);
+        ArgumentNullException.ThrowIfNull(skillNames);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -196,6 +205,7 @@ internal static class SkillsCommandResultFactory
             {
                 host,
                 tiers,
+                skillNames,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 updateResult.TargetRoot,
@@ -222,10 +232,12 @@ internal static class SkillsCommandResultFactory
         SkillScopeKind scope,
         string? repositoryRoot,
         string reloadGuidance,
-        IReadOnlyList<string> tiers)
+        IReadOnlyList<string> tiers,
+        IReadOnlyList<string> skillNames)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(tiers);
+        ArgumentNullException.ThrowIfNull(skillNames);
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
@@ -249,6 +261,7 @@ internal static class SkillsCommandResultFactory
             {
                 host,
                 tiers,
+                skillNames,
                 scope = ToScopeLiteral(scope),
                 repositoryRoot,
                 uninstallResult.TargetRoot,
@@ -272,16 +285,19 @@ internal static class SkillsCommandResultFactory
         SkillScopeKind scope,
         string? repositoryRoot,
         string reloadGuidance,
-        IReadOnlyList<string> tiers)
+        IReadOnlyList<string> tiers,
+        IReadOnlyList<string> skillNames)
     {
         ArgumentNullException.ThrowIfNull(result);
         ArgumentNullException.ThrowIfNull(tiers);
+        ArgumentNullException.ThrowIfNull(skillNames);
         ArgumentException.ThrowIfNullOrWhiteSpace(reloadGuidance);
 
         var payload = new
         {
             host = result.Host,
             tiers,
+            skillNames,
             scope = ToScopeLiteral(scope),
             repositoryRoot,
             result.TargetRoot,

--- a/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsDoctorCommand.cs
@@ -42,7 +42,8 @@ internal sealed class SkillsDoctorCommand
     /// <param name="scope"> Required install scope (project|user). </param>
     /// <param name="repoRoot"> --repoRoot, Optional repository root override for project scope. </param>
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Required when <paramref name="skill" /> is omitted. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Required when <paramref name="tier" /> is omitted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.DoctorSubcommand)]
@@ -52,6 +53,7 @@ internal sealed class SkillsDoctorCommand
         string? repoRoot = null,
         string? targetDir = null,
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -89,9 +91,10 @@ internal sealed class SkillsDoctorCommand
             return errorResult.ExitCode;
         }
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeRequiredPackageSelection(
             UcliCommandNames.SkillsDoctor,
             tier,
+            skill,
             out errorResult);
         if (errorResult is not null)
         {
@@ -107,7 +110,7 @@ internal sealed class SkillsDoctorCommand
             return targetErrorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsDoctor, packagesResult.Failure!);
@@ -119,7 +122,13 @@ internal sealed class SkillsDoctorCommand
         if (packagesResult.Value!.Count == 0)
         {
             var emptyDoctorResult = new SkillDoctorResult(normalizedHost!, targetResult.Value!.TargetRoot, Array.Empty<SkillDoctorDiagnostic>());
-            var emptyCommandResult = SkillsCommandResultFactory.CreateDoctor(emptyDoctorResult, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+            var emptyCommandResult = SkillsCommandResultFactory.CreateDoctor(
+                emptyDoctorResult,
+                normalizedScope.Value,
+                repositoryRoot,
+                reloadGuidance,
+                selection.Tiers.Select(static tier => tier.Value).ToArray(),
+                selection.SkillNames);
             commandResultWriter.WriteToStandardOutput(emptyCommandResult);
             return emptyCommandResult.ExitCode;
         }
@@ -130,7 +139,13 @@ internal sealed class SkillsDoctorCommand
                 targetResult.Value!.TargetRoot,
                 cancellationToken)
             .ConfigureAwait(false);
-        var commandResult = SkillsCommandResultFactory.CreateDoctor(doctorResult, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+        var commandResult = SkillsCommandResultFactory.CreateDoctor(
+            doctorResult,
+            normalizedScope.Value,
+            repositoryRoot,
+            reloadGuidance,
+            selection.Tiers.Select(static tier => tier.Value).ToArray(),
+            selection.SkillNames);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsExportCommand.cs
@@ -35,7 +35,8 @@ internal sealed class SkillsExportCommand
     /// <param name="host"> Required target host (claude|copilot|openai). </param>
     /// <param name="output"> Required output directory. </param>
     /// <param name="format"> Optional output format (directory|zip). </param>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Required when <paramref name="skill" /> is omitted. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Required when <paramref name="tier" /> is omitted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ExportSubcommand)]
@@ -44,6 +45,7 @@ internal sealed class SkillsExportCommand
         string? output = null,
         string? format = null,
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -81,9 +83,10 @@ internal sealed class SkillsExportCommand
             return errorResult.ExitCode;
         }
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeRequiredPackageSelection(
             UcliCommandNames.SkillsExport,
             tier,
+            skill,
             out errorResult);
         if (errorResult is not null)
         {
@@ -91,7 +94,7 @@ internal sealed class SkillsExportCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsExport, packagesResult.Failure!);
@@ -107,7 +110,14 @@ internal sealed class SkillsExportCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateExport(exportResult, packagesResult.Value!, normalizedHost!, normalizedFormat.Value, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+        var commandResult = SkillsCommandResultFactory.CreateExport(
+            exportResult,
+            packagesResult.Value!,
+            normalizedHost!,
+            normalizedFormat.Value,
+            reloadGuidance,
+            selection.Tiers.Select(static tier => tier.Value).ToArray(),
+            selection.SkillNames);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsInstallCommand.cs
@@ -42,7 +42,8 @@ internal sealed class SkillsInstallCommand
     /// <param name="dryRun"> --dryRun, Whether to return the install plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>
     /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Required when <paramref name="skill" /> is omitted. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Required when <paramref name="tier" /> is omitted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.InstallSubcommand)]
@@ -55,6 +56,7 @@ internal sealed class SkillsInstallCommand
         bool force = false,
         bool printDiff = false,
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -92,9 +94,10 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeRequiredPackageSelection(
             UcliCommandNames.SkillsInstall,
             tier,
+            skill,
             out errorResult);
         if (errorResult is not null)
         {
@@ -102,7 +105,7 @@ internal sealed class SkillsInstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsInstall, packagesResult.Failure!);
@@ -120,7 +123,14 @@ internal sealed class SkillsInstallCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateInstall(installResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+        var commandResult = SkillsCommandResultFactory.CreateInstall(
+            installResult,
+            normalizedHost!,
+            normalizedScope.Value,
+            repositoryRoot,
+            reloadGuidance,
+            selection.Tiers.Select(static tier => tier.Value).ToArray(),
+            selection.SkillNames);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsListCommand.cs
@@ -29,19 +29,22 @@ internal sealed class SkillsListCommand
 
     /// <summary> Executes the skills list command and emits the JSON result contract. </summary>
     /// <param name="tier"> Optional SKILL tier literals. Omit to list all defined tiers. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Omit to list all selected tiers. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.ListSubcommand)]
     public async Task<int> ListAsync (
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         CommandExecutionState.MarkStarted();
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeOptionalTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeOptionalPackageSelection(
             UcliCommandNames.SkillsList,
             tier,
+            skill,
             out var errorResult);
         if (errorResult is not null)
         {
@@ -49,7 +52,7 @@ internal sealed class SkillsListCommand
             return errorResult.ExitCode;
         }
 
-        var catalogResult = await packageProvider.GetPackageCatalogAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var catalogResult = await packageProvider.GetPackageCatalogAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         var commandResult = catalogResult.IsSuccess
             ? SkillsCommandResultFactory.CreateList(
                 catalogResult.Value!,

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUninstallCommand.cs
@@ -41,7 +41,8 @@ internal sealed class SkillsUninstallCommand
     /// <param name="targetDir"> --targetDir, Optional target root path under the repository root. </param>
     /// <param name="dryRun"> --dryRun, Whether to return the uninstall plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be deleted. </param>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Required when <paramref name="skill" /> is omitted. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Required when <paramref name="tier" /> is omitted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UninstallSubcommand)]
@@ -53,6 +54,7 @@ internal sealed class SkillsUninstallCommand
         bool dryRun = false,
         bool force = false,
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -90,9 +92,10 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeRequiredPackageSelection(
             UcliCommandNames.SkillsUninstall,
             tier,
+            skill,
             out errorResult);
         if (errorResult is not null)
         {
@@ -100,7 +103,7 @@ internal sealed class SkillsUninstallCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUninstall, packagesResult.Failure!);
@@ -117,7 +120,14 @@ internal sealed class SkillsUninstallCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateUninstall(uninstallResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+        var commandResult = SkillsCommandResultFactory.CreateUninstall(
+            uninstallResult,
+            normalizedHost!,
+            normalizedScope.Value,
+            repositoryRoot,
+            reloadGuidance,
+            selection.Tiers.Select(static tier => tier.Value).ToArray(),
+            selection.SkillNames);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
+++ b/src/Ucli/Hosting/Cli/Skills/SkillsUpdateCommand.cs
@@ -42,7 +42,8 @@ internal sealed class SkillsUpdateCommand
     /// <param name="dryRun"> --dryRun, Whether to return the update plan without writing. </param>
     /// <param name="force"> Whether managed local modifications can be overwritten. </param>
     /// <param name="printDiff"> --printDiff, Whether structured file diffs should be included. </param>
-    /// <param name="tier"> Required SKILL tier literals. </param>
+    /// <param name="tier"> Optional SKILL tier literals. Required when <paramref name="skill" /> is omitted. </param>
+    /// <param name="skill"> Optional exact SKILL name literals. Required when <paramref name="tier" /> is omitted. </param>
     /// <param name="cancellationToken"> The cancellation token propagated by command execution. </param>
     /// <returns> The exit code contained in the emitted command result. </returns>
     [Command(UcliCommandNames.UpdateSubcommand)]
@@ -55,6 +56,7 @@ internal sealed class SkillsUpdateCommand
         bool force = false,
         bool printDiff = false,
         string[]? tier = null,
+        string[]? skill = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -92,9 +94,10 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
-        var normalizedTiers = SkillsCommandOptionNormalizer.NormalizeTiers(
+        var selection = SkillsCommandOptionNormalizer.NormalizeRequiredPackageSelection(
             UcliCommandNames.SkillsUpdate,
             tier,
+            skill,
             out errorResult);
         if (errorResult is not null)
         {
@@ -102,7 +105,7 @@ internal sealed class SkillsUpdateCommand
             return errorResult.ExitCode;
         }
 
-        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, normalizedTiers!, cancellationToken).ConfigureAwait(false);
+        var packagesResult = await packageProvider.GetPackagesAsync(UcliSkillTierLiterals.Defined, selection!.Tiers, selection.SkillNames, cancellationToken).ConfigureAwait(false);
         if (!packagesResult.IsSuccess)
         {
             var packageErrorResult = SkillsCommandResultFactory.CreateSkillFailure(UcliCommandNames.SkillsUpdate, packagesResult.Failure!);
@@ -120,7 +123,14 @@ internal sealed class SkillsUpdateCommand
                 cancellationToken)
             .ConfigureAwait(false);
         var reloadGuidance = hostAdapters.GetAdapter(normalizedHost!).Value!.Descriptor.ReloadGuidance;
-        var commandResult = SkillsCommandResultFactory.CreateUpdate(updateResult, normalizedHost!, normalizedScope.Value, repositoryRoot, reloadGuidance, normalizedTiers!.Select(static tier => tier.Value).ToArray());
+        var commandResult = SkillsCommandResultFactory.CreateUpdate(
+            updateResult,
+            normalizedHost!,
+            normalizedScope.Value,
+            repositoryRoot,
+            reloadGuidance,
+            selection.Tiers.Select(static tier => tier.Value).ToArray(),
+            selection.SkillNames);
         commandResultWriter.WriteToStandardOutput(commandResult);
         return commandResult.ExitCode;
     }

--- a/src/Ucli/Ucli.csproj
+++ b/src/Ucli/Ucli.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.5.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
   </ItemGroup>
 

--- a/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
+++ b/tests/Ucli.Architecture.Tests/Ucli.Architecture.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="MackySoft.AgentSkills" Version="0.5.0" />
+    <PackageReference Include="MackySoft.AgentSkills" Version="0.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
+++ b/tests/Ucli.Tests/Packaging/PackageMetadataTests.cs
@@ -154,7 +154,7 @@ public sealed class PackageMetadataTests
             .GetProperty("tools")
             .GetProperty("mackysoft.agentskills.cli");
 
-        Assert.Equal("0.5.0", tool.GetProperty("version").GetString());
+        Assert.Equal("0.6.0", tool.GetProperty("version").GetString());
         Assert.Contains(
             "agent-skills",
             tool.GetProperty("commands").EnumerateArray().Select(static command => command.GetString()));

--- a/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
+++ b/tests/Ucli.Tests/SkillsCliOutputContractTests.cs
@@ -10,6 +10,7 @@ namespace MackySoft.Ucli.Tests;
 public sealed class SkillsCliOutputContractTests
 {
     private const string HostUnsupportedCode = "SKILL_HOST_UNSUPPORTED";
+    private const string SkillInputInvalidCode = "SKILL_INPUT_INVALID";
     private const string InstallTargetContentDigestMismatchCode = "SKILL_INSTALL_TARGET_CONTENT_DIGEST_MISMATCH";
     private const string InstallTargetHostArtifactDigestMismatchCode = "SKILL_INSTALL_TARGET_HOST_ARTIFACT_DIGEST_MISMATCH";
     private const string InstallTargetHostConflictCode = "SKILL_INSTALL_TARGET_HOST_CONFLICT";
@@ -17,6 +18,7 @@ public sealed class SkillsCliOutputContractTests
     private const string InvalidArgumentCode = "INVALID_ARGUMENT";
     private const string PathUnsafeCode = "SKILL_PATH_UNSAFE";
     private const string UnknownOptionMessage = "Argument '--unknown' is not recognized.";
+    private const string SelectedSingleSkillName = "ucli-read-project";
 
     private static readonly string[] ExpectedSkillNames =
     [
@@ -103,6 +105,7 @@ public sealed class SkillsCliOutputContractTests
         var payload = outputJson.RootElement.GetProperty("payload");
         JsonAssert.For(payload)
             .HasArrayLength("tiers", 1)
+            .HasArrayLength("skillNames", 0)
             .HasArrayLength("availableTiers", 3)
             .HasArrayLength("skills", ExpectedSkillNames.Length)
             .HasArrayLength("supportedHosts", 3)
@@ -170,6 +173,7 @@ public sealed class SkillsCliOutputContractTests
         JsonAssert.For(outputJson.RootElement)
             .HasProperty("payload", payload => payload
                 .HasArrayLength("tiers", 1)
+                .HasArrayLength("skillNames", 0)
                 .HasArrayLength("availableTiers", 3)
                 .HasArrayLength("skills", 0));
         Assert.Equal(tier, outputJson.RootElement.GetProperty("payload").GetProperty("tiers")[0].GetString());
@@ -178,9 +182,9 @@ public sealed class SkillsCliOutputContractTests
 
     [Theory]
     [Trait("Size", "Small")]
-    [InlineData("""{"tiers":["internal"],"availableTiers":[{"tier":"basic","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
-    [InlineData("""{"tiers":["basic"],"availableTiers":[{"tier":"internal","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
-    [InlineData("""{"tiers":["basic"],"availableTiers":[{"tier":"basic","skillCount":-1}],"skills":[],"supportedHosts":[]}""")]
+    [InlineData("""{"tiers":["internal"],"skillNames":[],"availableTiers":[{"tier":"basic","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
+    [InlineData("""{"tiers":["basic"],"skillNames":[],"availableTiers":[{"tier":"internal","skillCount":0}],"skills":[],"supportedHosts":[]}""")]
+    [InlineData("""{"tiers":["basic"],"skillNames":[],"availableTiers":[{"tier":"basic","skillCount":-1}],"skills":[],"supportedHosts":[]}""")]
     public void SkillsListPayloadSchema_RejectsInvalidTierInventory (string payloadJson)
     {
         using var payload = JsonDocument.Parse(payloadJson);
@@ -210,6 +214,7 @@ public sealed class SkillsCliOutputContractTests
             .EnumerateArray()
             .Select(static tier => tier.GetString() ?? string.Empty)
             .ToArray());
+        Assert.Empty(payload.GetProperty("skillNames").EnumerateArray());
         Assert.Equal(["basic", "advanced", "developer"], ReadPayloadStringArray(outputJson.RootElement, "availableTiers", "tier"));
         Assert.Equal(ExpectedSkillNames, payload
             .GetProperty("skills")
@@ -238,12 +243,69 @@ public sealed class SkillsCliOutputContractTests
             .EnumerateArray()
             .Select(static tier => tier.GetString() ?? string.Empty)
             .ToArray());
+        Assert.Empty(payload.GetProperty("skillNames").EnumerateArray());
         Assert.Equal(["basic", "advanced", "developer"], ReadPayloadStringArray(outputJson.RootElement, "availableTiers", "tier"));
         Assert.Equal(ExpectedSkillNames, payload
             .GetProperty("skills")
             .EnumerateArray()
             .Select(static skill => skill.GetProperty("skillName").GetString())
             .ToArray());
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsList_WithSkillName_ReturnsExactSkill ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(UcliCommandNames.Skills, UcliCommandNames.ListSubcommand, "--skill", SelectedSingleSkillName);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+
+        var payload = outputJson.RootElement.GetProperty("payload");
+        Assert.Equal(["basic", "advanced", "developer"], payload
+            .GetProperty("tiers")
+            .EnumerateArray()
+            .Select(static tier => tier.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.Equal([SelectedSingleSkillName], payload
+            .GetProperty("skillNames")
+            .EnumerateArray()
+            .Select(static skillName => skillName.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.Equal([SelectedSingleSkillName], payload
+            .GetProperty("skills")
+            .EnumerateArray()
+            .Select(static skill => skill.GetProperty("skillName").GetString() ?? string.Empty)
+            .ToArray());
+        AssertPayloadMatchesSchema(outputJson.RootElement);
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsList_WithTierAndMismatchedSkillName_ReturnsInvalidArgument ()
+    {
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Skills,
+            UcliCommandNames.ListSubcommand,
+            "--tier",
+            "advanced",
+            "--skill",
+            SelectedSingleSkillName);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsList,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, SkillInputInvalidCode);
+        Assert.Contains("does not match selected tiers", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
     }
 
     [Theory]
@@ -273,11 +335,11 @@ public sealed class SkillsCliOutputContractTests
     [InlineData(UcliCommandNames.UpdateSubcommand, UcliCommandNames.SkillsUpdate)]
     [InlineData(UcliCommandNames.UninstallSubcommand, UcliCommandNames.SkillsUninstall)]
     [InlineData(UcliCommandNames.DoctorSubcommand, UcliCommandNames.SkillsDoctor)]
-    public async Task SkillsOperationSubcommand_WithoutTier_ReturnsInvalidArgument (
+    public async Task SkillsOperationSubcommand_WithoutPackageSelection_ReturnsInvalidArgument (
         string subcommand,
         string expectedCommand)
     {
-        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"missing-tier-{subcommand}");
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", $"missing-selection-{subcommand}");
         var result = await CliProcessRunner.RunCommandAsync(CreateMissingTierScenarioArgs(subcommand, scope.CreateDirectory("repo"), scope.GetPath("exported")));
 
         using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
@@ -288,7 +350,7 @@ public sealed class SkillsCliOutputContractTests
             status: "error",
             exitCode: (int)CliExitCode.InvalidArgument);
         CommandResultAssert.HasSingleError(outputJson.RootElement, InvalidArgumentCode);
-        Assert.Contains("Option '--tier' is required.", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Option '--tier' or '--skill' is required.", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
     }
 
     [Theory]
@@ -317,7 +379,8 @@ public sealed class SkillsCliOutputContractTests
             exitCode: (int)CliExitCode.Success);
         JsonAssert.For(outputJson.RootElement)
             .HasProperty("payload", payload => payload
-                .HasArrayLength("tiers", 1));
+                .HasArrayLength("tiers", 1)
+                .HasArrayLength("skillNames", 0));
         Assert.Equal("advanced", outputJson.RootElement.GetProperty("payload").GetProperty("tiers")[0].GetString());
     }
 
@@ -350,6 +413,7 @@ public sealed class SkillsCliOutputContractTests
             .HasProperty("payload", payload => payload
                 .HasString("host", "openai")
                 .HasArrayLength("tiers", 1)
+                .HasArrayLength("skillNames", 0)
                 .HasString("format", "directory")
                 .HasString("outputRoot", outputRoot)
                 .HasArrayLength("skills", ExpectedSkillNames.Length)
@@ -362,6 +426,80 @@ public sealed class SkillsCliOutputContractTests
             Assert.True(File.Exists(Path.Combine(outputRoot, skillName, "agent-skill.json")), skillName);
             Assert.True(File.Exists(Path.Combine(outputRoot, skillName, "agents", "openai.yaml")), skillName);
         }
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsExport_WithSkillNameOnly_WritesMatchingPackage ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "export-openai-skill");
+        var outputRoot = scope.GetPath("exported");
+
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Skills,
+            UcliCommandNames.ExportSubcommand,
+            "--host",
+            "openai",
+            "--skill",
+            SelectedSingleSkillName,
+            "--output",
+            outputRoot);
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.Success, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsExport,
+            status: "ok",
+            exitCode: (int)CliExitCode.Success);
+        JsonAssert.For(outputJson.RootElement)
+            .HasProperty("payload", payload => payload
+                .HasArrayLength("tiers", 3)
+                .HasArrayLength("skillNames", 1)
+                .HasArrayLength("skills", 1)
+                .HasInt32("skillCount", 1));
+        var payload = outputJson.RootElement.GetProperty("payload");
+        Assert.Equal([SelectedSingleSkillName], payload
+            .GetProperty("skillNames")
+            .EnumerateArray()
+            .Select(static skillName => skillName.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.Equal([SelectedSingleSkillName], payload
+            .GetProperty("skills")
+            .EnumerateArray()
+            .Select(static skillName => skillName.GetString() ?? string.Empty)
+            .ToArray());
+        Assert.True(File.Exists(Path.Combine(outputRoot, SelectedSingleSkillName, "SKILL.md")));
+        Assert.False(Directory.Exists(Path.Combine(outputRoot, ExpectedSkillNames[0])));
+    }
+
+    [Fact]
+    [Trait("Size", "Medium")]
+    public async Task SkillsExport_WithTierAndMismatchedSkillName_ReturnsInvalidArgument ()
+    {
+        using var scope = TestDirectories.CreateTempScope("skills-cli-output-contract", "export-skill-tier-mismatch");
+
+        var result = await CliProcessRunner.RunCommandAsync(
+            UcliCommandNames.Skills,
+            UcliCommandNames.ExportSubcommand,
+            "--host",
+            "openai",
+            "--tier",
+            "advanced",
+            "--skill",
+            SelectedSingleSkillName,
+            "--output",
+            scope.GetPath("exported"));
+
+        using var outputJson = StdoutJsonParser.ParseSinglePrettyPrintedObject(result.StdOut);
+        Assert.Equal((int)CliExitCode.InvalidArgument, result.ExitCode);
+        CommandResultAssert.HasStandardEnvelope(
+            outputJson.RootElement,
+            command: UcliCommandNames.SkillsExport,
+            status: "error",
+            exitCode: (int)CliExitCode.InvalidArgument);
+        CommandResultAssert.HasSingleError(outputJson.RootElement, SkillInputInvalidCode);
+        Assert.Contains("does not match selected tiers", outputJson.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/Ucli.SchemaGenerator/Program.cs
+++ b/tools/Ucli.SchemaGenerator/Program.cs
@@ -1285,6 +1285,7 @@ internal static class Program
         return ObjectSchema(
             additionalProperties: false,
             Required("tiers", ArraySchema(SkillTierLiteralSchema())),
+            Required("skillNames", ArraySchema(StringSchema())),
             Required("availableTiers", ArraySchema(CreateSkillsListTierSchema())),
             Required("skills", ArraySchema(CreateSkillsListSkillSchema())),
             Required("supportedHosts", ArraySchema(CreateSkillsListSupportedHostSchema())));


### PR DESCRIPTION
## Summary
- update AgentSkills dependencies and generated official SKILL manifests to 0.6.0 ordering
- add exact --skill package selection for skills list/export/install/update/uninstall/doctor
- preserve selected skillNames in CLI payloads and schema output

## Verification
- bash scripts/verify.sh